### PR TITLE
add sphinx page for `gen-prefix-map`

### DIFF
--- a/examples/PersonSchema/personinfo/prefixmap/personinfo.json
+++ b/examples/PersonSchema/personinfo/prefixmap/personinfo.json
@@ -1,5 +1,9 @@
 {
+   "CODE": "http://example.org/code/",
+   "GEO": "http://example.org/geoloc/",
    "GSSO": "http://purl.obolibrary.org/obo/GSSO_",
+   "P": "http://example.org/P/",
+   "ROR": "http://example.org/ror/",
    "famrel": "https://example.org/FamilialRelations#",
    "linkml": "https://w3id.org/linkml/",
    "personinfo": "https://w3id.org/linkml/examples/personinfo/",
@@ -19,3 +23,4 @@
       "@id": "schema:Person"
    }
 }
+

--- a/examples/PersonSchema/personinfo/prefixmap/personinfo.tsv
+++ b/examples/PersonSchema/personinfo/prefixmap/personinfo.tsv
@@ -1,0 +1,14 @@
+CODE	http://example.org/code/
+GEO	http://example.org/geoloc/
+GSSO	http://purl.obolibrary.org/obo/GSSO_
+P	http://example.org/P/
+ROR	http://example.org/ror/
+famrel	https://example.org/FamilialRelations#
+linkml	https://w3id.org/linkml/
+personinfo	https://w3id.org/linkml/examples/personinfo/
+prov	http://www.w3.org/ns/prov#
+rdf	http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs	http://www.w3.org/2000/01/rdf-schema#
+schema	http://schema.org/
+skos	http://example.org/UNKNOWN/skos/
+xsd	http://www.w3.org/2001/XMLSchema#

--- a/sphinx/generators/prefixgen.rst
+++ b/sphinx/generators/prefixgen.rst
@@ -1,0 +1,48 @@
+Prefix Generator
+================
+
+Overview
+--------
+
+The prefix generator can be used to create a mapping between prefixes and URIs or IRIs. Prefixes 
+are essentially shorthands or aliases to these longer URIs or IRIs. The aliases and their corresponding 
+expansions are specified as key value pairs under the :code:`prefixes` section of a LinkML schema. 
+You can read more about `prefixes <https://linkml.io/linkml/schemas/uris-and-mappings.html?highlight=prefixes#prefixes>`__ and 
+`URIs, IRIs and CURIEs <https://linkml.io/linkml/schemas/uris-and-mappings.html?highlight=prefixes#background-uris-iris-and-curies>`__ in the 
+`URIs and Mappings <https://linkml.io/linkml/schemas/uris-and-mappings.html?highlight=prefixes#uris-and-mappings>`__ section of 
+the docs.
+
+Example Output
+--------------
+
+`personinfo.json <https://github.com/linkml/linkml/tree/main/examples/PersonSchema/personinfo/prefixmap/personinfo.json>`_
+`personinfo.tsv <https://github.com/linkml/linkml/tree/main/examples/PersonSchema/personinfo/prefixmap/personinfo.tsv>`_
+
+To generate a JSON style mapping, run:
+
+.. code:: bash
+
+   gen-prefix-map examples/personinfo.yaml --output examples/personinfo.json
+
+To generate a simple TSV style mapping, run:
+
+.. code:: bash
+
+   gen-prefix-map examples/personinfo.yaml --output examples/personinfo.tsv
+
+If you want to simply view the data in the format of your choice, use the :code:`--format` option.
+
+Docs
+----
+      
+Command Line
+^^^^^^^^^^^^
+
+.. click:: linkml.generators.prefixmapgen:cli
+    :prog: gen-prefix-map
+    :nested: full
+
+Code
+^^^^
+
+.. currentmodule:: linkml.generators.prefixmapgen


### PR DESCRIPTION
This PR does the following:

- add sphinx page for the `gen-prefix-map` command as required in issue #446 
- remove `personinfo.yaml` as the example output from `gen-prefix-map` and add JSON and TSV output files instead