### PR TITLE
Add `author` string to workspace template render context

### DIFF
--- a/linkml/workspaces/cli.py
+++ b/linkml/workspaces/cli.py
@@ -26,6 +26,7 @@ import requests
 VERSION_STR = str
 TEMPLATE_SUFFIX = ".jinja"
 ABOUT_FILE = 'about.yaml'
+SKIP_FILES = ["poetry.lock"]
 PROJECT_TEMPLATE_API_URL = 'https://api.github.com/repos/linkml/linkml-project-template/releases/latest'
 
 
@@ -235,6 +236,9 @@ def new(
         for f in files:
             source_path = os.path.join(root, f)
             target_path = os.path.join(target_directory, f)
+            if f in SKIP_FILES:
+                logging.info(f'Skipping {source_path}')
+                continue
             if Path(source_path + TEMPLATE_SUFFIX).exists():
                 logging.info(f'Skipping {source_path}, will be written from {TEMPLATE_SUFFIX}')
                 continue


### PR DESCRIPTION
This adds a new `--author` CLI option to the workspace generation CLI. The value is then passed to the template rendering context so that it can be used to correctly populate the `pyproject.toml` file in the template. The author string needs to be in the format `name <email>` and `git config` is used to attempt generating a sensible default. That may fail in which case the user will need to specify the `--author` option to proceed.

Another small change in here is the addition of a variable to control files in the template project which should _not_ be copied in to the generated project. In particular, I think it's better to allow the generated project to generate its own `poetry.lock` file now that the generated project's `pyproject.toml` is not going to be the same as the template repo's `pyproject.toml`.

See also:
  * https://github.com/linkml/linkml-project-template/issues/22