### PR TITLE
Add two parameters to markdowngen

### DIFF
--- a/tests/test_scripts/output/genmarkdown/help
+++ b/tests/test_scripts/output/genmarkdown/help
@@ -7,6 +7,8 @@ Options:
   -c, --classes TEXT              Class(es) to emit
   -i, --img                       Download YUML images to 'image' directory
   --noimages                      Do not (re-)generate images
+  --notypesdir                    Do not create a separate types directory
+  --warnonexist                   Warn if output file already exists
   -f, --format [md]               Output format (default=md)
   --metadata / --no-metadata      Include metadata in output
                                   (default=--metadata)

--- a/tests/test_scripts/test_gen_markdown.py
+++ b/tests/test_scripts/test_gen_markdown.py
@@ -26,6 +26,10 @@ class GenMarkdownTestCase(ClickTestCase):
         self.do_test(f'-c example -i ', 'issue2', is_directory=True)
         self._exists('issue2', 'images', 'Example.svg')
 
+    def test_no_types(self):
+        """ Test the no types directory setting """
+        self.do_test(f'--notypesdir --warnonexist --log_level WARNING', 'meta_no_types', is_directory=True)
+
     @unittest.expectedFailure
     def test_issue_2_excerpt(self):
         # This was a part of the unit tests for a while.  We have NO idea why we thought that markdown should NOT

--- a/tests/utils/clicktestcase.py
+++ b/tests/utils/clicktestcase.py
@@ -113,7 +113,9 @@ class ClickTestCase(TestEnvironmentTestCase):
 
         if add_yaml and (not arg_list or arg_list[0] != '--help'):
             arg_list.insert(0, self.env.meta_yaml)
-            arg_list += ["--importmap", self.env.import_map, "--log_level", DEFAULT_LOG_LEVEL_TEXT]
+            arg_list += ["--importmap", self.env.import_map]
+            if '--log_level' not in arg_list:
+                arg_list += ["--log_level", DEFAULT_LOG_LEVEL_TEXT]
 
         target = os.path.join(self.testdir, testFileOrDirectory)
         self.temp_file_path(self.testdir, is_dir=True)


### PR DESCRIPTION
--notypesdir -- if present, don't put types into a subdirectory
--warnonexist -- if present, warn before overwriting an existing file

This was done to allow linkml-model to put everything in the root directory without breaking other software