### PR TITLE
docgen method to get class from which slot was inherited

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -726,7 +726,19 @@ class DocGenerator(Generator):
         slot_list = [slot.name for slot in sv.class_induced_slots(class_name=cls.name)]
 
         return list(set(slot_list).difference(self.get_direct_slots(cls)))
+    
+    def get_slot_inherited_from(self, class_name: ClassDefinitionName, slot_name: SlotDefinitionName) -> List[ClassDefinitionName]:
+        """Get the name of the class that a given slot is inherited from.
 
+        :param class_name: name of the class whose slot we are checking
+        :param slot_name: name of slot in consideration
+        :return: list of classes
+        """
+        sv = self.schemaview
+        induced_slot = sv.induced_slot(slot_name, class_name)
+        ancestors = sv.class_ancestors(class_name)
+        return list(set(induced_slot.domain_of).intersection(ancestors))
+    
     def get_mixin_inherited_slots(self, cls: ClassDefinition) -> Dict[str, List[str]]:
         """Fetch list of all slots acquired through mixing.
 

--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -369,6 +369,14 @@ class DocGenerator(Generator):
             return self._markdown_link(camelcase(e.name))
         else:
             return e.name
+        
+    def links(self, e_list: List[DefinitionName]) -> List[str]:
+        """Render list of element documentation pages as hyperlinks.
+
+        :param e_list: list of elements
+        :return: list of hyperlinked elements
+        """
+        return list(map(self.link, e_list))
 
     def _exclude_type(self, t: TypeDefinition) -> bool:
         return self._is_external(t) and not self.schemaview.schema.id.startswith(

--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -715,7 +715,7 @@ class DocGenerator(Generator):
         return cls.slots + list(cls.attributes.keys())
 
     def get_indirect_slots(self, cls: ClassDefinition) -> List[SlotDefinitionName]:
-        """Fetch list of all is_a inherited attributes of a class, i.e., 
+        """Fetch list of all inherited attributes of a class, i.e., 
         all slots that belong to the domain of a class.
 
         :param cls: class for which we want to determine the attributes
@@ -724,7 +724,7 @@ class DocGenerator(Generator):
         sv = self.schemaview
         
         slot_list = [slot.name for slot in sv.class_induced_slots(class_name=cls.name)]
-        
+
         return list(set(slot_list).difference(self.get_direct_slots(cls)))
     
     def get_slot_inherited_from(self, class_name: ClassDefinitionName, slot_name: SlotDefinitionName) -> List[ClassDefinitionName]:

--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -724,13 +724,8 @@ class DocGenerator(Generator):
         sv = self.schemaview
         
         slot_list = [slot.name for slot in sv.class_induced_slots(class_name=cls.name)]
-
-        induced_slots = list(set(slot_list).difference(self.get_direct_slots(cls)))
-
-        for _, m_slots in self.get_mixin_inherited_slots(cls).items():
-            induced_slots = set(induced_slots).difference(m_slots)
-
-        return induced_slots
+        
+        return list(set(slot_list).difference(self.get_direct_slots(cls)))
     
     def get_slot_inherited_from(self, class_name: ClassDefinitionName, slot_name: SlotDefinitionName) -> List[ClassDefinitionName]:
         """Get the name of the class that a given slot is inherited from.

--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -715,7 +715,7 @@ class DocGenerator(Generator):
         return cls.slots + list(cls.attributes.keys())
 
     def get_indirect_slots(self, cls: ClassDefinition) -> List[SlotDefinitionName]:
-        """Fetch list of all inherited attributes of a class, i.e., 
+        """Fetch list of all is_a inherited attributes of a class, i.e., 
         all slots that belong to the domain of a class.
 
         :param cls: class for which we want to determine the attributes
@@ -725,7 +725,12 @@ class DocGenerator(Generator):
         
         slot_list = [slot.name for slot in sv.class_induced_slots(class_name=cls.name)]
 
-        return list(set(slot_list).difference(self.get_direct_slots(cls)))
+        induced_slots = list(set(slot_list).difference(self.get_direct_slots(cls)))
+
+        for _, m_slots in self.get_mixin_inherited_slots(cls).items():
+            induced_slots = set(induced_slots).difference(m_slots)
+
+        return induced_slots
     
     def get_slot_inherited_from(self, class_name: ClassDefinitionName, slot_name: SlotDefinitionName) -> List[ClassDefinitionName]:
         """Get the name of the class that a given slot is inherited from.

--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -33,21 +33,15 @@ URI: {{ gen.uri_link(element) }}
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
 {%- if gen.get_direct_slots(element)|length > 0 %}
-{%- for d_slot in gen.get_direct_slots(element) %} | {{ gen.link(schemaview.get_slot(d_slot)) }} | {{ gen.cardinality(schemaview.get_slot(d_slot)) }} <br/> {{ schemaview.get_slot(d_slot).range }} | {{ schemaview.get_slot(d_slot).description }} | direct |
-{%- endfor -%}
-{%- endif -%}
-{%- if gen.get_indirect_slots(element)|length > 0 %}
-{%- for i_slot in gen.get_indirect_slots(element) %} | 
-{{ gen.link(schemaview.get_slot(i_slot)) }} | {{ gen.cardinality(schemaview.get_slot(i_slot)) }} <br/> {{ schemaview.get_slot(i_slot).range }} | {{ schemaview.get_slot(i_slot).description }} | induced <br/> class: {{ gen.get_slot_inherited_from(element.name, i_slot)|join(', ') }} |
-{%- endfor -%}
-{%- endif -%}
-{%- if not gen.get_mixin_inherited_slots(element).vars %}
-{%- for m_name, m_slots in gen.get_mixin_inherited_slots(element).items() %}
-{%- for m_slot in m_slots %}
-| {{ gen.link(schemaview.get_slot(m_slot)) }} | {{ gen.cardinality(schemaview.get_slot(m_slot)) }} <br/> {{ gen.link(schemaview.get_slot(m_slot).range) }} | {{ schemaview.get_slot(m_slot).description }} | mixin inherited <br/> class: {{ gen.name(schemaview.get_class(m_name)) }}|
-{%- endfor -%}
-{%- endfor -%}
-{%- endif %}
+{% for d_slot in gen.get_direct_slots(element) -%}
+| {{ gen.link(schemaview.get_slot(d_slot)) }} | {{ gen.cardinality(schemaview.get_slot(d_slot)) }} <br/> {{ schemaview.get_slot(d_slot).range }} | {{ schemaview.get_slot(d_slot).description }} | direct |
+{% endfor -%}
+{% endif -%}
+{% if gen.get_indirect_slots(element)|length > 0 -%}
+{% for i_slot in gen.get_indirect_slots(element) -%}
+| {{ gen.link(schemaview.get_slot(i_slot)) }} | {{ gen.cardinality(schemaview.get_slot(i_slot)) }} <br/> {{ schemaview.get_slot(i_slot).range }} | {{ schemaview.get_slot(i_slot).description }} | induced <br/> Class: _{{ gen.get_slot_inherited_from(element.name, i_slot)|join(', ') }}_ |
+{% endfor -%}
+{% endif -%}
 
 {% if schemaview.usage_index().get(element.name) %}
 ## Usages

--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -32,17 +32,22 @@ URI: {{ gen.uri_link(element) }}
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-{% for s in schemaview.class_induced_slots(element.name) -%}
-{% if s.name in gen.get_direct_slots(element) -%}
-| {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{ gen.link(s.range) }} | {{ s.description }}  | direct |
-{% endif -%}
-{%- if s.name in gen.get_indirect_slots(element) -%}
-| {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{ gen.link(s.range) }} | {{ s.description }}  | inherited |
-{% endif -%}
-{%- if s.name in gen.get_mixin_inherited_slots(element).items() -%}
-| {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{ gen.link(s.range) }} | {{ s.description }}  | mixin |
-{% endif -%}
-{%- endfor %}
+{%- if gen.get_direct_slots(element)|length > 0 %}
+{%- for d_slot in gen.get_direct_slots(element) %} | {{ gen.link(schemaview.get_slot(d_slot)) }} | {{ gen.cardinality(schemaview.get_slot(d_slot)) }} <br/> {{ schemaview.get_slot(d_slot).range }} | {{ schemaview.get_slot(d_slot).description }} | direct |
+{%- endfor -%}
+{%- endif -%}
+{%- if gen.get_indirect_slots(element)|length > 0 %}
+{%- for i_slot in gen.get_indirect_slots(element) %} | 
+{{ gen.link(schemaview.get_slot(i_slot)) }} | {{ gen.cardinality(schemaview.get_slot(i_slot)) }} <br/> {{ schemaview.get_slot(i_slot).range }} | {{ schemaview.get_slot(i_slot).description }} | induced <br/> class: {{ gen.get_slot_inherited_from(element.name, i_slot)|join(', ') }} |
+{%- endfor -%}
+{%- endif -%}
+{%- if not gen.get_mixin_inherited_slots(element).vars %}
+{%- for m_name, m_slots in gen.get_mixin_inherited_slots(element).items() %}
+{%- for m_slot in m_slots %}
+| {{ gen.link(schemaview.get_slot(m_slot)) }} | {{ gen.cardinality(schemaview.get_slot(m_slot)) }} <br/> {{ gen.link(schemaview.get_slot(m_slot).range) }} | {{ schemaview.get_slot(m_slot).description }} | mixin inherited <br/> class: {{ gen.name(schemaview.get_class(m_name)) }}|
+{%- endfor -%}
+{%- endfor -%}
+{%- endif %}
 
 {% if schemaview.usage_index().get(element.name) %}
 ## Usages
@@ -64,7 +69,7 @@ URI: {{ gen.uri_link(element) }}
 | ---  | ---  |
 {% for m, mt in schemaview.get_mappings(element.name).items() -%}
 {% if mt|length > 0 -%}
-| {{ m }} | {{ mt }}|join(', ') |
+| {{ m }} | {{ mt|join(', ') }} |
 {% endif -%}
 {% endfor %}
 

--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -39,7 +39,7 @@ URI: {{ gen.uri_link(element) }}
 {% endif -%}
 {% if gen.get_indirect_slots(element)|length > 0 -%}
 {% for i_slot in gen.get_indirect_slots(element) -%}
-| {{ gen.link(schemaview.get_slot(i_slot)) }} | {{ gen.cardinality(schemaview.get_slot(i_slot)) }} <br/> {{ schemaview.get_slot(i_slot).range }} | {{ schemaview.get_slot(i_slot).description }} | induced <br/> Class: _{{ gen.get_slot_inherited_from(element.name, i_slot)|join(', ') }}_ |
+| {{ gen.link(schemaview.get_slot(i_slot)) }} | {{ gen.cardinality(schemaview.get_slot(i_slot)) }} <br/> {{ schemaview.get_slot(i_slot).range }} | {{ schemaview.get_slot(i_slot).description }} | {{ gen.links(gen.get_slot_inherited_from(element.name, i_slot))|join(', ') }} |
 {% endfor -%}
 {% endif -%}
 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -415,7 +415,7 @@ class DocGeneratorTestCase(unittest.TestCase):
         actual_result = gen.get_indirect_slots(cls)
         expected_result = ["ended at time", "metadata", "started at time", "is current"]
         
-        self.assertListEqual(sorted(expected_result), sorted(actual_result))
+        self.assertCountEqual(expected_result, actual_result)
 
         # test assertion for mixed in slots of a class
         cls = sv.get_class("Organization")
@@ -423,6 +423,18 @@ class DocGeneratorTestCase(unittest.TestCase):
         expected_result = {"HasAliases": ["aliases"]}
 
         self.assertDictEqual(actual_result, expected_result)
+
+    def test_class_slots_inheritance(self):
+        gen = DocGenerator(SCHEMA, mergeimports=True, no_types_dir=True)
+
+        sv = SchemaView(SCHEMA)
+        test_class = sv.get_class("BirthEvent")
+        test_slot = sv.get_slot("started at time")
+
+        expected_result = ["Event"]
+        actual_result = gen.get_slot_inherited_from(class_name=test_class.name, slot_name=test_slot.name)
+
+        self.assertListEqual(expected_result, actual_result)
 
     def test_use_slot_uris(self):
         tdir = env.input_path("docgen_html_templates")


### PR DESCRIPTION
This method seeks to add more information to the slots table that appears on a class's documentation page, by telling us about how a particular slot was inherited in the context of a class.