### PR TITLE
`inheritance_tree()` support for slot descendants

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -403,8 +403,12 @@ class DocGenerator(Generator):
         """
         s, depth = self._tree(element, focus=element.name, **kwargs)
         if children:
-            for c in self.schemaview.class_children(element.name, mixins=False):
-                s += self._tree_info(self.schemaview.get_class(c), depth + 1, **kwargs)
+            if isinstance(element, ClassDefinition):
+                all_children = self.schemaview.class_children(element.name, mixins=False)
+            else:
+                all_children = self.schemaview.slot_children(element.name, mixins=False)
+            for c in all_children:
+                s += self._tree_info(self.schemaview.get_element(c), depth + 1, **kwargs)
         return s
 
     def _tree(

--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -341,6 +341,16 @@ slots:
   metadata:
     range: AnyObject
     description: Example of a slot that has an unconstrained range
+  # slots added for inheritance tree purposes
+  tree_slot_A:
+  tree_slot_B:
+    is_a: tree_slot_A
+  tree_slot_C:
+    is_a: tree_slot_B
+    mixins: mixin_slot_I
+  mixin_slot_I:
+    mixin: true
+    
 
 enums:
   FamilialRelationshipType:

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -218,6 +218,11 @@ class DocGeneratorTestCase(unittest.TestCase):
             "ceo.md", "Range: [Person](Person.md)", after="Properties"
         )
         # TODO: external links
+        
+        # test slot hierarchy
+        assert_mdfile_contains(
+            "tree_slot_B.md", "tree_slot_C", after="tree_slot_B"
+        )
 
     def test_docgen_rank_ordering(self):
         """Tests overriding default order"""

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -271,7 +271,7 @@ class DocGeneratorTestCase(unittest.TestCase):
             "index.md",
             "AliasPredicateEnum",
             after="## Enumerations",
-            followed_by=["SeverityOptions"],
+            followed_by=["PvFormulaOptions"],
             outdir=META_MD_DIR,
         )
         assert_mdfile_contains(


### PR DESCRIPTION
Expand inheritance_tree() in docgen to show descendants for slots in addition to classes.