### PR TITLE
RFC: Improvements/changes to sqlalachemygen

### DIFF
--- a/linkml/generators/sqlalchemy/sqlalchemy_declarative_template.py
+++ b/linkml/generators/sqlalchemy/sqlalchemy_declarative_template.py
@@ -4,51 +4,69 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql.sqltypes import *
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.sql.schema import MetaData
 
-Base = declarative_base()
+metadata_obj = MetaData(schema="{{schemaname(model_path)}}")
+Base = declarative_base(metadata=metadata_obj)
 metadata = Base.metadata
 
-{% for c in classes %}
+{% for c in classes if is_join_table(c) %}
+{{tablename(c.name)}} = Table(
+    "{{tablename(c.name)}}",
+    Base.metadata,
+{% for s in c.attributes.values() -%}
+     Column("{{columnname(s.alias)}}", {{s.annotations["sql_type"].value}}
+           {%- if "foreign_key" in s.annotations -%}, ForeignKey("{{schemaname(model_path)}}.{{ columnname(s.annotations["foreign_key"].value) }}", deferrable=True,) {%- endif -%}
+           {%- if "primary_key" in s.annotations -%}, primary_key=True {%- endif -%}
+           {%- if "autoincrement" in s.annotations -%}, autoincrement=True {% endif -%}
+           {%- if "required" in s.annotations -%}, nullable=False {% endif -%}
+           ),
+    {% endfor %}
+    comment = \"\"\"{{c.comments[0]}}\"\"\",
+)
+{% endfor %}
+
+{% for c in classes if not is_join_table(c) %}
 class {{classname(c.name)}}({% if c.is_a %}{{ classname(c.is_a) }}{% else %}Base{% endif %}):
     \"\"\"
     {% if c.description %}{{c.description}}{% else %}{{c.alias}}{% endif %}
     \"\"\"
-    __tablename__ = '{{c.name}}'
-    
+    __tablename__ = "{{tablename(c.name)}}"
+
     {% for s in c.attributes.values() -%}
-    {{s.alias}} = Column({{s.annotations['sql_type'].value}}
-           {%- if 'foreign_key' in s.annotations -%}, ForeignKey('{{ s.annotations['foreign_key'].value }}') {%- endif -%}
+    {{columnname(s.alias)}} = Column({{s.annotations["sql_type"].value}}
+           {%- if 'foreign_key' in s.annotations -%}, ForeignKey('{{schemaname(model_path)}}.{{ columnname(s.annotations['foreign_key'].value) }}',  deferrable=True,) {%- endif -%}
            {%- if 'primary_key' in s.annotations -%}, primary_key=True {%- endif -%}
            {%- if 'autoincrement' in s.annotations -%}, autoincrement=True {% endif -%}
            {%- if "required" in s.annotations -%}, nullable=False {% endif -%}
            )
     {% if 'foreign_key' in s.annotations and 'original_slot' in s.annotations -%}
-    {{s.annotations['original_slot'].value}} = relationship("{{classname(s.range)}}", uselist=False, foreign_keys=[{{s.alias}}])
+    {{columnname(s.annotations['original_slot'].value)}} = relationship("{{classname(s.range)}}", uselist=False)
     {% endif -%}
     {% endfor %}
-    
+
     {%- for mapping in backrefs[c.name] %}
     {% if mapping.mapping_type == "ManyToMany" %}
     # ManyToMany
-    {{mapping.source_slot}} = relationship( "{{ classname(mapping.target_class) }}", secondary="{{ mapping.join_class }}")
+    {{columnname(mapping.source_slot)}} = relationship( "{{ classname(mapping.target_class) }}", secondary={{tablename(mapping.join_class)}})
     {% elif mapping.mapping_type == "MultivaluedScalar" %}
-    {{mapping.source_slot}}_rel = relationship( "{{ classname(mapping.join_class) }}" )
-    {{mapping.source_slot}} = association_proxy("{{mapping.source_slot}}_rel", "{{mapping.target_slot}}",
-                                  creator=lambda x_: {{ classname(mapping.join_class) }}({{mapping.target_slot}}=x_))
+    {{columnname(mapping.source_slot)}}_rel = relationship( "{{ classname(mapping.join_class) }}" )
+    {{columnname(mapping.source_slot)}} = association_proxy("{{mapping.source_slot}}_rel", "{{mapping.target_slot}}",
+                                  creator=lambda x_: {{ classname(mapping.join_class) }}({{columnname(mapping.target_slot)}}=x_))
     {% else %}
     # One-To-Many: {{mapping}}
-    {{mapping.source_slot}} = relationship( "{{ classname(mapping.target_class) }}", foreign_keys="[{{ mapping.target_class }}.{{mapping.target_slot}}]")
+    {{columnname(mapping.source_slot)}} = relationship( "{{ classname(mapping.target_class) }}", foreign_keys="[{{ mapping.target_class }}.{{columnname(mapping.target_slot)}}]")
     {% endif -%}
     {%- endfor %}
-    
+
     def __repr__(self):
         return f"{{c.name}}(
         {%- for s in c.attributes.values() -%}
-        {{s.alias}}={self.{{s.alias}}}, 
+        {{s.alias}}={self.{{s.alias}}},
         {%- endfor %})"
-        
-    
-        
+
+
+
     {% if c.is_a or c.mixins %}
     # Using concrete inheritance: see https://docs.sqlalchemy.org/en/14/orm/inheritance.html
     __mapper_args__ = {

--- a/linkml/generators/sqlalchemygen.py
+++ b/linkml/generators/sqlalchemygen.py
@@ -64,7 +64,8 @@ class SQLAlchemyGenerator(Generator):
     ) -> str:
         # src_sv = SchemaView(self.schema)
         # self.schema = src_sv.schema
-        sqltr = RelationalModelTransformer(self.schemaview)
+        # use two underscores to distinguish it from the snake case underscore
+        sqltr = RelationalModelTransformer(self.schemaview, join_table_separator="__")
         if foreign_key_policy:
             sqltr.foreign_key_policy = foreign_key_policy
         tgen = SQLTableGenerator(self.schemaview.schema)

--- a/linkml/generators/sqlalchemygen.py
+++ b/linkml/generators/sqlalchemygen.py
@@ -126,6 +126,9 @@ class SQLAlchemyGenerator(Generator):
             mappings=tr_result.mappings,
             backrefs=backrefs,
             classname=camelcase,
+            schemaname=underscore,
+            tablename=underscore,
+            columnname=underscore,
             no_model_import=no_model_import,
             is_join_table=lambda c: any(
                 tag for tag in c.annotations.keys() if tag == "linkml:derived_from"

--- a/linkml/generators/sqlalchemygen.py
+++ b/linkml/generators/sqlalchemygen.py
@@ -259,7 +259,7 @@ def cli(
         foreign_key_policy = ForeignKeyPolicy.NO_FOREIGN_KEYS
     print(gen.generate_sqla(template=t, foreign_key_policy=foreign_key_policy))
     if generate_classes:
-        raise NotImplementedError(f"generate classes not implemented")
+        raise NotImplementedError("generate classes not implemented")
 
 
 if __name__ == "__main__":

--- a/linkml/generators/sqlalchemygen.py
+++ b/linkml/generators/sqlalchemygen.py
@@ -71,9 +71,10 @@ class SQLAlchemyGenerator(Generator):
         tgen = SQLTableGenerator(self.schemaview.schema)
         tr_result = sqltr.transform(**kwargs)
         tr_schema = tr_result.schema
+        tr_schema_view = SchemaView(tr_schema)
         for c in tr_schema.classes.values():
             for a in c.attributes.values():
-                sql_range = tgen.get_sql_range(a, tr_schema)
+                sql_range = tgen.get_sql_range(a, tr_schema, tr_schema_view)
                 sql_type = sql_range.__repr__()
                 ann = Annotation("sql_type", sql_type)
                 a.annotations[ann.tag] = ann

--- a/linkml/generators/sqltablegen.py
+++ b/linkml/generators/sqltablegen.py
@@ -225,7 +225,9 @@ class SQLTableGenerator(Generator):
             e = schema.enums[range]
             if e.permissible_values is not None:
                 vs = [str(v) for v in e.permissible_values]
-                return Enum(name=e.name, *vs)
+                enum = Enum(name=e.name, *vs)
+                enum.inherit_schema = True
+                return enum
         if range in METAMODEL_TYPE_TO_BASE:
             range_base = METAMODEL_TYPE_TO_BASE[range]
         elif range in schema.types:

--- a/linkml/generators/sqltablegen.py
+++ b/linkml/generators/sqltablegen.py
@@ -10,8 +10,8 @@ from linkml_runtime.linkml_model import (ClassDefinition, SchemaDefinition,
 from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml_runtime.utils.schemaview import SchemaView
 from sqlalchemy import Column, ForeignKey, MetaData, Table, create_mock_engine
-from sqlalchemy.types import (Boolean, Date, DateTime, Enum, Float, Integer,
-                              Text, Time)
+from sqlalchemy.types import (BigInteger, Boolean, Date, DateTime, Enum, Float,
+                              Integer, Text, Time)
 
 from linkml._version import __version__
 from linkml.generators.yamlgen import YAMLGenerator
@@ -51,6 +51,7 @@ RANGEMAP = {
     "NCName": Text(),
     "URIorCURIE": Text(),
     "int": Integer(),
+    "bigint": BigInteger(),
     "Decimal": Integer(),
     "double": Float(),
     "float": Float(),


### PR DESCRIPTION
These are changes we had to do to make it easier for us to automatically generate and use models as sqlalchemy models. The goal was that we could reuse the python files "as is" without manual changes afterwards. This is an attempt to upstream these changes to see if any of them are of interest. If not, we will simply keep our forked scripts :-)

I tried to split this into multiple commits, but e.g. the changes to the final sqlalchemy jinja template could probably be split further.

There are a few more changes, like adding a base class to declaritive_base so one can add mixins from outside, but I can do these easily via some postprocessing (search&replace):

```
try:
    from .base import {{classname(model_path)}}Base as _Base
except ImportError:
    class _Base:
        pass

# Each model needs to have its own Base to not get clashes in the alembic handling
# when some classes are defined multiple times!
Base = declarative_base(cls=_Base, ...)
```

Let me know if there is anything interesting in these so I can add tests...