### PR TITLE
Added test for #532

### DIFF
--- a/linkml/utils/converter.py
+++ b/linkml/utils/converter.py
@@ -1,5 +1,5 @@
 import click
-from linkml.utils import validation
+from linkml.utils import validation, datautils
 from linkml_runtime.utils.compile_python import compile_python
 from linkml_runtime.utils.schemaview import SchemaView
 
@@ -62,17 +62,11 @@ def cli(input, module, target_class, context=None, output=None, input_format=Non
 
     inargs = {}
     outargs = {}
-    if input_format == 'json-ld':
-        if len(context) == 0:
-            if schema is not None:
-                context = [_get_context(schema)]
-            else:
-                raise Exception('Must pass in context OR schema for RDF output')
-        inargs['contexts'] = list(context)[0]
-    if input_format == 'rdf' or input_format == 'ttl':
+    if datautils._is_rdf_format(input_format):
         if sv is None:
             raise Exception(f'Must pass schema arg')
         inargs['schemaview'] = sv
+        inargs['fmt'] = input_format
     if _is_xsv(input_format):
         if index_slot is None:
             index_slot = infer_index_slot(sv, target_class)

--- a/linkml/utils/datautils.py
+++ b/linkml/utils/datautils.py
@@ -25,13 +25,14 @@ dumpers_loaders = {
     'json': (JSONDumper, JSONLoader),
     'rdf': (RDFLibDumper, RDFLibLoader),
     'ttl': (RDFLibDumper, RDFLibLoader),
-    'json-ld': (RDFDumper, RDFLoader),
+    'json-ld': (RDFLibDumper, RDFLibLoader),
     'csv': (CSVDumper, CSVLoader),
     'tsv': (CSVDumper, CSVLoader),
 }
 
 aliases = {
     'ttl': 'rdf',
+    'jsonld': 'json-ld',
 }
 
 def _get_format(path: str, specified_format: str =None, default=None):
@@ -54,6 +55,10 @@ def _get_format(path: str, specified_format: str =None, default=None):
 
 def _is_xsv(fmt: str) -> bool:
     return fmt == 'csv' or fmt == 'tsv'
+
+def _is_rdf_format(fmt: str) -> bool:
+    return fmt == 'rdf' or fmt == 'ttl' or fmt == 'json-ld'
+
 
 def get_loader(fmt: str) -> Loader:
     return dumpers_loaders[fmt][1]()

--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -25,7 +25,7 @@ class JsonSchemaDataValidator(DataValidator):
         return self.validate_object(obj)
 
     def validate_object(self, data: YAMLRoot, target_class: Type[YAMLRoot] = None,
-                        closed: bool = True):
+                        closed: bool = True) -> None:
         """
         validates instance data against a schema
 
@@ -93,6 +93,9 @@ def cli(input, module, target_class, output=None, input_format=None,
                 raise Exception('--index-slot is required for CSV input')
         inargs['index_slot'] = index_slot
         inargs['schema'] = schema
+    if datautils._is_rdf_format(input_format):
+        inargs['schemaview'] = sv
+        inargs['fmt'] = input_format
     obj = loader.load(source=input,  target_class=py_target_class, **inargs)
     # Validation
     if schema is None:

--- a/sphinx/developers/tool-developer-guide.rst
+++ b/sphinx/developers/tool-developer-guide.rst
@@ -264,54 +264,56 @@ number of rows and columns may be embedding too much application logic
 in the schema. Instead we encourage thinking of "semantic types". For
 example, you could define two types:
 
-```yaml
-types:
+.. code-block:: yaml
 
-  NameString:
-    typeof: string
-    pattern: "^[^\\n]$"
-    description: A description that holds a human readable name
-    comments:
-     - This is designed to support different styles of names from
-       multiple languages, but certain characters such as newlines are
-       never in names
+  types:
+  
+    NameString:
+      typeof: string
+      pattern: "^[^\\n]$"
+      description: A description that holds a human readable name
+      comments:
+       - This is designed to support different styles of names from
+         multiple languages, but certain characters such as newlines are
+         never in names
+  
+    FormattedString:
+      typeof: string
+      description: >-
+        A string in which characters such as newlines are
+        permitted and used for formatting
+  
+  slots:
+    full_name:
+      range: NameString
+    address:
+      range: FormattedString
 
-  FormattedString:
-    typeof: string
-    description: >-
-      A string in which characters such as newlines are
-      permitted and used for formatting
 
-slots:
-  full_name:
-    range: NameString
-  address:
-    range: FormattedString
-
-```
 
 And then hardcode these types into the application.
 
 A more flexible approach would be instead to use annotations on the
 types:
 
-```yaml
-types:
+.. code-block:: yaml
+                
+  types:
+  
+    NameString:
+      typeof: string
+      pattern: "^[^\\n]$"
+      description: ...
+      annotations:
+        dash.singleLine: true
+  
+    FormattedString:
+      typeof: string
+      description: ...
+      annotations:
+        dash.singleLine: false
+  
 
-  NameString:
-    typeof: string
-    pattern: "^[^\\n]$"
-    description: ...
-    annotations:
-      dash.singleLine: true
-
-  FormattedString:
-    typeof: string
-    description: ...
-    annotations:
-      dash.singleLine: false
-
-```
 
 This is better as you can reuse the same vocabulary on different
 types, and you introduce decoupling between specific schemas and your
@@ -330,30 +332,31 @@ Consider a schema that reuses standard vocabularies such as wgs84 for
 slots:
 
 
-```yaml
-prefixes:
-  wgs: http://www.w3.org/2003/01/geo/wgs84_pos#
-  schema: http://schema.org/
+.. code-block:: yaml
 
-slots:
-  latitude:
-    domain: geolocation value
-    range: decimal degree
-    description: >-
-      latitude
-    slot_uri: wgs:lat
-    exact_mappings:
-      - schema:latitude
+  prefixes:
+    wgs: http://www.w3.org/2003/01/geo/wgs84_pos#
+    schema: http://schema.org/
+  
+  slots:
+    latitude:
+      domain: geolocation value
+      range: decimal degree
+      description: >-
+        latitude
+      slot_uri: wgs:lat
+      exact_mappings:
+        - schema:latitude
+  
+    longitude:
+      domain: geolocation value
+      range: decimal degree
+      description: >-
+        longitude
+      slot_uri: wgs:long
+      exact_mappings:
+        - schema:longitude
 
-  longitude:
-    domain: geolocation value
-    range: decimal degree
-    description: >-
-      longitude
-    slot_uri: wgs:long
-    exact_mappings:
-      - schema:longitude
-```
 
 Applications may choose to have specific behavior for lat-long fields,
 for example, including a map widget. Applications may also choose to
@@ -396,27 +399,29 @@ certain conventions are followed, then generic applications can be made
 For example, if we model quantity values as classes and reuse the
 concept from the standard `qudt<http://qudt.org/>` vocabulary:
 
-```yaml
-  quantity value:
-    description: >-
-      A simple quantity, e.g. 2cm
-    attributes:
-      verbatim:
-        description: >-
-          Unnormalized atomic string representation, should in syntax {number} {unit}
-      has unit:
-        description: >-
-          The unit of the quantity
-        slot_uri: qudt:unit
-      has numeric value:
-        description: >-
-          The number part of the quantity
-        range:
-          double
-    class_uri: qudt:QuantityValue
-    mappings:
-      - schema:QuantityValue
-```
+.. code-block:: yaml
+
+    quantity value:
+      description: >-
+        A simple quantity, e.g. 2cm
+      attributes:
+        verbatim:
+          description: >-
+            Unnormalized atomic string representation, should in syntax {number} {unit}
+        has unit:
+          description: >-
+            The unit of the quantity
+          slot_uri: qudt:unit
+        has numeric value:
+          description: >-
+            The number part of the quantity
+          range:
+            double
+      class_uri: qudt:QuantityValue
+      mappings:
+        - schema:QuantityValue
+
+
 
 Then applications can be aware of the semantics of this field and act
 accordingly; for example:

--- a/tests/test_issues/input/linkml_issue_532.yaml
+++ b/tests/test_issues/input/linkml_issue_532.yaml
@@ -1,0 +1,58 @@
+id: http://resource.isamples.org/schema/0.3
+name: physicalSample
+description: Schema for documenting physical samples
+license: https://creativecommons.org/publicdomain/zero/1.0/
+version: 20211022
+prefixes:
+  linkml: https://w3id.org/linkml/
+  isam: http://resource.isamples.org/schema/
+default_prefix: isam
+imports:
+  - linkml:types
+default_range: string
+
+
+classes:
+  PhysicalSampleRecord:
+    description: This is a data object that is a digital representation of a physical
+      sample. It provides descriptive properties for any iSamples physical sample.
+    slots:
+      - id
+      - relatedResource
+
+  SampleRelation:
+    description: Object specifying relationships to other samples, (particularly between
+            subsamples and parent samples), or beteen samples and other related 
+            information, e.g. publications using data from the sample or providing 
+            background information to understand the sample.
+    slots:
+      - target
+      - relationship
+    slot_usage:
+      target:
+        required: true
+      relationship:
+        required: true
+
+ 
+slots:
+  id:
+    identifier: true
+  relatedResource:
+    range: SampleRelation
+    description: link to related resource with relationship property to indicate
+      nature of connection. Target should be identifier for a resource.
+    multivalued: true
+    inlined_as_list: true   ### necessary: see https://github.com/linkml/linkml/pull/488
+  relationship:
+    range: string
+    description: term to identify realationship between host sample and the sample
+      relation target. Should be controlled vocabulary (ScopedName). for now
+      start with string, 'derivedFrom'.
+  target:
+    range: string
+    description: identifier for the target resource in the relationship. Start
+      with string, should be Identifier object.
+   
+  
+

--- a/tests/test_issues/input/linkml_issue_532_data.jsonld
+++ b/tests/test_issues/input/linkml_issue_532_data.jsonld
@@ -1,0 +1,16 @@
+{
+   "@context": {
+      "isam": "http://resource.isamples.org/schema/",
+      "linkml": "https://w3id.org/linkml/",
+      "@vocab": "http://resource.isamples.org/schema/",
+      "relatedResource": {
+         "@type": "@id"
+      }
+   },
+   "@id": "metadata/21547/Car2PIRE_0334",
+    "@type": "isam:PhysicalSampleRecord",
+    "relatedResource":[ {   
+        "target": "ark:/21547/Cat2INDO106431.1",
+        "relationship": "derived"
+    }]
+}

--- a/tests/test_issues/input/linkml_issue_532_data_fail.jsonld
+++ b/tests/test_issues/input/linkml_issue_532_data_fail.jsonld
@@ -1,0 +1,15 @@
+{
+   "@context": {
+      "isam": "http://resource.isamples.org/schema/",
+      "linkml": "https://w3id.org/linkml/",
+      "@vocab": "http://resource.isamples.org/schema/",
+      "relatedResource": {
+         "@type": "@id"
+      }
+   },
+   "@id": "metadata/21547/Car2PIRE_0334",
+    "@type": "isam:PhysicalSampleRecord",
+    "relatedResource":[ {   
+        "target": "ark:/21547/Cat2INDO106431.1"
+    }]
+}

--- a/tests/test_issues/test_linkml_issue_532.py
+++ b/tests/test_issues/test_linkml_issue_532.py
@@ -1,0 +1,56 @@
+import os
+import unittest
+
+from linkml_runtime.loaders import rdflib_loader
+from linkml_runtime.utils.schemaview import SchemaView
+from rdflib import URIRef, Graph, Literal
+from rdflib.namespace import OWL, RDFS, RDF, XSD
+
+from linkml import METAMODEL_CONTEXT_URI
+from linkml.generators.jsonldcontextgen import ContextGenerator
+from linkml.generators.owlgen import OwlSchemaGenerator
+from linkml.generators.pythongen import PythonGenerator
+from linkml.generators.rdfgen import RDFGenerator
+from linkml.generators.yamlgen import YAMLGenerator
+from linkml.validators import JsonSchemaDataValidator
+from tests.utils.compare_rdf import compare_rdf
+from tests.utils.test_environment import TestEnvironmentTestCase
+from tests.test_issues.environment import env
+
+class Issue532TestCase(TestEnvironmentTestCase):
+    """
+    Tests: https://github.com/linkml/linkml/issues/532
+
+    """
+    env = env
+
+
+    def test_issue_532(self):
+
+        schemafile = env.input_path('linkml_issue_532.yaml')
+        sv = SchemaView(schemafile)
+        datafile = env.input_path('linkml_issue_532_data.jsonld')
+        python_module = PythonGenerator(schemafile).compile_module()
+        target_class = python_module.__dict__['PhysicalSampleRecord']
+        obj = rdflib_loader.load(datafile,
+                                 fmt='json-ld',
+                                 target_class=target_class,
+                                 schemaview=sv)
+        validator = JsonSchemaDataValidator(sv.schema)
+        # throws an error if invalid
+        validator.validate_object(obj)
+
+        # test deliberately invalid data
+        with self.assertRaises(Exception):
+            bad_obj = rdflib_loader.load(env.input_path('linkml_issue_532_data_fail.jsonld'),
+                                         fmt='json-ld',
+                                         target_class=target_class,
+                                         schemaview=sv)
+            results = validator.validate_object(bad_obj)
+
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_issues/test_linkml_issue_532.py
+++ b/tests/test_issues/test_linkml_issue_532.py
@@ -49,8 +49,5 @@ class Issue532TestCase(TestEnvironmentTestCase):
             results = validator.validate_object(bad_obj)
 
 
-
-
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Made command line utils aware of json-ld as a format,
and pass it accordingly. This removes the necessity
to first convert from json-ld to rdf using an external tool,
see also #532
