### PR TITLE
fix the furo installation in docs workflow

### DIFF
--- a/.github/workflows/doc_pages.yaml
+++ b/.github/workflows/doc_pages.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: snok/install-poetry@v1.3
 
       - name: install
-        run: poetry install -E "docs furo"
+        run: poetry install -E docs
 
       - name: Build documentation.
         run: |

--- a/.github/workflows/doc_pages.yaml
+++ b/.github/workflows/doc_pages.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: snok/install-poetry@v1.3
 
       - name: install
-        run: poetry install -E docs
+        run: poetry install -E "docs furo"
 
       - name: Build documentation.
         run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -1615,12 +1615,11 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 
 
 [extras]
 docs = ["sphinx", "sphinx-rtd-theme"]
-furo = []
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.6"
-content-hash = "294bac16fc14768cc90c592516efb89a29fc6b7b09930b18da8628512e7f87f4"
+content-hash = "d6264f415efecb1446961fa9e745b6ae188618513536c9c16003ff28b471861f"
 
 [metadata.files]
 alabaster = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,7 @@ nbformat = "*"
 coverage = "^6.4.1"
 
 [tool.poetry.extras]
-docs = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-mermaid"]
-furo = ["furo"]
+docs = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-mermaid", "furo"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
After moving `furo` to `extras` it needs to be added to the `extras` installation step in the doc b building workflow.

Update: Since `furo` is relevant to `docs`, I just added it within `extras`:`docs` in the interest of keeping it clean.