### PR TITLE
ensure example_runner initializes PythonGenerator safely. Fixes #1219

### DIFF
--- a/linkml/workspaces/example_runner.py
+++ b/linkml/workspaces/example_runner.py
@@ -86,7 +86,11 @@ class ExampleRunner:
         :return:
         """
         if self._python_module is None:
-            pygen = PythonGenerator(self.schemaview.schema)
+            # See: https://github.com/linkml/linkml/issues/1219
+            src = self.schemaview.schema.source_file
+            if not src:
+                src = self.schemaview.schema
+            pygen = PythonGenerator(src)
             self._python_module = pygen.compile_module()
         return self._python_module
 


### PR DESCRIPTION
note this fix should not be necessary after we have: #1228
