### PR TITLE
update previous implementation of excel generator module

### DIFF
--- a/linkml/generators/excelgen.py
+++ b/linkml/generators/excelgen.py
@@ -1,16 +1,11 @@
 import os
-from typing import Union, TextIO, Optional, List, Dict, Tuple
+from typing import Union, TextIO, Optional, List
 
 import click
 import openpyxl
 
 from linkml.utils.generator import Generator, shared_arguments
-from linkml.utils.helpers import remove_duplicates
-from linkml_runtime.linkml_model.meta import (
-    SchemaDefinition,
-    ClassDefinition,
-    SlotDefinition,
-)
+from linkml_runtime.linkml_model.meta import SchemaDefinition, ClassDefinition
 from linkml_runtime.utils.formatutils import camelcase
 
 
@@ -54,44 +49,6 @@ class ExcelGenerator(Generator):
 
         return wb_name
 
-    @staticmethod
-    def _slot_formatting(slots_list: List[Tuple[str, str]]) -> Dict[str, List[str]]:
-        """Static internal method for formatting the slot information read in visit_slot()
-        in a parseable format.
-
-        :param slots_list: List of tuples with each tuple containing information in the
-            ``(slot_owner, slot_name)`` format
-        :type slots_list: List[Tuple[str, str]]
-        :return: A dictionary with the same information, with ``slot_owner`` as keys, and
-            the slot names as associated lists
-        :rtype: Dict[str, List[str]]
-
-        TODO: This is basically a utility method, so it can be moved to ``utils``
-        """
-        formatted_slots_dict: Dict = {}
-
-        slots_list = remove_duplicates(slots_list)
-
-        for slot_owner, slot_name in slots_list:
-            formatted_slots_dict.setdefault(camelcase(slot_owner), []).append(slot_name)
-
-        return formatted_slots_dict
-
-    def _write_to_excel(self, slots_dict: Dict[str, List[str]]) -> None:
-        """Internal method to write slot names to Excel worksheets.
-
-        :param slots_dict: Formatted dictionary as returned by call to
-            ``self._slot_formatting()``
-        :type slots_dict: Dict[str, List[str]]
-        """
-        wb = openpyxl.load_workbook(self.wb_name)
-
-        for slot_owner, slot_name in slots_dict.items():
-            if slot_owner in wb.sheetnames:
-                wb[slot_owner].append(slot_name)
-
-                wb.save(self.wb_name)
-
     def __init__(
         self,
         schema: Union[str, TextIO, SchemaDefinition],
@@ -103,31 +60,23 @@ class ExcelGenerator(Generator):
         self.workbook.remove(self.workbook["Sheet"])
         super().__init__(schema, **kwargs)
 
-    def create_spreadsheet(self, ws_name: str = None) -> None:
+    def _create_spreadsheet(self, ws_name: str, columns: List[str]) -> None:
         """Method to add worksheets to the Excel workbook.
 
         :param ws_name: Name of each of the worksheets
-        :type ws_name: str, optional
+        :type ws_name: str
+        :param columns: Columns that are relevant to each of the worksheets
+        :type columns: List[str]
         """
-        self.workbook.create_sheet(ws_name)
+        ws = self.workbook.create_sheet(ws_name)
+        ws.append(columns)
         self.workbook.save(self.wb_name)
 
     def visit_class(self, cls: ClassDefinition) -> bool:
         """Overridden from generator framework."""
-        self.create_spreadsheet(ws_name=camelcase(cls.name))
-
-        slots = ExcelGenerator._slot_formatting(
-            slots_list=ExcelGenerator.sheet_name_cols
-        )
-
-        self._write_to_excel(slots_dict=slots)
+        self._create_spreadsheet(ws_name=camelcase(cls.name), columns=cls.slots)
 
         return True
-
-    def visit_slot(self, aliased_slot_name: str, slot: SlotDefinition) -> None:
-        """Overridden from generator framework."""
-        for slot_owner in slot.domain_of:
-            ExcelGenerator.sheet_name_cols.append((slot_owner, aliased_slot_name))
 
 
 @shared_arguments(ExcelGenerator)

--- a/tests/test_generators/test_excelgen.py
+++ b/tests/test_generators/test_excelgen.py
@@ -38,9 +38,9 @@ class ExcelGenTestCase(unittest.TestCase):
         assert sorted(employee_cols_list) == [
             "age in years",
             "aliases",
+            "employee_last name",
             "first name",
             "id",
-            "last name",
         ]
 
         # test case to check the column names in Manager worksheet
@@ -51,7 +51,14 @@ class ExcelGenTestCase(unittest.TestCase):
             cell_obj = wb_obj["Manager"].cell(row=1, column=i)
             manager_cols_list.append(cell_obj.value)
 
-        assert sorted(manager_cols_list) == ["has employees"]
+        assert sorted(manager_cols_list) == [
+            "age in years",
+            "aliases",
+            "employee_last name",
+            "first name",
+            "has employees",
+            "id",
+        ]
 
         # test case to check the column names in Organization worksheet
         organization_cols_list = []


### PR DESCRIPTION
This PR seeks to reimplement the Excel Generator module. The code doesn't intercept the `visit_class_slot()` method at all. It just works with `visit_class()`.

Test
-----

The code was run on the [mixs schema](https://github.com/cmungall/mixs-source/blob/main/model/schema/mixs.yaml), and the resultant xlsx file can be found here: [mixs_excelgen_0.0.1.xlsx](https://github.com/linkml/linkml/files/7215534/mixs_excelgen_0.0.1.xlsx).