### PR TITLE
Add testing for alternative python versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7.1, 3.8, 3.9]
+        python-version: [3.7.1, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Closes #404 

Since this project claims to work on py37+, I added explicit tests for py37, py39, and the newly released py310. These tests are applied in both the main.yml and pr-test.yml configurations.

I found in https://github.com/mapping-commons/sssom-py/pull/167/checks?check_run_id=3837024754 that it breaks in py310, so this is expected to fail and lead to other bug fixes for the time being