### PR TITLE
Add stacktrace option w/ default no trace.

### DIFF
--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -18,6 +18,7 @@ import abc
 import logging
 import os
 import re
+import sys
 from contextlib import redirect_stdout
 from dataclasses import dataclass, field
 from io import StringIO
@@ -153,13 +154,17 @@ class Generator(metaclass=abc.ABCMeta):
     metamodel: SchemaLoader = None
     """A SchemaLoader instance that points to the LinkML metamodel (meta.yaml)"""
 
+    stacktrace: bool = False
+    """True means print stack trace, false just error message"""
+
     def __post_init__(self) -> None:
         if not self.logger:
             self.logger = logging.getLogger()
         #    logging.basicConfig()
         #    self.logger = logging.getLogger(self.__class__.__name__)
         #    self.logger.setLevel(log_level)
-
+        if not self.stacktrace:
+            sys.tracebacklimit = 0
         if self.format is None:
             self.format = self.valid_formats[0]
         if self.format not in self.valid_formats:
@@ -977,6 +982,14 @@ def shared_arguments(g: Type[Generator]) -> Callable[[Command], Command]:
                 help="Merge imports into source file (default=mergeimports)",
             )
         )
+        f.params.append(
+            Option(
+                ("--stacktrace/--no-stacktrace",),
+                default=False,
+                help="Print a stack trace when an error occurs (default=stacktrace)",
+            )
+        )
+
         return f
 
     return decorator

--- a/tests/test_issues/input/issue_65_new.yaml
+++ b/tests/test_issues/input/issue_65_new.yaml
@@ -1,0 +1,20 @@
+id: https://w3id.org/linkml/examples/personinfo
+name: personinfo
+imports:
+  - linkml:types
+  - stuff
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://gridlock.org
+default_range: string
+subsets:
+  a:
+    description: simple subset
+
+# Note: this file should NOT end with newline.  The pycharm IDE seems pretty insistent on fixing this, however, so
+#       we make sure it IS off in the test itself.
+classes:
+  Person:
+    in_subset:
+       - a
+       -


### PR DESCRIPTION
Common parameter for all CLI tools. "--stacktrace/--no-stacktrace"

tests/test_issues/input/issue_65_new.yaml is a sample w/ an error in it.

Fix for issue #101 .  Also addresses part of issue #65.  Notes:
1) There isn't a unit test for this fix -- the test file, `issue_65_new.yaml`, creates a really ugly error message if there is stack
trace, and a one-liner with this fix.  The problem, however, is the UnitTest harness overrides those fixes, so you can't see them.  