### PR TITLE
Fix non-stopping CI on windows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,7 +77,7 @@ jobs:
           poetry run coverage run -m unittest discover
           poetry run coverage xml
           poetry run coverage report -m
-
+        shell: bash
       #----------------------------------------------
       #           upload coverage results
       #----------------------------------------------

--- a/linkml/utils/schemaloader.py
+++ b/linkml/utils/schemaloader.py
@@ -191,7 +191,6 @@ class SchemaLoader:
                     logging.warning(
                         f'Class: "{cls.name}" attribute "{attribute.name}" - '
                         f"mangled name: {mangled_slot_name} already exists",
-                        attribute.name,
                     )
                 new_slot = SlotDefinition(**attribute.__dict__)
                 new_slot.domain_of.append(cls.name)

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -272,7 +272,7 @@ class TestEnvironment:
         if not self.eval_single_file(expected_file, actual, filtr, comparator):
             if self.fail_on_error:
                 self.make_temp_dir(os.path.dirname(actual_file), clear=False)
-                with open(actual_file, "w") as actualf:
+                with open(actual_file, "w", encoding="UTF-8") as actualf:
                     actualf.write(actual)
         return actual
 
@@ -303,7 +303,7 @@ class TestEnvironment:
             self.log(expected_file_path, msg)
         if msg and not self.fail_on_error:
             self.make_temp_dir(os.path.dirname(expected_file_path), clear=False)
-            with open(expected_file_path, "w") as outf:
+            with open(expected_file_path, "w", encoding="UTF-8") as outf:
                 outf.write(actual_text)
         return not msg
 


### PR DESCRIPTION
As suggested in https://github.com/actions/runner-images/issues/6668

Update: This fixes the problem but reveals that the tests on Windows produce (overlooked) errors which should be fixed before merging this. --> Done in #1206

Closes #1200