### PR TITLE
Set Poetry version to 1.3.2 in all workflows

### DIFF
--- a/.github/workflows/doc_pages.yaml
+++ b/.github/workflows/doc_pages.yaml
@@ -18,7 +18,9 @@ jobs:
           python-version: 3.9
 
       - name: Install Poetry
-        run: pip install poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.2
 
       - name: install
         run: poetry install -E docs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,11 @@ jobs:
           - os: windows-latest
             python-version: "3.8"
 
+    # See https://github.com/snok/install-poetry#running-on-windows
+    defaults:
+      run:
+        shell: bash
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -42,8 +47,9 @@ jobs:
       #          install & configure poetry
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3.1
+        uses: snok/install-poetry@v1
         with:
+          version: 1.3.2
           virtualenvs-create: true
           virtualenvs-in-project: true
 

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -18,9 +18,12 @@ jobs:
           python-version: 3.9
 
       - name: Install Poetry
-        run: |
-          pip install poetry
-          poetry self add "poetry-dynamic-versioning[plugin]"
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.2
+
+      - name: Add dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
 
       # - name: Install dependencies
       #   run: poetry install --no-interaction


### PR DESCRIPTION
In order to work around:

* https://github.com/python-poetry/poetry/issues/7611 (effects Poetry 1.4.0 on Windows)
* https://github.com/python-poetry/poetry/issues/7686 (effects Poetry 1.4.1 on all platforms)

This pins the Poetry version in workflows to 1.3.2. IMO specifying a version of Poetry to use in workflows is a good idea that can hopefully avoid these kinds of surprises in the future. When the above issues are resolved I'm hoping we can bump the version number but not do away with the version specification altogether.

Fixes #1354 