### PR TITLE
Add dynamic versioning and --version command line option

### DIFF
--- a/linkml/_version.py
+++ b/linkml/_version.py
@@ -1,0 +1,7 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("linkml")
+except PackageNotFoundError:
+    # package is not installed
+    __version__ = "0.0.0"

--- a/linkml/utils/converter.py
+++ b/linkml/utils/converter.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import List
 
@@ -15,6 +16,8 @@ from linkml.utils import datautils, validation
 from linkml.utils.datautils import (_get_context, _get_format, _is_xsv,
                                     dumpers_loaders, get_dumper, get_loader,
                                     infer_index_slot, infer_root_class)
+
+from linkml._version import __version__
 
 
 @click.command()
@@ -61,6 +64,7 @@ from linkml.utils.datautils import (_get_context, _get_format, _is_xsv,
     help="Infer missing slot values",
 )
 @click.option("--context", "-c", multiple=True, help="path to JSON-LD context file")
+@click.version_option(__version__)
 @click.argument("input")
 def cli(
     input,

--- a/linkml/utils/converter.py
+++ b/linkml/utils/converter.py
@@ -64,7 +64,7 @@ from linkml._version import __version__
     help="Infer missing slot values",
 )
 @click.option("--context", "-c", multiple=True, help="path to JSON-LD context file")
-@click.version_option(__version__)
+@click.version_option(__version__, "-V", "--version")
 @click.argument("input")
 def cli(
     input,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ packages = [
     { include = "linkml" }
 ]
 
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "pep440"
+
 [tool.poetry.scripts]    
 gen-jsonld-context = "linkml.generators.jsonldcontextgen:cli"
 gen-prefix-map = "linkml.generators.prefixmapgen:cli"
@@ -130,5 +135,5 @@ coverage = "^6.4.1"
 docs = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-mermaid", "furo"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"

--- a/tests/test_utils/test_converter.py
+++ b/tests/test_utils/test_converter.py
@@ -58,3 +58,9 @@ class TestCommandLineInterface(unittest.TestCase):
             self.assertEqual(p2["age_in_months"], 240)
             self.assertEqual(p2["age_category"], "adult")
             self.assertEqual(p2["full_name"], "first2 last2")
+
+    def test_version(self):
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(cli, ["--version"])
+        # self.assertEqual(0, result.exit_code)  # fails! unclear why result.exit_code is 1 not 0
+        self.assertIn("version", result.stdout)


### PR DESCRIPTION
This addresses partly #1034. Click by default supports only the long format `--version` but not `-V`. ~~In my opinion the short form is not important to have and I suggest to stick with click´s default.~~ I added both '-V' and '--version' in a later commit.

Still to do: Adapt all other command line tools. I just added this to linkml-convert as an example to get feedback before continuing.

Closes #378