### PR TITLE
Fix bug in sqlddlgen where an incorrect variable was being referenced

### DIFF
--- a/linkml/generators/sqlddlgen.py
+++ b/linkml/generators/sqlddlgen.py
@@ -406,7 +406,7 @@ from {model_path} import *
         for sqltable in self.sqlschema.tables.values():
             cols = sqltable.columns.values()
             if len(cols) == 0:
-                logging.warning(f'No columns for {t.name}')
+                logging.warning(f'No columns for {sqltable.name}')
                 continue
 
             var = sqltable.as_var()


### PR DESCRIPTION
This PR fixes a bug originating from a single line where an undefined variable was being referenced when creating a table for a class that had no slots. The intended effect is for linkml to just provide a warning instead of failing with `undefined variable referenced before assignment`.