### PR TITLE
Support `has_member` and `all_members` in JSON Schema generator

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -87,14 +87,11 @@ class JsonSchema(UserDict):
             
             self['required'].append(canonical_name)
 
-    def add_keyword(self, keyword: str, value: Any, applies_to_all_array_elements: bool = False):
+    def add_keyword(self, keyword: str, value: Any):
         if value is None:
             return
         
-        if applies_to_all_array_elements and self.is_array:
-            self['items'][keyword] = value
-        else:
-            self[keyword] = value
+        self[keyword] = value
 
     @property
     def is_array(self):
@@ -320,6 +317,18 @@ class JsonSchemaGenerator(Generator):
             typ = "string"
 
         return (typ, fmt, reference)
+    
+    def get_value_constraints_for_slot(self, slot: Union[AnonymousSlotExpression, None]) -> JsonSchema:
+        if slot is None:
+            return JsonSchema()
+        
+        constraints = JsonSchema()
+        constraints.add_keyword('pattern', slot.pattern)
+        constraints.add_keyword('minimum', slot.minimum_value)
+        constraints.add_keyword('maximum', slot.maximum_value)
+        constraints.add_keyword('const', slot.equals_string)
+        constraints.add_keyword('const', slot.equals_number)
+        return constraints
 
     def get_subschema_for_slot(self, slot: SlotDefinition, omit_type: bool = False) -> JsonSchema:
         slot_has_range_union = slot.any_of is not None and len(slot.any_of) > 0 and all(s.range is not None for s in slot.any_of)
@@ -380,15 +389,19 @@ class JsonSchemaGenerator(Generator):
 
         prop.add_keyword('description', slot.description)
 
-        prop.add_keyword('pattern', slot.pattern, applies_to_all_array_elements=True)
-        prop.add_keyword('minimum', slot.minimum_value, applies_to_all_array_elements=True)
-        prop.add_keyword('maximum', slot.maximum_value, applies_to_all_array_elements=True)
-        prop.add_keyword('const', slot.equals_string, applies_to_all_array_elements=True)
-        prop.add_keyword('const', slot.equals_number, applies_to_all_array_elements=True)
+        own_constraints = self.get_value_constraints_for_slot(slot)
 
         if prop.is_array:
+            all_element_constraints = self.get_value_constraints_for_slot(slot.all_members)
+            any_element_constraints = self.get_value_constraints_for_slot(slot.has_member)
             prop.add_keyword('minItems', slot.minimum_cardinality)
             prop.add_keyword('maxItems', slot.maximum_cardinality)
+            prop["items"].update(own_constraints)
+            prop["items"].update(all_element_constraints)
+            if any_element_constraints:
+                prop["contains"] = any_element_constraints
+        else:
+            prop.update(own_constraints)
 
         if prop.is_object:
             prop.add_keyword('minProperties', slot.minimum_cardinality)

--- a/tests/test_generators/input/jsonschema_multivalued_element_constraints.yaml
+++ b/tests/test_generators/input/jsonschema_multivalued_element_constraints.yaml
@@ -17,8 +17,31 @@ schema:
       multivalued: true
       pattern: e.*
 
-    # TODO: this should also contain test cases for has_member and all_members
-    # See: https://github.com/linkml/linkml/issues/1107
+    int_list_with_all_members:
+      range: integer
+      multivalued: true
+      all_members:
+        minimum_value: 2
+        maximum_value: 5
+
+    int_list_with_has_member:
+      range: integer
+      multivalued: true
+      has_member:
+        minimum_value: 2
+        maximum_value: 5
+
+    string_list_with_all_members:
+      range: string
+      multivalued: true
+      all_members:
+        pattern: e.*
+
+    string_list_with_has_member:
+      range: string
+      multivalued: true
+      has_member:
+        pattern: e.*
 
   classes:
     Test:
@@ -26,6 +49,10 @@ schema:
       slots:
         - int_list
         - string_list
+        - int_list_with_all_members
+        - int_list_with_has_member
+        - string_list_with_all_members
+        - string_list_with_has_member
 json_schema:
   properties:
     int_list:
@@ -34,6 +61,20 @@ json_schema:
         maximum: 5
     string_list:
       items:
+        pattern: e.*
+    int_list_with_all_members:
+      items:
+        minimum: 2
+        maximum: 5
+    int_list_with_has_member:
+      contains:
+        minimum: 2
+        maximum: 5
+    string_list_with_all_members:
+      items:
+        pattern: e.*
+    string_list_with_has_member:
+      contains:
         pattern: e.*
 data_cases:
   - data: 
@@ -53,3 +94,37 @@ data_cases:
         - echo
         - foxtrot
     error_message: Failed validating 'pattern'
+  - data: 
+      int_list_with_all_members: [2, 3, 4, 5]
+  - data:
+      int_list_with_all_members: [1, 2, 3]
+    error_message: Failed validating 'minimum'
+  - data: 
+      int_list_with_has_member: [2, 3, 4, 5]
+  - data:
+      int_list_with_has_member: [0, 1, 2]
+  - data:
+      int_list_with_has_member: [6, 7, 8]
+    error_message: Failed validating 'contains'
+  - data:
+      string_list_with_all_members: 
+        - echo
+        - elephant
+  - data:
+      string_list_with_all_members: 
+        - echo
+        - foxtrot
+    error_message: Failed validating 'pattern'
+  - data:
+      string_list_with_has_member: 
+        - echo
+        - elephant
+  - data:
+      string_list_with_has_member: 
+        - echo
+        - foxtrot
+  - data:
+      string_list_with_has_member: 
+        - foxtrot
+        - golf
+    error_message: Failed validating 'contains'


### PR DESCRIPTION
This is the second half of #1107. It adds support for recognizing `has_member` and `all_members` on multivalued slots in `jsonschemagen`.

Fixes #1107 