### PR TITLE
stub out subproperty question

### DIFF
--- a/docs/faq/modeling.md
+++ b/docs/faq/modeling.md
@@ -165,3 +165,6 @@ In future, the LinkML framework will
 
  * warn if a reserved term is used
  * provide a mechanism for transparent mapping between a schema element and a "safe" version of the element
+
+## What is a good use case of subproperty_of? 
+


### PR DESCRIPTION
I checked through various LinkML schemas ( NMDC, ccdh, biodatamodels, sssom) and I don't see a recent use case for this one.  Biolink Model uses `subproperty_of` in slot_usage to define that the predicate in this association is constrained to be a child of the existing predicate `homologous to`.  Alternatively, I could set `is_a` in `slot_usage` for `predicate` in this association to be `homologous to`?  

current biolink:
```
  gene to gene homology association:
    description: >-
      A homology association between two genes. May be orthology (in which
      case the species of subject and object should differ) or paralogy
      (in which case the species may be the same)
    is_a: gene to gene association
    defining_slots:
      - subject
      - predicate
      - object
    slot_usage:
      predicate:
        subproperty_of: homologous to
        symmetric: true
        description: >-
          homology relationship type
```

vs. 

```
  gene to gene homology association:
    description: >-
      A homology association between two genes. May be orthology (in which
      case the species of subject and object should differ) or paralogy
      (in which case the species may be the same)
    is_a: gene to gene association
    defining_slots:
      - subject
      - predicate
      - object
    slot_usage:
      predicate:
        is_a: homologous to
        symmetric: true
        description: >-
          homology relationship type
```

It looks like I get more if I use `is_a` (in the python serialization) -- it constrains on the range of the ancestor? (in this case because the ancestor, `related_to` is the only slot in the hierarchy that has a domain/range constraint):
`is_a`:
```
        if self._is_empty(self.predicate):
            self.MissingRequiredField("predicate")
        if not isinstance(self.predicate, list):
            self.predicate = [self.predicate] if self.predicate is not None else []
        self.predicate = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.predicate]
```
vs. `subproperty_of`
```
        if self._is_empty(self.predicate):
            self.MissingRequiredField("predicate")
        if not isinstance(self.predicate, PredicateType):
            self.predicate = PredicateType(self.predicate)
```



