### PR TITLE
Un-break the build (pydanticgen template fix)

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -48,6 +48,7 @@ class ConfiguredBaseModel(WeakRefShimBaseModel,
                 extra = {% if allow_extra %}'allow'{% else %}'forbid'{% endif %},
                 arbitrary_types_allowed = True,
                 use_enum_values = True):
+    pass
 
 {% for e in enums.values() %}
 class {{ e.name }}(str, Enum):


### PR DESCRIPTION
Replaces the pass statement that I accidentally deleted when fixing a merge conflict in the github ui
