### PR TITLE
[WIP] Pydanticgen: support polymorphism using type designators

### DIFF
--- a/linkml/generators/common/__init__.py
+++ b/linkml/generators/common/__init__.py
@@ -1,0 +1,17 @@
+from linkml_runtime.linkml_model.meta import SlotDefinition, ClassDefinition
+from linkml_runtime.utils.schemaview import SchemaView
+from linkml_runtime.utils.formatutils import camelcase
+
+def get_type_designator_value(sv: SchemaView, type_designator_slot: SlotDefinition, class_def: ClassDefinition) -> str:
+    """
+        retuns the correct value for a type designator field for a given class, depending on its range
+        this implements the logic described in https://github.com/linkml/linkml/issues/945:
+    """
+    target_value = None
+    if type_designator_slot.range == 'uri':
+        target_value = sv.get_uri(class_def,expand=True,native=True)
+    elif type_designator_slot.range == 'string':
+        target_value = camelcase(class_def.name)
+    else:
+        target_value = sv.get_uri(class_def,expand=False)
+    return target_value

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -26,7 +26,7 @@ default_template = """
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, Field
 from linkml_runtime.linkml_model import Decimal
 

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -209,6 +209,7 @@ class PydanticGenerator(OOCodeGenerator):
                             + slot_values[camelcase(class_def.name)][slot.name]
                             + "]"
                         )
+                    slot_values[camelcase(class_def.name)][slot.name] = slot_values[camelcase(class_def.name)][slot.name] + ", const=True"
                 # Multivalued slots that are either not inlined (just an identifier) or are
                 # inlined as lists should get default_factory list, if they're inlined but
                 # not as a list, that means a dictionary
@@ -272,7 +273,10 @@ class PydanticGenerator(OOCodeGenerator):
             sv.get_identifier_slot(range_cls.name) is None
             and not sv.is_mixin(range_cls.name)
         ):
-            return f"{camelcase(slot.range)}"
+            if len([x for x in sv.class_induced_slots(slot.range) if x.designates_type]) > 0:
+                return f"Union[" + ",".join([camelcase(c) for c in sv.class_descendants(slot.range)]) + "]"
+            else:
+                return f"{camelcase(slot.range)}"
 
         # For the more difficult cases, set string as the default and attempt to improve it
         range_cls_identifier_slot_range = "str"

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -269,7 +269,7 @@ class PydanticGenerator(OOCodeGenerator):
 
         # Inline the class itself only if the class is defined as inline, or if the class has no
         # identifier slot and also isn't a mixin.
-        if slot.inlined or (
+        if slot.inlined or slot.inlined_as_list or (
             sv.get_identifier_slot(range_cls.name) is None
             and not sv.is_mixin(range_cls.name)
         ):
@@ -367,7 +367,7 @@ class PydanticGenerator(OOCodeGenerator):
                     # logging.error(f'range: {s.range} is unknown')
                     raise Exception(f"range: {s.range}")
                 if s.multivalued:
-                    if collection_key is None:
+                    if collection_key is None or s.inlined_as_list:
                         pyrange = f"List[{pyrange}]"
                     else:
                         pyrange = f"Dict[{collection_key}, {pyrange}]"

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -200,9 +200,11 @@ class PydanticGenerator(OOCodeGenerator):
             for slot_name in sv.class_slots(class_def.name):
                 slot = sv.induced_slot(slot_name, class_def.name)
                 if slot.designates_type:
+                    class_curie = f'{default_prefix}:{camelcase(class_def.name)}'
+                    class_uri = str(self.namespaces.uri_for(class_curie) if ":" in class_curie else class_curie)
                     slot_values[camelcase(class_def.name)][
                         slot.name
-                    ] = f'"{default_prefix}:{camelcase(class_def.name)}"'
+                    ] = f'"{class_uri}"'
                     if slot.multivalued:
                         slot_values[camelcase(class_def.name)][slot.name] = (
                             "["

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -14,6 +14,7 @@ from linkml_runtime.linkml_model.meta import (Annotation, ClassDefinition,
 from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml_runtime.utils.schemaview import SchemaView
 
+from linkml.generators.common import get_type_designator_value
 from linkml._version import __version__
 from linkml.generators.oocodegen import OOCodeGenerator
 from linkml.utils.generator import shared_arguments
@@ -200,11 +201,10 @@ class PydanticGenerator(OOCodeGenerator):
             for slot_name in sv.class_slots(class_def.name):
                 slot = sv.induced_slot(slot_name, class_def.name)
                 if slot.designates_type:
-                    class_curie = f'{default_prefix}:{camelcase(class_def.name)}'
-                    class_uri = str(self.namespaces.uri_for(class_curie) if ":" in class_curie else class_curie)
+                    target_value = get_type_designator_value(sv, slot, class_def)
                     slot_values[camelcase(class_def.name)][
                         slot.name
-                    ] = f'"{class_uri}"'
+                    ] = f'"{target_value}"'
                     if slot.multivalued:
                         slot_values[camelcase(class_def.name)][slot.name] = (
                             "["

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -195,6 +195,7 @@ class Generator(metaclass=abc.ABCMeta):
         else:
             self.schemaview = SchemaView(schema)
             self.schema = self.schemaview.schema
+        self._init_namespaces()
 
     def _initialize_using_schemaloader(self, schema: Union[str, TextIO, SchemaDefinition, "Generator"]):
         # currently generators are very liberal in what they accept, including
@@ -244,10 +245,12 @@ class Generator(metaclass=abc.ABCMeta):
             self.source_file_size = loader.source_file_size
             self.schema_location = loader.schema_location
             self.schema_defaults = loader.schema_defaults
-            if self.namespaces is None:
-                self.namespaces = Namespaces()
-                for prefix in self.schema.prefixes.values():
-                    self.namespaces[prefix.prefix_prefix] = prefix.prefix_reference
+
+    def _init_namespaces(self):
+        if self.namespaces is None:
+            self.namespaces = Namespaces()
+            for prefix in self.schema.prefixes.values():
+                self.namespaces[prefix.prefix_prefix] = prefix.prefix_reference
 
     def serialize(self, **kwargs) -> str:
         """

--- a/tests/test_issues/test_pydantic_polymorphism.py
+++ b/tests/test_issues/test_pydantic_polymorphism.py
@@ -1,0 +1,108 @@
+import  unittest
+
+from linkml.generators.pydanticgen import PydanticGenerator
+from tests.test_issues.environment import env
+from tests.utils.test_environment import TestEnvironmentTestCase
+from linkml_runtime.utils.compile_python import compile_python
+
+schema_str = """
+id: http://example.org
+name: inline-dict-test
+imports:
+  - https://w3id.org/linkml/types
+prefixes:
+  x: http://example.org/
+default_prefix: x
+default_range: string
+description: test
+
+classes:
+  NamedThing:
+    slots:
+      - id
+      - full_name
+      - thingtype
+  Person:
+    is_a: NamedThing
+    slots:
+      - height
+  Organisation:
+    is_a: NamedThing
+    slots:
+      - number_of_employees
+  Container:
+    tree_root: true
+    slots:
+      - things
+slots:
+  id:
+    identifier: true
+    range: string
+    required: true
+  thingtype:
+    designates_type: true
+    range: uriorcurie
+  full_name:
+    range: string
+  height:
+    range: integer
+  number_of_employees:
+    range: integer
+  things:
+    range: NamedThing
+    multivalued: true
+    inlined_as_list: true
+"""
+
+data_str = """
+{
+  "things": [
+    {
+      "id": 1,
+      "thingtype": "x:Person",
+      "full_name": "phoebe",
+      "height": 10
+    },
+    {
+      "id": 2,
+      "thingtype": "x:Organisation",
+      "full_name": "University of Earth",
+      "number_of_employees": 2
+    }
+  ]
+}
+"""
+
+
+class PydanticPolymorphismTestCase(TestEnvironmentTestCase):
+    env = env
+
+    def test_pydantic_obey_range(self):
+        gen = PydanticGenerator(schema_str)
+        output = gen.serialize()
+        output_subset = [line for line in output.splitlines() if "thingtype" in line]
+        assert len(output_subset) > 0
+        assert "const=True" in output_subset[0]
+        assert len([x for x in output_subset if 'x:Person' in x]) == 1
+
+        gen = PydanticGenerator(schema_str.replace("uriorcurie","uri"))
+        output = gen.serialize()
+        output_subset = [line for line in output.splitlines() if "thingtype" in line]
+        assert len(output_subset) > 0
+        assert "const=True" in output_subset[0]
+        assert len([x for x in output_subset if 'http://example.org/Person' in x]) == 1
+
+    def test_pydantic_load_poly_data(self):
+        gen = PydanticGenerator(schema_str)
+        output = gen.serialize()
+        mod = compile_python(output, "testschema")
+        data = mod.Container.parse_raw(data_str)
+        assert len([x for x in data.things if type(x) == mod.Person]) == 1
+        assert len([x for x in data.things if type(x) == mod.Organisation]) == 1
+
+
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This makes the following modifications:
* The type designators are const=True now in pydantic so that pydantic can use them to determine which class needs to be instantiated
* We specify a union of all possible types (using class_descendants) for the range of an slot that refers to a class having a type designator

References:
* https://github.com/pydantic/pydantic/issues/503
* https://github.com/linkml/linkml/issues/1099

Open questions:
* I use two APIs that are slow (i think): the induced slots and the descendants of the class. is this okay ?
* I now only enable polymorphism for things that have a type designator. Actually, in some cases it should be possible to enable polymorphism for things without a type designator (pydantic will simply try all classes and takes the first one that validates). However, i think this is a safe approach for now
* I have no idea (and i would need help) in order to add tests and documentation.
* I think the python dataclasses generator needs a similar modification