### PR TITLE
Rdf issues

### DIFF
--- a/linkml/generators/jsonldgen.py
+++ b/linkml/generators/jsonldgen.py
@@ -2,15 +2,18 @@
 
 """
 import os
+from copy import deepcopy
 from typing import Any, Optional
 
 import click
-from jsonasobj2 import as_json, items
+from jsonasobj2 import as_json, items, loads
 
 from linkml import METAMODEL_CONTEXT_URI
 from linkml_runtime.linkml_model.meta import ClassDefinitionName, SlotDefinitionName, TypeDefinitionName, \
     ElementName, SlotDefinition, ClassDefinition, TypeDefinition, SubsetDefinitionName, SubsetDefinition
 from linkml_runtime.utils.formatutils import camelcase, underscore
+
+from linkml.generators.jsonldcontextgen import ContextGenerator
 from linkml.utils.generator import Generator, shared_arguments
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
@@ -19,6 +22,10 @@ class JSONLDGenerator(Generator):
     generatorname = os.path.basename(__file__)
     generatorversion = "0.0.2"
     valid_formats = ['jsonld', 'json']      # jsonld includes @type and @context.  json is pure JSON
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.original_schema = deepcopy(self.schema)
 
     def _add_type(self, node: YAMLRoot) -> dict:
         if self.format == 'jsonld':
@@ -75,7 +82,8 @@ class JSONLDGenerator(Generator):
         self._visit(cls)
         cls.class_uri = self.namespaces.uri_for(cls.class_uri)
         # Slot usage is a construction artifact
-        cls.slot_usage = []
+        # TODO: Figure out why this is here.  It isn't good form to alter a schema that may be used by other things
+        cls.slot_usage = {}
         return False
 
     def visit_slot(self, aliased_slot_name: str, slot: SlotDefinition) -> None:
@@ -91,14 +99,19 @@ class JSONLDGenerator(Generator):
 
     def end_schema(self, context: str = None, **_) -> None:
         self._add_type(self.schema)
-        json_obj = self.schema
         base_prefix = self.default_prefix()
 
         # JSON LD adjusts context reference using '@base'.  If context is supplied and not a URI, generate an
         # absolute URI for it
-        if context is None:
-            model_context = self.schema.source_file.replace('.yaml', '.prefixes.context.jsonld')
-            context = [METAMODEL_CONTEXT_URI, f'file:./{model_context}']
+        if context is None and self.format == 'jsonld':
+            # TODO: Once we get pyld running w/ relative contexts, we need to figure out how to generate and add
+            #       the relative (?) context reference below
+            # model_context = self.schema.source_file.replace('.yaml', '.prefixes.context.jsonld')
+            # context = [METAMODEL_CONTEXT_URI, f'file://./{model_context}']
+            # TODO: The _visit function above alters the schema in situ
+            add_prefixes = ContextGenerator(self.original_schema, model=False, metadata=False).serialize()
+            add_prefixes_json = loads(add_prefixes)
+            context = [METAMODEL_CONTEXT_URI, add_prefixes_json['@context']]
         elif isinstance(context, str):               # Some of the older code doesn't do multiple contexts
             context = [context]
         elif isinstance(context, tuple):
@@ -108,15 +121,16 @@ class JSONLDGenerator(Generator):
 
         # Absolute file paths have to have a prefix
         for ci in range(0, len(context)):
-            if context[ci].startswith('/'):           # TODO: how do we deal with absolute DOS paths?
+            if isinstance(context[ci], str) and context[ci].startswith('/'):           # TODO: how do we deal with absolute DOS paths?
                 context[ci] = 'file://' + context[ci]
 
         if self.format == 'jsonld':
-            json_obj["@context"] = context[0] if len(context) == 1 and not base_prefix else context
+            self.schema["@context"] = context[0] if len(context) == 1 and not base_prefix else context
             if base_prefix:
-                json_obj["@context"].append({'@base': base_prefix})
+                self.schema["@context"].append({'@base': base_prefix})
         # json_obj["@id"] = self.schema.id
-        print(as_json(json_obj, indent="  "))
+        print(as_json(self.schema, indent="  "))
+        self.schema = self.original_schema
 
 
 @shared_arguments(JSONLDGenerator)

--- a/linkml/generators/rdfgen.py
+++ b/linkml/generators/rdfgen.py
@@ -31,7 +31,7 @@ class RDFGenerator(Generator):
         return g.serialize(format='turtle' if self.format == 'ttl' else self.format).decode()
 
     def end_schema(self, output: Optional[str] = None, context: str = METAMODEL_CONTEXT_URI, **_) -> None:
-        gen = JSONLDGenerator(self, fmt=JSONLDGenerator.valid_formats[0], emit_metadata=self.emit_metadata,
+        gen = JSONLDGenerator(self, fmt=JSONLDGenerator.valid_formats[0], metadata=self.emit_metadata,
                               importmap=self.importmap)
         # Iterate over permissible text strings making them URI compatible
         for e in gen.schema.enums.values():

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -33,7 +33,7 @@ class Generator(metaclass=abc.ABCMeta):
     def __init__(self,
                  schema: Union[str, TextIO, SchemaDefinition, "Generator"],
                  format: Optional[str] = None,
-                 emit_metadata: bool = True,
+                 metadata: bool = True,
                  useuris: Optional[bool] = None,
                  importmap: Optional[str] = None,
                  log_level: int = DEFAULT_LOG_LEVEL_INT,
@@ -48,7 +48,7 @@ class Generator(metaclass=abc.ABCMeta):
         :param schema: metamodel compliant schema.  Can be URI, file name, actual schema, another generator, an
         open file or a pre-parsed schema.
         :param format: expected output format
-        :param emit_metadata: True means include date, generator, etc. information in source header if appropriate
+        :param metadata: True means include date, generator, etc. information in source header if appropriate
         :param useuris: True means declared class slot uri's are used.  False means use model uris
         :param importmap: File name of import mapping file -- maps import name/uri to target
         :param log_level: Logging level
@@ -68,10 +68,10 @@ class Generator(metaclass=abc.ABCMeta):
             format = self.valid_formats[0]
         assert format in self.valid_formats, f"Unrecognized format: {format}"
         self.format = format
-        self.emit_metadata = emit_metadata
+        self.emit_metadata = metadata
         self.merge_imports = mergeimports
-        self.source_file_date = source_file_date if emit_metadata else None
-        self.source_file_size = source_file_size if emit_metadata else None
+        self.source_file_date = source_file_date if metadata else None
+        self.source_file_size = source_file_size if metadata else None
         if isinstance(schema, Generator):
             gen = schema
             self.schema = gen.schema
@@ -87,7 +87,7 @@ class Generator(metaclass=abc.ABCMeta):
             self.logger = gen.logger
         else:
             loader = SchemaLoader(schema, self.base_dir, useuris=useuris, importmap=importmap, logger=self.logger,
-                                  mergeimports=mergeimports, emit_metadata=emit_metadata,
+                                  mergeimports=mergeimports, emit_metadata=metadata,
                                   source_file_date=self.source_file_date, source_file_size=self.source_file_size)
             loader.resolve()
             self.schema = loader.schema

--- a/linkml/utils/schemaloader.py
+++ b/linkml/utils/schemaloader.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from typing import Union, TextIO, Optional, Set, List, cast, Dict, Mapping, Tuple, Iterator
 from urllib.parse import urlparse
 
+from jsonasobj2 import values
 from linkml_runtime.linkml_model.meta import SchemaDefinition, SlotDefinition, SlotDefinitionName, ClassDefinition, \
     ClassDefinitionName, TypeDefinitionName, TypeDefinition, ElementName, EnumDefinition, EnumDefinitionName
 from linkml_runtime.utils.context_utils import parse_import_map
@@ -592,7 +593,7 @@ class SchemaLoader:
                     visit(cls.is_a)
                 for mixin in cls.mixins:
                     visit(mixin)
-                for slot_usage in cls.slot_usage.values():
+                for slot_usage in values(cls.slot_usage):
                     if slot_usage.alias:
                         self.raise_value_error(f'Class: "{cls.name}" - alias not permitted in slot_usage slot:'
                                                f' {slot_usage.alias}')

--- a/tests/test_issues/test_issue_332.py
+++ b/tests/test_issues/test_issue_332.py
@@ -1,5 +1,7 @@
 import unittest
 
+from jsonasobj2 import loads, JsonObj, as_json
+
 from linkml.generators.jsonldgen import JSONLDGenerator
 from tests.test_issues.environment import env
 
@@ -7,26 +9,50 @@ from tests.test_issues.environment import env
 class JSONContextTestCase(unittest.TestCase):
     def test_context(self):
         """ Test no context in the argument"""
-        self.assertIn('''"@context": [
-    [
-      "https://w3id.org/linkml/meta.context.jsonld"
-    ],''', JSONLDGenerator(env.input_path('issue_332.yaml')).serialize())
+        json_ld = JSONLDGenerator(env.input_path('issue_332.yaml')).serialize()
+        json_ld_obj = loads(json_ld)
+        expected = JsonObj([
+            "https://w3id.org/linkml/meta.context.jsonld",
+            {
+              "meta": "https://w3id.org/linkml/",
+              "test14": "https://example.com/test14/",
+              "@vocab": "https://example.com/test14/"
+            },
+            {
+              "@base": "https://example.com/test14/"
+            }
+          ]
+        )
+        self.assertEqual(as_json(expected), as_json(json_ld_obj['@context']))
 
     def test_context_2(self):
         """ Test a single context argument """
-        self.assertIn('''"@context": [
-    [
-      "http://some.org/nice/meta.context.jsonld"
-    ],''', JSONLDGenerator(env.input_path('issue_332.yaml')).serialize(context="http://some.org/nice/meta.context.jsonld"))
+        json_ld = JSONLDGenerator(env.input_path('issue_332.yaml')).\
+            serialize(context="http://some.org/nice/meta.context.jsonld")
+        json_ld_obj = loads(json_ld)
+        expected = JsonObj([
+               "http://some.org/nice/meta.context.jsonld",
+               {
+                  "@base": "https://example.com/test14/"
+               }
+            ]
+        )
+        self.assertEqual(as_json(expected), as_json(json_ld_obj['@context']))
 
     def test_context_3(self):
         """ Test multi context arguments """
-        self.assertIn('''"@context": [
-    [
-      "http://some.org/nice/meta.context.jsonld",
-      "http://that.org/meta.context.jsonld"
-    ],''', JSONLDGenerator(env.input_path('issue_332.yaml')).
-              serialize(context=["http://some.org/nice/meta.context.jsonld", "http://that.org/meta.context.jsonld"]))
+        json_ld = JSONLDGenerator(env.input_path('issue_332.yaml')).\
+            serialize(context=["http://some.org/nice/meta.context.jsonld", "http://that.org/meta.context.jsonld"])
+        json_ld_obj = loads(json_ld)
+        expected = JsonObj([
+               "http://some.org/nice/meta.context.jsonld",
+               "http://that.org/meta.context.jsonld",
+               {
+                  "@base": "https://example.com/test14/"
+               }
+            ]
+        )
+        self.assertEqual(as_json(expected), as_json(json_ld_obj['@context']))
 
 
 if __name__ == '__main__':

--- a/tests/test_scripts/input/includes/simple_types.yaml
+++ b/tests/test_scripts/input/includes/simple_types.yaml
@@ -1,0 +1,11 @@
+id: https://raw.githubusercontent.com/linkml/linkml/main/tests/test_scripts/input/includes/simple_types
+description: Type definition to be used in json-ld test case
+
+prefixes:
+  xsd: http://www.w3.org/2001/XMLSchema#
+  slotpfx: http://samples.r.us/slot/
+
+types:
+  simple string:
+    uri: xsd:string
+    base: str

--- a/tests/test_scripts/input/simple_slots.yaml
+++ b/tests/test_scripts/input/simple_slots.yaml
@@ -1,0 +1,14 @@
+id: https://raw.githubusercontent.com/linkml/linkml/main/tests/test_scripts/input/simple_slots
+description: Slot definition to be included in jsonld test case
+
+imports:
+  includes/simple_types
+
+prefixes:
+  foo: http://samples.r.us/foo#
+  slotpfx: http://samples.r.us/slot/
+
+slots:
+  state:
+    slot_uri: foo:state
+    range: simple string

--- a/tests/test_scripts/input/simple_uri_test.yaml
+++ b/tests/test_scripts/input/simple_uri_test.yaml
@@ -1,0 +1,23 @@
+id: https://raw.githubusercontent.com/linkml/linkml/main/tests/test_scripts/input/simple_uri_test
+name: simple_uri_test
+
+description: A test of various forms of jsonld context generation
+
+imports:
+  - linkml:extensions
+  - simple_slots
+  - includes/simple_types
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  foo: http://samples.r.us/foo#
+  bar: http://samples.r.us/bar_
+
+
+classes:
+  model:
+    class_uri: foo:model
+    slots:
+      - state
+    exact_mappings:
+      - bar:whaoo

--- a/tests/test_scripts/test_gen_jsonld_context.py
+++ b/tests/test_scripts/test_gen_jsonld_context.py
@@ -23,7 +23,38 @@ class GenContextTestCase(ClickTestCase):
         self.do_test('-f xsv', 'meta_error', expected_error=click.exceptions.BadParameter)
         self.do_test('--niggles', 'meta2_error', expected_error=click.exceptions.NoSuchOption)
 
+    def test_prefix_options(self):
+        """ Test various prefix emission options"""
+        # prefixes only, no-merge
+        self.do_test([self.env.input_path('simple_uri_test.yaml'), '--no-metadata', '--no-mergeimports', '--no-model'],
+                     'simple_uri_test.no_merge.prefixes_only.context.jsonld', add_yaml=False)
+        # flat prefixes only, no-merge
+        self.do_test([self.env.input_path('simple_uri_test.yaml'), '--no-metadata', '--no-mergeimports', '--no-model', '--flatprefixes'],
+                     'simple_uri_test.no_merge.flatprefixes_only.context.jsonld', add_yaml=False)
+        # model only, no-merge
+        self.do_test([self.env.input_path('simple_uri_test.yaml'), '--no-metadata', '--no-mergeimports', '--no-prefixes'],
+                     'simple_uri_test.no_merge.model_only.context.jsonld', add_yaml=False)
+        # both, no-merge
+        self.do_test([self.env.input_path('simple_uri_test.yaml'), '--no-metadata', '--no-mergeimports', '--model', '--prefixes'],
+                     'simple_uri_test.no_merge.context.jsonld', add_yaml=False)
+        # prefixes only, merge
+        self.do_test([self.env.input_path('simple_uri_test.yaml'), '--no-metadata', '--mergeimports', '--no-model'],
+                     'simple_uri_test.merge.prefixes_only.context.jsonld', add_yaml=False)
+        # flat prefixes only, merge
+        self.do_test([self.env.input_path('simple_uri_test.yaml'), '--no-metadata', '--mergeimports', '--no-model', '--flatprefixes'],
+                     'simple_uri_test.merge.flatprefixes_only.context.jsonld', add_yaml=False)
+        # model only, merge
+        self.do_test([self.env.input_path('simple_uri_test.yaml'), '--no-metadata', '--mergeimports', '--no-prefixes'],
+                     'simple_uri_test.merge.model_only.context.jsonld', add_yaml=False)
+        # both, merge
+        self.do_test([self.env.input_path('simple_uri_test.yaml'), '--no-metadata', '--mergeimports', '--model', '--prefixes'],
+                     'simple_uri_test.merge.context.jsonld', add_yaml=False)
+
+
     def test_slot_class_uri(self):
+        # Note: two warnings are expected below:
+        #   WARNING:ContextGenerator:No namespace defined for URI: http://example.org/slot/su
+        #   WARNING:ContextGenerator:No namespace defined for URI: http://example.org/class/cu
         self.do_test(env.input_path('uri_tests.yaml'), 'uri_tests.jsonld', filtr=ldcontext_metadata_filter,
                      add_yaml=False)
 

--- a/tests/test_scripts/test_gen_python.py
+++ b/tests/test_scripts/test_gen_python.py
@@ -60,10 +60,10 @@ types:
    string:
       base: str
       uri: xsd:string'''
-        output = pythongen.PythonGenerator(yaml, "py", emit_metadata=True, source_file_date="August 10, 2020", source_file_size=173).serialize()
+        output = pythongen.PythonGenerator(yaml, "py", metadata=True, source_file_date="August 10, 2020", source_file_size=173).serialize()
         self.assertTrue(output.startswith(f'# Auto generated from None by pythongen.py version: '
                                           f'{pythongen.PythonGenerator.generatorversion}'))
-        output = pythongen.PythonGenerator(yaml, "py", emit_metadata=False).serialize()
+        output = pythongen.PythonGenerator(yaml, "py", metadata=False).serialize()
         self.assertTrue(output.startswith('\n# id: https://w3id.org/biolink/metamodel'))
 
     def test_multi_id(self):

--- a/tests/utils/clicktestcase.py
+++ b/tests/utils/clicktestcase.py
@@ -118,7 +118,7 @@ class ClickTestCase(TestEnvironmentTestCase):
                 arg_list += ["--log_level", DEFAULT_LOG_LEVEL_TEXT]
 
         target = os.path.join(self.testdir, testFileOrDirectory)
-        self.temp_file_path(self.testdir, is_dir=True)
+        self.temp_file_path(is_dir=True)
 
         def do_gen():
             if is_directory:


### PR DESCRIPTION
This set of changes addresses the issues on the RDF being emitted incorrectly.  To summarize the problem:

To emit a LinkML model in RDF, _two_ contexts are required;
1) __meta.context.jsonld__ -- this provides all the built in prefixes for types, linkml, etc. as well as the definitions of the various LinkML model elements.
2) __<target>.prefixes.context.jsonld__ -- the _prefixes_ that are used in the model definition.  Note that we cannot include the model element definitions, because, if LinkML defines an element named "slot" and biolink_model defines a _different_ element named "slot", including the entire biolink_model.context.jsonld would override the LinkML definition.

One of the major issues with the current `pyld` distro is that it doesn't support relative URL's, meaning that we have to supply absolute URL's as JSON-LD context.  As we don't have any established policy as to where model context.jsonld files go, we've updated the JSON-LD emitter to include the target prefixes inline.  __Note:__ at the moment, if you pass ANY contexts into the jsonld generator, it will completely override this behavior