### PR TITLE
Fix erdiagramgen issue where mermaid output contains enum variable name

### DIFF
--- a/linkml/generators/erdiagramgen.py
+++ b/linkml/generators/erdiagramgen.py
@@ -39,6 +39,9 @@ class IdentifyingType(str, Enum):
     IDENTIFYING = "--"
     NON_IDENTIFYING = ".."
 
+    def __str__(self):
+        return self.value
+
 
 class Cardinality(pydantic.BaseModel):
     """ Cardinality of a slot.


### PR DESCRIPTION
This PR closes #1210 where the enum `IdentifyingType.IDENTIFYING` was being printed in the mermaid markdown output.

I added a `__str__` method to the `IdentifyingType` enum so it'll render correctly.

## Before 

```mermaid
erDiagram
Dataset ||IdentifyingType.IDENTIFYING}o Distribution : "distribution"
```

## After

```mermaid
erDiagram
Dataset ||--}o Distribution : "distribution"
```