### PR TITLE
fix(docgen): emphasizing multiline descriptions

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -6,7 +6,10 @@
 
 
 {% if element.description %}
-_{{ element.description }}_
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
 {% endif %}
 
 {% if element.abstract %}

--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -1,7 +1,10 @@
 # Enum: {{ gen.name(element) }}
 
 {% if element.description %}
-_{{ element.description }}_
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
 {% endif %}
 
 URI: {{ gen.uri_link(element) }}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -5,7 +5,10 @@
 {%- endif -%}
 
 {% if element.description %}
-_{{ element.description }}_
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
 {% endif %}
 
 URI: {{ gen.uri_link(element) }}

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -5,7 +5,10 @@
 {%- endif -%}
 
 {% if element.description %}
-_{{ element.description }}_
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
 {% endif %}
 
 URI: {{ gen.uri_link(element) }}

--- a/linkml/generators/docgen/type.md.jinja2
+++ b/linkml/generators/docgen/type.md.jinja2
@@ -1,7 +1,10 @@
 # Type: {{ gen.name(element) }}
 
 {% if element.description %}
-_{{ element.description }}_
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
 {% endif %}
 
 URI: {{ gen.uri_link(element) }}


### PR DESCRIPTION
The MarkDown markup for emphasizing being used for descriptions fails if the description is multiline. This patch splits first the description and then adds the emphasis to each single line.

Fixes #1350 