### PR TITLE
Adding SchemaFixer, this is a general purpose utility for enhancing schemas. Includes:

### DIFF
--- a/linkml/utils/schema_builder.py
+++ b/linkml/utils/schema_builder.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass, field
 from typing import Union, List, Dict
 
-from linkml_runtime.linkml_model import SchemaDefinition, ClassDefinition, SlotDefinition, Prefix
-
-
-# TODO: move to linkml_runtime
+from linkml_runtime.linkml_model import SchemaDefinition, ClassDefinition, SlotDefinition, Prefix, PermissibleValue, \
+    EnumDefinition
+from linkml_runtime.utils.formatutils import camelcase, underscore
 
 
 @dataclass
@@ -12,11 +11,18 @@ class SchemaBuilder:
     """
     Builder class for SchemaDefinitions
     """
-    schema: SchemaDefinition = field(default_factory=lambda: SchemaDefinition(id='http://example.org/test/',
-                                                                              name='test-schema'))
+    name: str = None
+    schema: SchemaDefinition = None
+
+    def __post_init__(self):
+        name = self.name
+        if name is None:
+            name = 'test-schema'
+        self.schema = SchemaDefinition(id=f'http://example.org/{name}',
+                                       name=name)
 
     def add_class(self, cls: Union[ClassDefinition, str], slots: List[Union[str, SlotDefinition]] = None,
-                  slot_usage: Dict[str, SlotDefinition] = None, **kwargs) -> "SchemaBuilder":
+                  slot_usage: Dict[str, SlotDefinition] = None, use_attributes=False, **kwargs) -> "SchemaBuilder":
         """
         Adds a class to the schema
 
@@ -24,17 +30,24 @@ class SchemaBuilder:
         :param slots:
         :param slot_usage:
         :param kwargs:
-        :return:
+        :return: builder
         """
         if not isinstance(cls, ClassDefinition):
             cls = ClassDefinition(cls)
         self.schema.classes[cls.name] = cls
-        if slots is not None:
+        if use_attributes:
             for s in slots:
-                self.add_slot(s, cls.name)
-        if slot_usage:
-            for k, v in slot_usage.items():
-                cls.slot_usage[k] = v
+                if isinstance(s, SlotDefinition):
+                    cls.attributes[s.name] = s
+                else:
+                    raise ValueError(f'If use_attributes=True then slots must be SlotDefinitions')
+        else:
+            if slots is not None:
+                for s in slots:
+                    self.add_slot(s, cls.name)
+            if slot_usage:
+                for k, v in slot_usage.items():
+                    cls.slot_usage[k] = v
         for k, v in kwargs.items():
             setattr(cls, k, v)
         return self
@@ -45,7 +58,7 @@ class SchemaBuilder:
 
         :param slot:
         :param class_name: if specified, this will become a valid slot for the class
-        :return:
+        :return: builder
         """
         if isinstance(slot, str):
             slot = SlotDefinition(slot)
@@ -62,34 +75,59 @@ class SchemaBuilder:
 
         :param slot_name:
         :param kwargs:
-        :return:
+        :return: builder
         """
         slot = self.schema.slots[slot_name]
         for k, v in kwargs.items():
             setattr(slot, k, v)
         return self
 
-    def add_prefix(self, prefix: str, url: str):
+    def add_enum(self, enum_def: Union[EnumDefinition, str], permissible_values: List[Union[str, PermissibleValue]] = None
+                  ) -> "SchemaBuilder":
+        """
+        Adds an enum to the schema
+
+        :param enum_def:
+        :param permissible_values:
+        :return: builder
+        """
+        if not isinstance(enum_def, EnumDefinition):
+            enum_def = EnumDefinition(enum_def)
+        self.schema.enums[enum_def.name] = enum_def
+        if permissible_values is not None:
+            for pv in permissible_values:
+                if isinstance(pv, str):
+                    pv = PermissibleValue(text=pv)
+                    enum_def.permissible_values[pv.text] = pv
+        return self
+
+    def add_prefix(self, prefix: str, url: str) -> "SchemaBuilder":
         """
         Adds a prefix for use with CURIEs
 
         :param prefix:
         :param url:
-        :return:
+        :return: builder
         """
         obj = Prefix(prefix_prefix=prefix, prefix_reference=url)
         self.schema.prefixes[obj.prefix_prefix] = obj
+        return self
 
-    def add_defaults(self):
+    def add_defaults(self) -> "SchemaBuilder":
         """
         Sets defaults, including:
 
         - default_range
         - default imports to include linkml:types
         - default prefixes
+
+        :return: builder
         """
+        name = underscore(self.schema.name)
+        uri = self.schema.id
         self.schema.default_range = "string"
-        self.schema.default_prefix = "ex"
+        self.schema.default_prefix = name
         self.schema.imports.append("linkml:types")
         self.add_prefix("linkml", "https://w3id.org/linkml/")
-        self.add_prefix("ex", "https://example.org/test/")
+        self.add_prefix(name, f"{uri}/")
+        return self

--- a/linkml/utils/schema_fixer.py
+++ b/linkml/utils/schema_fixer.py
@@ -1,0 +1,210 @@
+import re
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import List, Callable
+
+from linkml_runtime import SchemaView
+from linkml_runtime.dumpers import json_dumper
+from linkml_runtime.linkml_model import SchemaDefinition, ClassDefinition, ClassDefinitionName, SlotDefinition
+
+
+pattern = re.compile(r'(?<!^)(?=[A-Z])')
+
+def uncamel(n: str) -> str:
+    return pattern.sub(' ', n)
+
+
+@dataclass
+class SchemaFixer:
+    """
+    Multiple methods for adding additional information to schemas
+    """
+    history: List[str] = None
+
+    def add_titles(self, schema: SchemaDefinition):
+        """
+        Add titles to all elements if not present.
+
+        Title will be generated from the name, expanding CamelCase => Camel Case,
+        and replacing underscores with spaces.
+
+        :param schema: input schema, will be modified in place
+        :return:
+        """
+        sv = SchemaView(schema)
+        for e in sv.all_elements().values():
+            if e.title is not None:
+                continue
+            title = e.name.replace('_', ' ')
+            title = uncamel(title).lower()
+            e.title = title
+            self._add_history(f'added title {title} to {e.name}')
+
+
+    def add_container(self, schema: SchemaDefinition, class_name: str = 'Container',
+                      force: bool = False, **kwargs) -> ClassDefinition:
+        """
+        Adds a container class
+
+        Also wraps :ref:`add_index_slots`
+
+        :param schema: input schema, will be modified in place
+        :param class_name: name for container
+        :param force: if true, force adding a container, even if present
+        :return: container class
+        """
+        sv = SchemaView(schema)
+        tree_roots = [c for c in sv.all_classes().values() if c.tree_root]
+        if len(tree_roots) > 0:
+            if force:
+                logging.info(f'Forcing addition of containers')
+            else:
+                raise ValueError(f'Schema already has containers: {tree_roots}')
+        container = ClassDefinition(class_name, tree_root=True)
+        sv.add_class(container)
+        self._add_history(f'added container {container.name}')
+        self.add_index_slots(schema, container.name, **kwargs)
+        return container
+
+
+    def add_index_slots(self, schema: SchemaDefinition, container_name: ClassDefinitionName, inlined_as_list = False,
+                        must_have_identifier=False, slot_name_func: Callable = None, convert_camel_case=False) -> List[SlotDefinition]:
+        """
+        Adds index slots to a container pointing at all top-level classes
+
+        :param schema: input schema, will be modified in place
+        :param container_name:
+        :param inlined_as_list:
+        :param must_have_identifier:
+        :param slot_name_func: function to determine the name of the slot from the class
+        :return: new slots
+        """
+        sv = SchemaView(schema)
+        container = sv.get_class(container_name)
+        ranges = set()
+        for cn in sv.all_classes():
+            for s in sv.class_induced_slots(cn):
+                ranges.add(s.range)
+        top_level_classes = [c for c in sv.all_classes().values() if not c.tree_root and c.name not in ranges]
+        if must_have_identifier:
+            top_level_classes = [c for c in top_level_classes if sv.get_identifier_slot(c.name) is not None]
+        index_slots = []
+        for c in top_level_classes:
+            has_identifier = sv.get_identifier_slot(c.name)
+            if slot_name_func:
+                sn = slot_name_func(c)
+            else:
+                cn = c.name
+                if convert_camel_case:
+                    cn = uncamel(cn).lower()
+                cn = cn.replace(' ', '_')
+                sn = f'{cn}_index'
+            index_slot = SlotDefinition(sn,
+                                        range=c.name,
+                                        multivalued=True,
+                                        inlined_as_list=not has_identifier or inlined_as_list)
+            index_slots.append(index_slot)
+            schema.slots[index_slot.name] = index_slot
+            container.slots.append(index_slot.name)
+            self._add_history(f'Adding container slot: {index_slot.name}')
+        return index_slots
+
+    def attributes_to_slots(self, schema: SchemaDefinition, remove_redundant_slot_usage=True) -> None:
+        """
+        Convert all attributes to slots
+
+        :param schema:
+        :param remove_redundant_slot_usage:
+        :return:
+        """
+        sv = SchemaView(schema)
+        new_slots = []
+        for c in sv.all_classes().values():
+            for a in c.attributes:
+                new_slots.append(a)
+                self.merge_slot_usage(sv, c, a)
+                del c.attributes[a.name]
+        for slot in new_slots:
+            if slot.name in sv.all_slots():
+                raise ValueError(f'Duplicate slot {slot.name}')
+            sv.add_slot(slot)
+            self._add_history(f'Adding slot from attribute: {slot.name}')
+        if remove_redundant_slot_usage:
+            self.remove_redundant_slot_usage(schema)
+
+    def merge_slot_usage(self, sv: SchemaView, cls: ClassDefinition, slot: SlotDefinition, overwrite=False):
+        """
+        Merge a SlotDefinition into the class_usage for a class
+
+        If the class has no slot usage defined for that slot, then the class usage
+        will be set to the input slot
+
+        otherwise, each metaslot will be individually merged
+
+        :param sv:
+        :param cls:
+        :param slot:
+        :param overwrite: if True then overwrite conflicting values rather than raising error
+        :return:
+        """
+        if slot.name not in cls.slot_usage:
+            cls.slot_usage[slot.name] = slot
+        else:
+            su = cls.slot_usage[slot.name]
+            for k, v in vars(slot).items():
+                if v is not None and v != [] and v != {}:
+                    curr_v = getattr(su, k, None)
+                    if not overwrite and curr_v and curr_v != v:
+                        raise ValueError(f'Conflict in {cls.name}.{slot.name}, attr {k} {v} != {curr_v}')
+                    setattr(su, k, v)
+            self._add_history(f'Merged slot usage: {slot.name}')
+
+    def remove_redundant_slot_usage(self, schema: SchemaDefinition, class_name: ClassDefinitionName = None):
+        """
+        Remove parts of slot_usage that can be inferred
+
+        :param schema:
+        :param class_name:
+        :return:
+        """
+        sv = SchemaView(schema)
+        if class_name is None:
+            for class_name in sv.all_classes():
+                self.remove_redundant_slot_usage(schema, class_name)
+        else:
+            cls = sv.get_class(class_name)
+            for sn, slot in cls.slot_usage.items():
+                del cls.slot_usage[sn]
+                sv.set_modified()
+                induced_slot = sv.induced_slot(sn, class_name)
+                cls.slot_usage[sn] = slot
+                sv.set_modified()
+                to_delete = []
+                for metaslot_name, metaslot in vars(slot).items():
+                    if metaslot_name == 'name':
+                        continue
+                    v = getattr(slot, metaslot_name, None)
+                    induced_v = getattr(induced_slot, metaslot_name, None)
+                    if v is not None and v != [] and v != {} and v == induced_v:
+                        logging.info(f'REDUNDANT: {class_name}.{sn}[{metaslot_name}] = {v}')
+                        to_delete.append(metaslot_name)
+                for metaslot_name in to_delete:
+                    del slot[metaslot_name]
+                    self._add_history(f'Removed redundant: {class_name}.slot_usage[{sn}].[{metaslot_name}]')
+            empty_keys = []
+            for sn, slot in cls.slot_usage.items():
+                metaslot_keys = list(json_dumper.to_dict(slot).keys())
+                if metaslot_keys == [] or metaslot_keys == ['name']:
+                    empty_keys.append(sn)
+            for k in empty_keys:
+                del cls.slot_usage[k]
+
+
+    def remove_unused_prefixes(self, schema: SchemaDefinition):
+        raise NotImplementedError
+
+    def _add_history(self, txt: str):
+        if self.history is None:
+            self.history = []
+        self.history.append(txt)

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -1,0 +1,40 @@
+import unittest
+
+from linkml_runtime.dumpers import yaml_dumper
+
+from linkml.utils.schema_builder import SchemaBuilder
+
+MY_CLASS = 'MyClass'
+MY_ENUM = 'MyEnum'
+FULL_NAME = "full name"
+DESC = "description"
+LIVING = "Living"
+DEAD = "Dead"
+
+
+class SchemaBuilderTestCase(unittest.TestCase):
+    """
+    Tests SchemaBuilder
+    """
+
+    def test_build_schema(self):
+        """
+        test a minimal schema with no primary names declared
+        """
+        b = SchemaBuilder()
+        slots = [FULL_NAME, DESC]
+        b.add_class(MY_CLASS, slots)
+        b.add_enum(MY_ENUM, [LIVING, DEAD])
+        s = b.schema
+        c = s.classes[MY_CLASS]
+        e = s.enums[MY_ENUM]
+        self.assertEqual(c.name, MY_CLASS)
+        self.assertCountEqual(slots, c.slots)
+        self.assertEqual(e.name, MY_ENUM)
+        self.assertCountEqual([LIVING, DEAD], e.permissible_values)
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils/test_schema_fixer.py
+++ b/tests/test_utils/test_schema_fixer.py
@@ -1,0 +1,177 @@
+import unittest
+from copy import deepcopy
+
+from linkml_runtime.dumpers import yaml_dumper
+from linkml_runtime.linkml_model import SlotDefinitionName
+
+from linkml.utils.schema_builder import SchemaBuilder
+from linkml.utils.schema_fixer import SchemaFixer
+from tests.output.meta import SlotDefinition
+
+MY_CLASS = 'MyClass'
+MY_CLASS2 = 'MyClass2'
+MY_ENUM = 'MyEnum'
+ID = 'id'
+FULL_NAME = "full_name"
+DESC = "description"
+LIVING = "Living"
+DEAD = "Dead"
+
+
+class SchemaFixerTestCase(unittest.TestCase):
+    """
+    Tests SchemaFixer
+    """
+
+    def test_add_titles(self):
+        b = SchemaBuilder()
+        slots = [FULL_NAME, DESC]
+        b.add_class(MY_CLASS, slots)
+        b.add_enum(MY_ENUM, [LIVING, DEAD])
+        s = b.schema
+        fixer = SchemaFixer()
+        fixer.add_titles(s)
+        print(fixer.history)
+        print(yaml_dumper.dumps(s))
+        c = s.classes[MY_CLASS]
+        e = s.enums[MY_ENUM]
+        self.assertEqual(c.title, 'my class')
+        self.assertEqual(e.title, 'my enum')
+        self.assertEqual(s.slots[FULL_NAME].title, 'full name')
+
+    def test_add_container(self):
+        b = SchemaBuilder()
+        slots = [FULL_NAME, DESC]
+        b.add_class(MY_CLASS, slots)
+        s = b.schema
+        fixer = SchemaFixer()
+        container_name = 'MyContainer'
+        fixer.add_container(s, class_name=container_name, convert_camel_case=True)
+        c = s.classes[container_name]
+        index_slot_name = SlotDefinitionName('my_class_index')
+        self.assertCountEqual([index_slot_name], c.slots)
+        self.assertTrue(c.tree_root)
+        index_slot = s.slots[index_slot_name]
+        self.assertTrue(index_slot.multivalued)
+        self.assertEqual(MY_CLASS, index_slot.range)
+        self.assertTrue(index_slot.inlined_as_list)
+
+
+    def test_attributes_to_slots(self):
+        b = SchemaBuilder()
+        b.add_class(MY_CLASS, [SlotDefinition(FULL_NAME),
+                               SlotDefinition(DESC)])
+        s = b.schema
+        fixer = SchemaFixer()
+        fixer.attributes_to_slots(s, remove_redundant_slot_usage=False)
+        print(fixer.history)
+        print(yaml_dumper.dumps(s))
+        c = s.classes[MY_CLASS]
+        self.assertCountEqual([FULL_NAME, DESC], c.slots)
+        self.assertEqual({}, c.attributes)
+        self.assertEqual(s.slots[FULL_NAME].name, FULL_NAME)
+        self.assertEqual(s.slots[DESC].name, DESC)
+
+
+    def test_merge_slot_usage(self):
+        b = SchemaBuilder()
+        b.add_class(MY_CLASS)
+        s = b.schema
+        fixer = SchemaFixer()
+        c = s.classes[MY_CLASS]
+        fixer.merge_slot_usage(s,
+                               c,
+                               SlotDefinition(FULL_NAME,
+                                              description='desc1',
+                                              range='string'))
+        print(yaml_dumper.dumps(s))
+        su = c.slot_usage[FULL_NAME]
+        self.assertEqual('desc1', su.description)
+        self.assertEqual('string', su.range)
+        fixer.merge_slot_usage(s,
+                               c,
+                               SlotDefinition(FULL_NAME,
+                                              #description='desc2',
+                                              comments=['comment1'],
+                                              is_a='foo',
+                                              range='string'))
+        print(yaml_dumper.dumps(s))
+        su = c.slot_usage[FULL_NAME]
+        with self.assertRaises(ValueError):
+            fixer.merge_slot_usage(s,
+                                   c,
+                                   SlotDefinition(FULL_NAME,
+                                                  description='desc2'))
+        self.assertEqual('desc1', su.description)
+        fixer.merge_slot_usage(s,
+                               c,
+                               SlotDefinition(FULL_NAME,
+                                              description='desc2'),
+                               overwrite=True)
+        print(yaml_dumper.dumps(s))
+        su = c.slot_usage[FULL_NAME]
+        self.assertEqual('desc2', su.description)
+
+
+    def test_remove_redundant(self):
+        b = SchemaBuilder()
+        s = b.schema
+        s.default_range = 'string'
+        slot1 = SlotDefinition(ID,
+                               title='identifier',
+                               description='unique identifier')
+        slot2 = SlotDefinition(FULL_NAME,
+                               description='full name',
+                               range='string')
+        slot3 = SlotDefinition(DESC,
+                               description='used to describe')
+        b.add_class(MY_CLASS,
+                    [slot1.name, slot2.name, slot3.name])
+        c = s.classes[MY_CLASS]
+        c.slot_usage[ID] = SlotDefinition(ID, identifier=True, comments=['my comment1'], description='unique identifier')
+        c.slot_usage[FULL_NAME] = SlotDefinition(FULL_NAME, range='string', description='full name', pattern='^.*$')
+        c.slot_usage[DESC] = SlotDefinition(DESC, range='string')
+        b.add_slot(deepcopy(slot1)).add_slot(deepcopy(slot2))
+        fixer = SchemaFixer()
+        fixer.remove_redundant_slot_usage(s)
+        self.assertEqual(c.slot_usage[ID].identifier, True)
+        self.assertEqual(c.slot_usage[ID].comments, ['my comment1'])
+        self.assertEqual(c.slot_usage[FULL_NAME].pattern, '^.*$')
+        self.assertNotIn(DESC, c.slot_usage)
+        self.assertNotIn('description', c.slot_usage[ID])
+        self.assertNotIn('range', c.slot_usage[FULL_NAME])
+
+
+    def test_attributes_to_slots_remove_redundant(self):
+        b = SchemaBuilder()
+        b.add_class(MY_CLASS, [SlotDefinition(ID,
+                                              identifier=True),
+                               SlotDefinition(FULL_NAME,
+                                              description='full name',
+                                              range='string'),
+                               SlotDefinition(DESC,
+                                              description='description')])
+        b.add_class(MY_CLASS2, [SlotDefinition(FULL_NAME,
+                                               description='full name2',
+                                               range='string'),
+                                SlotDefinition(DESC,
+                                               description='description')])
+        s = b.schema
+        fixer = SchemaFixer()
+        fixer.attributes_to_slots(s, remove_redundant_slot_usage=True)
+        print(fixer.history)
+        print(yaml_dumper.dumps(s))
+        c = s.classes[MY_CLASS]
+        self.assertCountEqual([ID, FULL_NAME, DESC], c.slots)
+        self.assertEqual({}, c.attributes)
+        self.assertEqual(s.slots[FULL_NAME].name, FULL_NAME)
+        self.assertEqual(s.slots[DESC].name, DESC)
+
+
+
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- add titles by de-camelify-snakifying names
- add a default container class
- add index slots
- convert slots to attributes
- remove redundant slot usage

This library will grow to include common checks as well, and can be seen
as an analog of flake8/black.

TBD: move into its own repo?
