### PR TITLE
Update pypi-publish.yaml for poetry-dynamic-versioning

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Build source and wheel archives
         run: |
-          poetry version $(git describe --tags --abbrev=0)
           poetry build
 
       - name: Publish distribution 📦 to PyPI


### PR DESCRIPTION
FYI: With [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning) this line (see diff) should not be required anymore. But please double-check before merging. I don't want to break your release pipeline.