### PR TITLE
replace `pkg_resources` methods with `importlib` methods

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -8,7 +8,7 @@ from typing import (Callable, Dict, Iterable, Iterator, List, Optional, Set,
                     TextIO, Tuple, TypeVar, Union)
 
 import click
-import pkg_resources
+import importlib.util
 from jinja2 import Environment, FileSystemLoader, Template
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model.meta import (Annotation, ClassDefinition,
@@ -297,7 +297,8 @@ class DocGenerator(Generator):
                         f"Could not find {base_file_name} in {self.template_directory} - falling back to default"
                     )
             if not folder:
-                folder = pkg_resources.resource_filename(__name__, "docgen")
+                package_dir = os.path.dirname(importlib.util.find_spec(__name__).origin)
+                folder = os.path.join(package_dir, "docgen", "")
             loader = FileSystemLoader(folder)
             env = Environment(loader=loader)
             customize_environment(env)

--- a/linkml/generators/javagen.py
+++ b/linkml/generators/javagen.py
@@ -2,7 +2,7 @@ import os
 from dataclasses import field, dataclass
 from typing import Optional
 import click
-import pkg_resources
+import importlib.util
 from jinja2 import Environment, FileSystemLoader, Template
 from linkml_runtime.linkml_model.meta import TypeDefinition
 
@@ -106,7 +106,8 @@ class JavaGenerator(OOCodeGenerator):
 
     def serialize(self, directory: str, **kwargs) -> None:
         if self.generate_records:
-            javagen_folder = pkg_resources.resource_filename(__name__, "javagen")
+            package_dir = os.path.dirname(importlib.util.find_spec(__name__).origin)
+            javagen_folder = os.path.join(package_dir, "javagen", "")
             loader = FileSystemLoader(javagen_folder)
             env = Environment(loader=loader)
             template_obj = env.get_template("java_record_template.jinja2")

--- a/linkml/generators/typescriptgen.py
+++ b/linkml/generators/typescriptgen.py
@@ -7,7 +7,6 @@ from typing import (Callable, Dict, Iterator, List, Optional, Set, TextIO,
                     Tuple, Union)
 
 import click
-import pkg_resources
 from jinja2 import Environment, FileSystemLoader, Template
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model.meta import (Annotation, ClassDefinition,


### PR DESCRIPTION
pkg_resources is deprecated and the setuptools docs recommends moving to importlib https://setuptools.pypa.io/en/latest/pkg_resources.html

The `pkg_resources` module has a dependency on `setuptools`. Taking a look at the `pyproject.toml` file, we're not installing `setuptools`, either as a dev dependency or as a regular dependency. We don't have `setuptools` in our environment, so that means no access to the `pkg_resources` module either. 

We need to use equivalent methods from the standard `importlib` module in place of `pkg_resources` methods that we are currently using.