### PR TITLE
Pydanticgen: fixes to description quoting & class ordering 

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -62,17 +62,16 @@ class {{ c.name }}(
     {{ c.description }}
     \"\"\"
     {%- endif %}
-    {% for attr in c.attributes.values() -%}
+    {% for attr in c.attributes.values() if c.attributes -%}
     {{attr.name}}: {{ attr.annotations['python_range'].value }} = Field(None
     {%- if attr.title != None %}, title="{{attr.title}}"{% endif -%}
     {%- if attr.description %}, description=\"\"\"{{attr.description}}\"\"\"{% endif -%}
     {%- if attr.minimum_value != None %}, ge={{attr.minimum_value}}{% endif -%}
     {%- if attr.maximum_value != None %}, le={{attr.maximum_value}}{% endif -%}
     )
-    {% endfor %}
-    {% if not c.attributes %}
+    {% else -%}
     None
-    {% endif %}
+    {% endfor %}
 {% endfor %}
 
 # Update forward refs

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -1,6 +1,6 @@
 import os
 from copy import deepcopy
-from typing import Union, TextIO, Dict
+from typing import Union, TextIO, Dict, List
 
 import click
 from jinja2 import Template
@@ -23,9 +23,21 @@ from datetime import datetime, date
 from enum import Enum
 from typing import List, Dict, Optional
 from pydantic import BaseModel, Field
+from pydantic.dataclasses import dataclass
+from pydantic.typing import ForwardRef
 
-metamodel_version = {{metamodel_version}}
-version = {{version if version else None}}
+metamodel_version = "{{metamodel_version}}"
+version = "{{version if version else None}}"
+
+# Pydantic config and validators
+class PydanticConfig:
+    \"\"\" Pydantic config https://pydantic-docs.helpmanual.io/usage/model_config/ \"\"\"
+
+    validate_assignment = True
+    validate_all = True
+    underscore_attrs_are_private = True
+    extra = 'forbid'
+    arbitrary_types_allowed = True  # TODO re-evaluate this
 
 {% for e in enums.values() %}
 class {{ e.name }}(str, Enum):
@@ -40,6 +52,7 @@ class {{ e.name }}(str, Enum):
 {% endfor %}
 
 {% for c in schema.classes.values() %}
+@dataclass(config=PydanticConfig)
 class {{ c.name }}( 
                    {%- if c.is_a %}{{c.is_a}}{% else %}BaseModel{% endif -%}
                    {#- {%- for p in c.mixins %}, "{{p}}" {% endfor -%} -#} 
@@ -62,8 +75,10 @@ class {{ c.name }}(
     {% endif %}
 {% endfor %}
 
-{% for c in schema.classes.values() %}
-{{ c.name }}.update_forward_refs()
+# Update forward refs
+# see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
+{% for c in schema.classes.values() -%}
+{{ c.name }}.__pydantic_model__.update_forward_refs()
 {% endfor %}
 """
 
@@ -116,6 +131,41 @@ class PydanticGenerator(OOCodeGenerator):
 
         return enums
 
+    def sort_classes(self, clist: List[ClassDefinition]) -> List[ClassDefinition]:
+        """
+        sort classes such that if C is a child of P then C appears after P in the list
+
+        Overridden method include mixin classes
+
+        TODO: This should move to SchemaView
+        """
+        clist = list(clist)
+        slist = []  # sorted
+        while len(clist) > 0:
+            can_add = False
+            for i in range(len(clist)):
+                candidate = clist[i]
+                can_add = False
+                if candidate.is_a:
+                    candidates = [candidate.is_a] + candidate.mixins
+                else:
+                    candidates = candidate.mixins
+                if not candidates:
+                    can_add = True
+                else:
+                    if set(candidates) <= set([p.name for p in slist]):
+                        can_add = True
+                if can_add:
+                    slist = slist + [candidate]
+                    del clist[i]
+                    break
+            if not can_add:
+                raise ValueError(
+                    f'could not find suitable element in {clist} that does not ref {slist}'
+                )
+        return slist
+
+
     def serialize(self) -> str:
         sv = self.schemaview
 
@@ -129,17 +179,21 @@ class PydanticGenerator(OOCodeGenerator):
         sv = self.schemaview
         schema = sv.schema
         #print(f'# SV c={sv.all_classes().keys()}')
-        pyschema = SchemaDefinition(id=schema.id, name=schema.name, description=schema.description)
-
+        pyschema = SchemaDefinition(id=schema.id, name=schema.name, description=schema.description.replace("\"", "\\\""))
         enums = self.generate_enums(sv.all_enums())
 
-        for class_name, class_original in sv.all_classes().items():
+        sorted_classes = self.sort_classes(list(sv.all_classes().values()))
+
+        for class_original in sorted_classes:
             class_def: ClassDefinition
             class_def = deepcopy(class_original)
+            class_name = class_original.name
             class_def.name = camelcase(class_original.name)
             if class_def.is_a:
                 class_def.is_a = camelcase(class_def.is_a)
             class_def.mixins = [camelcase(p) for p in class_def.mixins]
+            if class_def.description:
+                class_def.description = class_def.description.replace("\"", "\\\"")
             pyschema.classes[class_def.name] = class_def
             for attribute in list(class_def.attributes.keys()):
                 del class_def.attributes[attribute]
@@ -148,6 +202,8 @@ class PydanticGenerator(OOCodeGenerator):
                 s = deepcopy(sv.induced_slot(sn, class_name))
                 # logging.error(f'Induced slot {class_name}.{sn} == {s.name} {s.range}')
                 s.name = underscore(s.name)
+                if s.description:
+                    s.description = s.description.replace("\"", "\\\"")
                 class_def.attributes[s.name] = s
                 collection_key = None
                 if s.range in sv.all_classes():

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -54,7 +54,7 @@ class {{ e.name }}(str, Enum):
 {% for c in schema.classes.values() %}
 @dataclass(config=PydanticConfig)
 class {{ c.name }}( 
-                   {%- if c.is_a %}{{c.is_a}}{% else %}BaseModel{% endif -%}
+                   {%- if c.is_a %}{{c.is_a}}{% endif -%}
                    {#- {%- for p in c.mixins %}, "{{p}}" {% endfor -%} -#} 
                   ):
     {% if c.description -%}

--- a/tests/test_generators/output/kitchen_sink_pydantic.py
+++ b/tests/test_generators/output/kitchen_sink_pydantic.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 from pydantic import BaseModel, Field
+from pydantic.dataclasses import dataclass
 
-metamodel_version = None
-version = None
+metamodel_version = "None"
+version = "None"
+
+# Pydantic config and validators
+class PydanticConfig:
+    """ Pydantic config https://pydantic-docs.helpmanual.io/usage/model_config/ """
+
+    validate_assignment = True
+    validate_all = True
+    underscore_attrs_are_private = True
+    extra = 'forbid'
+    arbitrary_types_allowed = True  # TODO re-evaluate this
 
 
 class FamilialRelationshipType(str, Enum):
@@ -33,21 +44,22 @@ class OtherCodes(str, Enum):
     a_b = "a b"
     
 
-
-
-class HasAliases(BaseModel):
+@dataclass(config=PydanticConfig)
+class HasAliases:
     
     aliases: Optional[List[str]] = Field(None)
     
-    
 
-class Friend(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Friend:
     
     name: Optional[str] = Field(None)
     
-    
 
-class Person(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Person:
     """
     A person, living or dead
     """
@@ -61,73 +73,82 @@ class Person(BaseModel):
     has_birth_event: Optional[BirthEvent] = Field(None)
     aliases: Optional[List[str]] = Field(None)
     
-    
 
-class Organization(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Organization:
     
     id: Optional[str] = Field(None)
     name: Optional[str] = Field(None)
     aliases: Optional[List[str]] = Field(None)
     
-    
 
-class Place(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Place:
     
     id: Optional[str] = Field(None)
     name: Optional[str] = Field(None)
     aliases: Optional[List[str]] = Field(None)
     
-    
 
-class Address(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Address:
     
     street: Optional[str] = Field(None)
     city: Optional[str] = Field(None)
     
-    
 
-class Concept(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Concept:
     
     id: Optional[str] = Field(None)
     name: Optional[str] = Field(None)
     in_code_system: Optional[str] = Field(None)
     
-    
 
+
+@dataclass(config=PydanticConfig)
 class DiagnosisConcept(Concept):
     
     id: Optional[str] = Field(None)
     name: Optional[str] = Field(None)
     in_code_system: Optional[str] = Field(None)
     
-    
 
+
+@dataclass(config=PydanticConfig)
 class ProcedureConcept(Concept):
     
     id: Optional[str] = Field(None)
     name: Optional[str] = Field(None)
     in_code_system: Optional[str] = Field(None)
     
-    
 
-class Event(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Event:
     
     started_at_time: Optional[date] = Field(None)
     ended_at_time: Optional[date] = Field(None)
     is_current: Optional[bool] = Field(None)
-    metadata: Optional[AnyObject] = Field(None, description="""Example of a slot that has an unconstrained range""")
-    
+    metadata: Optional[Any] = Field(None, description="""Example of a slot that has an unconstrained range""")
     
 
-class Relationship(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Relationship:
     
     started_at_time: Optional[date] = Field(None)
     ended_at_time: Optional[date] = Field(None)
     related_to: Optional[str] = Field(None)
     type: Optional[str] = Field(None)
     
-    
 
+
+@dataclass(config=PydanticConfig)
 class FamilialRelationship(Relationship):
     
     started_at_time: Optional[date] = Field(None)
@@ -135,18 +156,20 @@ class FamilialRelationship(Relationship):
     related_to: str = Field(None)
     type: FamilialRelationshipType = Field(None)
     
-    
 
+
+@dataclass(config=PydanticConfig)
 class BirthEvent(Event):
     
     in_location: Optional[str] = Field(None)
     started_at_time: Optional[date] = Field(None)
     ended_at_time: Optional[date] = Field(None)
     is_current: Optional[bool] = Field(None)
-    metadata: Optional[AnyObject] = Field(None, description="""Example of a slot that has an unconstrained range""")
-    
+    metadata: Optional[Any] = Field(None, description="""Example of a slot that has an unconstrained range""")
     
 
+
+@dataclass(config=PydanticConfig)
 class EmploymentEvent(Event):
     
     employed_at: Optional[str] = Field(None)
@@ -154,10 +177,11 @@ class EmploymentEvent(Event):
     started_at_time: Optional[date] = Field(None)
     ended_at_time: Optional[date] = Field(None)
     is_current: Optional[bool] = Field(None)
-    metadata: Optional[AnyObject] = Field(None, description="""Example of a slot that has an unconstrained range""")
-    
+    metadata: Optional[Any] = Field(None, description="""Example of a slot that has an unconstrained range""")
     
 
+
+@dataclass(config=PydanticConfig)
 class MedicalEvent(Event):
     
     in_location: Optional[str] = Field(None)
@@ -166,16 +190,18 @@ class MedicalEvent(Event):
     started_at_time: Optional[date] = Field(None)
     ended_at_time: Optional[date] = Field(None)
     is_current: Optional[bool] = Field(None)
-    metadata: Optional[AnyObject] = Field(None, description="""Example of a slot that has an unconstrained range""")
-    
+    metadata: Optional[Any] = Field(None, description="""Example of a slot that has an unconstrained range""")
     
 
-class WithLocation(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class WithLocation:
     
     in_location: Optional[str] = Field(None)
     
-    
 
+
+@dataclass(config=PydanticConfig)
 class MarriageEvent(Event):
     
     married_to: Optional[str] = Field(None)
@@ -183,10 +209,11 @@ class MarriageEvent(Event):
     started_at_time: Optional[date] = Field(None)
     ended_at_time: Optional[date] = Field(None)
     is_current: Optional[bool] = Field(None)
-    metadata: Optional[AnyObject] = Field(None, description="""Example of a slot that has an unconstrained range""")
-    
+    metadata: Optional[Any] = Field(None, description="""Example of a slot that has an unconstrained range""")
     
 
+
+@dataclass(config=PydanticConfig)
 class Company(Organization):
     
     ceo: Optional[str] = Field(None)
@@ -194,53 +221,50 @@ class Company(Organization):
     name: Optional[str] = Field(None)
     aliases: Optional[List[str]] = Field(None)
     
-    
 
-class CodeSystem(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class CodeSystem:
     
     id: Optional[str] = Field(None)
     name: Optional[str] = Field(None)
     
-    
 
-class Dataset(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Dataset:
     
     persons: Optional[List[Person]] = Field(None)
     companies: Optional[List[Company]] = Field(None)
     activities: Optional[List[Activity]] = Field(None)
     code_systems: Optional[List[CodeSystem]] = Field(None)
     
-    
 
-class FakeClass(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class FakeClass:
     
     test_attribute: Optional[str] = Field(None)
     
-    
 
-class ClassWithSpaces(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class ClassWithSpaces:
     
     slot_with_space_1: Optional[str] = Field(None)
     
-    
 
+
+@dataclass(config=PydanticConfig)
 class SubclassTest(ClassWithSpaces):
     
     slot_with_space_2: Optional[ClassWithSpaces] = Field(None)
     slot_with_space_1: Optional[str] = Field(None)
     
-    
 
-class AnyObject(BaseModel):
-    """
-    Example of unconstrained class
-    """
-    
-    
-    None
-    
 
-class Activity(BaseModel):
+@dataclass(config=PydanticConfig)
+class Activity:
     """
     a provence-generating activity
     """
@@ -252,9 +276,10 @@ class Activity(BaseModel):
     used: Optional[str] = Field(None)
     description: Optional[str] = Field(None)
     
-    
 
-class Agent(BaseModel):
+
+@dataclass(config=PydanticConfig)
+class Agent:
     """
     a provence-generating agent
     """
@@ -262,58 +287,33 @@ class Agent(BaseModel):
     acted_on_behalf_of: Optional[str] = Field(None)
     was_informed_by: Optional[str] = Field(None)
     
-    
 
 
 
-HasAliases.update_forward_refs()
-
-Friend.update_forward_refs()
-
-Person.update_forward_refs()
-
-Organization.update_forward_refs()
-
-Place.update_forward_refs()
-
-Address.update_forward_refs()
-
-Concept.update_forward_refs()
-
-DiagnosisConcept.update_forward_refs()
-
-ProcedureConcept.update_forward_refs()
-
-Event.update_forward_refs()
-
-Relationship.update_forward_refs()
-
-FamilialRelationship.update_forward_refs()
-
-BirthEvent.update_forward_refs()
-
-EmploymentEvent.update_forward_refs()
-
-MedicalEvent.update_forward_refs()
-
-WithLocation.update_forward_refs()
-
-MarriageEvent.update_forward_refs()
-
-Company.update_forward_refs()
-
-CodeSystem.update_forward_refs()
-
-Dataset.update_forward_refs()
-
-FakeClass.update_forward_refs()
-
-ClassWithSpaces.update_forward_refs()
-
-SubclassTest.update_forward_refs()
-
-AnyObject.update_forward_refs()
-
-Activity.update_forward_refs()
-
-Agent.update_forward_refs()
+# Update forward refs
+# see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
+HasAliases.__pydantic_model__.update_forward_refs()
+Friend.__pydantic_model__.update_forward_refs()
+Person.__pydantic_model__.update_forward_refs()
+Organization.__pydantic_model__.update_forward_refs()
+Place.__pydantic_model__.update_forward_refs()
+Address.__pydantic_model__.update_forward_refs()
+Concept.__pydantic_model__.update_forward_refs()
+DiagnosisConcept.__pydantic_model__.update_forward_refs()
+ProcedureConcept.__pydantic_model__.update_forward_refs()
+Event.__pydantic_model__.update_forward_refs()
+Relationship.__pydantic_model__.update_forward_refs()
+FamilialRelationship.__pydantic_model__.update_forward_refs()
+BirthEvent.__pydantic_model__.update_forward_refs()
+EmploymentEvent.__pydantic_model__.update_forward_refs()
+MedicalEvent.__pydantic_model__.update_forward_refs()
+WithLocation.__pydantic_model__.update_forward_refs()
+MarriageEvent.__pydantic_model__.update_forward_refs()
+Company.__pydantic_model__.update_forward_refs()
+CodeSystem.__pydantic_model__.update_forward_refs()
+Dataset.__pydantic_model__.update_forward_refs()
+FakeClass.__pydantic_model__.update_forward_refs()
+ClassWithSpaces.__pydantic_model__.update_forward_refs()
+SubclassTest.__pydantic_model__.update_forward_refs()
+Activity.__pydantic_model__.update_forward_refs()
+Agent.__pydantic_model__.update_forward_refs()

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -40,7 +40,6 @@ class PydanticGeneratorTestCase(unittest.TestCase):
             p2 = Person(**dataset_dict['persons'][0])
             ds1 = Dataset(**dataset_dict)
             print(ds1)
-            print(Person.schema_json(indent=2))
             assert len(ds1.persons) == 2
         test_dynamic()
 


### PR DESCRIPTION
I also brought the PydanticConfig  over from biolink_model_pydantic and set the dataclass annotation.

For now, the class ordering is just sitting locally within pydanticgen, but I put in a note about moving it to SchemaView. 

It looks like we've made it past the initial syntax error stage, so it may be possible to use with FastAPI.