### PR TITLE
add the link to the range of a slot

### DIFF
--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -22,7 +22,7 @@ URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 
 ## Properties
 
- * Range: {{element.range}}
+ * Range: {{gen.link(element.range)}}
 
 {% if schemaview.usage_index().get(element.name) %}
 | used by | used in | type | used |


### PR DESCRIPTION
adresses #778

This PR alters the default Jinja template for the slot documentation by adding a link to the documentation of the class specified in the range of the slot.