### PR TITLE
Turned off title case in schema name

### DIFF
--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -56,7 +56,7 @@ class MarkdownGenerator(Generator):
 
         with open(self.exist_warning(directory, 'index.md'), 'w') as ixfile:
             with redirect_stdout(ixfile):
-                self.frontmatter(f"{self.schema.name.title()} schema")
+                self.frontmatter(f"{self.schema.name} schema")
                 self.para(be(self.schema.description))
 
                 self.header(3, 'Classes')


### PR DESCRIPTION
By default, LinkML displays schema names in Markdown in title case. This is not ideal in cases where the schema name is an acronym, e.g. `CCDH` is turned into `Ccdh`. This PR changes the display of schema names to be exactly as entered in the `schema.name` field.