### PR TITLE
ensure that excel generator works when running `gen-project`

### DIFF
--- a/linkml/generators/projectgen.py
+++ b/linkml/generators/projectgen.py
@@ -51,7 +51,7 @@ GEN_MAP = {
     # # linkml/generators/javagen.py uses different architecture from most of the other generators
     # # also linkml/generators/excelgen.py, which has a different mechanism for determining the output path
     # 'java': (JavaGenerator, 'java/{name}.java', {'directory': '{parent}'}),
-    # 'excel': (ExcelGenerator, 'excel/{name}.xlsx', {'output': '{parent}/{name}.xlsx'}),
+    'excel': (ExcelGenerator, 'excel/{name}.xlsx', {'output': '{parent}/{name}.xlsx'}),
 }
 
 @lru_cache()
@@ -113,7 +113,14 @@ class ProjectGenerator:
                 gen_path_full = '/'.join(parts)
                 all_gen_args = {**default_gen_args, **config.generator_args.get(gen_name, {})}
                 gen: Generator
+                
+                # special check for output key because ExcelGenerator and
+                # SSSOMGenerator read in output file name during initialization
+                if "output" in all_gen_args:
+                    all_gen_args["output"] = all_gen_args["output"].format(name=name, parent=parent_dir)
+
                 gen = gen_cls(local_path, **all_gen_args)
+
                 serialize_args = {'mergeimports': config.mergeimports}
                 for k, v in all_gen_args.items():
                     # all ARG_DICT values are interpolatable
@@ -122,11 +129,19 @@ class ProjectGenerator:
                     serialize_args[k] = v
                 logging.info(f' {gen_name} ARGS: {serialize_args}')
                 gen_dump = gen.serialize(**serialize_args)
-                if parts[-1] != '':
-                    # markdowngen does not write to a file
-                    logging.info(f'  WRITING TO: {gen_path_full}')
-                    with open(gen_path_full, 'w', encoding='UTF-8') as stream:
-                        stream.write(gen_dump)
+
+                if gen_name != "excel":
+                    if parts[-1] != '':
+                        # markdowngen does not write to a file
+                        logging.info(f'  WRITING TO: {gen_path_full}')
+                        with open(gen_path_full, 'w', encoding='UTF-8') as stream:
+                            stream.write(gen_dump)
+                else:
+                    # special handling for excel generator
+                    # we do not need to route the output
+                    # into a file like the other generators
+                    gen.serialize(**serialize_args)
+                
 
 @click.command()
 @click.option("--dir", "-d",


### PR DESCRIPTION
Fix the generation of Excel artifact when running `gen-project`.
 
The core idea behind the fix is that `--output` is an argument that is accepted by the ExcelGenerator object, and not by the `serialize()` method. So we need to make sure the appropriate path to the xlsx file is passed to the `gen` object during initialization.

The same fix will need to be applied if we decide to add the SSSOM artifact to gen-project as well.

CC: @hrshdhgd @turbomam 