### PR TITLE
Use package name ("linkml") to look up version

### DIFF
--- a/linkml/_version.py
+++ b/linkml/_version.py
@@ -5,7 +5,7 @@ except ImportError:
     import importlib_metadata as metadata  # pragma: no cover
                 
 try:
-    __version__ = metadata.version(__name__)
+    __version__ = metadata.version(__package__)
 except metadata.PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"  # pragma: no cover


### PR DESCRIPTION
Using `__name__` is not correct. Its value is `"__main__"` and therefore the linkml version cannot be found and is set to "0.0.0".

Closes #1195