### PR TITLE
add dependency relationship between classes linked by a slot

### DIFF
--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -12,6 +12,7 @@
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} <.. {{ s.range }} : {{ gen.name(s) }}
       {% endfor %}
 
       {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
@@ -19,6 +20,7 @@
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} <.. {{ s.range }} : {{ gen.name(s )}}
       {% endfor %}
 ```
 {% elif schemaview.class_parents(element.name) %}
@@ -30,6 +32,7 @@
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} <.. {{ s.range }} : {{ gen.name(s )}}
       {% endfor %}
 ```
 {% elif schemaview.class_children(element.name)  %}
@@ -41,6 +44,7 @@
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} <.. {{ s.range }} : {{ gen.name(s )}}
       {% endfor %}
 ```
 {% else %}
@@ -49,6 +53,7 @@
     class {{ gen.name(element) }}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} <.. {{ s.range }} : {{ gen.name(s )}}
       {% endfor %}
 ```
 {% endif %}


### PR DESCRIPTION
Examples of what this PR introduces in the NMDC Schema, say:

1. Beneficial rendering: can easily visualize the linking

<img width="295" alt="Screen Shot 2023-03-01 at 3 16 10 PM" src="https://user-images.githubusercontent.com/20239224/222288523-f9697bc0-9a8b-4412-a50b-13f1d4826269.png">

2. Not so useful rendering: too many slots for a class to class relationship compressed into a small space. This is a mkdocs limitation

<img width="828" alt="Screen Shot 2023-03-01 at 3 17 19 PM" src="https://user-images.githubusercontent.com/20239224/222288661-e355125b-c62c-49e1-b970-3b844bd1e959.png">

