### PR TITLE
Fix shaclgen by making mixins and classes without parents not closed

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -59,7 +59,7 @@ class ShaclGenerator(Generator):
             class_uri = URIRef(sv.get_uri(c, expand=True))
             shape_pv(RDF.type, SH.NodeShape)
             shape_pv(SH.targetClass, class_uri)  ## TODO
-            if c.mixin or not c.is_a:
+            if c.mixin or not c.abstract:
                 shape_pv(SH.closed, Literal(False))
             else:
                 shape_pv(SH.closed, Literal(True))

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -59,7 +59,7 @@ class ShaclGenerator(Generator):
             class_uri = URIRef(sv.get_uri(c, expand=True))
             shape_pv(RDF.type, SH.NodeShape)
             shape_pv(SH.targetClass, class_uri)  ## TODO
-            if c.mixin or not c.abstract:
+            if c.mixin or c.abstract:
                 shape_pv(SH.closed, Literal(False))
             else:
                 shape_pv(SH.closed, Literal(True))

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -59,7 +59,10 @@ class ShaclGenerator(Generator):
             class_uri = URIRef(sv.get_uri(c, expand=True))
             shape_pv(RDF.type, SH.NodeShape)
             shape_pv(SH.targetClass, class_uri)  ## TODO
-            shape_pv(SH.closed, Literal(True))
+            if c.mixin or not c.is_a:
+                shape_pv(SH.closed, Literal(False))
+            else:
+                shape_pv(SH.closed, Literal(True))
             if c.title is not None:
                 shape_pv(SH.name, Literal(c.title))
             if c.description is not None:

--- a/tests/test_generators/test_shaclgen.py
+++ b/tests/test_generators/test_shaclgen.py
@@ -16,7 +16,7 @@ EXPECTED = [
     (rdflib.term.URIRef('https://w3id.org/linkml/tests/kitchen_sink/Person'),
      rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
      rdflib.term.URIRef('http://www.w3.org/ns/shacl#NodeShape')),
-    (rdflib.term.URIRef('https://w3id.org/linkml/tests/kitchen_sink/Person'),
+    (rdflib.term.URIRef('https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept'),
      rdflib.term.URIRef('http://www.w3.org/ns/shacl#closed'),
      rdflib.term.Literal('true', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#boolean')))
 ]

--- a/tests/test_generators/test_shaclgen.py
+++ b/tests/test_generators/test_shaclgen.py
@@ -16,7 +16,7 @@ EXPECTED = [
     (rdflib.term.URIRef('https://w3id.org/linkml/tests/kitchen_sink/Person'),
      rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
      rdflib.term.URIRef('http://www.w3.org/ns/shacl#NodeShape')),
-    (rdflib.term.URIRef('https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept'),
+    (rdflib.term.URIRef('https://w3id.org/linkml/tests/kitchen_sink/Person'),
      rdflib.term.URIRef('http://www.w3.org/ns/shacl#closed'),
      rdflib.term.Literal('true', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#boolean')))
 ]


### PR DESCRIPTION
Fix shaclgen by making mixins and abstract classes `sh:closed false` in the shaclgen, more details in the discussion with @cmungall in https://github.com/linkml/linkml/issues/1249