### PR TITLE
Add metamodel version and version to the outputs generated by various generators

### DIFF
--- a/linkml/generators/csvgen.py
+++ b/linkml/generators/csvgen.py
@@ -23,6 +23,12 @@ class CsvGenerator(Generator):
         self.sep: Optional[str] = None
         self.closure: Optional[Set[ClassDefinitionName]] = None       # List of classes to include in output
         self.writer: Optional[DictWriter] = None
+        self.generate_header()
+
+    def generate_header(self):
+        print(f"# metamodel_version: {self.schema.metamodel_version}")
+        if self.schema.version:
+            print(f"# version: {self.schema.version}")
 
     def visit_schema(self, classes: List[ClassDefinitionName] = None, **_) -> None:
         # Note: classes comes from the "root" argument

--- a/linkml/generators/golrgen.py
+++ b/linkml/generators/golrgen.py
@@ -51,6 +51,12 @@ class GolrSchemaGenerator(Generator):
         self.dirname: str = directory
         self.class_obj: Optional[GOLRClass] = None
 
+    def generate_header(self):
+        headers = [f"# metamodel_version: {self.schema.metamodel_version}"]
+        if self.schema.version:
+            headers.append(f"# version: {self.schema.version}")
+        return headers
+
     def visit_schema(self, directory: str, **_) -> None:
         self.dirname = directory
         if directory:
@@ -73,6 +79,7 @@ class GolrSchemaGenerator(Generator):
         fn = os.path.join(self.dirname, underscore(cls.name + '-config.yaml'))
         if len(self.class_obj.fields) > 1:
             with open(fn, 'w') as f:
+                f.write(''.join(self.generate_header()))
                 f.write(as_yaml(self.class_obj))
 
     def visit_class_slot(self, cls: ClassDefinition, aliased_slot_name: str, slot: SlotDefinition) -> None:

--- a/linkml/generators/graphqlgen.py
+++ b/linkml/generators/graphqlgen.py
@@ -16,6 +16,12 @@ class GraphqlGenerator(Generator):
 
     def __init__(self, schema: Union[str, TextIO, SchemaDefinition], **kwargs) -> None:
         super().__init__(schema, **kwargs)
+        self.generate_header()
+
+    def generate_header(self):
+        print(f"# metamodel_version: {self.schema.metamodel_version}")
+        if self.schema.version:
+            print(f"# version: {self.schema.version}")
 
     def visit_class(self, cls: ClassDefinition) -> bool:
         etype = 'interface' if (cls.abstract or cls.mixin) and not cls.mixins else 'type'

--- a/linkml/generators/javagen.py
+++ b/linkml/generators/javagen.py
@@ -23,6 +23,11 @@ package {{ doc.package }};
 import java.util.List;
 import lombok.*;
 
+
+{% if metamodel_version %}/* metamodel_version: {{metamodel_version}} */{% endif %}
+{% if model_version %}/* version: {{model_version}} */{% endif %}
+
+
 {% if cls.source_class.description %}/**
   {{ cls.source_class.description }}
 **/{% endif %}
@@ -78,7 +83,7 @@ class JavaGenerator(OOCodeGenerator):
         self.directory = directory
         for oodoc in oodocs:
             cls = oodoc.classes[0]
-            code = template_obj.render(doc=oodoc, cls=cls)
+            code = template_obj.render(doc=oodoc, cls=cls, metamodel_version=self.schema.metamodel_version, model_version=self.schema.version)
 
             os.makedirs(directory, exist_ok=True)
             filename = f'{oodoc.name}.java'

--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -81,6 +81,8 @@ class ContextGenerator(Generator):
                 comments += f'''
     Generation date: {self.schema.generation_date}
     Schema: {self.schema.name}
+    metamodel version: {self.schema.metamodel_version}
+    model version: {self.schema.version if self.schema.version else None}
     '''
             comments += f'''
     id: {self.schema.id}

--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -65,6 +65,8 @@ class JsonSchemaGenerator(Generator):
         self.inline = inline
         self.schemaobj = JsonObj(title=self.schema.name,
                                  type="object",
+                                 metamodel_version=self.schema.metamodel_version,
+                                 version=self.schema.version if self.schema.version else None,
                                  properties={},
                                  additionalProperties=not_closed)
         for p, c in self.entryProperties.items():

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -67,7 +67,10 @@ class MarkdownGenerator(Generator):
 
         with open(self.exist_warning(directory, index_file), 'w') as ixfile:
             with redirect_stdout(ixfile):
-                self.frontmatter(f"{self.schema.name} schema")
+                self.frontmatter(f"{self.schema.name}")
+                self.para(
+                    f"**metamodel version:** {self.schema.metamodel_version}\n\n**version:** {self.schema.version}"
+                )
                 self.para(be(self.schema.description))
 
                 self.header(3, 'Classes')

--- a/linkml/generators/protogen.py
+++ b/linkml/generators/protogen.py
@@ -21,6 +21,12 @@ class ProtoGenerator(Generator):
     def __init__(self, schema: Union[str, TextIO, SchemaDefinition], **kwargs) -> None:
         super().__init__(schema, **kwargs)
         self.relative_slot_num = 0
+        self.generate_header()
+
+    def generate_header(self):
+        print(f"// metamodel_version: {self.schema.metamodel_version}")
+        if self.schema.version:
+            print(f"// version: {self.schema.version}")
 
     def visit_class(self, cls: ClassDefinition) -> bool:
         if cls.mixin or cls.abstract or not cls.slots:

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -24,6 +24,9 @@ from enum import Enum
 from typing import List, Dict, Optional
 from pydantic import BaseModel, Field
 
+metamodel_version = {{metamodel_version}}
+version = {{version if version else None}}
+
 {% for e in enums.values() %}
 class {{ e.name }}(str, Enum):
     {% if e.description -%}
@@ -178,7 +181,7 @@ class PydanticGenerator(OOCodeGenerator):
                     pyrange = f'Optional[{pyrange}]'
                 ann = Annotation('python_range', pyrange)
                 s.annotations[ann.tag] = ann
-        code = template_obj.render(schema=pyschema, underscore=underscore, enums=enums)
+        code = template_obj.render(schema=pyschema, underscore=underscore, enums=enums, metamodel_version=self.schema.metamodel_version, version=self.schema.version)
         return code
 
 

--- a/linkml/generators/pythongen.py
+++ b/linkml/generators/pythongen.py
@@ -121,6 +121,7 @@ from linkml_runtime.utils.curienamespace import CurieNamespace
 {self.gen_imports()}
 
 metamodel_version = "{self.schema.metamodel_version}"
+version = {'"' + self.schema.version + '"' if self.schema.version else None}
 
 # Overwrite dataclasses _init_fn to add **kwargs in __init__
 dataclasses._init_fn = dataclasses_init_fn_with_kwargs

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -29,6 +29,12 @@ class ShaclGenerator(Generator):
         self.schemaview = SchemaView(schema)
         self.schema = self.schemaview.schema
         self.format = format
+        self.generate_header()
+
+    def generate_header(self):
+        print(f"# metamodel_version: {self.schema.metamodel_version}")
+        if self.schema.version:
+            print(f"# version: {self.schema.version}")
 
     def serialize(self, **args) -> None:
         g = self.as_graph()

--- a/linkml/generators/shexgen.py
+++ b/linkml/generators/shexgen.py
@@ -37,6 +37,12 @@ class ShExGenerator(Generator):
             self.namespaces[METAMODEL_NAMESPACE_NAME] = METAMODEL_NAMESPACE
         self.meta = Namespace(self.namespaces.join(self.namespaces[METAMODEL_NAMESPACE_NAME], ''))  # URI for the metamodel
         self.base = Namespace(self.namespaces.join(self.namespaces._base, ''))    # Base URI for what is being modeled
+        self.generate_header()
+
+    def generate_header(self):
+        print(f"# metamodel_version: {self.schema.metamodel_version}")
+        if self.schema.version:
+            print(f"# version: {self.schema.version}")
 
     def visit_schema(self, **_):
         # Adjust the schema context to include the base model URI

--- a/linkml/generators/sqlddlgen.py
+++ b/linkml/generators/sqlddlgen.py
@@ -196,6 +196,7 @@ class SQLDDLGenerator(Generator):
         self.rename_foreign_keys = rename_foreign_keys
         self.direct_mapping = direct_mapping
         self.sqlschema = SQLSchema()
+        self.generate_header()
 
     def _is_hidden(self, cls: ClassDefinition) -> bool:
         if cls.mixin or cls.abstract:
@@ -206,6 +207,11 @@ class SQLDDLGenerator(Generator):
         https://stackoverflow.com/questions/1881123/table-naming-underscore-vs-camelcase-namespaces-singular-vs-plural
         """
         return underscore(cn)
+
+    def generate_header(self):
+        print(f"/* metamodel_version: {self.schema.metamodel_version} */")
+        if self.schema.version:
+            print(f"/* version: {self.schema.version} */")
 
     def end_schema(self, **kwargs) -> None:
         self._transform_sqlschema()


### PR DESCRIPTION
This PR address concerns raised in https://github.com/linkml/linkml/issues/285 where metamodel version and model version were not being included as part of the serialization.

This PR replaces https://github.com/linkml/linkml/pull/288 (now closed).

