### PR TITLE
alphabetical ordering of classes in `class_hierarchy_as_tuples()`

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -472,10 +472,16 @@ class DocGenerator(Generator):
 
         Simply iterate through all tuples, drawing each in the appropriate way
 
+        Note: By default all classes are ordered alphabetically
+
         :return: tuples (depth: int, cls: ClassDefinitionName)
         """
         sv = self.schemaview
         roots = sv.class_roots(mixins=False)
+
+        # by default the classes are sorted alphabetically
+        roots = sorted(roots, key=str.casefold, reverse=True)
+
         # the stack holds tuples of depth-class that have still to be processed.
         # we seed this with all root classes (which have depth 0)
         # note the stack is processed from the last element first, ie. LIFO

--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -490,7 +490,8 @@ class DocGenerator(Generator):
         while len(stack) > 0:
             depth, class_name = stack.pop()
             yield depth, class_name
-            for child in sv.class_children(class_name=class_name, mixins=False):
+            children = sorted(sv.class_children(class_name=class_name, mixins=False), key=str.casefold, reverse=True)
+            for child in children:
                 # depth first - place at end of stack (to be processed next)
                 stack.append((depth+1, child))
 

--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -237,7 +237,13 @@ classes:
     attributes:
       slot with space 2:
         range: class with spaces
-  sub subclass test:
+  # these below two sub classes at the same depth have
+  # been added to check if class hierarchy methods
+  # follow lexigraphic sorting
+  Sub sub class 2:
+    is_a: subclass test
+  tub sub class 1:
+    description: Same depth as Sub sub class 1
     is_a: subclass test
 
 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -169,21 +169,26 @@ class DocGeneratorTestCase(unittest.TestCase):
         actual_result = list(actual_result)
 
         # assertion to make sure that children are listed after parents
+        # and that siblings, i.e., classes at the same depth are sorted
+        # alphabetically
         # parent: class with spaces
         # child at depth 1: subclass test
-        # child at depth 2: sub subclass test
+        # child at depth 2: Sub sub class 2
+        # child at depth 2: tub sub class 1
 
         # classes related by is_a relationship
-        # sub subclass test is_a subclass test is_a class with spaces
+        # Sub sub class 2 is_a subclass test is_a class with spaces
+        # tub sub class 1 is_a subclass test is_a class with spaces
 
         parent_order = actual_result.index([(dep, cls) for dep, cls in actual_result if cls == "class with spaces"][0])
         sub_class_order = actual_result.index([(dep, cls) for dep, cls in actual_result if cls == "subclass test"][0])
-        sub_sub_class_order = actual_result.index([(dep, cls) for dep, cls in actual_result if cls == "sub subclass test"][0])
+        sub_sub_class_order = actual_result.index([(dep, cls) for dep, cls in actual_result if cls == "Sub sub class 2"][0])
+        tub_sub_class_order = actual_result.index([(dep, cls) for dep, cls in actual_result if cls == "tub sub class 1"][0])
         
-        self.assertGreater(sub_sub_class_order, sub_class_order, parent_order)
+        self.assertGreater(tub_sub_class_order, sub_sub_class_order, sub_class_order, parent_order)
 
         expected_result = [(0, 'activity'), (0, 'Address'), (0, 'agent'), (0, 'AnyObject'), 
-                           (0, 'class with spaces'), (1, 'subclass test'), (2, 'sub subclass test'), 
+                           (0, 'class with spaces'), (1, 'subclass test'), (2, 'Sub sub class 2'), (2, 'tub sub class 1'),
                            (0, 'CodeSystem'), (0, 'Concept'), (1, 'ProcedureConcept'), (1, 'DiagnosisConcept'), 
                            (0, 'Dataset'), (0, 'Event'), (1, 'MarriageEvent'), (1, 'MedicalEvent'), 
                            (1, 'EmploymentEvent'), (1, 'BirthEvent'), (0, 'FakeClass'), (0, 'Friend'), (0, 'HasAliases'), 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -185,7 +185,9 @@ class DocGeneratorTestCase(unittest.TestCase):
         sub_sub_class_order = actual_result.index([(dep, cls) for dep, cls in actual_result if cls == "Sub sub class 2"][0])
         tub_sub_class_order = actual_result.index([(dep, cls) for dep, cls in actual_result if cls == "tub sub class 1"][0])
         
-        self.assertGreater(tub_sub_class_order, sub_sub_class_order, sub_class_order, parent_order)
+        self.assertGreater(tub_sub_class_order, sub_sub_class_order)
+        self.assertGreater(sub_sub_class_order, sub_class_order)
+        self.assertGreater(sub_class_order, parent_order)
 
         expected_result = [(0, 'activity'), (0, 'Address'), (0, 'agent'), (0, 'AnyObject'), 
                            (0, 'class with spaces'), (1, 'subclass test'), (2, 'Sub sub class 2'), (2, 'tub sub class 1'),

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -182,13 +182,13 @@ class DocGeneratorTestCase(unittest.TestCase):
         
         self.assertGreater(sub_sub_class_order, sub_class_order, parent_order)
 
-        expected_result = [(0, 'agent'), (0, 'activity'), (0, 'AnyObject'), (0, 'class with spaces'), 
-                           (1, 'subclass test'), (2, 'sub subclass test'), (0, 'FakeClass'), 
-                           (0, 'Dataset'), (0, 'CodeSystem'), (0, 'WithLocation'), (0, 'Relationship'), 
-                           (1, 'FamilialRelationship'), (0, 'Event'), (1, 'MarriageEvent'), (1, 'MedicalEvent'), 
-                           (1, 'EmploymentEvent'), (1, 'BirthEvent'), (0, 'Concept'), (1, 'ProcedureConcept'), 
-                           (1, 'DiagnosisConcept'), (0, 'Address'), (0, 'Place'), (0, 'Organization'), 
-                           (1, 'Company'), (0, 'Person'), (0, 'Friend'), (0, 'HasAliases')]
+        expected_result = [(0, 'activity'), (0, 'Address'), (0, 'agent'), (0, 'AnyObject'), 
+                           (0, 'class with spaces'), (1, 'subclass test'), (2, 'sub subclass test'), 
+                           (0, 'CodeSystem'), (0, 'Concept'), (1, 'ProcedureConcept'), (1, 'DiagnosisConcept'), 
+                           (0, 'Dataset'), (0, 'Event'), (1, 'MarriageEvent'), (1, 'MedicalEvent'), 
+                           (1, 'EmploymentEvent'), (1, 'BirthEvent'), (0, 'FakeClass'), (0, 'Friend'), (0, 'HasAliases'), 
+                           (0, 'Organization'), (1, 'Company'), (0, 'Person'), (0, 'Place'), (0, 'Relationship'), 
+                           (1, 'FamilialRelationship'), (0, 'WithLocation')]
                            
         self.assertCountEqual(actual_result, expected_result)
         


### PR DESCRIPTION
There is no inherent sorting mechanism followed by `class_hierarchy_as_tuples()`. This PR seeks to add a default alphabetical sorting strategy to the method.