### PR TITLE
First pass at pydanticgen docs

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -87,20 +87,18 @@ class PydanticGenerator(OOCodeGenerator):
     visit_all_class_slots = False
 
     def __init__(self, schema: Union[str, TextIO, SchemaDefinition],
-                 package: str = None,
                  template_file: str = None,
                  format: str = valid_formats[0],
                  genmeta: bool=False, gen_classvars: bool=True, gen_slots: bool=True, **kwargs) -> None:
         self.sourcefile = schema
         self.schemaview = SchemaView(schema)
         self.schema = self.schemaview.schema
-        self.package = package
         self.template_file = template_file
 
     def map_type(self, t: TypeDefinition) -> str:
         return TYPEMAP.get(t.base, t.base)
 
-    def serialize(self, directory: str = None) -> None:
+    def serialize(self) -> None:
         sv = self.schemaview
 
         if self.template_file is not None:
@@ -173,14 +171,12 @@ class PydanticGenerator(OOCodeGenerator):
 
 
 @shared_arguments(PydanticGenerator)
-@click.option("--output_directory", default="output", help="Output directory for individually generated class files")
-@click.option("--package", help="Package name where relevant for generated class files")
 @click.option("--template_file", help="Optional jinja2 template to use for class generation")
 @click.command()
-def cli(yamlfile, output_directory=None, package=None, template_file=None, head=True, emit_metadata=False, genmeta=False, classvars=True, slots=True, **args):
+def cli(yamlfile, template_file=None, head=True, emit_metadata=False, genmeta=False, classvars=True, slots=True, **args):
     """Generate pydantic classes to represent a LinkML model"""
-    gen = PydanticGenerator(yamlfile, package=package, template_file=template_file, emit_metadata=head, genmeta=genmeta, gen_classvars=classvars, gen_slots=slots,  **args)
-    print(gen.serialize(output_directory))
+    gen = PydanticGenerator(yamlfile, template_file=template_file, emit_metadata=head, genmeta=genmeta, gen_classvars=classvars, gen_slots=slots,  **args)
+    print(gen.serialize())
 
 
 if __name__ == '__main__':

--- a/sphinx/generators/pydantic.rst
+++ b/sphinx/generators/pydantic.rst
@@ -1,4 +1,4 @@
-Java
+Pydantic
 ======
 
 Overview
@@ -28,7 +28,7 @@ Code
 
 Additional Notes
 ----------------
-
+LinkML contains two Python generators. The Pydantic dataclass generator is specifically useful for FastAPI, but is newer and less full featured than the standard `Python generator <python.html>`_.
 
 
 Biolink Example

--- a/sphinx/generators/pydantic.rst
+++ b/sphinx/generators/pydantic.rst
@@ -1,0 +1,50 @@
+Java
+======
+
+Overview
+--------
+
+The Pydantic Generator produces Pydantic flavored python dataclasses from a linkml model,
+with optional support for user-supplied jinja2 templates to generate alternate classes.
+
+Docs
+----
+
+Command Line
+^^^^^^^^^^^^
+
+.. currentmodule:: linkml.generators.pydanticgen
+
+.. click:: linkml.generators.pydanticgen:cli
+    :prog: gen-pydantic
+    :nested: short
+
+Code
+^^^^
+
+
+.. autoclass:: PydanticGenerator
+    :members: serialize
+
+Additional Notes
+----------------
+
+
+
+Biolink Example
+---------------
+
+Begin by downloading the Biolink Model YAML and adding a virtual environment and installing linkml.
+
+.. code-block:: bash
+
+    curl -OJ https://raw.githubusercontent.com/biolink/biolink-model/master/biolink-model.yaml
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install linkml
+
+Now generate the classes using the `gen-pydantic` command
+
+.. code-block:: bash
+
+    gen-pydantic biolink-model.yaml > biolink-model.py


### PR DESCRIPTION
also removed output directory and package parameters that didn't have any effect on pydanticgen.
