### PR TITLE
Remove sorting of slots on class pages

### DIFF
--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -151,7 +151,7 @@ class MarkdownGenerator(Generator):
                 self.header(2, 'Attributes')
 
                 # List all of the slots that directly belong to the class
-                slot_list = [slot for slot in [self.schema.slots[sn] for sn in sorted(cls.slots)]]
+                slot_list = [slot for slot in [self.schema.slots[sn] for sn in cls.slots]]
                 own_slots = [slot for slot in slot_list if cls.name in slot.domain_of]
                 if own_slots:
                     self.header(3, 'Own')


### PR DESCRIPTION
At the CCDH project, we have slots arranged within classes thematically -- for instance, [Specimen](https://cancerdhc.github.io/ccdhmodel/v1.0.1/Specimen/) begins with identifiers, followed by metadata like description, followed by specimen and analyte types, and so on. By default, Markdown generation rearranges slots alphabetically, which disrupts this order. We propose that the slots on class pages are arranged in the same order as in the schema; if not, we could maybe add a command-line argument or a configuration file to change this setting.

This PR implements this change by turning off sorting of slots on the class page.