### PR TITLE
Add support for multivalued slot constraints in JSON Schema generator

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -376,6 +376,12 @@ class JsonSchemaGenerator(Generator):
         if slot.equals_number is not None:
             prop['const'] = slot.equals_number
 
+        if slot.minimum_cardinality is not None:
+            prop['minItems'] = slot.minimum_cardinality
+
+        if slot.maximum_cardinality is not None:
+            prop['maxItems'] = slot.maximum_cardinality
+
         if slot.any_of is not None and len(slot.any_of) > 0:
             if not slot_has_range_union:
                 prop['anyOf'] = [self.get_subschema_for_slot(s, omit_type) for s in slot.any_of]

--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -377,10 +377,16 @@ class JsonSchemaGenerator(Generator):
             prop['const'] = slot.equals_number
 
         if slot.minimum_cardinality is not None:
-            prop['minItems'] = slot.minimum_cardinality
+            if prop['type'] == 'array':
+                prop['minItems'] = slot.minimum_cardinality
+            elif prop['type'] == 'object':
+                prop['minProperties'] = slot.minimum_cardinality
 
         if slot.maximum_cardinality is not None:
-            prop['maxItems'] = slot.maximum_cardinality
+            if prop['type'] == 'array':
+                prop['maxItems'] = slot.maximum_cardinality
+            elif prop['type'] == 'object':
+                prop['maxProperties'] = slot.maximum_cardinality
 
         if slot.any_of is not None and len(slot.any_of) > 0:
             if not slot_has_range_union:

--- a/tests/test_generators/input/jsonschema_multivalued_slot_cardinality.yaml
+++ b/tests/test_generators/input/jsonschema_multivalued_slot_cardinality.yaml
@@ -1,0 +1,98 @@
+schema:
+  id: http://example.org/test_multivalued_slot_constraints
+  name: test_multivalued_slot_constraints
+
+  imports:
+    - https://w3id.org/linkml/types
+
+  slots:
+    int_list:
+      range: integer
+      multivalued: true
+      minimum_cardinality: 2
+      maximum_cardinality: 5
+    
+    int_dict:
+      range: KeyedInt
+      multivalued: true
+      inlined: true
+      inlined_as_list: false
+      minimum_cardinality: 3
+      maximum_cardinality: 4
+
+    id:
+      range: string
+      identifier: true
+
+    value:
+      range: integer
+      required: true
+
+  classes:
+    KeyedInt:
+      slots:
+        - id
+        - value
+    Test:
+      tree_root: true
+      slots:
+        - int_list
+        - int_dict
+json_schema:
+  properties:
+    int_list:
+      minItems: 2
+      maxItems: 5
+    int_dict:
+      minProperties: 3
+      maxProperties: 4
+data_cases:
+  - data: 
+      int_list: [1, 2]
+  - data:
+      int_list: [1]
+    error_message: Failed validating 'minItems'
+  - data: 
+      int_list: [1, 2, 3, 4, 5]
+  - data:
+      int_list: [1, 2, 3, 4, 5, 6]
+    error_message: Failed validating 'maxItems'
+  - data:
+      int_dict: 
+        1:
+          value: 1
+        2:
+          value: 2
+        3:
+          value: 3
+  - data:
+      int_dict: 
+        1:
+          value: 1
+        2:
+          value: 2
+    error_message: Failed validating 'minProperties'
+  - data:
+      int_dict: 
+        1:
+          value: 1
+        2:
+          value: 2
+        3:
+          value: 3
+        4:
+          value: 4
+  - data:
+      int_dict: 
+        1:
+          value: 1
+        2:
+          value: 2
+        3:
+          value: 3
+        4:
+          value: 4
+        5:
+          value: 5
+    error_message: Failed validating 'maxProperties'
+        

--- a/tests/test_generators/input/jsonschema_range_union_cases.yaml
+++ b/tests/test_generators/input/jsonschema_range_union_cases.yaml
@@ -88,6 +88,7 @@ schema:
       slots:
         - s2
     Test:
+      tree_root: true
       slots:
         - letter_enum_single_value
         - letter_enum_multi_value
@@ -103,74 +104,139 @@ schema:
         - c1_or_c2_multi_value
         - grab_bag
 
-valid_cases:
-  - letter_enum_single_value: "ALPHA"
-  - letter_enum_multi_value: ["BRAVO", "CHARLIE"]
-  - letter_or_number_enum_single_value: "ONE"
-  - letter_or_number_enum_multi_value: ["TWO", "DELTA"]
-  - integer_single_value: 0
-  - integer_multi_value: [0, 1]
-  - integer_or_string_single_value: "zero"
-  - integer_or_string_multi_value: ["zero", 1]
-  - c1_single_value:
-      s1: 'hi'
-  - c1_mutli_value:
-      - s1: 'hi'
-      - s1: 'hello'
-  - c1_or_c2_single_value:
-      s2: 'hi'
-  - c1_or_c2_multi_value:
-      - s1: 'hi'
-      - s2: 'hello'
-  - grab_bag:
-      - s1: 'two'
-      - ONE
-      - 0
-
-invalid_cases:
-  - letter_enum_single_value: "ONE"
-  - letter_enum_single_value: ["ALPHA", "BRAVO"]
-  - letter_enum_multi_value: "ALPHA"
-  - letter_enum_multi_value: ["ONE", "CHARLIE"]
-  - letter_or_number_enum_single_value: ["ONE"]
-  - letter_or_number_enum_single_value: "NOT_A_VALUE"
-  - letter_or_number_enum_multi_value: "ALPHA"
-  - letter_or_number_enum_multi_value: ["ALPHA", "THREE", "NOT_A_VALUE"]
-  - integer_single_value: [0]
-  - integer_single_value: "zero"
-  - integer_multi_value: 0
-  - integer_multi_value: ["zero"]
-  - integer_or_string_single_value: [0]
-  - integer_or_string_single_value: false
-  - integer_or_string_multi_value: "zero"
-  - integer_or_string_multi_value: [0, "one", false]
-  - c1_single_value:
-    - s1: 'hi'
-  - c1_single_value:
-      s2: 'hi'
-  - c1_mutli_value:
-      s2: 'hi'
-  - c1_mutli_value:
-    - s2: 'hi'
-  - c1_or_c2_single_value:
-    - s1: 'hi'
-  - c1_or_c2_single_value:
-      s3: 'hi'
-  - c1_or_c2_multi_value:
-      s1: 'hi'
-  - c1_or_c2_multi_value:
-    - s1: 'hi'
-    - s2: 'hello'
-    - s3: 'hola'
-  - grab_bag:
-    - s2: 'two'
-    - ONE
-    - 0
-  - grab_bag:
-    - s1: 'two'
-    - ONE
-    - false
-  - grab_bag:
-    - s1: 'two'
-    - five
-    - 5
+data_cases:
+  - data:
+      letter_enum_single_value: ALPHA
+  - data:
+      letter_enum_multi_value: [BRAVO, CHARLIE]
+  - data:
+      letter_or_number_enum_single_value: ONE
+  - data:
+      letter_or_number_enum_multi_value: [TWO, DELTA]
+  - data:
+      integer_single_value: 0
+  - data:
+      integer_multi_value: [0, 1]
+  - data:
+      integer_or_string_single_value: zero
+  - data:
+      integer_or_string_multi_value: [zero, 1]
+  - data:
+      c1_single_value:
+        s1: hi
+  - data:
+      c1_mutli_value:
+        - s1: hi
+        - s1: hello
+  - data:
+      c1_or_c2_single_value:
+        s2: hi
+  - data:
+      c1_or_c2_multi_value:
+        - s1: hi
+        - s2: hello
+  - data:
+      grab_bag:
+        - s1: two
+        - ONE
+        - 0
+  - data:
+      letter_enum_single_value: ONE
+    error_message: is not one of
+  - data:
+      letter_enum_single_value: [ALPHA, BRAVO]
+    error_message: is not one of
+  - data:
+      letter_enum_multi_value: ALPHA
+    error_message: is not of type 'array'
+  - data:
+      letter_enum_multi_value: [ONE, CHARLIE]
+    error_message: is not one of
+  - data:
+      letter_or_number_enum_single_value: [ONE]
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      letter_or_number_enum_single_value: NOT_A_VALUE
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      letter_or_number_enum_multi_value: ALPHA
+    error_message: is not of type 'array'
+  - data:
+      letter_or_number_enum_multi_value: [ALPHA, THREE, NOT_A_VALUE]
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      integer_single_value: [0]
+    error_message: is not of type 'integer'
+  - data:
+      integer_single_value: zero
+    error_message: is not of type 'integer'
+  - data:
+      integer_multi_value: 0
+    error_message: is not of type 'array'
+  - data:
+      integer_multi_value: [zero]
+    error_message: is not of type 'integer'
+  - data:
+      integer_or_string_single_value: [0]
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      integer_or_string_single_value: false
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      integer_or_string_multi_value: zero
+    error_message: is not of type 'array'
+  - data:
+      integer_or_string_multi_value: [0, one, false]
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      c1_single_value:
+        - s1: 'hi'
+    error_message: is not of type 'object'
+  - data:
+      c1_single_value:
+        s2: 'hi'
+    error_message: Additional properties are not allowed
+  - data:
+      c1_mutli_value:
+        s2: 'hi'
+    error_message: is not of type 'array'
+  - data:
+      c1_mutli_value:
+        - s2: 'hi'
+    error_message: Additional properties are not allowed
+  - data:
+      c1_or_c2_single_value:
+        - s1: 'hi'
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      c1_or_c2_single_value:
+        s3: 'hi'
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      c1_or_c2_multi_value:
+        s1: 'hi'
+    error_message: is not of type 'array'
+  - data:
+      c1_or_c2_multi_value:
+        - s1: 'hi'
+        - s2: 'hello'
+        - s3: 'hola'
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      grab_bag:
+        - s2: 'two'
+        - ONE
+        - 0
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      grab_bag:
+        - s1: 'two'
+        - ONE
+        - false
+    error_message: Failed validating 'anyOf' in schema
+  - data:
+      grab_bag:
+        - s1: 'two'
+        - five
+        - 5
+    error_message: is not one of

--- a/tests/test_generators/input/jsonschema_top_class_identifier.yaml
+++ b/tests/test_generators/input/jsonschema_top_class_identifier.yaml
@@ -1,0 +1,16 @@
+schema:
+  id: http://example.org/test_top_class_identifier
+  name: test_top_class_identifier
+
+  slots:
+    id:
+      identifier: true
+
+  classes:
+    Test:
+      tree_root: true
+      slots:
+        - id
+json_schema:
+  required:
+    - id

--- a/tests/test_generators/input/jsonschema_type_inheritance.yaml
+++ b/tests/test_generators/input/jsonschema_type_inheritance.yaml
@@ -1,0 +1,29 @@
+schema:
+  id: http://example.org/test_type_inheritance
+  name: test_type_inheritance
+
+  types:
+    alpha:
+      base: double 
+    beta:
+      typeof: alpha
+
+  slots:
+    alpha_slot:
+      range: alpha
+    beta_slot:
+      range: beta
+
+  classes:
+    Test:
+      tree_root: true
+      slots:
+        - alpha_slot
+        - beta_slot
+
+json_schema:
+  properties:
+    alpha_slot:
+      type: number
+    beta_slot:
+      type: number

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -120,6 +120,7 @@ class JsonSchemaTestCase(unittest.TestCase):
                     self.assertRaises(jsonschema.ValidationError, do_validate)
 
     def test_type_inheritance(self):
+        """Tests that a type definition's typeof slot is correctly accounted for."""
         # TODO: can this be a compliance case too?
         schema = """
 id: http://example.org/test_type_inheritance
@@ -174,6 +175,19 @@ classes:
 
 
     def test_rules(self):
+        """Tests translation of various types of class rules.
+        
+        The external YAML file holds various test cases. Each test case defines
+        the `rules` that will be inserted into a class of the baseline schema, 
+        some expected JSON Schema, and various data instances. The test iterates
+        through each test case and:
+          1) constructs a LinkML schema and passes it to JsonSchemaGenerator
+          2) verifies that the expected JSON Schema is a subset of the actual
+             JSON Schema that was generated
+          3) validates each data instance against the JSON Schema and verifies
+             that it either successfully validates or does not validate with 
+             the expected error message
+        """
         with open(RULES_CASES) as cases_file:
             cases = yaml.safe_load(cases_file)
 
@@ -221,6 +235,18 @@ classes:
 
 
     def test_range_unions(self):
+        """Tests various permutations of range unions.
+        
+        The external YAML files holds a complete LinkML schema and various data 
+        instances. The schema defines one class with numerous slots. Each slot
+        represents a combination of:
+          * simple range vs range union
+          * ranges of enums, types, classes
+          * multivalued true vs false
+        The data instances are divided into cases that are expected to validate 
+        successfully against the generated JSON Schema and those that are expected
+        to throw a ValidationError.
+        """
         with open(RANGE_UNION_CASES, "r") as f:
             cases = yaml.safe_load(f)
 


### PR DESCRIPTION
This addresses the cardinality constraints in #1107. There is also a bit of refactoring the jsonschemagen tests.

This does _not_ address the membership constraints discussed in #1107. Those will need an update of `linkml-model` (see https://github.com/linkml/linkml-model/pull/131). I figured we could get these changes is now and circle back to the membership constraints later.