### PR TITLE
Fix issue 273: Generation of SQLAlchemy classes fails when handling enums

### DIFF
--- a/linkml/generators/sqlddlgen.py
+++ b/linkml/generators/sqlddlgen.py
@@ -320,7 +320,7 @@ class SQLDDLGenerator(Generator):
             e = self.schema.enums[range]
             if e.permissible_values is not None:
                 vs = [str(v) for v in e.permissible_values]
-                return Enum(*vs)
+                return Enum(name=e.name, *vs)
         if range in RANGEMAP:
             return RANGEMAP[range]
         else:

--- a/linkml/generators/sqlddlgen.py
+++ b/linkml/generators/sqlddlgen.py
@@ -342,7 +342,7 @@ class SQLDDLGenerator(Generator):
 
     def generate_ddl(self) -> None:
         def dump(sql, *multiparams, **params):
-            print(sql.compile(dialect=engine.dialect))
+            print(f"{str(sql.compile(dialect=engine.dialect)).rstrip()};")
         engine = create_mock_engine(
             f'{self.dialect}://./MyDb',
             strategy='mock',

--- a/linkml/generators/sqlddlgen.py
+++ b/linkml/generators/sqlddlgen.py
@@ -341,10 +341,12 @@ class SQLDDLGenerator(Generator):
         return f'tbl_{underscore(t)}'
 
     def generate_ddl(self) -> None:
+        def dump(sql, *multiparams, **params):
+            print(sql.compile(dialect=engine.dialect))
         engine = create_mock_engine(
             f'{self.dialect}://./MyDb',
             strategy='mock',
-            executor= lambda sql, *multiparams, **params: print(f'{str(sql).rstrip()};'))
+            executor= dump)
         schema_metadata = MetaData()
         for t in self.sqlschema.tables.values():
             cls = t.mapped_to

--- a/tests/test_issues/test_issue_273.py
+++ b/tests/test_issues/test_issue_273.py
@@ -11,9 +11,7 @@ class IssueSQLGenTestCase(TestEnvironmentTestCase):
 
     def test_sqlddlgen(self):
         PATH = env.input_path('issue_273.yaml')
-        # TODO: determine why 'postgresql' doesn't work
-        #dialects = ['mssql+pyodbc', 'postgresql+pygresql']
-        dialects = ['mssql+pyodbc', 'sqlite+pysqlite', 'mysql+pymysql']
+        dialects = ['mssql+pyodbc', 'sqlite+pysqlite', 'mysql+pymysql', 'postgresql+pygresql']
         for dialect in dialects:
             gen = SQLDDLGenerator(PATH, dialect=dialect)
             ddl = gen.serialize()


### PR DESCRIPTION
This PR fixes the bug discovered when trying to generate SQLAlchemy classes and DDL for postgresql dialect.

This was because of two things:
- the executor used to serialize SQL statements was causing issues
- the name of enum was not being passed from linkml model to the `sqlalchemy.sql.sqltypes.Enum` object (which is required for Postgres - https://docs.sqlalchemy.org/en/14/core/type_basics.html#sqlalchemy.types.Enum.params.name)

