### PR TITLE
Replace `simple_name` with `name` in the Slot header in the Markdown generator

### DIFF
--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -250,7 +250,7 @@ class MarkdownGenerator(Generator):
             obj_type = 'Enum'
         else:
             obj_type = 'Class'
-        self.header(1, f"{obj_type}: {simple_name}" + (f" _(deprecated)_" if obj.deprecated else ""))
+        self.header(1, f"{obj_type}: {name}" + (f" _(deprecated)_" if obj.deprecated else ""))
         self.para(be(obj.description))
         print(f'URI: [{curie}]({uri})')
         print()


### PR DESCRIPTION
In the Markdown generator, the Slot page currently uses the "simple name" (i.e. the CURIE without the prefix) of the slot in the page header. When a slot is defined as part of a class (such as e.g. [Specimen.derived_product](https://cancerdhc.github.io/ccdhmodel/v1.0.1/specimen__derived_product/)), this is displayed as `Slot: specimen__derived_product`, which is not very readable. In the CCDH project, we have replaced this with the `name` field of the slot, giving us the much more readable "Slot: derived_product".

Alternatively, we could include the defining class in the Slot page header, possibly with a link to the entity (i.e. "[Specimen](https://cancerdhc.github.io/ccdhmodel/v1.0.1/Specimen/).derived_product"). I'm not sure which one makes more sense given how LinkML works with slot definitions.