### PR TITLE
Fixing aliasing of rdf type.

### DIFF
--- a/linkml/utils/datautils.py
+++ b/linkml/utils/datautils.py
@@ -33,7 +33,7 @@ dumpers_loaders = {
 }
 
 aliases = {
-    "ttl": "rdf",
+    "rdf": "ttl",
     "jsonld": "json-ld",
 }
 
@@ -66,7 +66,7 @@ def _is_xsv(fmt: str) -> bool:
 
 
 def _is_rdf_format(fmt: str) -> bool:
-    return fmt == "rdf" or fmt == "ttl" or fmt == "json-ld"
+    return fmt == "rdf" or fmt == "ttl" or fmt == "turtle" or fmt == "json-ld"
 
 
 def get_loader(fmt: str) -> Loader:

--- a/tests/test_utils/test_converter.py
+++ b/tests/test_utils/test_converter.py
@@ -41,7 +41,7 @@ class TestCommandLineInterface(unittest.TestCase):
             cli, ["-s", SCHEMA, YAML_OUT, "-t", "rdf", "-o", RDF_OUT]
         )
         result = self.runner.invoke(
-            cli, ["-s", SCHEMA, RDF_OUT, "-t", "rdf", "-o", JSON_OUT]
+            cli, ["-s", SCHEMA, RDF_OUT, "-t", "json", "-o", JSON_OUT]
         )
         with open(JSON_OUT) as file:
             obj = json.load(file)


### PR DESCRIPTION
A file suffix ".rdf" should map to the format ttl,
rather than the other way around

Fixes #1019
