### PR TITLE
Fix 404 to the csvs.md page

### DIFF
--- a/docs/data/conversion.rst
+++ b/docs/data/conversion.rst
@@ -184,7 +184,7 @@ See `RDF <rdf.md>`__ for more details
 Loading from and dumping to CSVs
 --------------------------------
 
-See `CSVs <csvs.md>`__ for more details
+See `CSVs <./csvs.html>`__ for more details
 
 Inferring missing values
 ------------------------


### PR DESCRIPTION
Link under https://linkml.io/linkml/data/conversion.html?highlight=csvs#loading-from-and-dumping-to-csvs goes to https://linkml.io/linkml/data/csvs.md (not HTML)