### PR TITLE
Trigger on push to main in addition to PR

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,14 @@
 
 name: Build and test linkml
 
-on: [pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
This should help to avoid breaking main. (related to #1328, #1329 - I think #1323 was the breaking change)

On `workflow_dispatch` is for manually starting the pipeline.