### PR TITLE
Address linkml-convert issue in tutorial

### DIFF
--- a/docs/intro/tutorial01.md
+++ b/docs/intro/tutorial01.md
@@ -35,9 +35,11 @@ id: https://w3id.org/linkml/examples/personinfo
 name: personinfo
 prefixes:
   linkml: https://w3id.org/linkml/
+  personinfo: https://w3id.org/linkml/examples/personinfo
 imports:
   - linkml:types
 default_range: string
+default_prefix: personinfo
   
 classes:
   Person:


### PR DESCRIPTION
This PR fixes the documentation in tutorial 1 that results in an incorrect rdf serialization by adding a `default_prefix` based on the `personinfo` IRI. 