### PR TITLE
Update to remove workflow warnings

### DIFF
--- a/.github/workflows/doc_pages.yaml
+++ b/.github/workflows/doc_pages.yaml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -32,7 +32,7 @@ jobs:
           cp -r _build/* ../gh-pages/
       - name: Deploy documentation.
         if: ${{ github.event_name == 'push' }}
-        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: gh-pages
           force: true


### PR DESCRIPTION
* Updating to enforce use of @actions/core to 1.10.0
* Upgrade github-pages-deploy-action to v4.4.1