### PR TITLE
Add workflow for Docker build and publish 

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,51 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: linkml/linkml
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: cmungall
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,36 @@
-# set base image (host OS)
-FROM python:3.9
+FROM python:3.9-bullseye as builder
 
 # https://stackoverflow.com/questions/53835198/integrating-python-poetry-with-docker
-ENV YOUR_ENV=${YOUR_ENV} \
-  PYTHONFAULTHANDLER=1 \
+ENV PYTHONFAULTHANDLER=1 \
   PYTHONUNBUFFERED=1 \
   PYTHONHASHSEED=random \
   PIP_NO_CACHE_DIR=off \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=100 \
-  POETRY_VERSION=1.1.13
+  POETRY_VERSION=1.2.1
 
-# System deps:
+# Install Poetry
 RUN pip install "poetry==$POETRY_VERSION"
+RUN poetry self add "poetry-dynamic-versioning[plugin]"
 
-# set the working directory in the container
-WORKDIR /work
+WORKDIR /code
 
-RUN pip install linkml
+# Build project. The .git directory is needed for poetry-dynamic-versioning
+COPY ./.git ./.git
+COPY pyproject.toml poetry.lock README.md .
+COPY linkml linkml/
+RUN poetry build 
+
+#######################################
+FROM python:3.9-bullseye as runner
+
+RUN useradd --create-home linkmluser
+WORKDIR /home/linkmluser
+USER linkmluser
+ENV PATH="${PATH}:/home/linkmluser/.local/bin"
+
+COPY --from=builder /code/dist/*.whl /tmp
+RUN pip install --user /tmp/*.whl
 
 # command to run on container start
 CMD [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY linkml linkml/
 RUN poetry build 
 
 #######################################
-FROM python:3.9-bullseye as runner
+FROM python:3.9-slim-bullseye as runner
 
 RUN useradd --create-home linkmluser
 WORKDIR /home/linkmluser


### PR DESCRIPTION
These changes:

* Update the Dockerfile so that the `linkml` package is installed from source in the image. Previously it was installed from PyPI, but going forward we don't want to have to wait for the package to be published to PyPI before building a Docker image and publishing it to Docker Hub. 
* Add a GitHub Actions workflow for building a Docker image and publishing it to Docker Hub. It will run on PRs and pushes to `main` and pushes to `v*` tags. The push to Docker Hub will be skipped for PRs, but it will still verify that the Docker image build works. Pushes to `main` or `v*` tags will publish the image to Docker Hub. 

Fixes #1102 