### PR TITLE
Make predicate_cardinality rendering identical to range_cardinality rendering

### DIFF
--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -412,7 +412,7 @@ class MarkdownGenerator(Generator):
         if slot.multivalued:
             card_str = '1..*' if slot.required else '0..*'
         else:
-            card_str = 'REQ' if slot.required else 'OPT'
+            card_str = '1..1' if slot.required else '0..1'
         return f"  <sub>{card_str}</sub>"
 
     @staticmethod


### PR DESCRIPTION
@mbrush requested this on the CCDH model documentation, so I thought I'd send the idea upstream: I'm not sure if predicate_cardinality rendering should always be identical to range_cardinality rendering, but maybe this should be configurable? Also, in the future, 'REQ' and 'OPT' are probably going to be harder to internationalize than '1..1' and '0..1'.