### PR TITLE
Initialise `config_file` in linter cli

### DIFF
--- a/linkml/linter/cli.py
+++ b/linkml/linter/cli.py
@@ -47,6 +47,7 @@ def get_yaml_files(root: Path) -> Iterable[str]:
 @click.option("-o", "--output", type=click.File("w"), default="-")
 @click.option("--fix/--no-fix", default=False)
 def main(schema: Path, fix: bool, config: str, format: str, output):
+    config_file = None
     if config:
         config_file = config
     else:


### PR DESCRIPTION
Ensure that the `config_file` variable is initialised to avoid errors if no config file is present