### PR TITLE
[feature] add support for dropdowns based on enums in schema

### DIFF
--- a/linkml/generators/excelgen.py
+++ b/linkml/generators/excelgen.py
@@ -120,10 +120,8 @@ class ExcelGenerator(Generator):
         if cls.name in self.workbook.sheetnames:
             if slot.range in self.enum_dict:
 
-                # TODO: the below list needs to be dynamically populated with items 
-                # in dropdown
-                # basically the values associated with an enum type
-                valid = '"The,earth,revolves,around,sun"'
+                valid = ','.join(self.enum_dict[slot.range])
+                valid = '"' + valid + '"'
 
                 ws = self.workbook[cls.name]
 
@@ -137,7 +135,7 @@ class ExcelGenerator(Generator):
                 dv = DataValidation(type="list", formula1=valid, allow_blank=True)
                 ws.add_data_validation(dv)
 
-                dv.add(f"{col_letter}1:{col_letter}1048576")
+                dv.add(f"{col_letter}2:{col_letter}1048576")
 
                 wb.save(self.wb_name)
 


### PR DESCRIPTION
This PR is still a work in progress. It seeks to add drop down support to the Excel sheet generated by `gen-excel` based on the enums specified in the LinkML schema.

I have split up the PR into 4 tasks:

- [x] intercept `visit_enum` and store the data in an appropriate data structure
- [x] intercept `visit_class_slot` so you know what slots to apply the drop downs to
- [x] replace harcoded list with dynamically generated list of valid values
- [x] apply list generated above to the right slots
