### PR TITLE
Support `minimum` and `maximum` properties in JSON Schema output

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -153,6 +153,10 @@ class JsonSchemaGenerator(Generator):
         if slot.pattern:
             # See https://github.com/linkml/linkml/issues/193
             prop.pattern = slot.pattern
+        if slot.minimum_value is not None:
+            prop.minimum = slot.minimum_value
+        if slot.maximum_value is not None:
+            prop.maximum = slot.maximum_value
         self.clsobj.properties[underscore(aliased_slot_name)] = prop
         if self.topCls is not None and camelcase(self.topCls) == camelcase(cls.name) or \
                 self.topCls is None and cls.tree_root:

--- a/tests/test_generators/input/kitchen_sink_failtest_inst_01.yaml
+++ b/tests/test_generators/input/kitchen_sink_failtest_inst_01.yaml
@@ -40,14 +40,14 @@
           - related_to: P:002
             type: NON_EXISTENT_RELATION
 - description: age lower than threshold
-  skip: true ## TODO
+  skip: false
   dataset:
     persons:
       - id: P
         name: benjamin button
         age_in_years: -5
 - description: age higher than threshold
-  skip: true ## TODO
+  skip: false
   dataset:
     persons:
       - id: P


### PR DESCRIPTION
This PR seeks to handle the accommodation of `minimum` and `maximum` properties in the JSON Schema output, when values are specified in the LinkML schema, like such:

```
id: https://w3id.org/linkml/examples/personinfo
name: personinfo
prefixes:
  linkml: https://w3id.org/linkml/
imports:
  - linkml:types
default_range: string

classes:
  Person:
    attributes:
      id:
        identifier: true     ## unique key for a person
      full_name:
        required: true       ## must be supplied
        description:
          name of the person
      aliases:
        multivalued: true    ## range is a list
        description:
          other names for the person
      phone:
        pattern: "^[\\d\\(\\)\\-]+$"   ## regular expression
      age:
        range: integer       ## an int between 0 and 200
        minimum_value: 0
        maximum_value: 200
  Container:
    attributes:
      persons:
        multivalued: true
        inlined_as_list: true
        range: Person
```

Merging this PR will resolve issue #376.