### PR TITLE
Add option to include range class descendants in generated jsonschema

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -60,7 +60,7 @@ class JsonSchemaGenerator(Generator):
         self.inline = False
         self.topCls = top_class  ## JSON object is one instance of this
         self.entryProperties = {}
-        self.include_range_class_descendants = kwargs["include_range_class_descendants"] if "include_range_class_descendants" else False
+        self.include_range_class_descendants = kwargs["include_range_class_descendants"] if "include_range_class_descendants" in kwargs else False
         # JSON-Schema does not have inheritance,
         # so we duplicate slots from inherited parents and mixins
         self.visit_all_slots = True

--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -60,7 +60,7 @@ class JsonSchemaGenerator(Generator):
         self.inline = False
         self.topCls = top_class  ## JSON object is one instance of this
         self.entryProperties = {}
-        self.include_range_class_descendants = kwargs["include_range_class_descendants"]
+        self.include_range_class_descendants = kwargs["include_range_class_descendants"] if "include_range_class_descendants" else False
         # JSON-Schema does not have inheritance,
         # so we duplicate slots from inherited parents and mixins
         self.visit_all_slots = True


### PR DESCRIPTION
This PR adds the functionality as described in issue #652 where an optional flag `--include-range-class-constraints` for jsonschema-gen will add all descendants of the range class when defining the type of the property in jsonschema.

@cmungall would be curious to hear your thoughts on this. Not sure if this is a niche use case or if an approach like this is not ideal for the JSON Schema realm.