### PR TITLE
Pydantic gen: switch to external uri/curie by default, still accept native uri/curie.

### DIFF
--- a/linkml/generators/common/type_designators.py
+++ b/linkml/generators/common/type_designators.py
@@ -25,7 +25,13 @@ def get_accepted_type_designator_values(sv: SchemaView, type_designator_slot: Sl
             sv.get_uri(class_def, expand=False, native=True),
             sv.get_uri(class_def, expand=False, native=False),
         ]
-    if type_designator_slot.range == 'uri':
+    # unique, but with order preserved (https://stackoverflow.com/a/17016257)
+    accepted_uri_values = list(dict.fromkeys(accepted_uri_values))
+
+    slot_types = set(sv.type_ancestors(type_designator_slot.range))
+    uri_types = ['uri', 'uriorcurie']
+
+    if slot_types.intersection(uri_types):
         return accepted_uri_values
     elif type_designator_slot.range == 'string':
         return [camelcase(class_def.name)]

--- a/linkml/generators/common/type_designators.py
+++ b/linkml/generators/common/type_designators.py
@@ -1,24 +1,29 @@
 from linkml_runtime.linkml_model.meta import SlotDefinition, ClassDefinition
 from linkml_runtime.utils.schemaview import SchemaView
 from linkml_runtime.utils.formatutils import camelcase
-from typing import List
+from typing import List, Tuple
 
 def get_type_designator_value(sv: SchemaView, type_designator_slot: SlotDefinition, class_def: ClassDefinition) -> str:
     """
         retuns the correct value for a type designator field for a given class, depending on its range
         this implements the logic described in https://github.com/linkml/linkml/issues/945:
     """
-    target_value = None
-    if type_designator_slot.range == 'uri':
-        target_value = sv.get_uri(class_def,expand=True,native=False)
-    elif type_designator_slot.range == 'string':
-        target_value = camelcase(class_def.name)
+    slot_types = set(sv.type_ancestors(type_designator_slot.range))
+    if 'uri' in slot_types:
+        return sv.get_uri(class_def,expand=True,native=False)
+    elif 'uriorcurie' in slot_types:
+        return sv.get_uri(class_def,expand=False, native=False)
+    elif 'string' in slot_types:
+        return camelcase(class_def.name)
     else:
-        target_value = sv.get_uri(class_def,expand=False, native=False)
-    return target_value
+        return sv.get_uri(class_def,expand=False, native=False)
 
 
 def get_accepted_type_designator_values(sv: SchemaView, type_designator_slot: SlotDefinition, class_def: ClassDefinition) -> List[str]:
+    """
+        retuns the accepted values for a type designator field for a given class, depending on its range
+        this implements the logic described in https://github.com/linkml/linkml/issues/945:
+    """
     accepted_uri_values = [
             sv.get_uri(class_def, expand=True, native=True),
             sv.get_uri(class_def, expand=True, native=False),

--- a/linkml/generators/common/type_designators.py
+++ b/linkml/generators/common/type_designators.py
@@ -1,6 +1,7 @@
 from linkml_runtime.linkml_model.meta import SlotDefinition, ClassDefinition
 from linkml_runtime.utils.schemaview import SchemaView
 from linkml_runtime.utils.formatutils import camelcase
+from typing import List
 
 def get_type_designator_value(sv: SchemaView, type_designator_slot: SlotDefinition, class_def: ClassDefinition) -> str:
     """
@@ -9,9 +10,24 @@ def get_type_designator_value(sv: SchemaView, type_designator_slot: SlotDefiniti
     """
     target_value = None
     if type_designator_slot.range == 'uri':
-        target_value = sv.get_uri(class_def,expand=True,native=True)
+        target_value = sv.get_uri(class_def,expand=True,native=False)
     elif type_designator_slot.range == 'string':
         target_value = camelcase(class_def.name)
     else:
-        target_value = sv.get_uri(class_def,expand=False)
+        target_value = sv.get_uri(class_def,expand=False, native=False)
     return target_value
+
+
+def get_accepted_type_designator_values(sv: SchemaView, type_designator_slot: SlotDefinition, class_def: ClassDefinition) -> List[str]:
+    accepted_uri_values = [
+            sv.get_uri(class_def, expand=True, native=True),
+            sv.get_uri(class_def, expand=True, native=False),
+            sv.get_uri(class_def, expand=False, native=True),
+            sv.get_uri(class_def, expand=False, native=False),
+        ]
+    if type_designator_slot.range == 'uri':
+        return accepted_uri_values
+    elif type_designator_slot.range == 'string':
+        return [camelcase(class_def.name)]
+    else:
+        return accepted_uri_values

--- a/tests/test_generators/output/kitchen_sink_pydantic.py
+++ b/tests/test_generators/output/kitchen_sink_pydantic.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Union, Literal
 from pydantic import BaseModel as BaseModel, Field
 from linkml_runtime.linkml_model import Decimal
 

--- a/tests/test_issues/test_pydantic_polymorphism.py
+++ b/tests/test_issues/test_pydantic_polymorphism.py
@@ -4,6 +4,47 @@ from linkml.generators.pydanticgen import PydanticGenerator
 from tests.test_issues.environment import env
 from tests.utils.test_environment import TestEnvironmentTestCase
 from linkml_runtime.utils.compile_python import compile_python
+from pydantic import ValidationError
+type_hierarchy_schema_str = """
+id: http://example.org
+name: inline-dict-test
+imports:
+  - https://w3id.org/linkml/types
+prefixes:
+  x: http://example.org/
+default_prefix: x
+default_range: string
+description: test
+
+classes:
+  NamedThing:
+    slots:
+      - id
+      - category
+  Person:
+    is_a: NamedThing
+
+types:
+  category type:
+    typeof: uriorcurie
+    description: >-
+      see biolink model
+
+slots:
+  id:
+    identifier: true
+    range: string
+    required: true
+  type:
+    slot_uri: rdf:type
+    multivalued: true
+  category:
+    is_a: type
+    range: category type
+    designates_type: true
+    is_class_field: true
+    multivalued: true
+"""
 
 schema_str = """
 id: http://example.org
@@ -101,6 +142,16 @@ class PydanticPolymorphismTestCase(TestEnvironmentTestCase):
         output_subset = [line for line in output.splitlines() if "thingtype" in line]
         self.assertGreater(len(output_subset), 0)
         self.assertEqual(len([x for x in output_subset if 'http://example.org/Person' in x]) ,1)
+
+    def test_type_hierarchy(self):
+        gen_range_not_specified = PydanticGenerator(type_hierarchy_schema_str)
+        output = gen_range_not_specified.serialize()
+        mod = compile_python(output, "testschema")
+        _ = mod.Person()
+        _ = mod.Person(category=['http://example.org/Person'])
+        _ = mod.Person(category=['x:Person'])
+        self.assertRaises(ValidationError, lambda: mod.Person(category=['x:NamedThing']))
+
 
     def test_pydantic_load_poly_data(self):
         gen = PydanticGenerator(schema_str)

--- a/tests/test_issues/test_pydantic_polymorphism.py
+++ b/tests/test_issues/test_pydantic_polymorphism.py
@@ -24,6 +24,7 @@ classes:
       - thingtype
   Person:
     is_a: NamedThing
+    class_uri: "http://testbreaker/not-the-uri-you-expect"
     slots:
       - height
   Organisation:
@@ -88,19 +89,17 @@ class PydanticPolymorphismTestCase(TestEnvironmentTestCase):
         gen = PydanticGenerator(schema_str)
         output = gen.serialize()
         
-        self.assertNotRegexpMatches(output, "Union\[[a-zA-Z0-9]*\]", "a python Union should always have more than one option")
+        self.assertNotRegex(output, "Union\[[a-zA-Z0-9]*\]", "a python Union should always have more than one option")
 
         output_subset = [line for line in output.splitlines() if "thingtype" in line]
         self.assertGreater(len(output_subset), 0)
         
-        self.assertTrue("const=True" in output_subset[0])
         self.assertEqual(len([x for x in output_subset if 'x:Person' in x]),1)
 
         gen = PydanticGenerator(schema_str.replace("uriorcurie","uri"))
         output = gen.serialize()
         output_subset = [line for line in output.splitlines() if "thingtype" in line]
         self.assertGreater(len(output_subset), 0)
-        self.assertTrue("const=True" in output_subset[0])
         self.assertEqual(len([x for x in output_subset if 'http://example.org/Person' in x]) ,1)
 
     def test_pydantic_load_poly_data(self):


### PR DESCRIPTION
as discussed with @hsolbrig 

* Use external curie/uri by default if available. Native uri/curie is still accepted
* When the range is uri, we still accept the known curies, and when the range is uriorcurie, we also still accept uri's.

generated code: 

```python
class NamedThing(ConfiguredBaseModel):
    
    id: str = Field(None)
    full_name: Optional[str] = Field(None)
    thingtype: Literal["http://example.org/NamedThing","http://example.org/NamedThing","x:NamedThing","x:NamedThing"] = Field("x:NamedThing")
    


class Person(NamedThing):
    
    height: Optional[int] = Field(None)
    id: str = Field(None)
    full_name: Optional[str] = Field(None)
    thingtype: Literal["http://example.org/Person","http://testbreaker/not-the-uri-you-expect","x:Person","http://testbreaker/not-the-uri-you-expect"] = Field("x:Person")
    


class Organisation(NamedThing):
    
    number_of_employees: Optional[int] = Field(None)
    id: str = Field(None)
    full_name: Optional[str] = Field(None)
    thingtype: Literal["http://example.org/Organisation","http://example.org/Organisation","x:Organisation","x:Organisation"] = Field("x:Organisation")
```
