### PR TITLE
fix no-prefix warning

### DIFF
--- a/examples/organization.yaml
+++ b/examples/organization.yaml
@@ -11,6 +11,7 @@ types:
 
 prefixes:
   ORGDATA: http://example.org/sample/organization/data/
+  xsd: http://www.w3.org/2001/XMLSchema#
     
 classes:
 


### PR DESCRIPTION
alternatively, could replace definition of string type with
```
imports:
  - linkml:types
```
, which sets the `xsd` prefix, and also demonstrates use of "built-in" types.

But, this fix gets e.g. `gen-json-schema` to stop warning about a missing `xsd` prefix and retains the tutorial quality of the example in defining a string type.