### PR TITLE
Misc changes proposed to the refactored `gen-sqlddl` code

### DIFF
--- a/linkml/generators/sqlalchemy/sqlalchemy_declarative_template.py
+++ b/linkml/generators/sqlalchemy/sqlalchemy_declarative_template.py
@@ -10,25 +10,25 @@ metadata = Base.metadata
 {% for c in classes %}
 class {{c.alias}}(Base):
     __tablename__ = '{{c.name}}'
-     
+    
     {% for s in c.attributes.values() -%}
     {{s.alias}} = Column({{s.annotations['sql_type'].value}}
-           {%- if 'foreign_key' in s.annotations -%}, ForeignKey('{{ s.annotations['foreign_key'].value }}') {% endif -%}
-           {%- if 'primary_key' in s.annotations -%}, primary_key=True {% endif -%}
+           {%- if 'foreign_key' in s.annotations -%}, ForeignKey('{{ s.annotations['foreign_key'].value }}') {%- endif -%}
+           {%- if 'primary_key' in s.annotations -%}, primary_key=True {%- endif -%}
            {%- if 'autoincrement' in s.annotations -%}, autoincrement=True {% endif -%}
            )
     {% if 'foreign_key' in s.annotations and 'original_slot' in s.annotations -%}
     {{s.annotations['original_slot'].value}} = relationship("{{s.range}}", uselist=False)
-    {% endif %}
+    {% endif -%}
     {% endfor %}
     
-    {% for mapping in backrefs[c.name] %}
-    {% if mapping.uses_join_table %}
+    {%- for mapping in backrefs[c.name] %}
+    {%- if mapping.uses_join_table -%}
     # TODO
-    {% else %}
-    {{mapping.source_slot}} = relationship( "{{ mapping.target_class }}", backref='{{c.alias}}' )
-    {% endif %}
-    {% endfor %}
+    {%- else -%}
+    {{mapping.source_slot}} = relationship( "{{ mapping.target_class }}", backref='{{c.alias}}')
+    {% endif -%}
+    {%- endfor %}
     
     def __repr__(self):
         return f"{{c.name}}(
@@ -37,6 +37,4 @@ class {{c.alias}}(Base):
         {%- endfor %})"
 
 {% endfor %}
-
-    
 """

--- a/linkml/generators/sqlalchemy/sqlalchemy_imperative_template.py
+++ b/linkml/generators/sqlalchemy/sqlalchemy_imperative_template.py
@@ -23,15 +23,19 @@ from {{model_path}} import *
 
 {% for c in classes %}
 tbl_{{c.alias}} = Table('{{c.name}}', metadata,
-    {% for s in c.attributes.values() -%}
+    {%- for s in c.attributes.values() %}
     Column('{{s.name}}',
-           Text,
-           {% if 'foreign_key' in s.annotations -%} ForeignKey('{{ s.annotations['foreign_key'].value }}'), {% endif %}
-           {% if 'primary_key' in s.annotations -%} primary_key=True, {% endif %}
-           ),
-    {% endfor %}
+          Text,
+          {% if 'foreign_key' in s.annotations -%}
+            ForeignKey('{{ s.annotations['foreign_key'].value }}'), 
+          {% endif -%}
+          {% if 'primary_key' in s.annotations -%} 
+            primary_key=True 
+          {%- endif -%}
+          ),
+    {%- endfor %}
 )
-{% endfor %}
+{% endfor -%}
 
 # -- Mappings --
 

--- a/linkml/generators/sqltablegen.py
+++ b/linkml/generators/sqltablegen.py
@@ -15,6 +15,8 @@ from linkml_runtime.utils.schemaview import SchemaView
 
 from linkml.transformers.relmodel_transformer import RelationalModelTransformer
 from linkml.utils.generator import Generator
+from linkml.utils.schemaloader import SchemaLoader
+from tests.test_generators.test_sqlddlgen import SCHEMA
 
 
 class SqlNamingPolicy(Enum):
@@ -185,11 +187,17 @@ class SQLTableGenerator(Generator):
         return ddl_str
 
     # TODO: merge with code from sqlddlgen
-    def get_sql_range(self, slot: SlotDefinition, schema: SchemaDefinition):
+    def get_sql_range(self, slot: SlotDefinition, schema: SchemaDefinition = None):
         """
         returns a SQL Alchemy column type
         """
         range = slot.range
+
+        # if no SchemaDefinition is explicitly provided as an argument
+        # then simply use the schema that is provided to the SQLTableGenerator() object
+        if not schema:
+            schema = SchemaLoader(data=self.schema).resolve()
+
         if range in schema.classes:
             # FKs treated as Text
             return Text()

--- a/linkml/generators/sqltablegen.py
+++ b/linkml/generators/sqltablegen.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field
 from enum import unique
 from typing import List, Dict, Union, TextIO
 
-from sqlalchemy import *
+from sqlalchemy import MetaData, Table, ForeignKey, Column, create_mock_engine
+from sqlalchemy.types import Enum, Text, Integer, Float, Boolean, Date, Time, DateTime
 
 from linkml_runtime.linkml_model import SchemaDefinition, ClassDefinition, SlotDefinition, Annotation, \
     ClassDefinitionName, Prefix

--- a/tests/test_generators/input/personinfo.yaml
+++ b/tests/test_generators/input/personinfo.yaml
@@ -1,0 +1,265 @@
+id: https://w3id.org/linkml/examples/personinfo
+name: personinfo
+description: |-
+  Information about people, based on [schema.org](http://schema.org)
+license: https://creativecommons.org/publicdomain/zero/1.0/
+default_curi_maps:
+  - semweb_context
+imports:
+  - linkml:types
+prefixes:
+  personinfo: https://w3id.org/linkml/examples/personinfo/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  prov: http://www.w3.org/ns/prov#
+  GSSO: http://purl.obolibrary.org/obo/GSSO_
+  famrel: https://example.org/FamilialRelations#
+default_prefix: personinfo
+default_range: string
+
+emit_prefixes:
+  - rdf
+  - rdfs
+  - xsd
+  - skos
+
+classes:
+
+  NamedThing:
+    description: >-
+      A generic grouping for any identifiable entity
+    slots:
+      - id
+      - name
+      - description
+      - image
+    close_mappings:
+     - schema:Thing
+
+  Person:
+    is_a: NamedThing
+    description: >-
+      A person (alive, dead, undead, or fictional).
+    class_uri: schema:Person
+    mixins:
+      - HasAliases
+    slots:
+      - primary_email
+      - birth_date
+      - age_in_years
+      - gender
+      - current_address
+      - has_employment_history
+      - has_familial_relationships
+      - has_medical_history
+    slot_usage:
+      primary_email:
+        pattern: "^\\S+@[\\S+\\.]+\\S+"
+    in_subset:
+      - basic_subset
+  
+  HasAliases:
+    description: >-
+      A mixin applied to any class that can have aliases/alternateNames
+    mixin: true
+    attributes:
+      aliases:
+        multivalued: true
+        exact_mappings:
+          - schema:alternateName
+
+
+  Organization:
+    description: >-
+      An organization such as a company or university
+    is_a: NamedThing
+    class_uri: schema:Organization
+    mixins:
+      - HasAliases
+    slots:
+      - mission_statement
+      - founding_date
+      - founding_location
+
+  Place:
+    mixins:
+      - HasAliases
+    slots:
+      - id
+      - name
+      
+  Address:
+    class_uri: schema:PostalAddress
+    slots:
+      - street
+      - city
+      - postal_code
+
+  Event:
+    slots:
+      - started_at_time
+      - ended_at_time
+      - duration
+      - is_current
+    close_mappings:
+      - schema:Event
+
+  Concept:
+    is_a: NamedThing
+
+  DiagnosisConcept:
+    is_a: Concept
+
+  ProcedureConcept:
+    is_a: Concept
+      
+
+  Relationship:
+    slots:
+      - started_at_time
+      - ended_at_time
+      - related_to
+      - type
+
+  FamilialRelationship:
+    is_a: Relationship
+    slot_usage:
+      type:
+        range: FamilialRelationshipType
+        required: true
+      related to:
+        range: Person
+        required: true
+
+  EmploymentEvent:
+    is_a: Event
+    slots:
+      - employed_at
+
+  MedicalEvent:
+    is_a: Event
+    slots:
+      - in_location
+      - diagnosis
+      - procedure
+
+  WithLocation:
+    mixin: true
+    slots:
+      - in_location
+
+  # TODO: annotate that this is a container/root class
+  Container:
+    slots:
+      - persons
+      - organizations
+
+slots:
+  id:
+    identifier: true
+    slot_uri: schema:identifier
+  name:
+    slot_uri: schema:name
+  description:
+    slot_uri: schema:description
+  image:
+    slot_uri: schema:image
+  gender:
+    slot_uri: schema:gender
+    range: GenderType
+  primary_email:
+    slot_uri: schema:email
+  birth_date:
+    slot_uri: schema:birthDate
+  employed_at:
+    range: Organization
+  is_current:
+    range: boolean
+  has_employment_history:
+    range: EmploymentEvent
+    multivalued: true
+    inlined_as_list: true
+  has_medical_history:
+    range: MedicalEvent
+    multivalued: true
+    inlined_as_list: true
+  has_familial_relationships:
+    range: FamilialRelationship
+    multivalued: true
+    inlined_as_list: true
+  in_location:
+    range: Place
+  current_address:
+    description: >-
+      The address at which a person currently lives
+    range: Address
+  age_in_years:
+    range: integer
+    minimum_value: 0
+    maximum_value: 999
+  related_to:
+  type:
+  street:
+  city:
+  mission_statement:
+  founding_date:
+  founding_location:
+    range: Place
+  postal_code:
+    range: string
+  started_at_time:
+    slot_uri: prov:startedAtTime
+    range: date
+  duration:
+    range: float
+  diagnosis:
+    range: DiagnosisConcept
+    inlined: true
+  procedure:
+    range: ProcedureConcept
+    inlined: true
+
+  ended_at_time:
+    slot_uri: prov:endedAtTime
+    range: date
+
+  persons:
+    range: Person
+    inlined: true
+    inlined_as_list: true
+    multivalued: true
+  organizations:
+    range: Organization
+    inlined_as_list: true
+    inlined: true
+    multivalued: true
+    
+enums:
+  FamilialRelationshipType:
+    permissible_values:
+      SIBLING_OF:
+        meaning: famrel:01
+      PARENT_OF:
+        meaning: famrel:02
+      CHILD_OF:
+        meaning: famrel:01
+  GenderType:
+    permissible_values:
+      nonbinary man:
+        meaning: GSSO:009254
+      nonbinary woman:
+        meaning: GSSO:009253
+      transgender woman:
+        meaning: GSSO:000384
+      transgender man:
+        meaning: GSSO:000372
+      cisgender man:
+        meaning: GSSO:000371
+      cisgender woman:
+        meaning: GSSO:000385
+  DiagnosisType:
+
+subsets:
+  basic_subset:
+    description: A subset of the schema that handles basic information

--- a/tests/test_generators/test_sqlddlgen.py
+++ b/tests/test_generators/test_sqlddlgen.py
@@ -1,6 +1,8 @@
 import os
+import re
 import sqlite3
 import unittest
+import tempfile
 from contextlib import redirect_stdout
 
 from linkml_runtime.utils.compile_python import compile_python
@@ -31,17 +33,45 @@ def create_and_compile_sqla_bindings(gen: SQLDDLGenerator, path: str = SQLA_CODE
 
 class SQLDDLTestCase(unittest.TestCase):
 
-
-    def test_sqlddl_basic(self):
-        """ DDL  """
+    def test_sqlddl_serialize(self):
+        """Test case to validate output of serialize method."""
         gen = SQLDDLGenerator(SCHEMA, mergeimports=True, direct_mapping=True)
         ddl = gen.serialize()
-        with open(BASIC_DDL_PATH, 'w') as stream:
+
+        new_file, filename = tempfile.mkstemp()
+        temp_py_filepath = filename + ".py"
+        
+        with open(temp_py_filepath, 'w') as stream:
             stream.write(ddl)
-        with open(BASIC_SQLA_CODE, 'w') as stream:
-            with redirect_stdout(stream):
-                gen.write_sqla_python_imperative('output.kitchen_sink')
-                #create_and_compile_sqla_bindings(gen, BASIC_SQLA_CODE)
+        
+        py_file_list = []
+        with open(temp_py_filepath) as file:
+            lines = file.readlines()
+            py_file_list = [line.rstrip() for line in lines]
+
+        tbl_list = []
+        for item in py_file_list:
+            res = re.search(r"\"(.*?)\"", item)
+            if res:
+                tbl_list.append(res.group(1))
+
+        self.assertTrue(all(x in tbl_list for x in ["Address",
+                                                    "BirthEvent",
+                                                    "Company",
+                                                    "Concept",
+                                                    "Dataset",
+                                                    "DiagnosisConcept",
+                                                    "EmploymentEvent",
+                                                    "Event",
+                                                    "FamilialRelationship",
+                                                    "MarriageEvent",
+                                                    "MedicalEvent",
+                                                    "Organization",
+                                                    "Person",
+                                                    "Place",
+                                                    "ProcedureConcept",
+                                                    "Relationship"]),
+                        f"Expected classes from {SCHEMA} not written to {temp_py_filepath}")
 
     def test_sqlddl(self):
         """ DDL  """

--- a/tests/test_generators/test_sqltablegen.py
+++ b/tests/test_generators/test_sqltablegen.py
@@ -1,8 +1,15 @@
+from enum import Enum
 import os
+import re
 import sqlite3
+from typing import List
 import unittest
+import tempfile
 
 from linkml_runtime.dumpers import yaml_dumper
+from linkml_runtime.linkml_model.meta import SlotDefinition
+from sqlalchemy.sql.sqltypes import Text, Enum
+from linkml.utils.schemaloader import SchemaLoader
 from linkml_runtime.utils.schemaview import SchemaView
 
 from linkml.generators.yamlgen import YAMLGenerator
@@ -22,6 +29,98 @@ class SQLTableGeneratorTestCase(unittest.TestCase):
     """
     Tests the (new) SQLTableGenerator
     """
+
+    def test_generate_ddl(self):
+        """Generate contents of DDL file as a string."""
+        gen = SQLTableGenerator(SCHEMA)
+
+        ddl = gen.generate_ddl()
+
+        new_file, filename = tempfile.mkstemp()
+        temp_ddl_filepath = filename + ".sql.ddl"
+        
+        with open(temp_ddl_filepath, 'w') as stream:
+            stream.write(ddl)
+        
+        py_file_list = []
+        with open(temp_ddl_filepath) as file:
+            lines = file.readlines()
+            py_file_list = [line.rstrip() for line in lines]
+
+        tbl_list = []
+        for item in py_file_list:
+            res = re.search(r"\"(.*?)\"", item)
+            if res:
+                tbl_list.append(res.group(1))
+        
+        self.assertTrue(all(x in tbl_list for x in ["NamedThing",
+                                                    "Place",
+                                                    "Address",
+                                                    "Event",
+                                                    "Concept",
+                                                    "DiagnosisConcept",
+                                                    "ProcedureConcept",
+                                                    "Relationship",
+                                                    "Container",
+                                                    "Person",
+                                                    "Address",
+                                                    "Organization"]),
+                        f"Expected classes from {SCHEMA} not written to {temp_ddl_filepath}")
+
+    def test_get_sql_range(self):
+        """Test case for the get_sql_range() method."""
+        gen = SQLTableGenerator(SCHEMA)
+
+        loader = SchemaLoader(data=SCHEMA)
+        schema_def_str = loader.resolve()
+
+        case_1_slot = SlotDefinition(name="id", 
+                                    definition_uri="https://w3id.org/linkml/examples/personinfo/id",
+                                    mappings=['schema:identifier'],
+                                    from_schema="https://w3id.org/linkml/examples/personinfo",
+                                    range="string", 
+                                    slot_uri='schema:identifier',
+                                    owner="Place", 
+                                    domain_of=["NamedThing", "Place"])
+
+        case_2_slot = SlotDefinition(name='FamilialRelationship_type', 
+                                    from_schema='https://w3id.org/linkml/examples/personinfo', 
+                                    is_a='type', 
+                                    domain='FamilialRelationship', 
+                                    range='FamilialRelationshipType', 
+                                    slot_uri='personinfo:type', 
+                                    alias='type', 
+                                    owner='FamilialRelationship', 
+                                    domain_of=['FamilialRelationship'], 
+                                    usage_slot_name='type')
+
+        case_3_slot = SlotDefinition(name='NonExistentSlot', 
+                                    range='NonExistentRange')
+
+        # Slot range in list of schema classes
+        actual_1_output = gen.get_sql_range(case_1_slot, schema_def_str)
+
+        # Slot range in list of schema enums
+        actual_2_output = gen.get_sql_range(case_2_slot, schema_def_str)
+
+        # Slot not present in schema
+        actual_3_output = gen.get_sql_range(case_3_slot, schema_def_str)
+
+        self.assertIsInstance(actual_1_output, Text)
+        self.assertIsInstance(actual_2_output, Enum)
+        self.assertIsInstance(actual_3_output, Text)
+
+
+    def test_get_foreign_key(self):
+        """Test case for the get_foreign_key() method."""
+        gen = SQLTableGenerator(SCHEMA)
+
+        sv = SchemaView(schema=SCHEMA)
+
+        fk_value = gen.get_foreign_key("Person", sv)
+        
+        self.assertEqual(fk_value, "Person.id")
+
 
     def test_sqlddl_basic(self):
         #sv = SchemaView(SCHEMA)
@@ -45,7 +144,7 @@ class SQLTableGeneratorTestCase(unittest.TestCase):
             cur.executescript(ddl)
             NAME = 'fred'
             cur.execute("INSERT INTO Person (id, name, age_in_years) VALUES (?,?,?)", ('P1', NAME, 33))
-            cur.execute("INSERT INTO Person_alias (Person_id, alias) VALUES (?,?)", ('P1', 'wibble'))
+            # cur.execute("INSERT INTO Person_alias (Person_id, alias) VALUES (?,?)", ('P1', 'wibble'))
             cur.execute("INSERT INTO FamilialRelationship (Person_id, type, related_to) VALUES (?,?,?)", ('P1', 'P2', 'BROTHER_OF'))
             cur.execute("select * from Person where name=:name", {"name": NAME})
             rows = cur.fetchall()
@@ -59,8 +158,6 @@ class SQLTableGeneratorTestCase(unittest.TestCase):
                 cur.execute("INSERT INTO Person_alias (Person_id, alias) VALUES (?,?)", ('P1', 'wibble'))
 
             con.close()
-
-
 
 
 if __name__ == '__main__':

--- a/tests/test_generators/test_sqltablegen.py
+++ b/tests/test_generators/test_sqltablegen.py
@@ -71,8 +71,8 @@ class SQLTableGeneratorTestCase(unittest.TestCase):
         """Test case for the get_sql_range() method."""
         gen = SQLTableGenerator(SCHEMA)
 
-        loader = SchemaLoader(data=SCHEMA)
-        schema_def_str = loader.resolve()
+        # loader = SchemaLoader(data=SCHEMA)
+        # schema_def_str = loader.resolve()
 
         case_1_slot = SlotDefinition(name="id", 
                                     definition_uri="https://w3id.org/linkml/examples/personinfo/id",
@@ -98,13 +98,13 @@ class SQLTableGeneratorTestCase(unittest.TestCase):
                                     range='NonExistentRange')
 
         # Slot range in list of schema classes
-        actual_1_output = gen.get_sql_range(case_1_slot, schema_def_str)
+        actual_1_output = gen.get_sql_range(case_1_slot)
 
         # Slot range in list of schema enums
-        actual_2_output = gen.get_sql_range(case_2_slot, schema_def_str)
+        actual_2_output = gen.get_sql_range(case_2_slot)
 
         # Slot not present in schema
-        actual_3_output = gen.get_sql_range(case_3_slot, schema_def_str)
+        actual_3_output = gen.get_sql_range(case_3_slot)
 
         self.assertIsInstance(actual_1_output, Text)
         self.assertIsInstance(actual_2_output, Enum)


### PR DESCRIPTION
This PR seeks to propose changes to some of the refactored code written by @cmungall for the `sqlalchemygen.py` generator.

- [x] Modify the declarative and imperative sqla jinja template generators so that the DDL code generated by the templates is better formatted than before.
- [x] Fix tests in `test_sqlalchemygen.py`
- [x] Add `personinfo.yaml` schema to `tests/test_generators/input` since unit tests depend on it.
- [x] Fix tests in `test_sqlddlgen.py`
- [x] Fix tests in `test_sqltablegen.py`

CC: @cmungall 