### PR TITLE
add required slot list to top level `required` property

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -190,10 +190,10 @@ class JsonSchemaGenerator(Generator):
         if slot.maximum_value is not None:
             prop.maximum = slot.maximum_value
         self.clsobj.properties[underscore(aliased_slot_name)] = prop
-        if self.topCls is not None and camelcase(self.topCls) == camelcase(cls.name) or \
-                self.topCls is None and cls.tree_root:
+        if (self.topCls is not None and camelcase(self.topCls) == camelcase(cls.name)) or \
+                (self.topCls is None and cls.tree_root):
             self.schemaobj.properties[underscore(aliased_slot_name)] = prop
-            
+
             if slot.required:
                 self.schemaobj.required.append(aliased_slot_name)
 


### PR DESCRIPTION
This PR seeks to address issue #433.

<img width="638" alt="Screen Shot 2021-10-25 at 1 45 42 PM" src="https://user-images.githubusercontent.com/20239224/138769791-fbf84c3b-f24c-4b91-9183-64dd9ec66133.png">

We can see the `required` property along with the list of required slots at the top level as scoped in the issue. Is this what is expected in the issue @cmungall?