### PR TITLE
Issue 106: add --not-closed/--closed to cli to control global additional properties

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-Bill Duncan <wdduncan@users.noreply.github.com>
+Bill Duncan <wdduncan@gmail.com>
 Chris Mungall <cjm@berkeleybop.org>
 Donny Winston <donny@polyneme.xyz>
 EC2 Default User <ec2-user@ip-172-31-29-45.ec2.internal>

--- a/Pipfile
+++ b/Pipfile
@@ -32,6 +32,7 @@ sqlalchemy = "*"
 nbconvert = "*"
 nbformat = "*"
 ipykernel = "*"
+chardet = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -1,13 +1,29 @@
 import os
-from typing import Union, TextIO, Optional
+from typing import Union, TextIO, Optional, Dict, Tuple
 
 import click
 from jsonasobj2 import JsonObj, as_json
-
-from linkml.utils.generator import Generator, shared_arguments
 from linkml_runtime.linkml_model.meta import SchemaDefinition, ClassDefinition, SlotDefinition
 from linkml_runtime.utils.formatutils import camelcase, be, underscore
 
+from linkml.utils.generator import Generator, shared_arguments
+
+# Map from underlying python data type to json equivalent
+# Note: The underlying types are a union of any built-in python datatype + any type defined in
+#       linkml-runtime/utils/metamodelcore.py
+# Note the keys are all lower case
+json_schema_types: Dict[str, Tuple[str, Optional[str]]] = {
+    "int": ("integer", None),
+    "integer": ("integer", None),
+    "bool": ("boolean", None),
+    "boolean": ("boolean", None),
+    "float": ("number", None),
+    "double": ("number", None),
+    "decimal": ("number", None),
+    "xsddate": ("string", "date"),
+    "xsddatetime": ("string", "date-time"),
+    "xsdtime": ("string", "time"),
+}
 
 class JsonSchemaGenerator(Generator):
     generatorname = os.path.basename(__file__)
@@ -26,7 +42,7 @@ class JsonSchemaGenerator(Generator):
         # so we duplicate slots from inherited parents and mixins
         self.visit_all_slots = True
 
-    def visit_schema(self, inline: bool = False, not_closed=True, **kwargs) -> None:
+    def visit_schema(self, inline: bool = False, not_closed=True, **kwargs) -> None:    
         self.inline = inline
         self.schemaobj = JsonObj(title=self.schema.name,
                                  type="object",
@@ -58,26 +74,13 @@ class JsonSchemaGenerator(Generator):
         self.schemaobj.definitions[camelcase(cls.name)] = self.clsobj
 
     def visit_class_slot(self, cls: ClassDefinition, aliased_slot_name: str, slot: SlotDefinition) -> None:
-        if slot.range in self.schema.classes and slot.inlined:
+        fmt = None
+        if slot.range in self.schema.types:
+            (rng, fmt) = json_schema_types.get(self.schema.types[slot.range].base.lower(), ("string", None))
+        elif slot.range in self.schema.classes and slot.inlined:
             rng = f"#/definitions/{camelcase(slot.range)}"
-        elif slot.range in self.schema.types:
-            rng = self.schema.types[slot.range].base
         else:
-            # note we assume string for non-lined complex objects
             rng = "string"
-
-        # translate to json-schema builtins
-        if rng == 'int':
-            rng = 'integer'
-        elif rng == 'Bool':
-            rng = 'boolean'
-        elif rng == 'str':
-            rng = 'string'
-        elif rng == 'float' or rng == 'double':
-            rng = 'number'
-        elif not rng.startswith('#'):
-            # URIorCURIE, etc
-            rng = 'string'
 
         if slot.inlined:
             # If inline we have to include redefined slots
@@ -89,9 +92,15 @@ class JsonSchemaGenerator(Generator):
                 prop = ref
         else:
             if slot.multivalued:
-                prop = JsonObj(type="array", items={'type': rng})
+                if fmt is None:
+                    prop = JsonObj(type="array", items={'type': rng})
+                else:
+                    prop = JsonObj(type="array", items={'type': rng, 'format': fmt})
             else:
-                prop = JsonObj(type=rng)
+                if fmt is None:
+                    prop = JsonObj(type=rng)
+                else:
+                    prop = JsonObj(type=rng, format=fmt)
         if slot.description:
             prop.description = slot.description
         if slot.required:

--- a/notebooks/examples.ipynb
+++ b/notebooks/examples.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-04-02T22:12:21.074327Z",
@@ -35,7 +35,19 @@
      "shell.execute_reply": "2021-04-02T22:12:21.669211Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'linkml.dumpers'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-3ba7d22fbdf6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mlinkml\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgenerators\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0myumlgen\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mYumlGenerator\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mlinkml_runtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0myamlutils\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mDupCheckYamlLoader\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 12\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mlinkml\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdumpers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjson_dumper\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mdumps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'linkml.dumpers'"
+     ]
+    }
+   ],
    "source": [
     "from IPython.core.display import display, HTML\n",
     "from types import ModuleType\n",
@@ -760,7 +772,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/tests/test_scripts/test_gen_json_schema.py
+++ b/tests/test_scripts/test_gen_json_schema.py
@@ -25,9 +25,6 @@ class GenJSONSchemaTestCase(ClickTestCase):
     def test_tree_root(self):
         self.do_test([env.input_path('roottest.yaml')], 'rootttest.jsonld', add_yaml=False)
 
-    def test_tree_root_closed(self):
-        self.do_test([env.input_path('roottest.yaml'), '--closed'], 'rootttest3.jsonld', add_yaml=False)
-
     def test_tree_root_args(self):
         self.do_test([env.input_path('roottest.yaml'), '-t', 'c2'], 'rootttest2.jsonld', add_yaml=False)
 

--- a/tests/test_scripts/test_gen_json_schema.py
+++ b/tests/test_scripts/test_gen_json_schema.py
@@ -28,6 +28,8 @@ class GenJSONSchemaTestCase(ClickTestCase):
     def test_tree_root_args(self):
         self.do_test([env.input_path('roottest.yaml'), '-t', 'c2'], 'rootttest2.jsonld', add_yaml=False)
 
-
+    def test_tree_root_closed(self):
+        self.do_test([env.input_path('roottest.yaml'), '--closed'], 'rootttest3.jsonld', add_yaml=False)
+        
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_scripts/test_gen_json_schema.py
+++ b/tests/test_scripts/test_gen_json_schema.py
@@ -30,6 +30,9 @@ class GenJSONSchemaTestCase(ClickTestCase):
 
     def test_tree_root_closed(self):
         self.do_test([env.input_path('roottest.yaml'), '--closed'], 'rootttest3.jsonld', add_yaml=False)
+    
+    def test_tree_root_closed(self):
+        self.do_test([env.input_path('roottest.yaml'), '--not-closed'], 'rootttest4.jsonld', add_yaml=False)
         
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_scripts/test_gen_json_schema.py
+++ b/tests/test_scripts/test_gen_json_schema.py
@@ -25,6 +25,9 @@ class GenJSONSchemaTestCase(ClickTestCase):
     def test_tree_root(self):
         self.do_test([env.input_path('roottest.yaml')], 'rootttest.jsonld', add_yaml=False)
 
+    def test_tree_root_closed(self):
+        self.do_test([env.input_path('roottest.yaml'), '--closed'], 'rootttest3.jsonld', add_yaml=False)
+
     def test_tree_root_args(self):
         self.do_test([env.input_path('roottest.yaml'), '-t', 'c2'], 'rootttest2.jsonld', add_yaml=False)
 


### PR DESCRIPTION
Fixes #106 

Add functionality to specify at the global level whether the schema allows additional properties.  
The default is `not-closed`; i.e., the schema does allow additional properties. Used `--closed` in the cli to set `additionalProperties: false`.