### PR TITLE
fix date format of `source_file_date`

### DIFF
--- a/linkml/utils/rawloader.py
+++ b/linkml/utils/rawloader.py
@@ -13,7 +13,7 @@ from linkml_runtime.linkml_model.meta import (
 )
 from linkml_runtime.loaders import yaml_loader
 from linkml_runtime.utils.yamlutils import YAMLMark, YAMLRoot
-from linkml_runtime.linkml_model.types import Datetime
+from linkml_runtime.utils.metamodelcore import XSDDateTime
 
 from linkml.utils.mergeutils import set_from_schema
 
@@ -101,12 +101,13 @@ def load_raw_schema(
 
     if emit_metadata:
         schema.source_file = schema_metadata.source_file
-        schema.source_file_date = (
+
+        schema.source_file_date = XSDDateTime(
             datetime.strptime(schema_metadata.source_file_date, "%a %b %d %H:%M:%S %Y")
             .replace(tzinfo=timezone.utc)
             .isoformat()
         )
-        
+
         schema.source_file_size = schema_metadata.source_file_size
         schema.generation_date = datetime.now().strftime("%Y-%m-%d %H:%M")
     schema.metamodel_version = metamodel_version


### PR DESCRIPTION
This PR seeks to address issue #312, i.e., to fix the current `time.ctime()` date time format so that it displays date time in the `YYYY-MM-DDThh:mm:ss` format, as noted by @balhoff in issue #89.

Here is the output from `minimal.yaml`:

```
name: foo
id: foo
prefixes:
  foo:
    prefix_prefix: foo
    prefix_reference: http://x.org/
default_prefix: foo
default_range: string
metamodel_version: 1.7.0
source_file: minimal.yaml
source_file_date: 2021-10-05 15:09:57
source_file_size: 81
generation_date: 2021-10-07 15:43
```