### PR TITLE
Applied URL formatting to `see_also`

### DIFF
--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -365,7 +365,7 @@ class MarkdownGenerator(Generator):
             prop_list('In Subsets', obj.in_subset)
             # from_schema
             # imported_from
-            prop_list('See also', obj.see_also)
+            prop_list('See also', [f'[{v}]({v})' for v in obj.see_also])
             prop_list('Exact Mappings', obj.exact_mappings)
             prop_list('Close Mappings', obj.close_mappings)
             prop_list('Narrow Mappings', obj.narrow_mappings)


### PR DESCRIPTION
## Important
Related to: https://github.com/linkml/linkml-runtime/pull/60. There is relevant discussion there.

Perhaps this is the one that should be merged instead.