### PR TITLE
inline code system as list in kitchen sink schema

### DIFF
--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -256,6 +256,7 @@ classes:
         multivalued: true
       code systems:
         range: CodeSystem
+        inlined_as_list: true
         inlined: true
         multivalued: true
     slots:

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -32,7 +32,7 @@ class PydanticGeneratorTestCase(unittest.TestCase):
             stream.write(code)
         # TODO: lowering the bar for the pydantic test until list to dict normalization is supported
         #  https://github.com/linkml/linkml/issues/1304
-        with open(DATA_NORMALIZED) as stream:
+        with open(DATA) as stream:
             dataset_dict = yaml.safe_load(stream)
         # NOTE: compile_python and dynamic compilation in general does not seem to work
         # for pydantic code. As an alternative, we import the generated model within a function

--- a/tests/test_generators/test_typescriptgen.py
+++ b/tests/test_generators/test_typescriptgen.py
@@ -21,7 +21,7 @@ class TypescriptGeneratorTestCase(unittest.TestCase):
         assert "export type OrganizationId" in tss
         assert_in("export interface Person  extends HasAliases")
         assert_in("has_familial_relationships?: FamilialRelationship[]")
-        assert_in("code_systems?: {[index: CodeSystemId]: CodeSystem }")
+        assert_in("code_systems?: CodeSystem[]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There was a mismatch between the schema and data for the kitchen sink test data in generators. I previously created a data file that matched the schema, but this PR takes a look at what happens if I change the schema to match the data file instead.