### PR TITLE
Add prefixes from the model to the shacl-gen

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -38,6 +38,10 @@ class ShaclGenerator(Generator):
     def as_graph(self) -> None:
         sv = self.schemaview
         g = Graph()
+        g.bind("sh", SH)
+        for pfx in self.schema.prefixes.values():
+            g.bind(str(pfx.prefix_prefix), pfx.prefix_reference)
+
         for c in sv.all_classes().values():
             def shape_pv(p, v):
                 if v is not None:


### PR DESCRIPTION
Add the `sh` prefix, and all prefixes defined in the LinkML model to the SHACL graph in the `shacl-gen` to make the SHACL shapes more readable