### PR TITLE
Test for data, schema and Makefile for linkml-sqldb dump of datetimes

### DIFF
--- a/tests/test_issues/input/issue_816/birthday_schema.Makefile
+++ b/tests/test_issues/input/issue_816/birthday_schema.Makefile
@@ -1,0 +1,42 @@
+SCHEMA_FILE=birthday_schema.yaml
+RUN=poetry run
+OUTDIR=../../output/issue_816/
+
+.PHONY: clean all query_dumped_db
+
+# contacts_data_converted.tsv
+
+all: clean \
+$(OUTDIR)birthday_schema_generated.yaml \
+$(OUTDIR)contacts_data_converted.yaml \
+query_dumped_db
+
+clean:
+	rm -rf $(OUTDIR)birthday_schema_generated.yaml
+	rm -rf $(OUTDIR)contacts_data_converted.yaml
+	rm -rf $(OUTDIR)contacts_data.db
+
+$(OUTDIR)birthday_schema_generated.yaml:
+	# lightweight schema validation
+	# or gen-linkml --format yaml
+	$(RUN) gen-yaml $(SCHEMA_FILE) > $@
+
+$(OUTDIR)contacts_data_converted.yaml: $(SCHEMA_FILE) contacts_data.tsv
+	# show that LinkML tools can handle this data in general
+	$(RUN) linkml-convert \
+		--output $@ \
+		--target-class Contacts \
+		--index-slot people \
+		--schema $^
+
+$(OUTDIR)contacts_data.db:  $(SCHEMA_FILE) contacts_data.tsv
+	$(RUN) linkml-sqldb dump\
+		--db $@ \
+		--target-class Contacts \
+		--index-slot people \
+		--schema $^
+
+query_dumped_db: $(OUTDIR)contacts_data.db
+	sqlite3 $< \
+		".headers on" \
+		"select * from Person" ""

--- a/tests/test_issues/input/issue_816/birthday_schema.yaml
+++ b/tests/test_issues/input/issue_816/birthday_schema.yaml
@@ -1,0 +1,25 @@
+name: Birthdays
+id: http://example.com/birthdays
+default_prefix: birthdays
+default_range: string
+imports: linkml:types
+prefixes:
+  birthdays: http://example.com/birthdays/
+  linkml: https://w3id.org/linkml/
+slots:
+  birthdate:
+    range: datetime
+  person_name:
+  people:
+    range: Person
+    multivalued: true
+    inlined_as_list: true
+classes:
+  Person:
+    slots:
+      - person_name
+      - birthdate
+  Contacts:
+    slots:
+      - people
+

--- a/tests/test_issues/input/issue_816/contacts_data.tsv
+++ b/tests/test_issues/input/issue_816/contacts_data.tsv
@@ -1,0 +1,4 @@
+person_name	birthdate
+Abraham	2022-01-13T20:03:48.999191
+Milhouse	2022-01-13T20:03:48.999191
+Seymour	2022-01-13T20:03:48.999191

--- a/tests/test_issues/output/issue_816/README.md
+++ b/tests/test_issues/output/issue_816/README.md
@@ -1,0 +1,1 @@
+forcing creation of this directory


### PR DESCRIPTION
for #816 

I'm pushing some data, a schema and a Makefile that illustrate my problem with `linkml-sqldb dump` and dates

[`make all`](l/linkml/blob/issue-816-postgres-dates/tests/test_issues/input/issue_816/birthday_schema.Makefile) will convert a TSV with `datetime`s into YAML but `linkml-sqldb dump` doesn't work (unless you change the range of birthdate to `string`, or something like that.)