### PR TITLE
move `Aliases` section into common metadata

### DIFF
--- a/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/linkml/generators/docgen/common_metadata.md.jinja2
@@ -1,3 +1,12 @@
+{% if element.aliases %}
+## Aliases
+
+* Aliases:
+{% for alias in element.aliases %}
+    * {{ alias }}
+{% endfor %}
+{% endif %}
+
 {% if element.examples %}
 ## Examples
 

--- a/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/linkml/generators/docgen/common_metadata.md.jinja2
@@ -1,10 +1,9 @@
 {% if element.aliases %}
 ## Aliases
 
-* Aliases:
 {% for alias in element.aliases %}
-    * {{ alias }}
-{% endfor %}
+* {{ alias }}
+{%- endfor %}
 {% endif %}
 
 {% if element.examples %}

--- a/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/linkml/generators/docgen/common_metadata.md.jinja2
@@ -6,6 +6,12 @@
 {%- endfor %}
 {% endif %}
 
+{% if element.alias %}
+## Alias
+
+{{ alias }}
+{% endif %}
+
 {% if element.examples %}
 ## Examples
 

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -45,20 +45,15 @@ URI: {{ gen.uri_link(element) }}
 ## Properties
 
 * Range: {{gen.link(element.range)}}
+{%- if element.multivalued != None %}
 * Multivalued: {{ element.multivalued }}
-{% if element.aliases %}
-* Aliases:
-{% for alias in element.aliases %}
-    * {{ alias }}
-{% endfor %}
 {% endif %}
-
-{% if element.required %}
+{%- if element.required != None %}
 * Required: {{ element.required }}
-{% elif element.recommended %}
+{% elif element.recommended != None %}
 * Recommended: {{ element.recommended }}
 {% endif %}
-{% if schemaview.is_mixin(element.name) %}
+{%- if schemaview.is_mixin(element.name) %}
 * Mixin: {{ element.mixin }}
 {% endif %}
 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -237,6 +237,11 @@ class DocGeneratorTestCase(unittest.TestCase):
             "tree_slot_C.md", "[mixin_slot_I](mixin_slot_I.md)"
         )
 
+        # test that Aliases is showing from common metadata
+        assert_mdfile_contains(
+            "EmploymentEventType.md", "* HR code", after="## Aliases"
+        )
+
     def test_docgen_rank_ordering(self):
         """Tests overriding default order"""
         gen = DocGenerator(SCHEMA, mergeimports=True, no_types_dir=True, sort_by="rank")


### PR DESCRIPTION
`Aliases` information to be moved into common metadata shared by all elements. This also fixes issue #23 