### PR TITLE
Adding sort-by option, allowing for sorting by rank

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -5,7 +5,6 @@
 {%- endif -%}
 
 
-
 {% if element.description %}
 _{{ element.description }}_
 {% endif %}
@@ -63,10 +62,10 @@ URI: {{ gen.uri_link(element) }}
 
 ## Slots
 
-| Name | Range | Cardinality | Description  | Info |
-| ---  | --- | --- | --- | --- |
+| Name | Cardinality and Range  | Description  |
+| ---  | ---  | --- |
 {% for s in schemaview.class_induced_slots(element.name) -%}
-| {{gen.link(s)}} | {{gen.link(s.range)}} | {{ gen.cardinality(s) }} | {{s.description}}  | . |
+| {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{gen.link(s.range)}}  | {{s.description|enshorten}}  |
 {% endfor %}
 
 ## Usages

--- a/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/linkml/generators/docgen/common_metadata.md.jinja2
@@ -1,3 +1,19 @@
+{% if element.comments -%}
+## Comments
+
+{% for x in element.comments -%}
+* {{x}}
+{% endfor %}
+{% endif -%}
+
+{% if element.todos -%}
+## TODOs
+
+{% for x in element.todos -%}
+* {{x}}
+{% endfor %}
+{% endif -%}
+
 ## Identifier and Mapping Information
 
 {% if element.id_prefixes %}

--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -9,7 +9,7 @@ URI: {{ gen.uri(element) }}
 | Value | Meaning | Description | Info |
 | --- | --- | --- | --- |
 {% for pv in element.permissible_values.values() -%}
-| {{pv.text}} | {{pv.meaning}} | {{pv.description}} | |
+| {{pv.text}} | {{pv.meaning}} | {{pv.description|enshorten}} | |
 {% endfor %}
 
 {% include "common_metadata.md.jinja2" %}

--- a/linkml/generators/docgen/index.md.jinja2
+++ b/linkml/generators/docgen/index.md.jinja2
@@ -9,24 +9,32 @@ Name: {{ schema.name }}
 
 | Class | Description |
 | --- | --- |
-{% for c in schemaview.all_classes().values()|sort(attribute='name') -%}
-| {{gen.link(c)}} | {{c.description}} |
+{% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
+| {{gen.link(c)}} | {{c.description|enshorten}} |
 {% endfor %}
 
 ## Slots
 
 | Slot | Description |
 | --- | --- |
-{% for s in schemaview.all_slots().values()|sort(attribute='name') -%}
-| {{gen.link(s)}} | {{s.description}} |
+{% for s in gen.all_slot_objects()|sort(attribute=sort_by) -%}
+| {{gen.link(s)}} | {{s.description|enshorten}} |
 {% endfor %}
 
 ## Enumerations
 
 | Enumeration | Description |
 | --- | --- |
-{% for e in schemaview.all_enums().values()|sort(attribute='name') -%}
-| {{gen.link(e)}} | {{e.description}} |
+{% for e in gen.all_enum_objects()|sort(attribute=sort_by) -%}
+| {{gen.link(e)}} | {{e.description|enshorten}} |
+{% endfor %}
+
+## Types
+
+| Type | Description |
+| --- | --- |
+{% for t in gen.all_type_objects()|sort(attribute=sort_by) -%}
+| {{gen.link(t)}} | {{t.description|enshorten}} |
 {% endfor %}
 
 ## Subsets
@@ -34,5 +42,5 @@ Name: {{ schema.name }}
 | Subset | Description |
 | --- | --- |
 {% for ss in schemaview.all_subsets().values()|sort(attribute='name') -%}
-| {{gen.link(ss)}} | {{ss.description}} |
+| {{gen.link(ss)}} | {{ss.description|enshorten}} |
 {% endfor %}

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -1,9 +1,59 @@
 # {{ gen.name(element) }}
 
+{%- if header -%}
+{{header}}
+{%- endif -%}
+
+{% if element.description %}
 {{ element.description }}
-
-URI: {{ gen.uri(element) }}
-
+{% endif %}
 
 {% include "common_metadata.md.jinja2" %}
+
+## Classes in subset
+
+| Class | Description |
+| --- | --- |
+{% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
+{%- if element.name in c.in_subset -%}
+| {{gen.link(c)}} | {{c.description|enshorten}} |
+{% endif -%}
+{% endfor %}
+
+{% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
+{%- if element.name in c.in_subset -%}
+### {{ gen.name(c) }}
+
+{{c.description}}
+
+| Name | Cardinality and Range  | Description  |
+| ---  | ---  | --- |
+{% for s in gen.class_induced_slots(c.name)|sort(attribute=sort_by) -%}
+{% if element.name in s.in_subset or element.name in schemaview.get_slot(s.name).in_subset -%}
+| {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{gen.link(s.range)}}  | {{s.description|enshorten}} {% if s.identifier %}**identifier**{% endif %}  |
+{% endif -%}
+{% endfor %}
+
+{% endif -%}
+{% endfor %}
+
+## Slots in subset
+
+| Slot | Description |
+| --- | --- |
+{% for s in gen.all_slot_objects()|sort(attribute=sort_by) -%}
+{%- if element.name in s.in_subset -%}
+| {{gen.link(s)}} | {{s.description|enshorten}} |
+{% endif -%}
+{% endfor %}
+
+## Enumerations in subset
+
+| Enumeration | Description |
+| --- | --- |
+{% for e in schemaview.all_enums().values()|sort(attribute='name') -%}
+{%- if element.name in e.in_subset -%}
+| {{gen.link(e)}} | {{e.description|enshorten}} |
+{% endif -%}
+{% endfor %}
 

--- a/linkml/generators/docgen/type.md.jinja2
+++ b/linkml/generators/docgen/type.md.jinja2
@@ -5,8 +5,9 @@
 URI: {{ gen.uri(element) }}
 
 {{ gen.bullet(element, "base") }}
-{{ gen.bullet(element, "type_uri") }}
+{{ gen.bullet(element, "uri") }}
 {{ gen.bullet(element, "repr") }}
+{{ gen.bullet(element, "typeof") }}
 {{ gen.bullet(element, "pattern", backquote=True) }}
 {% if gen.number_value_range(element) %}
 * Numeric Value Range: {{gen.number_value_range(element)}}

--- a/tests/test_generators/input/core.yaml
+++ b/tests/test_generators/input/core.yaml
@@ -57,9 +57,11 @@ slots:
 
   id:
     identifier: true
+    rank: 1
 
   name:
     required: false
+    rank: 2
 
   description:
   

--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -44,13 +44,18 @@ see_also:
 subsets:
 
   subset A:
-    description: >-
+    rank: 2
+    description: |-
       test subset A
+
+      This is a subset for testing
     comments:
       - this subset is meaningless, it is just here for testing
+      - another comment
     aliases:
       - A
   subset B:
+    rank: 1
     description: >-
       test subset B
     aliases:
@@ -71,6 +76,7 @@ classes:
       - name
 
   Person:
+    rank: 2
     description: A person, living or dead
     in_subset:
       - subset A
@@ -94,6 +100,20 @@ classes:
       - schema:Person
 
   Organization:
+    rank: 3
+    description: |-
+      An organization.
+
+      This description
+      includes newlines
+
+      ## Markdown headers
+
+       * and
+       * a
+       * list
+
+
     mixins:
       - HasAliases
     slots:
@@ -145,6 +165,7 @@ classes:
       - type
 
   FamilialRelationship:
+    rank: 5
     is_a: Relationship
     slot_usage:
       type:
@@ -160,6 +181,7 @@ classes:
       - in location
 
   EmploymentEvent:
+    rank: 6
     is_a: Event
     slots:
       - employed at
@@ -203,6 +225,7 @@ classes:
 
   Dataset:
     tree_root: true
+    rank: 1
     attributes:
       persons:
         range: Person
@@ -259,6 +282,7 @@ slots:
   is current:
     range: boolean
   has employment history:
+    rank: 7
     range: EmploymentEvent
     multivalued: true
     inlined_as_list: true
@@ -271,6 +295,7 @@ slots:
     in_subset:
       - subset B
   has medical history:
+    rank: 5
     range: MedicalEvent
     multivalued: true
     inlined_as_list: true

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -1,22 +1,28 @@
 import logging
 import os
 import unittest
-from contextlib import redirect_stdout
 from copy import copy
 from typing import List
 
+from linkml_runtime.utils.introspection import package_schemaview
+
 from linkml.generators.docgen import DocGenerator
-from linkml.generators.markdowngen import MarkdownGenerator
 from tests.test_generators.environment import env
 
 SCHEMA = env.input_path('kitchen_sink.yaml')
 LATEX_DIR = env.expected_path('kitchen_sink_tex')
 MD_DIR = env.expected_path('kitchen_sink_md')
+META_MD_DIR = env.expected_path('meta_md')
 MD_DIR2 = env.expected_path('kitchen_sink_md2')
 HTML_DIR = env.expected_path('kitchen_sink_html')
 
+
+def assert_mdfile_does_not_contain(*args, **kwargs) -> None:
+    assert_mdfile_contains(*args, **kwargs, invert=True)
+
+
 def assert_mdfile_contains(filename, text, after:str =None, followed_by: List[str]=None,
-                           outdir=MD_DIR) -> None:
+                           outdir=MD_DIR, invert=False) -> None:
     found = False
     is_after = False  ## have we reached the after mark?
     with open(os.path.join(outdir, filename)) as stream:
@@ -36,15 +42,19 @@ def assert_mdfile_contains(filename, text, after:str =None, followed_by: List[st
                         if len(todo) > 0 and todo[0] in subsequent_line:
                             todo = todo[1:]
                     if len(todo) > 0:
-                        logging.error(f'Did not find: {todo}')
-                        assert False
+                        if not invert:
+                            logging.error(f'Did not find: {todo}')
+                        assert invert
                     else:
                         return
             if after is not None and after in line:
                 is_after = True
-    if not found:
+    if not found and not invert:
         logging.error(f'Failed to find {text} in {filename}')
-    assert found
+    if invert:
+        assert not found
+    else:
+        assert found
 
 class DocGeneratorTestCase(unittest.TestCase):
 
@@ -69,6 +79,14 @@ class DocGeneratorTestCase(unittest.TestCase):
         assert_mdfile_contains('Organization.md',
                                'slot_uri: skos:altLabel',
                                after='Induced')
+        # test truncating newlines
+        assert_mdfile_contains('index.md',
+                               'An organization',
+                               after='## Classes',
+                               followed_by=['## Slots'])
+        # this should be truncated
+        assert_mdfile_does_not_contain('index.md',
+                                       'Markdown headers')
         # test mermaid
         assert_mdfile_contains('Organization.md',
                                '```mermaid',
@@ -123,6 +141,15 @@ class DocGeneratorTestCase(unittest.TestCase):
         assert_mdfile_contains('index.md',
                                'a provence-generating activity',
                                after='Classes')
+        # test default ordering (currently name)
+        assert_mdfile_contains('index.md',
+                               'Agent',
+                               after='Activity',
+                               followed_by=['Company', 'Dataset', 'MedicalEvent', 'Organization'])
+        assert_mdfile_contains('index.md',
+                               'addresses',
+                               after='activities',
+                               followed_by=['ceo', 'city', 'diagnosis', 'persons'])
 
         # test subset docs
         assert_mdfile_contains('SubsetA.md',
@@ -138,6 +165,50 @@ class DocGeneratorTestCase(unittest.TestCase):
                                'Range: [Person](Person.md)',
                                after='Properties')
         # TODO: external links
+
+    def test_docgen_rank_ordering(self):
+        """ Tests overriding default order  """
+        gen = DocGenerator(SCHEMA, mergeimports=True, no_types_dir=True, sort_by='rank')
+        md = gen.serialize(directory=MD_DIR)
+        # test rank ordering
+        assert_mdfile_contains('index.md',
+                               'Person',
+                               after='Dataset',
+                               followed_by=['Organization', 'FamilialRelationship', 'EmploymentEvent', 'ClassWithSpaces'])
+        assert_mdfile_contains('index.md',
+                               '[name]',
+                               after='[id]',
+                               followed_by=['has_medical_history', 'has_employment_history', 'test_attribute'])
+
+    def test_gen_metamodel(self):
+        """ Tests generation of docs for metamodel """
+        metamodel_sv = package_schemaview('linkml_runtime.linkml_model.meta')
+        gen = DocGenerator(
+            metamodel_sv.schema,
+            mergeimports=True,
+            no_types_dir=True,
+            genmeta=True
+        )
+        gen.serialize(directory=META_MD_DIR)
+        assert_mdfile_contains('index.md',
+                               'ClassDefinition',
+                               after='## Classes',
+                               followed_by=['## Slots'],
+                               outdir=META_MD_DIR)
+        assert_mdfile_contains('index.md',
+                               'exact_mappings',
+                               after='## Slots',
+                               followed_by=['## Enumerations'],
+                               outdir=META_MD_DIR)
+        assert_mdfile_contains('index.md',
+                               'AliasPredicateEnum',
+                               after='## Enumerations',
+                               followed_by=['SeverityOptions'],
+                               outdir=META_MD_DIR)
+        assert_mdfile_contains('index.md',
+                               'String',
+                               after='## Types',
+                               outdir=META_MD_DIR)
 
     def test_myst_dialect(self):
         """


### PR DESCRIPTION
Adding an enshorten filter - this allows descriptions to be added
safely to tables. Previously newlines were breaking tables. This
eliminates all text after newline. It will also truncate the
description for inclusion in a table, and trim gloss after the period

Added tests for all of the above
