### PR TITLE
Remove sphinx_rtd_theme from extensions in docs config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.githubpages',
     'sphinx.ext.autosectionlabel',
-    'sphinx_rtd_theme',
     'sphinx_click',
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',


### PR DESCRIPTION
I like the new docs theme but this header permalink icon was driving me nuts:

<img width="529" alt="Screen Shot 2022-10-19 at 1 41 22 PM" src="https://user-images.githubusercontent.com/102547565/196799838-b3acf990-301b-49e1-a110-4539d42f8cb9.png">

Turns out there was a bit of leftover `sphinx_rtd_theme` setup left in the docs config that was causing it.