### PR TITLE
add content to homepage on PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,8 @@ url = https://github.com/linkml/linkml
 author = Harold Solbrig
 author_email = solbrig@jhu.edu
 summary = Linked Open Data Modeling Language
+description-file = README.md
+long-description-content-type = text/markdown
 home_page = http://linkml.github.io/linkml
 license = CC0 1.0 Universal
 python_requires = >=3.7


### PR DESCRIPTION
This PR seeks to populate the currently empty LinkML [homepage](https://pypi.org/project/linkml/) on PyPI with the same content as in the `README.md`.