### PR TITLE
feat(shacl): improve type generation

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -109,10 +109,11 @@ class ShaclGenerator(Generator):
                         prop_pv(SH.nodeKind, SH.IRI)
                     else:
                         prop_pv(SH.nodeKind, SH.BlankNode)
-                elif r in sv.all_types().values():
+                elif r in sv.all_types():
+                    prop_pv(SH.nodeKind, SH.Literal)
                     rt = sv.get_type(r)
                     if rt.uri:
-                        prop_pv(SH.datatype, rt.uri)
+                        prop_pv(SH.datatype, Literal(rt.uri))
                     else:
                         logging.error(f"No URI for type {rt.name}")
                 elif r in sv.all_enums():


### PR DESCRIPTION
This PR improves shaclgen.py by adding nodeKind and datatype for Linkml types (fixes https://github.com/linkml/linkml/issues/1299)

TODO: I am not sure if `sh:nodeKind sh:IRI` is correct and maybe should be `sh:nodeKind sh:Literal`.

Example output from this PR:
```
sh:property [ sh:datatype "xsd:anyURI" ;             <=========== added
            sh:description "Specifies a reference to a resource outside of the UCO." ;
            sh:nodeKind sh:IRI ;              <=========== added
            sh:order 3 ;
            sh:path core:externalReference ],
        [ sh:datatype "xsd:string" ;              <=========== added
            sh:description "The name of a particular concept characterization." ;
            sh:maxCount 1 ;
            sh:nodeKind sh:Literal ;               <=========== added
            sh:order 6 ;
            sh:path core:name ]
```