### PR TITLE
owlgen: no class needed for terms defined on other vocabularies

### DIFF
--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -225,6 +225,10 @@ class OwlSchemaGenerator(Generator):
         # representation, consult https://www.w3.org/TR/owl2-mapping-to-rdf/
         cls_uri = self._class_uri(cls.name)
         self.add_mappings(cls)
+        for mapping in cls.mappings:
+            if cls_uri == self.namespaces.uri_for(mapping):
+                logging.info(f"not adding class {cls.name} since it's only 'importing' an external term")
+                return
         self.add_metadata(cls, cls_uri)
         # add declaration
         self.graph.add((cls_uri, RDF.type, OWL.Class))
@@ -380,6 +384,10 @@ class OwlSchemaGenerator(Generator):
             return
 
         slot_uri = self._prop_uri(slot.name)
+        for mapping in slot.mappings:
+            if slot_uri == self.namespaces.uri_for(mapping):
+                logging.info(f"not adding slot {slot.name} since it's only 'importing' an external term")
+                return
         # logging.error(f'SLOT_URI={slot_uri}')
 
         # Slots may be modeled as Object or Datatype Properties


### PR DESCRIPTION
**Important NOTE**: this MR is a PoC or demo not ready for merging for the time being. I'm lack the expertise to asses if it's breaking something else.

This MR tries to address the issues mentioned in #1281.

If a class or slot are to be inherited from terms defined in external vocabularies (for example, https://rds.posccaesar.org/ontology/lis14/rdl/ in my case), a declaration is needed in the schema. That declaration provokes unexpected "exactMatch" entries instead of the expected "subClassOf"/"subPropertyOf".

### Example

Following schema
```
id: https://example.org/my-schema
prefixes:
  linkml: https://w3id.org/linkml/
  rdl: https://rds.posccaesar.org/ontology/lis14/rdl/
imports:
  - linkml:types
default_range: string

classes:
  MySubclass:
    is_a: FunctionalObject
  FunctionalObject:
    class_uri: rdl:FunctionalObject

slots:
  mySubslot:
    is_a: hasFeature
  hasFeature:
    slot_uri: rdl:hasFeature
```
Results in an OWL file with following entries:
```
[...]

<https://example.org/my-schema/MySubclass> a owl:Class,
        linkml:ClassDefinition ;
    rdfs:label "MySubclass" ;
    rdfs:subClassOf <https://example.org/my-schema/FunctionalObject> .

<https://example.org/my-schema/mySubslot> a owl:ObjectProperty,
        linkml:SlotDefinition ;
    rdfs:label "mySubslot" ;
    rdfs:range linkml:String ;
    rdfs:subPropertyOf rdl:hasFeature .

[...]

<https://example.org/my-schema/FunctionalObject> a owl:Class,
        linkml:ClassDefinition ;
    rdfs:label "FunctionalObject" ;
    skos:exactMatch rdl:FunctionalObject .

rdl:hasFeature a owl:ObjectProperty,
        linkml:SlotDefinition ;
    rdfs:label "hasFeature" ;
    rdfs:range linkml:String ;
    skos:exactMatch rdl:hasFeature .

[...]
```

Notice that

1. `FunctionalObject` gets a wrong URI, since it should be `rdl:FunctionalObject`. That's what the first commit tries to fix.
2. `<https://example.org/my-schema/mySubslot>` is already being defined as a ` rdfs:subPropertyOf rdl:hasFeature`, so no need to have the `rdl:hasFeature skos:exactMatch rdl:hasFeature` at the bottom. That's what the second commit tries to fix.

With the patch the output is what I'd expect:
```
[...]

<https://example.org/my-schema/MySubclass> a owl:Class,
        linkml:ClassDefinition ;
    rdfs:label "MySubclass" ;
    rdfs:subClassOf rdl:FunctionalObject .

<https://example.org/my-schema/mySubslot> a owl:ObjectProperty,
        linkml:SlotDefinition ;
    rdfs:label "mySubslot" ;
    rdfs:range linkml:String ;
    rdfs:subPropertyOf rdl:hasFeature .

[...]
```
without neither `rdl:Functional skos:exactMatch rdl:Functional` nor `rdl:hasFeature skos:exactMatch rdl:hasFeature`.