### PR TITLE
add `--output` option to `gen-linkml`

### DIFF
--- a/linkml/utils/helpers.py
+++ b/linkml/utils/helpers.py
@@ -2,7 +2,6 @@ def remove_duplicates(lst):
     """Remove duplicate tuples from a list of tuples."""
     return [t for t in (set(tuple(i) for i in lst))]
 
-def write_to_file(file_path, data, mode="w"):
-    """Write string data to a file."""
-    with open(file_path, mode) as f:
+def write_to_file(file_path, data, mode="w", encoding="utf-8"):
+    with open(file_path, mode, encoding=encoding) as f:
         f.write(data)

--- a/linkml/utils/helpers.py
+++ b/linkml/utils/helpers.py
@@ -1,3 +1,8 @@
 def remove_duplicates(lst):
     """Remove duplicate tuples from a list of tuples."""
     return [t for t in (set(tuple(i) for i in lst))]
+
+def write_to_file(file_path, data, mode="w"):
+    """Write string data to a file."""
+    with open(file_path, mode) as f:
+        f.write(data)


### PR DESCRIPTION
Allow users to specify path to which the output of `gen-linkml` should be outputted to.

The advantage of this can be seen when we want to read in the expected test result for comparison in a test case.