### PR TITLE
Minor fixes to YUML display in Markdown

### DIFF
--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -113,7 +113,8 @@ class MarkdownGenerator(Generator):
                         img_url = yg.serialize(classes=[cls.name])\
                             .replace('?', '%3F').replace(' ', '%20').replace('|', '&#124;')
 
-                    print(f'![img]({img_url})')
+                    print(f'[![img]({img_url})]({img_url})')
+
                 self.mappings(cls)
 
                 if cls.id_prefixes:

--- a/linkml/generators/yumlgen.py
+++ b/linkml/generators/yumlgen.py
@@ -24,7 +24,7 @@ yuml_inline = '++- '
 yuml_inline_rev = '-++'
 yuml_ref = '- '
 
-yuml_base = 'http://yuml.me/diagram/nofunky'
+yuml_base = 'https://yuml.me/diagram/nofunky'
 yuml_scale = ''                # ';scale:180' ';scale:80' for small
 yuml_dir = ';dir:TB'           # '
 yuml_class = '/class/'

--- a/tests/test_issues/test_issue_12.py
+++ b/tests/test_issues/test_issue_12.py
@@ -10,7 +10,7 @@ class Issue12UnitTest(unittest.TestCase):
     def test_domain_slots(self):
         """ has_phenotype shouldn't appear in the UML graph """
         yuml = YumlGenerator(env.input_path('issue_12.yaml')).serialize()
-        self.assertEqual('http://yuml.me/diagram/nofunky;dir:TB/class/[BiologicalEntity]++- '
+        self.assertEqual('https://yuml.me/diagram/nofunky;dir:TB/class/[BiologicalEntity]++- '
                          'required thing 0..1>[PhenotypicFeature],[BiologicalEntity]', yuml)
         resp = requests.get(yuml)
         self.assertTrue(resp.ok)


### PR DESCRIPTION
This PR makes two minor fixes to YUML display in Markdown:
* It replaces the `http://` URL with `https://` so that it can be invoked from HTTPS sites.
* It turns the YUML image on CCDH pages into a link to the YUML image itself. If you used the `--img` command line option, this will be relative links to the generated image ([example](https://cancerdhc.github.io/ccdhmodel/v1.0.1/BiologicProduct/)), otherwise this will be direct links to the YUML image on their server. In either case, the user can click on the image to see a full-size version of the image, which can be helpful if the images are very dense.