### PR TITLE
fix(owlgen): false prefix on class uri

### DIFF
--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -933,8 +933,12 @@ class OwlSchemaGenerator(Generator):
         return URIRef(ClassDefinition.class_class_uri + "#Mixin")
 
     def _class_uri(self, cn: Union[str, ClassDefinitionName]) -> URIRef:
-        c = self.schemaview.get_class(cn)
-        return URIRef(self.schemaview.get_uri(c, expand=True, native=self.use_native_uris))
+        c = self.schema.get_class(cn)
+        if c is not None and c.class_uri is not None:
+            return URIRef(self.schemaview.get_uri(c, expand=True, native=self.use_native_uris))
+        else:
+            logging.error(self.schema.classes)
+            raise Exception(f"No class_uri for {cn} // {c}")
 
     def _enum_uri(self, en: Union[str, EnumDefinitionName]) -> URIRef:
         sv = self.schemaview


### PR DESCRIPTION
The default prefix is being used for classes where "class_uri" is providing a different prefix. This patch fixes this issue.

Following schema

```
id: https://example.org/my-schema
prefixes:
  linkml: https://w3id.org/linkml/
  rdl: https://rds.posccaesar.org/ontology/lis14/rdl/
imports:
  - linkml:types
default_range: string

classes:
  MySubclass:
    is_a: FunctionalObject
  FunctionalObject:
    class_uri: rdl:FunctionalObject
```

Results in an OWL file with following entry
```
[...]

<https://example.org/my-schema/MySubclass> a owl:Class,
        linkml:ClassDefinition ;
    rdfs:label "MySubclass" ;
    rdfs:subClassOf <https://example.org/my-schema/FunctionalObject> .

[...]
```

Please notice that instead of `<https://example.org/my-schema/FunctionalObject>` it should say `rdl:FunctionalObject`. This PR tries to fix this issue.