### PR TITLE
JSON Schema output `definitions` attribute name change

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -51,7 +51,7 @@ class JsonSchemaGenerator(Generator):
         for p, c in self.entryProperties.items():
             self.schemaobj['properties'][p] = {
                 'type': "array",
-                'items': {'$ref': f"#/definitions/{camelcase(c)}"}}
+                'items': {'$ref': f"#/$defs/{camelcase(c)}"}}
         self.schemaobj['$schema'] = "http://json-schema.org/draft-07/schema#"
         self.schemaobj['$id'] = self.schema.id
         self.schemaobj['$defs'] = JsonObj()
@@ -102,10 +102,10 @@ class JsonSchemaGenerator(Generator):
         if slot.range in self.schema.types:
             (typ, fmt) = json_schema_types.get(self.schema.types[slot.range].base.lower(), ("string", None))
         elif slot.range in self.schema.enums:
-            reference = f"#/definitions/{camelcase(slot.range)}"
+            reference = f"#/$defs/{camelcase(slot.range)}"
             typ = 'object'
         elif slot.range in self.schema.classes and slot.inlined:
-            reference = f"#/definitions/{camelcase(slot.range)}"
+            reference = f"#/$defs/{camelcase(slot.range)}"
             typ = 'object'
         else:
             typ = "string"

--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -47,7 +47,6 @@ class JsonSchemaGenerator(Generator):
         self.schemaobj = JsonObj(title=self.schema.name,
                                  type="object",
                                  properties={},
-                                 definitions=JsonObj(),
                                  additionalProperties=not_closed)
         for p, c in self.entryProperties.items():
             self.schemaobj['properties'][p] = {
@@ -55,6 +54,7 @@ class JsonSchemaGenerator(Generator):
                 'items': {'$ref': f"#/definitions/{camelcase(c)}"}}
         self.schemaobj['$schema'] = "http://json-schema.org/draft-07/schema#"
         self.schemaobj['$id'] = self.schema.id
+        self.schemaobj['$defs'] = JsonObj()
 
     def end_schema(self, **_) -> None:
         print(as_json(self.schemaobj, sort_keys=True))
@@ -71,7 +71,7 @@ class JsonSchemaGenerator(Generator):
         return True
 
     def end_class(self, cls: ClassDefinition) -> None:
-        self.schemaobj.definitions[camelcase(cls.name)] = self.clsobj
+        self.schemaobj['$defs'][camelcase(cls.name)] = self.clsobj
 
     def visit_enum(self, enum: EnumDefinition) -> bool:
         # TODO: this only works with explicitly permitted values. It will need to be extended to
@@ -88,7 +88,7 @@ class JsonSchemaGenerator(Generator):
 
         permissible_values_texts = list(map(extract_permissible_text, enum.permissible_values or []))
 
-        self.schemaobj.definitions[camelcase(enum.name)] = JsonObj(
+        self.schemaobj['$defs'][camelcase(enum.name)] = JsonObj(
             title=camelcase(enum.name),
             type='string',
             enum=permissible_values_texts,

--- a/tests/test_generators/output/kitchen_sink.schema.json
+++ b/tests/test_generators/output/kitchen_sink.schema.json
@@ -1,8 +1,5 @@
 {
-   "$id": "https://w3id.org/linkml/tests/kitchen_sink",
-   "$schema": "http://json-schema.org/draft-07/schema#",
-   "additionalProperties": true,
-   "definitions": {
+   "$defs": {
       "Activity": {
          "additionalProperties": false,
          "description": "a provence-generating activity",
@@ -144,19 +141,19 @@
          "properties": {
             "activities": {
                "items": {
-                  "$ref": "#/definitions/Activity"
+                  "$ref": "#/$defs/Activity"
                },
                "type": "array"
             },
             "companies": {
                "items": {
-                  "$ref": "#/definitions/Company"
+                  "$ref": "#/$defs/Company"
                },
                "type": "array"
             },
             "persons": {
                "items": {
-                  "$ref": "#/definitions/Person"
+                  "$ref": "#/$defs/Person"
                },
                "type": "array"
             }
@@ -247,7 +244,7 @@
                "type": "string"
             },
             "type": {
-               "$ref": "#/definitions/FamilialRelationshipType"
+               "$ref": "#/$defs/FamilialRelationshipType"
             }
          },
          "required": [
@@ -298,7 +295,7 @@
          "description": "",
          "properties": {
             "diagnosis": {
-               "$ref": "#/definitions/DiagnosisConcept"
+               "$ref": "#/$defs/DiagnosisConcept"
             },
             "ended_at_time": {
                "format": "date",
@@ -311,7 +308,7 @@
                "type": "boolean"
             },
             "procedure": {
-               "$ref": "#/definitions/ProcedureConcept"
+               "$ref": "#/$defs/ProcedureConcept"
             },
             "started_at_time": {
                "format": "date",
@@ -351,7 +348,7 @@
          "properties": {
             "addresses": {
                "items": {
-                  "$ref": "#/definitions/Address"
+                  "$ref": "#/$defs/Address"
                },
                "type": "array"
             },
@@ -365,23 +362,23 @@
                "type": "array"
             },
             "has_birth_event": {
-               "$ref": "#/definitions/BirthEvent"
+               "$ref": "#/$defs/BirthEvent"
             },
             "has_employment_history": {
                "items": {
-                  "$ref": "#/definitions/EmploymentEvent"
+                  "$ref": "#/$defs/EmploymentEvent"
                },
                "type": "array"
             },
             "has_familial_relationships": {
                "items": {
-                  "$ref": "#/definitions/FamilialRelationship"
+                  "$ref": "#/$defs/FamilialRelationship"
                },
                "type": "array"
             },
             "has_medical_history": {
                "items": {
-                  "$ref": "#/definitions/MedicalEvent"
+                  "$ref": "#/$defs/MedicalEvent"
                },
                "type": "array"
             },
@@ -463,26 +460,10 @@
          "type": "object"
       }
    },
-   "properties": {
-      "activities": {
-         "items": {
-            "$ref": "#/definitions/Activity"
-         },
-         "type": "array"
-      },
-      "companies": {
-         "items": {
-            "$ref": "#/definitions/Company"
-         },
-         "type": "array"
-      },
-      "persons": {
-         "items": {
-            "$ref": "#/definitions/Person"
-         },
-         "type": "array"
-      }
-   },
+   "$id": "https://w3id.org/linkml/tests/kitchen_sink",
+   "$schema": "http://json-schema.org/draft-07/schema#",
+   "additionalProperties": true,
+   "properties": {},
    "title": "kitchen_sink",
    "type": "object"
 }

--- a/tests/test_issues/test_issue_129.py
+++ b/tests/test_issues/test_issue_129.py
@@ -20,7 +20,7 @@ class IssueJSONSchemaTypesTestCase(TestEnvironmentTestCase):
         sobj_str = env.generate_single_file('issue_129.json', lambda: generator(), value_is_returned=True)
 
         sobj = jsonasobj.loads(sobj_str)
-        defs = sobj['definitions']
+        defs = sobj['$defs']
         C = defs['C']
         props = C['properties']
         assert props['age_in_years']['type'] == 'integer'

--- a/tests/test_issues/test_issue_129.py
+++ b/tests/test_issues/test_issue_129.py
@@ -29,11 +29,11 @@ class IssueJSONSchemaTypesTestCase(TestEnvironmentTestCase):
         assert props['scores']['type'] == 'array'
         assert props['scores']['items']['type'] == 'number'
         # single-valued complex type, inlined
-        assert props['has_d']['$ref'] == "#/definitions/D"
+        assert props['has_d']['$ref'] == "#/$defs/D"
 
         # multi-valued, inlined
         assert props['has_ds']['type'] == 'array'
-        assert props['has_ds']['items']['$ref'] == "#/definitions/D"
+        assert props['has_ds']['items']['$ref'] == "#/$defs/D"
 
         # single-valued, non-inlined (foreign key)
         assert props['parent']['type'] == "string"

--- a/tests/test_issues/test_issue_202.py
+++ b/tests/test_issues/test_issue_202.py
@@ -15,7 +15,7 @@ class Issue202TestCase(TestEnvironmentTestCase):
                                             lambda: JsonSchemaGenerator(env.input_path('issue_202.yaml')).serialize(),
                                             value_is_returned=True)
         json_schema = loads(json_str)
-        self.assertEqual(json_schema.definitions.GeospatialDDCoordLocation.properties.latitude.type, "number")
+        self.assertEqual(json_schema["$defs"].GeospatialDDCoordLocation.properties.latitude.type, "number")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Per @gaurav's recommendation in issue #305, the following PR seeks to change the JSON Schema generator such that it outputs the JSON Schema with the new `$defs` attribute rather than using the `definitions` attribute.

I tested the PR on the `examples\organization.yaml` schema.

```
$ gen-json-schema examples/organization.yaml
```

Here's what the output looks like:

```
{
   "$defs": {
      "Employee": {
         "additionalProperties": false,
         "description": "A person employed by an organization",
         "properties": {
            "age_in_years": {
               "description": "The age of a person if living or age of death if not",
               "type": "integer"
            },
            "aliases": {
               "description": "An alternative name",
               "items": {
                  "type": "string"
               },
               "type": "array"
            },
            "first_name": {
               "description": "The first name of a person",
               "type": "string"
            },
            "id": {
               "description": "Unique identifier of a person",
               "type": "string"
            },
            "last_name": {
               "type": "string"
            }
         },
         "required": [
            "id",
            "last_name"
         ],
         "title": "Employee",
         "type": "object"
      },
      "Manager": {
         "additionalProperties": false,
         "description": "An employee who manages others",
         "properties": {
            "age_in_years": {
               "description": "The age of a person if living or age of death if not",
               "type": "integer"
            },
            "aliases": {
               "description": "An alternative name",
               "items": {
                  "type": "string"
               },
               "type": "array"
            },
            "first_name": {
               "description": "The first name of a person",
               "type": "string"
            },
            "has_employees": {
               "items": {
                  "$ref": "#/definitions/Employee"
               },
               "type": "array"
            },
            "id": {
               "description": "Unique identifier of a person",
               "type": "string"
            },
            "last_name": {
               "type": "string"
            }
         },
         "required": [
            "id",
            "last_name"
         ],
         "title": "Manager",
         "type": "object"
      },
      "Organization": {
         "additionalProperties": false,
         "description": "An entity comprised of blah blah",
         "properties": {
            "has_boss": {
               "$ref": "#/definitions/Manager"
            },
            "id": {
               "description": "Unique identifier of a person",
               "type": "string"
            },
            "name": {
               "description": "human readable name",
               "type": "string"
            }
         },
         "required": [
            "id"
         ],
         "title": "Organization",
         "type": "object"
      }
   },
   "$id": "http://example.org/sample/organization",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "properties": {},
   "title": "organization",
   "type": "object"
}
```