### PR TITLE
Show min, max and pattern on slot pages

### DIFF
--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -56,10 +56,10 @@ URI: {{ gen.uri_link(element) }}
 {% elif element.recommended %}
 * Recommended: {{ element.recommended }}
 {% endif -%}
-{% if element.minimum_value or element.minimum_value == 0 %}
+{% if element.minimum_value is not none %}
 * Minimum Value: {{ element.minimum_value|int }}
 {% endif -%}
-{% if element.maximum_value or element.maximum_value == 0 %}
+{% if element.maximum_value is not none %}
 * Maximum Value: {{ element.maximum_value|int }}
 {% endif -%}
 {% if element.pattern %}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -48,23 +48,26 @@ URI: {{ gen.uri_link(element) }}
 ## Properties
 
 * Range: {{gen.link(element.range)}}
-{%- if element.multivalued %}
+{% if element.multivalued %}
 * Multivalued: {{ element.multivalued }}
-{% endif %}
-{%- if element.required %}
+{% endif -%}
+{% if element.required %}
 * Required: {{ element.required }}
 {% elif element.recommended %}
 * Recommended: {{ element.recommended }}
-{% endif %}
-{%- if element.minimum_value %}
-* Minimum Value: {{ element.minimum_value }}
-{% endif %}
-{%- if element.maximum_value %}
-* Maximum Value: {{ element.maximum_value }}
-{% endif %}
-{%- if schemaview.is_mixin(element.name) %}
+{% endif -%}
+{% if element.minimum_value or element.minimum_value == 0 %}
+* Minimum Value: {{ element.minimum_value|int }}
+{% endif -%}
+{% if element.maximum_value or element.maximum_value == 0 %}
+* Maximum Value: {{ element.maximum_value|int }}
+{% endif -%}
+{% if element.pattern %}
+* Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}
+{% endif -%}
+{% if schemaview.is_mixin(element.name) %}
 * Mixin: {{ element.mixin }}
-{% endif %}
+{% endif -%}
 
 
 {% if schemaview.usage_index().get(element.name) %}

--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -38,6 +38,7 @@ prefixes:
   bizcodes: https://example.org/bizcodes/
   schema: http://schema.org/
 default_prefix: ks
+default_range: string
 see_also:
   - https://example.org/
 
@@ -356,6 +357,7 @@ slots:
     range: AnyObject
     description: Example of a slot that has an unconstrained range
   species name:
+    pattern: ^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\.[A-Z]+(-[0-9]{4})?$
   stomach count:
     range: integer
   # slots added for inheritance tree purposes

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -303,6 +303,24 @@ class DocGeneratorTestCase(unittest.TestCase):
             "Person.md",
             "Example: Person",
             after="## Examples",)
+        # Minimum Value showing up even if value is 0
+        assert_mdfile_contains(
+            "age_in_years.md",
+            "Minimum Value: 0",
+            after="## Properties"
+        )
+        # Maximum Value
+        assert_mdfile_contains(
+            "age_in_years.md",
+            "Maximum Value: 999",
+            after="## Properties"
+        )
+        # 
+        assert_mdfile_contains(
+            "species_name.md",
+            "Regex pattern: `^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\.[A-Z]+(-[0-9]{4})?$`",
+            after="## Properties"
+        )
         
         # checks correctness of the YAML representation of source schema
         person_source = gen.yaml(gen.schemaview.get_class("Person"))


### PR DESCRIPTION
This PR seeks to address the following requests:
* Slot documentation pages doesn't render minimum and maximum values of a slot if it is `0`
* Show regex pattern if it's present