### PR TITLE
Implement mixin inheritance in pydanticgen

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -114,13 +114,18 @@ class PydanticGenerator(OOCodeGenerator):
                  template_file: str = None,
                  allow_extra = False,
                  format: str = valid_formats[0],
-                 genmeta: bool=False, gen_classvars: bool=True, gen_slots: bool=True, **kwargs) -> None:
+                 genmeta: bool=False,
+                 gen_classvars: bool=True,
+                 gen_slots: bool=True,
+                 gen_mixin_inheritance: bool = True,
+                 **kwargs) -> None:
         self.sorted_class_names = None
         self.sourcefile = schema
         self.schemaview = SchemaView(schema)
         self.schema = self.schemaview.schema
         self.template_file = template_file
         self.allow_extra = allow_extra
+        self.gen_mixin_inheritance = gen_mixin_inheritance
 
     def map_type(self, t: TypeDefinition) -> str:
         return TYPEMAP.get(t.base, t.base)
@@ -205,7 +210,7 @@ class PydanticGenerator(OOCodeGenerator):
             class_parents = []
             if class_def.is_a:
                 class_parents.append(camelcase(class_def.is_a))
-            if class_def.mixins:
+            if self.gen_mixin_inheritance and class_def.mixins:
                 class_parents.extend([camelcase(mixin) for mixin in class_def.mixins])
             if len(class_parents) > 0:
                 # Use the sorted list of classes to order the parent classes, but reversed to match MRO needs

--- a/linkml/generators/sqlalchemygen.py
+++ b/linkml/generators/sqlalchemygen.py
@@ -130,7 +130,8 @@ class SQLAlchemyGenerator(Generator):
         elif compile_python_dataclasses:
             # concatenate the python dataclasses with the sqla code
             if pydantic:
-                pygen = PydanticGenerator(self.original_schema, allow_extra=True)
+                # mixin inheritance doesn't get along with SQLAlchemy's imperative (aka classical) mapping
+                pygen = PydanticGenerator(self.original_schema, allow_extra=True, gen_mixin_inheritance=False)
             else:
                 pygen = PythonGenerator(self.original_schema)
             dc_code = pygen.serialize()


### PR DESCRIPTION
At last week's LinkML meeting we talked through issue #687, and rather than taking biolink-model-pydantic's approach of always allowing either the class or the ID scalar, we thought it made more sense to implement mixin inheritance. 

The challenging bit was getting listing of classes to have a valid method resolution order in the class definition ([this is a nice explanation](https://www.educative.io/edpresso/what-is-mro-in-python)). 

This actually wasn't implemented yet in biolink-model-pydantic, which had a hardcoded fix to handle the one spot where the biolink model didn't just happen to get it right, but obviously we don't want to put it on the model to worry about the order in which classes are listed. 

Pydanticgen already sorts classes in working order for inheritance, so sorting the subset of parent classes in the same order and then reversing gives a valid MRO. 