### PR TITLE
python-dateutil release 2.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pyjsg>=0.11.6
 pyldmod>=2.0.5
 pyshex>=0.7.20
 pyshexc>=0.8.3
-python-dateutil
+python-dateutil>=2.8.1
 pyyaml~=5.1
 rdflib-jsonld>=0.5.0, <=0.6.1
 rdflib-pyldmod-compat>=0.1.2c

--- a/tests/test_issues/test_issue_476.py
+++ b/tests/test_issues/test_issue_476.py
@@ -1,0 +1,16 @@
+import unittest
+
+
+class ParserErrorTestCase(unittest.TestCase):
+    """Test case to make sure ParserError exception
+        type is present in the python dateutil 
+        dependency specified in the Pipfile."""
+    def test_missing_exception_type(self):
+        try:
+            from dateutil.parser import ParserError
+        except ImportError:
+            self.fail("ParserError() cannot be found in python-dateutil<2.8.1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
or greater needed to include ParseError definition (see https://github.com/dateutil/dateutil/releases/tag/2.8.1). Code breaks in projects using LinkML if they don't have the latest module dependency imported..