### PR TITLE
Removed unecesssary commas

### DIFF
--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -48,9 +48,9 @@ class ContextGenerator(Generator):
     emit_metadata: bool = field(default_factory=lambda: False)
     model: Optional[bool] = field(default_factory=lambda: True)
     base: Optional[str] = None
-    output: Optional[str] = None,
-    prefixes: Optional[bool] = field(default_factory=lambda: True),
-    flatprefixes: Optional[bool] = field(default_factory=lambda: False),
+    output: Optional[str] = None
+    prefixes: Optional[bool] = field(default_factory=lambda: True)
+    flatprefixes: Optional[bool] = field(default_factory=lambda: False)
 
     def __post_init__(self) -> None:
         super().__post_init__()


### PR DESCRIPTION
This was causing syntax errors in `sssom-py` for python v3.7(only). It's an easy fix, hence this PR.
```
sssom/context.py:8: in <module>
[45](https://github.com/mapping-commons/sssom-py/actions/runs/3058905396/jobs/4935653655#step:8:46)
    from linkml.generators.jsonldcontextgen import ContextGenerator
[46](https://github.com/mapping-commons/sssom-py/actions/runs/3058905396/jobs/4935653655#step:8:47)
E     File "/home/runner/work/sssom-py/sssom-py/.tox/py/lib/python3.7/site-packages/linkml/generators/jsonldcontextgen.py", line 51
[47](https://github.com/mapping-commons/sssom-py/actions/runs/3058905396/jobs/4935653655#step:8:48)
E       output: Optional[str] = None,
[48](https://github.com/mapping-commons/sssom-py/actions/runs/3058905396/jobs/4935653655#step:8:49)
E                                   ^
[49](https://github.com/mapping-commons/sssom-py/actions/runs/3058905396/jobs/4935653655#step:8:50)
E   SyntaxError: invalid syntax
```