### PR TITLE
Pydantic: stop generating Unions with only one member

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -275,7 +275,7 @@ class PydanticGenerator(OOCodeGenerator):
             sv.get_identifier_slot(range_cls.name) is None
             and not sv.is_mixin(range_cls.name)
         ):
-            if len([x for x in sv.class_induced_slots(slot.range) if x.designates_type]) > 0:
+            if len([x for x in sv.class_induced_slots(slot.range) if x.designates_type]) > 0 and len(sv.class_descendants(slot.range)) > 1:
                 return f"Union[" + ",".join([camelcase(c) for c in sv.class_descendants(slot.range)]) + "]"
             else:
                 return f"{camelcase(slot.range)}"

--- a/tests/test_issues/test_pydantic_polymorphism.py
+++ b/tests/test_issues/test_pydantic_polymorphism.py
@@ -34,6 +34,9 @@ classes:
     tree_root: true
     slots:
       - things
+  ContainerWithOneSibling:
+    slots:
+      - persons
 slots:
   id:
     identifier: true
@@ -50,6 +53,10 @@ slots:
     range: integer
   things:
     range: NamedThing
+    multivalued: true
+    inlined_as_list: true
+  persons:
+    range: Person
     multivalued: true
     inlined_as_list: true
 """
@@ -80,6 +87,9 @@ class PydanticPolymorphismTestCase(TestEnvironmentTestCase):
     def test_pydantic_obey_range(self):
         gen = PydanticGenerator(schema_str)
         output = gen.serialize()
+        
+        self.assertNotRegexpMatches(output, "Union\[[a-zA-Z0-9]*\]", "a python Union should always have more than one option")
+
         output_subset = [line for line in output.splitlines() if "thingtype" in line]
         self.assertGreater(len(output_subset), 0)
         


### PR DESCRIPTION
If a Union has only one member, there is no point in making it a Union. 

The resulting code still works with Unions with only one member, but IDEs like Visual studio code complain about it.