### PR TITLE
Change SHACL gen to make the shapes `sh:closed false` by default

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -59,7 +59,7 @@ class ShaclGenerator(Generator):
             class_uri = URIRef(sv.get_uri(c, expand=True))
             shape_pv(RDF.type, SH.NodeShape)
             shape_pv(SH.targetClass, class_uri)  ## TODO
-            shape_pv(SH.closed, Literal(True))
+            shape_pv(SH.closed, Literal(False))
             if c.title is not None:
                 shape_pv(SH.name, Literal(c.title))
             if c.description is not None:

--- a/tests/test_generators/test_shaclgen.py
+++ b/tests/test_generators/test_shaclgen.py
@@ -18,7 +18,7 @@ EXPECTED = [
      rdflib.term.URIRef('http://www.w3.org/ns/shacl#NodeShape')),
     (rdflib.term.URIRef('https://w3id.org/linkml/tests/kitchen_sink/Person'),
      rdflib.term.URIRef('http://www.w3.org/ns/shacl#closed'),
-     rdflib.term.Literal('true', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#boolean')))
+     rdflib.term.Literal('false', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#boolean')))
 ]
 
 class ShaclTestCase(unittest.TestCase):


### PR DESCRIPTION
Change SHACL gen to make the shapes `sh:closed false` instead of `sh:closed true`

The motives for this changes have been discussed with @cmungall in https://github.com/linkml/linkml/issues/1249