### PR TITLE
Make hierarchical indented rendering of class table default

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -139,6 +139,7 @@ class DocGenerator(Generator):
     gen_slots: bool = field(default_factory=lambda: True)
     no_types_dir: bool = field(default_factory=lambda: False)
     use_slot_uris: bool = field(default_factory=lambda: False)
+    hierarchical_class_view: bool = field(default_factory=lambda: False)
 
 
     def __post_init__(self):
@@ -883,12 +884,17 @@ class DocGenerator(Generator):
     help="Use IDs from slot_uri instead of names",
 )
 @click.option(
+    "--hierarchical-class-view/--no-hierarchical-class-view",
+    default=True,
+    help="Render class table on index page in a hierarchically indented view",
+)
+@click.option(
     "--example-directory",
     help="Folder in which example files are found. These are used to make inline examples"
 )
 @click.version_option(__version__, "-V", "--version")
 @click.command()
-def cli(yamlfile, directory, dialect, template_directory, use_slot_uris, **args):
+def cli(yamlfile, directory, dialect, template_directory, use_slot_uris, hierarchical_class_view, **args):
     """Generate documentation folder from a LinkML YAML schema
 
     Currently a default set of templates for markdown is provided (see the folder linkml/generators/docgen/)
@@ -912,6 +918,7 @@ def cli(yamlfile, directory, dialect, template_directory, use_slot_uris, **args)
         dialect=dialect,
         template_directory=template_directory,
         use_slot_uris=use_slot_uris,
+        hierarchical_class_view=hierarchical_class_view,
         **args,
     )
     print(gen.serialize())

--- a/linkml/generators/docgen/index.md.jinja2
+++ b/linkml/generators/docgen/index.md.jinja2
@@ -1,8 +1,9 @@
 # {% if schema.title %}{{ schema.title }}{% else %}{{ schema.name }}{% endif %}
 
-{{ schema.description }}
+{% if schema.description %}{{ schema.description }}{% endif %}
 
 URI: {{ schema.id }}
+
 Name: {{ schema.name }}
 
 {% if include_top_level_diagram %}
@@ -18,9 +19,15 @@ Name: {{ schema.name }}
 
 | Class | Description |
 | --- | --- |
+{% if gen.hierarchical_class_view -%}
+{% for u, v in gen.class_hierarchy_as_tuples() -%}
+| {{ "&nbsp;"|safe*u*8 }}{{ gen.link(schemaview.get_class(v)) }} | {{ schemaview.get_class(v).description }} |
+{% endfor %}
+{% else -%}
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
 | {{gen.link(c)}} | {{c.description|enshorten}} |
 {% endfor %}
+{% endif %}
 
 ## Slots
 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -625,6 +625,21 @@ class DocGeneratorTestCase(unittest.TestCase):
                 
         shutil.rmtree(md_temp_dir)
 
+    def test_hierarchical_class_view(self):
+        """Test to check if class table view on index page follows hierarchical view"""
+        gen = DocGenerator(SCHEMA, mergeimports=True, hierarchical_class_view=True)
+
+        md_temp_dir = tempfile.mkdtemp()
+
+        md = gen.serialize(directory=md_temp_dir)
+
+        assert_mdfile_contains("index.md", "Event", after="Dataset")
+        
+        assert_mdfile_contains("index.md", "BirthEvent", after="Event")
+
+        assert_mdfile_contains("index.md", "EmploymentEvent", after="BirthEvent")
+        
+        assert_mdfile_contains("index.md", "MarriageEvent", after="EmploymentEvent")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1435 

TODO: add unit test to check if classes are in fact hierarchically formatted when enabled, in test schemas ✅