### PR TITLE
Slot documentation pages with more detail

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -403,8 +403,12 @@ class DocGenerator(Generator):
         """
         s, depth = self._tree(element, focus=element.name, **kwargs)
         if children:
-            for c in self.schemaview.class_children(element.name, mixins=False):
-                s += self._tree_info(self.schemaview.get_class(c), depth + 1, **kwargs)
+            if isinstance(element, ClassDefinition):
+                all_children = self.schemaview.class_children(element.name, mixins=False)
+            else:
+                all_children = self.schemaview.slot_children(element.name, mixins=False)
+            for c in all_children:
+                s += self._tree_info(self.schemaview.get_element(c), depth + 1, **kwargs)
         return s
 
     def _tree(

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -20,9 +20,35 @@ URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 <!-- no inheritance hierarchy -->
 {% endif %}
 
+{% if schemaview.is_mixin(element.name) %}
+## Mixin Usage
+
+| mixed into | description | range | domain |
+| --- | --- | --- | --- |
+{% for s in schemaview.slot_children(element.name) -%}
+| {{ gen.link(s) }} | {{ schemaview.get_slot(s).description }} | {{ schemaview.get_slot(s).range }} | {{ schemaview.get_classes_by_slot(schemaview.get_slot(s))|join(', ') }} |
+{% endfor %}
+{% endif %}
+
 ## Properties
 
- * Range: {{gen.link(element.range)}}
+* Range: {{gen.link(element.range)}}
+* Multivalued: {{ element.multivalued }}
+{% if element.aliases %}
+* Aliases:
+    {% for alias in element.aliases -%}
+        * {{ alias }}
+{% endfor %}
+{% endif %}
+
+{% if element.required %}
+* Required: {{ element.required }}
+{% elif element.recommended %}
+* Recommended: {{ element.recommended }}
+{% endif %}
+{% if schemaview.is_mixin(element.name) %}
+* Mixin: {{ element.mixin }}
+{% endif %}
 
 {% if schemaview.usage_index().get(element.name) %}
 | used by | used in | type | used |
@@ -34,3 +60,14 @@ URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 
 {% include "common_metadata.md.jinja2" %}
 
+## LinkML Specification
+
+<details>
+```yaml
+{{ gen.yaml(element) }}
+```
+</details>
+
+{%- if footer -%}
+{{footer}}
+{%- endif -%}


### PR DESCRIPTION
- [ ] add more information under _Properties_ section of slot documentation pages, like multivalued, required, recommended, etc.
- [ ] if slot page is mixin, show helpful table with information about what slots it's mixed into, etc.
- [ ] In the NMDC Schema docs, we show the various classes that use a given slot. For example: https://microbiomedata.github.io/nmdc-schema/alkalinity/
  - [ ] Is that useful functionality in the main docgen templates? I can add it if is, if not, this PR is ready for review