### PR TITLE
Unit test and fix for issue #692

### DIFF
--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -107,6 +107,8 @@ class OwlSchemaGenerator(Generator):
                 self.graph.add((uri, SKOS.altLabel, Literal(s)))
         if e.title is not None:
             self.graph.add((uri, DCTERMS.title, Literal(e.title)))
+        if e.description is not None:
+            self.graph.add((uri, RDFS.comment, Literal(e.description)))
         if e.mappings is not None:
             for m in e.mappings:
                 m_uri = self.namespaces.uri_for(m)

--- a/tests/test_issues/test_linkml_issue_692.py
+++ b/tests/test_issues/test_linkml_issue_692.py
@@ -1,0 +1,67 @@
+import unittest
+
+from rdflib import URIRef, Graph
+from rdflib.namespace import RDFS, DCTERMS
+
+from linkml.generators.owlgen import OwlSchemaGenerator
+
+from tests.utils.test_environment import TestEnvironmentTestCase
+from tests.test_issues.environment import env
+
+# reported in https://github.com/linkml/linkml/issues/692
+# description metaproperty is not being exported with owl-gen
+
+schema_str = """
+id: http://example.org/description-export
+name: descriptionexport
+imports:
+  - https://w3id.org/linkml/types
+default_range: string
+
+classes:
+  Person:
+    title: A person
+    description: A person (alive, dead, undead, or fictional).
+    slots:
+        - name
+        - family name
+    
+slots:
+  name:
+    title: Name
+    description: The name of the item.
+  
+  family name:
+    title: Family name
+    description: Family name. In the U.S., the last name of a Person.
+"""
+
+class IssueDescriptionExportCase(TestEnvironmentTestCase):
+    env = env
+
+    # export the source schema containing both title and description
+    gen = OwlSchemaGenerator(schema_str, None, False, False, True, format="ttl")
+    output = gen.serialize()
+
+    # load back via rdflib
+    graph = Graph(base="http://example.org/description-export")
+    graph.parse(data=output, format="ttl")
+
+    # check if graph contains dcterms:title for class 'Person'
+    person_class = URIRef(f"{graph.base}/Person")
+    assert (person_class, DCTERMS.title, None) in graph
+
+    # check if graph contains dcterms:title for property 'name'
+    name_prop = URIRef(f"{graph.base}/name")
+    assert (name_prop, DCTERMS.title, None) in graph
+
+    # now check rdfs:comment for class 'Person'
+    assert (person_class, RDFS.comment, None) in graph
+
+    # and check rdfs:comment for property 'name' too
+    assert (name_prop, RDFS.comment, None) in graph
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have added the missing description export as rdfs:comment because of its broad usage in other well known ontologies.