### PR TITLE
new generator: projectgen, runs all other generators

### DIFF
--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -21,7 +21,8 @@ class MarkdownGenerator(Generator):
     valid_formats = ["md"]
     visit_all_class_slots = False
 
-    def __init__(self, schema: Union[str, TextIO, SchemaDefinition], no_types_dir: bool = False, noyuml: bool = False, warn_on_exist:bool = False, **kwargs) -> None:
+    def __init__(self, schema: Union[str, TextIO, SchemaDefinition], no_types_dir: bool = False,
+                 noyuml: bool = False, warn_on_exist:bool = False, **kwargs) -> None:
         super().__init__(schema, **kwargs)
         self.directory: Optional[str] = None
         self.image_directory: Optional[str] = None
@@ -34,6 +35,7 @@ class MarkdownGenerator(Generator):
         self.BASE = None
 
     def visit_schema(self, directory: str = None, classes: Set[ClassDefinitionName] = None, image_dir: bool = False,
+                     index_file: str = 'index.md',
                      noimages: bool = False, **_) -> None:
         self.gen_classes = classes if classes else []
         for cls in self.gen_classes:
@@ -55,7 +57,7 @@ class MarkdownGenerator(Generator):
         if not self.no_types_dir:
             os.makedirs(os.path.join(directory, 'types'), exist_ok=True)
 
-        with open(self.exist_warning(directory, 'index.md'), 'w') as ixfile:
+        with open(self.exist_warning(directory, index_file), 'w') as ixfile:
             with redirect_stdout(ixfile):
                 self.frontmatter(f"{self.schema.name} schema")
                 self.para(be(self.schema.description))
@@ -615,11 +617,12 @@ class MarkdownGenerator(Generator):
 @click.option("--dir", "-d", help="Output directory")
 @click.option("--classes", "-c", default=None, multiple=True, help="Class(es) to emit")
 @click.option("--img", "-i",  is_flag=True, help="Download YUML images to 'image' directory")
+@click.option("--index-file", "-I", help="Name of markdown file that holds index")
 @click.option("--noimages", is_flag=True, help="Do not (re-)generate images")
 @click.option("--noyuml", is_flag=True, help="Do not add yUML figures to pages")
 @click.option("--notypesdir", is_flag=True, help="Do not create a separate types directory")
 @click.option("--warnonexist", is_flag=True, help="Warn if output file already exists")
-def cli(yamlfile, dir, img, notypesdir, warnonexist, **kwargs):
+def cli(yamlfile, dir, img, index_file, notypesdir, warnonexist, **kwargs):
     """ Generate markdown documentation of a biolink model """
     MarkdownGenerator(yamlfile, no_types_dir=notypesdir, warn_on_exist=warnonexist, **kwargs)\
         .serialize(directory=dir, image_dir=img, **kwargs)

--- a/linkml/generators/projectgen.py
+++ b/linkml/generators/projectgen.py
@@ -1,0 +1,101 @@
+import os
+from pathlib import Path
+from typing import Union, Dict, List, Any
+from functools import lru_cache
+from dataclasses import dataclass, field
+
+import click
+import yaml
+
+from linkml_runtime.linkml_model.meta import SchemaDefinition, ClassDefinition, SlotDefinition
+from linkml_runtime.utils.formatutils import camelcase, lcamelcase
+from linkml.utils.generator import Generator, shared_arguments
+
+from linkml.generators.graphqlgen import GraphqlGenerator
+from linkml.generators.jsonldcontextgen import ContextGenerator
+from linkml.generators.jsonldgen import JSONLDGenerator
+from linkml.generators.jsonschemagen import JsonSchemaGenerator
+from linkml.generators.markdowngen import MarkdownGenerator
+from linkml.generators.owlgen import OwlSchemaGenerator
+from linkml.generators.prefixmapgen import PrefixGenerator
+from linkml.generators.protogen import ProtoGenerator
+from linkml.generators.pythongen import PythonGenerator
+from linkml.generators.rdfgen import RDFGenerator
+from linkml.generators.shexgen import ShExGenerator
+from linkml.generators.sqlddlgen import SQLDDLGenerator
+
+GEN_MAP = {
+    'graphql': (GraphqlGenerator, 'graphql/{name}.graphql', {}),
+    'jsonldcontext': (ContextGenerator, 'jsonld/{name}.context.jsonld', {}),
+    'jsonld': (JSONLDGenerator, 'jsonld/{name}.jsonld', {'context': '{parent}/{name}.context.jsonld'}),
+    'jsonschema': (JsonSchemaGenerator, 'jsonschema/{name}.schema.json', {}),
+    'markdown': (MarkdownGenerator, 'docs/',
+                 {'directory': '{parent}',
+                  'index_file': '{name}.md'}),
+    'owl': (OwlSchemaGenerator, 'owl/{name}.owl.ttl', {}),
+    'prefixmap': (PrefixGenerator, 'prefixmap/{name}.yaml', {}),
+    'proto': (ProtoGenerator, 'protobuf/{name}.proto', {}),
+    'python': (PythonGenerator, '{name}.py', {}),
+#    'rdf': (RDFGenerator, 'rdf/{name}.ttl', {}),
+#    'rdf': (RDFGenerator, 'rdf/{name}.ttl', {'context': '{parent}/../jsonld/{name}.context.jsonld'}),
+    'shex': (ShExGenerator, 'shex/{name}.shexj', {}),
+    'sqlddl': (SQLDDLGenerator, 'sqlschema/{name}.sql', {}),
+}
+
+@lru_cache()
+def get_local_imports(schema_path: str, dir: str):
+    print(f'GETTING IMPORTS = {schema_path}')
+    all_imports = [schema_path]
+    with open(schema_path) as stream:
+        with open(schema_path) as stream:
+            schema = yaml.safe_load(stream)
+            for imp in schema.get('imports', []):
+                imp_path = os.path.join(dir, imp) + '.yaml'
+                print(f' IMP={imp} //  path={imp_path}')
+                if os.path.isfile(imp_path):
+                    all_imports += get_local_imports(imp_path, dir)
+    return all_imports
+
+@dataclass
+class ProjectConfiguration:
+    directory: str = 'tmp'
+    generator_args: Dict[str, Any] = field(default_factory=lambda: {})
+
+class ProjectGenerator:
+
+    def generate(self, schema_path: str, config: ProjectConfiguration = ProjectConfiguration()):
+        Path(config.directory).mkdir(parents=True, exist_ok=True)
+        all_schemas = get_local_imports(schema_path, os.path.dirname(schema_path))
+        print(f'ALL_SCHEMAS = {all_schemas}')
+        for gen_name, (gen_cls, gen_path_fmt, gen_args) in GEN_MAP.items():
+            print(f'GEN: {gen_name}')
+            for local_path in all_schemas:
+                print(f' SCHEMA: {local_path}')
+                name = os.path.basename(local_path).replace('.yaml', '')
+                gen_path = gen_path_fmt.format(name=name)
+                gen_path_full = f'{config.directory}/{gen_path}'
+                parts = gen_path_full.split('/')
+                parent_dir = '/'.join(parts[0:-1])
+                print(f' PARENT={parent_dir}')
+                Path(parent_dir).mkdir(parents=True, exist_ok=True)
+                gen_path_full = '/'.join(parts)
+
+                gen: Generator
+                gen = gen_cls(local_path)
+                serialize_args = {'mergeimports': False}
+                for k, v in {**gen_args, **config.generator_args.get(gen_name, {})}.items():
+                    serialize_args[k] = v.format(name=name, parent=parent_dir)
+                print(f' ARGS: {serialize_args}')
+                gen_dump = gen.serialize(**serialize_args)
+                if parts[-1] != '':
+                    # markdowngen does not write to a file
+                    print(f'  WRITING TO: {gen_path_full}')
+                    with open(gen_path_full, 'w') as stream:
+                        stream.write(gen_dump)
+
+
+
+
+
+
+

--- a/linkml/utils/ifabsent_functions.py
+++ b/linkml/utils/ifabsent_functions.py
@@ -70,7 +70,7 @@ default_library: List[Tuple[Text, bool, Callable[[Match[str], SchemaLoader, Clas
     ("slot_uri", True, lambda _, loader, ___, ____: "None"),
     ("class_curie", True, lambda _, loader, ___, ____: "None"),
     ("slot_curie", True, lambda _, loader, ___, ____: "None"),
-    # TODO: If you assign a range in the consructor, mergeutils has no way of knowing whether the range
+    # TODO: If you assign a range in the constructor, mergeutils has no way of knowing whether the range
     #       was overridden or just defaulted.  We need to let the old code continue to work until we get
     #       this bit resolved
     # ("default_range", False, lambda _, loader, __, ____: f"ElementName({strval(loader.schema.default_range)})"),

--- a/tests/test_generators/test_projectgen.py
+++ b/tests/test_generators/test_projectgen.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+from contextlib import redirect_stdout
+
+
+from linkml.generators.projectgen import ProjectGenerator, ProjectConfiguration
+from tests.test_generators.environment import env
+
+SCHEMA = env.input_path('kitchen_sink.yaml')
+PROJECT_DIR = env.expected_path('ks')
+
+class ProjectGeneratorTestCase(unittest.TestCase):
+
+    def test_projectgen(self):
+        """ Generate whole project  """
+        config = ProjectConfiguration()
+        config.directory = PROJECT_DIR
+        gen = ProjectGenerator()
+        gen.generate(SCHEMA, config)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This generator runs all other generators

It can be used as a replacement to complex Makefiles. Instead of configuring each output, just do this

```bash
gen-project --dir /tmp/ks/ tests/test_generators/input/kitchen_sink.yaml 
```

This will create:

```
$ find /tmp/ks/
/tmp/ks/
/tmp/ks//shex
/tmp/ks//shex/kitchen_sink.shexj
/tmp/ks//shex/core.shexj
/tmp/ks//sqlschema
/tmp/ks//sqlschema/kitchen_sink.sql
/tmp/ks//sqlschema/core.sql
/tmp/ks//owl
/tmp/ks//owl/kitchen_sink.owl.ttl
/tmp/ks//owl/core.owl.ttl
/tmp/ks//core.py
/tmp/ks//docs
/tmp/ks//docs/Agent.md
/tmp/ks//docs/hasAliases__aliases.md
/tmp/ks//docs/related_to.md

...
...

/tmp/ks//docs/started_at_time.md
/tmp/ks//jsonschema
/tmp/ks//jsonschema/kitchen_sink.schema.json
/tmp/ks//jsonschema/core.schema.json
/tmp/ks//graphql
/tmp/ks//graphql/kitchen_sink.graphql
/tmp/ks//graphql/core.graphql
/tmp/ks//jsonld
/tmp/ks//jsonld/core.jsonld
/tmp/ks//jsonld/core.context.jsonld
/tmp/ks//jsonld/kitchen_sink.context.jsonld
/tmp/ks//jsonld/kitchen_sink.jsonld
/tmp/ks//kitchen_sink.py
/tmp/ks//protobuf
/tmp/ks//protobuf/core.proto
/tmp/ks//protobuf/kitchen_sink.proto
/tmp/ks//prefixmap
/tmp/ks//prefixmap/kitchen_sink.yaml
/tmp/ks//prefixmap/core.yaml
```


```bash
gen-project --help
Usage: gen-project [OPTIONS]

  Generate JSONLD file from biolink schema

Options:
  -d, --dir TEXT  directory in which to place generated files. E.g.
                  linkml_model, biolink_model

  --help          Show this message and exit.
```