### PR TITLE
Revert "Update pypi-publish.yaml for poetry-dynamic-versioning"

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Build source and wheel archives
         run: |
+          poetry version $(git describe --tags --abbrev=0)
           poetry build
 
       - name: Publish distribution 📦 to PyPI


### PR DESCRIPTION
Reverts linkml/linkml#1053

This caused:

```
Checking dist/linkml-0.0.0-py3-none-any.whl: PASSED
Checking dist/linkml-0.0.0.tar.gz: PASSED
Uploading distributions to https://upload.pypi.org/legacy/
Uploading linkml-0.0.0-py3-none-any.whl
25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/2[19](https://github.com/linkml/linkml/actions/runs/3346334410/jobs/5543010312#step:8:20).7 kB • --:-- • ?
 37% ━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━ 81.9/219.7 kB • 00:01 • 97.9 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 219.7/219.7 kB • 00:00 • 6.5 MB/s
25hWARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/          
         Read-only mode: Uploads are temporarily disabled.
```