### PR TITLE
fix Excel encoding issue

### DIFF
--- a/linkml/generators/excelgen.py
+++ b/linkml/generators/excelgen.py
@@ -69,6 +69,7 @@ class ExcelGenerator(Generator):
         :type columns: List[str]
         """
         ws = self.workbook.create_sheet(ws_name)
+        self.workbook.active = ws
         ws.append(columns)
         self.workbook.save(self.wb_name)
 


### PR DESCRIPTION
This PR resolves the following error message that comes up in Excel when you try to open the xlsx file generated by the `gen-excel` utility.

![image](https://user-images.githubusercontent.com/20239224/134982976-b1a9eba7-ec14-4eb5-96cb-5d09ec81575b.png)