### PR TITLE
unify template changes from MIxS and NMDC

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -81,11 +81,19 @@ URI: {{ gen.uri_link(element) }}
 
 ## Slots
 
-| Name | Cardinality and Range  | Description  |
-| ---  | ---  | --- |
+| Name | Range | Cardinality | Description | Inheritance |
+| ---  | --- | --- | --- | --- |
 {% for s in schemaview.class_induced_slots(element.name) -%}
-| {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{gen.link(s.range)}}  | {{s.description|enshorten}}  |
-{% endfor %}
+{% if s.name in gen.get_direct_slots(element) -%}
+| {{gen.link(s)}} | {{gen.link(s.range)}} | {{ gen.cardinality(s) }} | {{ s.description }}  | direct |
+{% endif -%}
+{%- if s.name in gen.get_indirect_slots(element) -%}
+| {{gen.link(s)}} | {{gen.link(s.range)}} | {{ gen.cardinality(s) }} | {{ s.description }}  | inherited |
+{% endif -%}
+{%- if s.name in gen.get_mixin_inherited_slots(element).items() -%}
+| {{gen.link(s)}} | {{gen.link(s.range)}} | {{ gen.cardinality(s) }} | {{ s.description }}  | mixin |
+{% endif -%}
+{%- endfor %}
 
 ## Usages
 
@@ -113,7 +121,7 @@ URI: {{ gen.uri_link(element) }}
 | ---  | ---  |
 {% for m, mt in schemaview.get_mappings(element.name).items() -%}
 {% if mt|length > 0 -%}
-| {{ m }} | {{ mt }} |
+| {{ m }} | {{ mt }}|join(', ') |
 {% endif -%}
 {% endfor %}
 

--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -128,7 +128,7 @@ URI: {{ gen.uri_link(element) }}
 {% endif -%}
 
 
-## LinkML Specification
+## LinkML Source
 
 <!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
 

--- a/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/linkml/generators/docgen/common_metadata.md.jinja2
@@ -33,7 +33,9 @@ Instances of this class *should* have identifiers with one of the following pref
 | property | value |
 | --- | --- |
 {% for a in element.annotations -%}
-| {{a}} | {{ element.annotations[a].value }} |
+{% if a.first() == '_' -%}
+| {{ a }} | {{ element.annotations[a].value }} |
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -1,16 +1,18 @@
-# {{ gen.name(element) }}
+# Enum: {{ gen.name(element) }}
 
-{{ element.description }}
+{% if element.description %}
+_{{ element.description }}_
+{% endif %}
 
-URI: {{ gen.uri(element) }}
+URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 
 {% if element.permissible_values -%}
 ## Permissible Values
 
-| Value | Meaning | Description | Info |
-| --- | --- | --- | --- |
+| Value | Meaning | Description |
+| --- | --- | --- |
 {% for pv in element.permissible_values.values() -%}
-| {{pv.text}} | {{pv.meaning}} | {{pv.description|enshorten}} | |
+| {{pv.text}} | {{pv.meaning}} | {{pv.description|enshorten}} |
 {% endfor %}
 {% else %}
 _This is a dynamic enum_
@@ -18,7 +20,7 @@ _This is a dynamic enum_
 
 {% include "common_metadata.md.jinja2" %}
 
-## Schema
+## LinkML Source
 
 <details>
 ```yaml

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -60,7 +60,7 @@ URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 
 {% include "common_metadata.md.jinja2" %}
 
-## LinkML Specification
+## LinkML Source
 
 <details>
 ```yaml

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -36,7 +36,7 @@ URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 * Multivalued: {{ element.multivalued }}
 {% if element.aliases %}
 * Aliases:
-{% for alias in element.aliases -%}
+{% for alias in element.aliases %}
     * {{ alias }}
 {% endfor %}
 {% endif %}

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -1,12 +1,15 @@
-# {{ gen.name(element) }}
+# Subset: {{ gen.name(element) }}
 
 {%- if header -%}
 {{header}}
 {%- endif -%}
 
 {% if element.description %}
-{{ element.description }}
+_{{ element.description }}_
 {% endif %}
+
+URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
+
 
 {% include "common_metadata.md.jinja2" %}
 

--- a/linkml/generators/docgen/type.md.jinja2
+++ b/linkml/generators/docgen/type.md.jinja2
@@ -1,8 +1,10 @@
-# {{ gen.name(element) }}
+# Type: {{ gen.name(element) }}
 
-{{ element.description }}
+{% if element.description %}
+_{{ element.description }}_
+{% endif %}
 
-URI: {{ gen.uri(element) }}
+URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 
 {{ gen.bullet(element, "base") }}
 {{ gen.bullet(element, "uri") }}


### PR DESCRIPTION
This PR seeks to pull in jinja template changes from the [MIxS](https://github.com/GenomicsStandardsConsortium/mixs/tree/update-doc-templates/doc_templates) and [NMDC](https://github.com/microbiomedata/nmdc-schema/tree/slot-inheritance-docs/src/doc-templates) Schema documentation templates.
 
A summary of the changes:
* Add additional information to slot table on class documentation pages to show whether slot is a directly slot, inherited class, or a class inherited from a mixin
* Ignore mappings that start with underscore in common_metadata.md.jinja2 since it looks an internal variable, but I could be wrong
* Indicate name of element in header
* Hyperlink URIs where necessary