### PR TITLE
Update examples.ipynb

### DIFF
--- a/notebooks/examples.ipynb
+++ b/notebooks/examples.ipynb
@@ -49,7 +49,7 @@
     }
    ],
    "source": [
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "from types import ModuleType\n",
     "\n",
     "from jsonasobj import as_json, loads\n",


### PR DESCRIPTION
When running the examples, I got the following message.

DeprecationWarning: Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython display
  from IPython.core.display import display, HTML