### PR TITLE
slots table breaking in few schemas

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -29,16 +29,16 @@ URI: {{ gen.uri_link(element) }}
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-{%- if gen.get_direct_slots(element)|length > 0 %}
-{% for d_slot in gen.get_direct_slots(element) -%}
+{% if gen.get_direct_slots(element)|length > 0 %}
+{%- for d_slot in gen.get_direct_slots(element) -%}
 | {{ gen.link(schemaview.get_slot(d_slot)) }} | {{ gen.cardinality(schemaview.get_slot(d_slot)) }} <br/> {{ gen.link(schemaview.get_slot(d_slot).range) }} | {{ schemaview.get_slot(d_slot).description|enshorten }} | direct |
 {% endfor -%}
 {% endif -%}
-{% if gen.get_indirect_slots(element)|length > 0 -%}
-{% for i_slot in gen.get_indirect_slots(element) -%}
+{% if gen.get_indirect_slots(element)|length > 0 %}
+{%- for i_slot in gen.get_indirect_slots(element) -%}
 | {{ gen.link(schemaview.get_slot(i_slot)) }} | {{ gen.cardinality(schemaview.get_slot(i_slot)) }} <br/> {{ gen.link(schemaview.get_slot(i_slot).range) }} | {{ schemaview.get_slot(i_slot).description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, i_slot))|join(', ') }} |
 {% endfor -%}
-{% endif -%}
+{% endif %}
 
 {% if schemaview.is_mixin(element.name) %}
 ## Mixin Usage

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -57,7 +57,7 @@ URI: {{ gen.uri_link(element) }}
 * Minimum Value: {{ element.minimum_value }}
 {% endif %}
 {%- if element.maximum_value %}
-* Minimum Value: {{ element.maximum_value }}
+* Maximum Value: {{ element.maximum_value }}
 {% endif %}
 {%- if schemaview.is_mixin(element.name) %}
 * Mixin: {{ element.mixin }}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -53,6 +53,12 @@ URI: {{ gen.uri_link(element) }}
 {% elif element.recommended %}
 * Recommended: {{ element.recommended }}
 {% endif %}
+{%- if element.minimum_value %}
+* Minimum Value: {{ element.minimum_value }}
+{% endif %}
+{%- if element.maximum_value %}
+* Minimum Value: {{ element.maximum_value }}
+{% endif %}
 {%- if schemaview.is_mixin(element.name) %}
 * Mixin: {{ element.mixin }}
 {% endif %}


### PR DESCRIPTION
The jinja templates in this PR have been tested on the kgcl and MIxS schemas, both of which had breaking slots table on class pages with the jinja templates from v1.3.15