### PR TITLE
Pass `schemaview` object to dumper while converting to JSONLD

### DIFF
--- a/linkml/utils/converter.py
+++ b/linkml/utils/converter.py
@@ -160,6 +160,7 @@ def cli(
                 raise Exception("Must pass in context OR schema for RDF output")
         outargs["contexts"] = list(context)
         outargs["fmt"] = "json-ld"
+        outargs["schemaview"] = sv
     if output_format == "rdf" or output_format == "ttl":
         if sv is None:
             raise Exception(f"Must pass schema arg")


### PR DESCRIPTION
At the current state of the code. When `linkml-convert` is run with a `jsonld` format as the targeted output, the `schemaview` does not get passed. This PR fixes that. 