### PR TITLE
underscore required slots when generating JSON Schema

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -196,7 +196,7 @@ class JsonSchemaGenerator(Generator):
             self.schemaobj.properties[underscore(aliased_slot_name)] = prop
 
             if slot.required:
-                self.schemaobj.required.append(aliased_slot_name)
+                self.schemaobj.required.append(underscore(aliased_slot_name))
 
 
 @shared_arguments(JsonSchemaGenerator)


### PR DESCRIPTION
This PR fixes a bug that has been causing issues with the `linkml-validate` utility:

To reproduce this bug,

Test schema YAML:
```yaml
id: https://w3id.org/test
name: Test-Schema
version: 0.1.0

imports:
- linkml:types

prefixes:
  linkml: https://w3id.org/linkml/

classes:
  person:
    slots:
      - first name
      - last name
      - email
    slot_usage:
      first name:
        required: true
      last name:
        required: true

slots:
  first name:
  
  last name:

  email:

```

Test instance data (as JSON):
```json
{
    "first_name": "John",
    "last_name": "Doe"
}
```

Command used for validation:
```sh
linkml-validate --schema test.yaml --target-class Person data.json
```

Error:
```sh
jsonschema.exceptions.ValidationError: 'first name' is a required property

Failed validating 'required' in schema:
    {'$defs': {'Person': {'additionalProperties': False,
                          'description': '',
                          'properties': {'email': {'type': 'string'},
                                         'first_name': {'type': 'string'},
                                         'last_name': {'type': 'string'}},
                          'required': ['first_name', 'last_name'],
                          'title': 'Person',
                          'type': 'object'}},
     '$id': 'https://w3id.org/test',
     '$schema': 'http://json-schema.org/draft-07/schema#',
     'additionalProperties': False,
     'properties': {'email': {'type': 'string'},
                    'first_name': {'type': 'string'},
                    'last_name': {'type': 'string'}},
     'required': ['first name', 'last name'],
     'title': 'Test-Schema',
     'type': 'object'}

On instance:
    {'first_name': 'John', 'last_name': 'Doe'}
```

The failed validation is due to the wrong serialization of required fields in the autogenerated JSON Schema. Note how it is `first name` (sentence case) instead of `first_name` (snake case).

The fix in this PR ensures that underscores are applied consistently throughout.