### PR TITLE
Explicitly set encoding for text files to UTF-8

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -147,7 +147,7 @@ class DocGenerator(Generator):
         path = Path(directory)
         path.mkdir(parents=True, exist_ok=True)
         file_name = f'{name}.{self._file_suffix()}'
-        with open(path / file_name, 'w') as stream:
+        with open(path / file_name, 'w', encoding='UTF-8') as stream:
             stream.write(out_str)
 
     def _file_suffix(self):

--- a/linkml/generators/golrgen.py
+++ b/linkml/generators/golrgen.py
@@ -78,7 +78,7 @@ class GolrSchemaGenerator(Generator):
     def end_class(self, cls: ClassDefinition) -> None:
         fn = os.path.join(self.dirname, underscore(cls.name + '-config.yaml'))
         if len(self.class_obj.fields) > 1:
-            with open(fn, 'w') as f:
+            with open(fn, 'w', encoding='UTF-8') as f:
                 f.write(''.join(self.generate_header()))
                 f.write(as_yaml(self.class_obj))
 

--- a/linkml/generators/infer_model.py
+++ b/linkml/generators/infer_model.py
@@ -235,7 +235,7 @@ def enrich(yamlfile, results, **args):
     cache = {}
     infer_enum_meanings(yamlobj, cache=cache)
     if results is not None:
-        with open(results, "w") as io:
+        with open(results, "w", encoding='UTF-8') as io:
             #io.write(str(cache))
             io.write(yaml.dump(cache))
     print(yaml.dump(yamlobj, default_flow_style=False, sort_keys=False))

--- a/linkml/generators/javagen.py
+++ b/linkml/generators/javagen.py
@@ -88,7 +88,7 @@ class JavaGenerator(OOCodeGenerator):
             os.makedirs(directory, exist_ok=True)
             filename = f'{oodoc.name}.java'
             path = os.path.join(directory, filename)
-            with open(path, 'w') as stream:
+            with open(path, 'w', encoding='UTF-8') as stream:
                 stream.write(code)
 
 

--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -114,7 +114,7 @@ class ContextGenerator(Generator):
                 context_content[k] = v
         context['@context'] = context_content
         if output:
-            with open(output, 'w') as outf:
+            with open(output, 'w', encoding='UTF-8') as outf:
                 outf.write(as_json(context))
         else:
             print(as_json(context))

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -65,7 +65,7 @@ class MarkdownGenerator(Generator):
         if not self.no_types_dir:
             os.makedirs(os.path.join(directory, 'types'), exist_ok=True)
 
-        with open(self.exist_warning(directory, index_file), 'w') as ixfile:
+        with open(self.exist_warning(directory, index_file), 'w', encoding='UTF-8') as ixfile:
             with redirect_stdout(ixfile):
                 self.frontmatter(f"{self.schema.name}")
                 self.para(
@@ -119,7 +119,7 @@ class MarkdownGenerator(Generator):
         if self.gen_classes and cls.name not in self.gen_classes:
             return False
 
-        with open(self.exist_warning(self.dir_path(cls)), 'w') as clsfile:
+        with open(self.exist_warning(self.dir_path(cls)), 'w', encoding='UTF-8') as clsfile:
             with redirect_stdout(clsfile):
                 class_curi = self.namespaces.uri_or_curie_for(str(self.namespaces._base), camelcase(cls.name))
                 class_uri = self.namespaces.uri_for(class_curi)
@@ -209,7 +209,7 @@ class MarkdownGenerator(Generator):
         return False
 
     def visit_type(self, typ: TypeDefinition) -> None:
-        with open(self.exist_warning(self.dir_path(typ)), 'w') as typefile:
+        with open(self.exist_warning(self.dir_path(typ)), 'w', encoding='UTF-8') as typefile:
             with redirect_stdout(typefile):
                 type_uri = typ.definition_uri
                 type_curie = self.namespaces.curie_for(type_uri)
@@ -225,7 +225,7 @@ class MarkdownGenerator(Generator):
                 self.element_properties(typ)
 
     def visit_slot(self, aliased_slot_name: str, slot: SlotDefinition) -> None:
-        with open(self.exist_warning(self.dir_path(slot)), 'w') as slotfile:
+        with open(self.exist_warning(self.dir_path(slot)), 'w', encoding='UTF-8') as slotfile:
             with redirect_stdout(slotfile):
                 import logging
                 slot_curie = self.namespaces.uri_or_curie_for(str(self.namespaces._base), underscore(slot.name))
@@ -256,7 +256,7 @@ class MarkdownGenerator(Generator):
                 self.element_properties(slot)
 
     def visit_enum(self, enum: EnumDefinition) -> None:
-        with open(self.exist_warning(self.dir_path(enum)), 'w') as enumfile:
+        with open(self.exist_warning(self.dir_path(enum)), 'w', encoding='UTF-8') as enumfile:
             with redirect_stdout(enumfile):
                 enum_curie = self.namespaces.uri_or_curie_for(str(self.namespaces._base), underscore(enum.name))
                 enum_uri = self.namespaces.uri_for(enum_curie)
@@ -264,7 +264,7 @@ class MarkdownGenerator(Generator):
                 self.element_properties(enum)
 
     def visit_subset(self, subset: SubsetDefinition) -> None:
-        with open(self.exist_warning(self.dir_path(subset)), 'w') as subsetfile:
+        with open(self.exist_warning(self.dir_path(subset)), 'w', encoding='UTF-8') as subsetfile:
             with redirect_stdout(subsetfile):
                 curie = self.namespaces.uri_or_curie_for(str(self.namespaces._base), underscore(subset.name))
                 uri = self.namespaces.uri_for(curie)

--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -88,7 +88,7 @@ class OwlSchemaGenerator(Generator):
     def end_schema(self, output: Optional[str] = None, **_) -> None:
         data = self.graph.serialize(format='turtle' if self.format in ['owl', 'ttl'] else self.format).decode()
         if output:
-            with open(output, 'w') as outf:
+            with open(output, 'w', encoding='UTF-8') as outf:
                 outf.write(data)
         else:
             print(data)

--- a/linkml/generators/prefixmapgen.py
+++ b/linkml/generators/prefixmapgen.py
@@ -75,12 +75,12 @@ class PrefixGenerator(Generator):
                 for prefix in sorted(self.emit_prefixes):
                     mapping[prefix] = self.namespaces[prefix]
 
-                with open(output, 'w') as outf:
+                with open(output, 'w', encoding='UTF-8') as outf:
                     writer = csv.writer(outf, delimiter='\t')
                     for key, value in mapping.items():
                         writer.writerow([key, value])
             else:
-                with open(output, 'w') as outf:
+                with open(output, 'w', encoding='UTF-8') as outf:
                     outf.write(as_json(context))
         else:
             if self.format == "tsv":

--- a/linkml/generators/projectgen.py
+++ b/linkml/generators/projectgen.py
@@ -115,7 +115,7 @@ class ProjectGenerator:
                 if parts[-1] != '':
                     # markdowngen does not write to a file
                     logging.info(f'  WRITING TO: {gen_path_full}')
-                    with open(gen_path_full, 'w') as stream:
+                    with open(gen_path_full, 'w', encoding='UTF-8') as stream:
                         stream.write(gen_dump)
 
 @click.command()

--- a/linkml/generators/rdfgen.py
+++ b/linkml/generators/rdfgen.py
@@ -43,7 +43,7 @@ class RDFGenerator(Generator):
         graph = Graph()
         graph.parse(data=jsonld_str, format="json-ld", base=str(self.namespaces._base), prefix=True)
         if output:
-            with open(output, 'w') as outf:
+            with open(output, 'w', encoding='UTF-8') as outf:
                 outf.write(self._data(graph))
         else:
             print(self._data(graph))

--- a/linkml/generators/shexgen.py
+++ b/linkml/generators/shexgen.py
@@ -131,7 +131,7 @@ class ShExGenerator(Generator):
             self.namespaces.load_graph(g)
             shex = str(ShExC(self.shex, base=sfx(self.namespaces._base), namespaces=g))
         if output:
-            with open(output, 'w') as outf:
+            with open(output, 'w', encoding='UTF-8') as outf:
                 outf.write(shex)
         else:
             print(shex)

--- a/linkml/generators/sparqlgen.py
+++ b/linkml/generators/sparqlgen.py
@@ -165,7 +165,7 @@ class SparqlGenerator(Generator):
             Path(directory).mkdir(parents=True, exist_ok=True)
             for qn, q in self.queries.items():
                 qpath = os.path.join(directory, f'{qn}.rq')
-                with open(qpath, 'w') as stream:
+                with open(qpath, 'w', encoding='UTF-8') as stream:
                     stream.write(q)
         return self.sparql
 

--- a/linkml/generators/sqlddlgen.py
+++ b/linkml/generators/sqlddlgen.py
@@ -473,7 +473,7 @@ def cli(yamlfile, sqla_file:str = None, python_import: str = None, **args):
     if sqla_file is not None:
         if python_import is None:
             python_import = gen.schema.name
-        with open(sqla_file, "w") as stream:
+        with open(sqla_file, "w", encoding='UTF-8') as stream:
             with redirect_stdout(stream):
                 gen.write_sqla_python_imperative(python_import)
 

--- a/linkml/generators/sssomgen.py
+++ b/linkml/generators/sssomgen.py
@@ -177,7 +177,7 @@ class SSSOMGenerator(Generator):
             k: v.prefix_reference for k, v in schema.prefixes.items()
         }
 
-        with open(self.output_file, "w") as sssom_tsv:
+        with open(self.output_file, "w", encoding='UTF-8') as sssom_tsv:
             for k, v in metadata.items():
                 if k != "curie_map":
                     sssom_tsv.write("#" + k + ": " + v + "\n")

--- a/linkml/utils/execute_tutorial.py
+++ b/linkml/utils/execute_tutorial.py
@@ -55,7 +55,7 @@ def execute_blocks(directory: str, blocks: List[Block]) -> List[str]:
         logging.info(f'# Block: {block.category} {block.title}')
         if block.is_file_block():
             path = PurePath(directory, block.title)
-            with open(path, 'w') as stream:
+            with open(path, 'w', encoding='UTF-8') as stream:
                 stream.write(block.content)
         elif block.is_bash():
             if 'no_execute' in block.annotations:
@@ -76,7 +76,7 @@ def execute_blocks(directory: str, blocks: List[Block]) -> List[str]:
             r = subprocess.run(cmd, cwd=directory, capture_output=True)
             block.output = r.stdout.decode("utf-8")
             if outpath:
-                with open(outpath, 'w') as stream:
+                with open(outpath, 'w', encoding='UTF-8') as stream:
                     logging.info(f'WRITING {len(block.output)} TO = {outpath}')
                     stream.write(block.output)
             block.error = r.stderr.decode("utf-8")

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -242,7 +242,7 @@ class TestEnvironment:
         if comparator is None:
             comparator = self.string_comparator
         if os.path.exists(expected_file_path):
-            with open(expected_file_path) as expf:
+            with open(expected_file_path, encoding="UTF-8") as expf:
                 expected_text = filtr(expf.read())
             msg = comparator(expected_text, filtr(actual_text))
         else:


### PR DESCRIPTION
This is required for windows which does not use UTF-8 by default. It fixes all unicode encoding/decoding errors when running the tests on windows (W10, Python 3.9.10).

Fixes #601