### PR TITLE
Added `poetry` install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ NAME = 'linkml'
 setup(
     name=NAME,
     setup_requires=['pbr'],
+    install_requires=['poetry'],
     pbr=True,
 )


### PR DESCRIPTION
Fix for: linkml-ws followup: make setup: poetry: command not found #753