### PR TITLE
Improve handling of range unions in jsonschemagen

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -317,15 +317,17 @@ class JsonSchemaGenerator(Generator):
             (typ, fmt) = json_schema_types.get(schema_type.base.lower(), ("string", None))
         elif slot.range in self.schemaview.all_enums().keys():
             reference = slot.range
-        elif (slot_is_inlined or parent_slot_is_inlined) and slot.range in self.schemaview.all_classes().keys():
-            descendants = [desc for desc in self.schemaview.class_descendants(slot.range) 
-                if not self.schemaview.get_class(desc).abstract]
-            if descendants and self.include_range_class_descendants:
-                reference = descendants
+        elif slot.range in self.schemaview.all_classes().keys():
+            if slot_is_inlined or parent_slot_is_inlined:
+                descendants = [desc for desc in self.schemaview.class_descendants(slot.range) 
+                    if not self.schemaview.get_class(desc).abstract]
+                if descendants and self.include_range_class_descendants:
+                    reference = descendants
+                else:
+                    reference = slot.range
             else:
-                reference = slot.range
-        else:
-            typ = "string"
+                id_slot = self.schemaview.get_identifier_slot(slot.range)
+                typ = id_slot.range or "string"
 
         return (typ, fmt, reference)
     
@@ -342,84 +344,58 @@ class JsonSchemaGenerator(Generator):
         return constraints
 
     def get_subschema_for_slot(self, slot: SlotDefinition, omit_type: bool = False) -> JsonSchema:
-        slot_has_range_union = slot.any_of is not None and len(slot.any_of) > 0 and all(s.range is not None for s in slot.any_of)
-        if omit_type:
-            prop = JsonSchema()
-        else:
-            slot_is_inlined = self.schemaview.is_inlined(slot)
+        prop = JsonSchema()
+        slot_is_multivalued = 'multivalued' in slot and slot.multivalued
+        slot_is_inlined = self.schemaview.is_inlined(slot)
+        if not omit_type:
+            typ, fmt, reference = self.get_type_info_for_slot_subschema(slot, slot_is_inlined)
+            if slot_is_inlined:
+                # If inline we have to include redefined slots
+                if slot_is_multivalued:
+                    range_id_slot, range_simple_dict_value_slot, range_required_slots = self._get_range_associated_slots(slot)
+                    # if the range class has an ID and the slot is not inlined as a list, then we need to consider
+                    # various inlined as dict formats
+                    if range_id_slot is not None and not slot.inlined_as_list:
+                        # At a minimum, the inlined dict can have keys (additionalProps) that are IDs
+                        # and the values are the range class but possibly omitting the ID.
+                        additionalProps = [JsonSchema.ref_for(reference, identifier_optional=True)]
 
-            if slot_has_range_union:
-                items = []
-                for sub_slot in slot.any_of:
-                    typ, fmt, reference = self.get_type_info_for_slot_subschema(sub_slot, slot_is_inlined)
-                    if reference is not None:
-                        item = JsonSchema.ref_for(reference)
-                    elif fmt is None:
-                        item = JsonSchema({"type": typ})
-                    else:
-                        item = JsonSchema({"type": typ, "format": fmt})
-                    items.append(item)
-                subschema = JsonSchema({
-                    "anyOf": items
-                })
-                if slot.multivalued:
-                    prop = JsonSchema.array_of(subschema)
-                else:
-                    prop = subschema
-            else:
-                typ, fmt, reference = self.get_type_info_for_slot_subschema(slot, slot_is_inlined)
-                if slot_is_inlined:
-                    # If inline we have to include redefined slots
-                    if slot.multivalued:
-                        range_id_slot, range_simple_dict_value_slot, range_required_slots = self._get_range_associated_slots(slot)
-                        # if the range class has an ID and the slot is not inlined as a list, then we need to consider
-                        # various inlined as dict formats
-                        if range_id_slot is not None and not slot.inlined_as_list:
-                            # At a minimum, the inlined dict can have keys (additionalProps) that are IDs
-                            # and the values are the range class but possibly omitting the ID.
-                            additionalProps = [JsonSchema.ref_for(reference, identifier_optional=True)]
+                        # If the range can be collected as a simple dict, then we can also accept the value
+                        # of that simple dict directly.
+                        if range_simple_dict_value_slot is not None:
+                            additionalProps.append(self.get_subschema_for_slot(range_simple_dict_value_slot))
 
-                            # If the range can be collected as a simple dict, then we can also accept the value
-                            # of that simple dict directly.
-                            if range_simple_dict_value_slot is not None:
-                                additionalProps.append(self.get_subschema_for_slot(range_simple_dict_value_slot))
+                        # If the range has no required slots, then null is acceptable
+                        if len(range_required_slots) == 0:
+                            additionalProps.append(JsonSchema({"type": "null"}))
 
-                            # If the range has no required slots, then null is acceptable
-                            if len(range_required_slots) == 0:
-                                additionalProps.append(JsonSchema({"type": "null"}))
-
-                            # If through the above logic we identified multiple acceptable forms, then wrap them
-                            # in an "anyOf", otherwise just take the only acceptable form
-                            if len(additionalProps) == 1:
-                                additionalProps = additionalProps[0]
-                            else:
-                                additionalProps = JsonSchema({
-                                    "anyOf": additionalProps
-                                })
-                            prop = JsonSchema({
-                                "type": "object",
-                                "additionalProperties": additionalProps
+                        # If through the above logic we identified multiple acceptable forms, then wrap them
+                        # in an "anyOf", otherwise just take the only acceptable form
+                        if len(additionalProps) == 1:
+                            additionalProps = additionalProps[0]
+                        else:
+                            additionalProps = JsonSchema({
+                                "anyOf": additionalProps
                             })
-                            self.top_level_schema.add_lax_def(reference, self.aliased_slot_name(range_id_slot))
-                        else:
-                            prop = JsonSchema.array_of(JsonSchema.ref_for(reference))
+                        prop = JsonSchema({
+                            "type": "object",
+                            "additionalProperties": additionalProps
+                        })
+                        self.top_level_schema.add_lax_def(reference, self.aliased_slot_name(range_id_slot))
                     else:
-                        prop = JsonSchema.ref_for(reference)
+                        prop = JsonSchema.array_of(JsonSchema.ref_for(reference))
                 else:
-                    if slot.multivalued:
-                        if reference is not None:
-                            prop = JsonSchema.array_of(JsonSchema.ref_for(reference))
-                        elif fmt is None:
-                            prop = JsonSchema.array_of(JsonSchema({"type": typ}))
-                        else:
-                            prop = JsonSchema.array_of(JsonSchema({"type": typ, "format": fmt}))
-                    else:
-                        if reference is not None:
-                            prop = JsonSchema.ref_for(reference)
-                        elif fmt is None:
-                            prop = JsonSchema({"type": typ})
-                        else:
-                            prop = JsonSchema({"type": typ, "format": fmt})
+                    prop = JsonSchema.ref_for(reference)
+            else:
+                if reference is not None:
+                    prop = JsonSchema.ref_for(reference)
+                elif typ and fmt is None:
+                    prop = JsonSchema({"type": typ})
+                elif typ:
+                    prop = JsonSchema({"type": typ, "format": fmt})
+
+                if slot_is_multivalued:
+                    prop = JsonSchema.array_of(prop)
 
         prop.add_keyword('description', slot.description)
 
@@ -441,20 +417,29 @@ class JsonSchemaGenerator(Generator):
             prop.add_keyword('minProperties', slot.minimum_cardinality)
             prop.add_keyword('maxProperties', slot.maximum_cardinality)
 
+        bool_subschema = JsonSchema()
         if slot.any_of is not None and len(slot.any_of) > 0:
-            if not slot_has_range_union:
-                prop['anyOf'] = [self.get_subschema_for_slot(s, omit_type=True) for s in slot.any_of]
+            bool_subschema['anyOf'] = [self.get_subschema_for_slot(s) for s in slot.any_of]
 
         if slot.all_of is not None and len(slot.all_of) > 0:
-            prop['allOf'] = [self.get_subschema_for_slot(s, omit_type=True) for s in slot.all_of]
+            bool_subschema['allOf'] = [self.get_subschema_for_slot(s) for s in slot.all_of]
 
         if slot.exactly_one_of is not None and len(slot.exactly_one_of) > 0:
-            prop['oneOf'] = [self.get_subschema_for_slot(s, omit_type=True) for s in slot.exactly_one_of]
+            bool_subschema['oneOf'] = [self.get_subschema_for_slot(s) for s in slot.exactly_one_of]
 
         if slot.none_of is not None and len(slot.none_of) > 0:
-            prop['not'] = {
-                'anyOf': [self.get_subschema_for_slot(s, omit_type=True) for s in slot.none_of]
+            bool_subschema['not'] = {
+                'anyOf': [self.get_subschema_for_slot(s) for s in slot.none_of]
             }
+
+        if bool_subschema:
+            if slot_is_multivalued:
+                if 'items' not in prop:
+                    prop['items'] = {}
+                prop["type"] = "array"
+                prop['items'].update(bool_subschema)
+            else:
+                prop.update(bool_subschema)
 
         return prop
 

--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -433,7 +433,7 @@ class JsonSchemaGenerator(Generator):
             }
 
         if bool_subschema:
-            if slot_is_multivalued:
+            if prop.is_array:
                 if 'items' not in prop:
                     prop['items'] = {}
                 prop["type"] = "array"

--- a/tests/test_generators/input/jsonschema_class_inheritance.yaml
+++ b/tests/test_generators/input/jsonschema_class_inheritance.yaml
@@ -1,0 +1,74 @@
+schema:
+  id: http://example.org/test_class_inheritance
+  name: test_class_inheritance
+
+  slots:
+    alpha_value:
+      range: string
+      required: true
+    gamma_value:
+      range: string
+      required: true
+    alpha_obj:
+      range: Alpha
+    beta_obj:
+      range: Beta
+    gamma_obj:
+      range: Gamma
+
+  classes:
+    Alpha:
+      slots:
+        - alpha_value
+    Beta:
+      is_a: Alpha
+    Gamma:
+      is_a: Beta
+      slots:
+        - gamma_value
+    Test:
+      tree_root: true
+      slots:
+        - alpha_obj
+        - beta_obj
+        - gamma_obj
+
+json_schema:
+  properties:
+    alpha_obj:
+      anyOf: 
+        - "$ref": "#/$defs/Alpha"
+        - "$ref": "#/$defs/Beta"
+        - "$ref": "#/$defs/Gamma"
+    beta_obj:
+      anyOf: 
+        - "$ref": "#/$defs/Beta"
+        - "$ref": "#/$defs/Gamma"
+    gamma_obj:
+      anyOf: 
+        - "$ref": "#/$defs/Gamma"
+
+data_cases:
+  - data:
+      alpha_obj:
+        alpha_value: v1
+  - data:
+      alpha_obj:
+        alpha_value: v1
+        gamma_value: v2
+  - data:
+      beta_obj:
+        alpha_value: v1
+  - data:
+      beta_obj:
+        alpha_value: v1
+        gamma_value: v2
+  - data:
+      gamma_obj:
+        alpha_value: v1
+    error_message: "'gamma_value' is a required property"
+  - data:
+      gamma_obj:
+        alpha_value: v1
+        gamma_value: v2
+  

--- a/tests/test_generators/input/jsonschema_collection_forms.yaml
+++ b/tests/test_generators/input/jsonschema_collection_forms.yaml
@@ -6,8 +6,11 @@ schema:
   default_range: string
 
   slots:
+    int_key:
+      identifier: true
+      range: integer
     key:
-      key: true
+      identifier: true
     value:
     value2:
     key_value_pairs:
@@ -18,6 +21,22 @@ schema:
       range: MoreThanOneNonKeySlot
       multivalued: true
       inlined: true
+    not_inlined_key_value_pairs:
+      range: KeyValuePair
+      multivalued: true
+      inlined: false
+    not_inlined_int_key_value_pairs:
+      range: IntKeyValuePair
+      multivalued: true
+      inlined: false
+    inlined_as_list_key_value_pair:
+      range: KeyValuePair
+      multivalued: true
+      inlined_as_list: true
+    inlined_as_list_int_key_value_pair:
+      range: IntKeyValuePair
+      multivalued: true
+      inlined_as_list: true
 
   classes:
     Test:
@@ -25,13 +44,26 @@ schema:
       slots:
         - key_value_pairs
         - more_than_one_non_key_slots
+        - not_inlined_key_value_pairs
+        - not_inlined_int_key_value_pairs
+        - inlined_as_list_key_value_pair
+        - inlined_as_list_int_key_value_pair
     KeyValuePair:
       slots:
         - key
         - value
+    IntKeyValuePair:
+      slots:
+        - int_key
+        - value
     MoreThanOneNonKeySlot:
       slots:
         - key
+        - value
+        - value2
+    IntMoreThanOneNonKeySlot:
+      slots:
+        - int_key
         - value
         - value2
 
@@ -77,3 +109,50 @@ data_cases:
         k1: v1
         k2: v2  
     error_message: "not valid under any of the given schemas"
+  - data:
+      not_inlined_key_value_pairs:
+        - k1
+        - k2
+  - data:
+      not_inlined_key_value_pairs:
+        k1: v1
+        k2: v2
+    error_message: "not of type 'array'"
+  - data:
+      not_inlined_int_key_value_pairs:
+        - 1
+        - 2
+  - data:
+      not_inlined_int_key_value_pairs:
+        - k1
+        - k2
+    error_message: "not of type 'integer'"
+  - data:
+      not_inlined_int_key_value_pairs:
+        1: v1
+        2: v2
+    error_message: "not of type 'array'"
+  - data:
+      inlined_as_list_key_value_pair:
+        - key: k1
+          value: v1
+        - key: k2
+          value: k2
+  - data:
+      inlined_as_list_key_value_pair:
+        k1: v1
+        k2: v2
+    error_message: "not of type 'array'"
+  - data:
+      inlined_as_list_int_key_value_pair:
+        - int_key: 1
+          value: v1
+        - int_key: 2
+          value: k2
+  - data:
+      inlined_as_list_int_key_value_pair:
+        1: 
+          value: v1
+        2: 
+          value: v2
+    error_message: "not of type 'array'"

--- a/tests/test_generators/input/jsonschema_range_union_cases.yaml
+++ b/tests/test_generators/input/jsonschema_range_union_cases.yaml
@@ -54,6 +54,18 @@ schema:
       any_of:
         - range: C1
         - range: C2
+    c1_xor_c2_single_value:
+      multivalued: false
+      inlined: true
+      exactly_one_of:
+        - range: C1
+        - range: C2
+    c1_xor_c2_multi_value:
+      multivalued: true
+      inlined_as_list: true
+      exactly_one_of:
+        - range: C1
+        - range: C2
     grab_bag:
       multivalued: true
       inlined_as_list: true
@@ -102,6 +114,8 @@ schema:
         - c1_mutli_value
         - c1_or_c2_single_value
         - c1_or_c2_multi_value
+        - c1_xor_c2_single_value
+        - c1_xor_c2_multi_value
         - grab_bag
 
 data_cases:
@@ -133,6 +147,13 @@ data_cases:
         s2: hi
   - data:
       c1_or_c2_multi_value:
+        - s1: hi
+        - s2: hello
+  - data:
+      c1_xor_c2_single_value:
+        s2: hi
+  - data:
+      c1_xor_c2_multi_value:
         - s1: hi
         - s2: hello
   - data:
@@ -222,6 +243,24 @@ data_cases:
         - s2: 'hello'
         - s3: 'hola'
     error_message: Failed validating 'anyOf' in schema
+  - data:
+      c1_xor_c2_single_value:
+        - s1: 'hi'
+    error_message: Failed validating 'oneOf' in schema
+  - data:
+      c1_xor_c2_single_value:
+        s3: 'hi'
+    error_message: Failed validating 'oneOf' in schema
+  - data:
+      c1_xor_c2_multi_value:
+        s1: 'hi'
+    error_message: is not of type 'array'
+  - data:
+      c1_xor_c2_multi_value:
+        - s1: 'hi'
+        - s2: 'hello'
+        - s3: 'hola'
+    error_message: Failed validating 'oneOf' in schema
   - data:
       grab_bag:
         - s2: 'two'

--- a/tests/test_generators/input/jsonschema_value_constraints.yaml
+++ b/tests/test_generators/input/jsonschema_value_constraints.yaml
@@ -46,6 +46,12 @@ schema:
       none_of:
         - equals_string: purple
         - equals_string: green
+    integer_over_ten_or_string_na:
+      exactly_one_of:
+        - range: integer
+          minimum_value: 10
+        - range: string
+          pattern: "[nN]/?[aA]"
 
   classes:
     Test:
@@ -61,6 +67,7 @@ schema:
         - string_all_patterns
         - string_exactly_one_pattern
         - string_none_of
+        - integer_over_ten_or_string_na
 
 data_cases:
   - data:
@@ -130,3 +137,16 @@ data_cases:
   - data: 
       string_none_of: green
     error_message: should not be valid under
+  - data:
+      integer_over_ten_or_string_na: 100
+  - data:
+      integer_over_ten_or_string_na: 5
+    error_message: 5 is less than the minimum
+  - data:
+      integer_over_ten_or_string_na: n/a
+  - data:
+      integer_over_ten_or_string_na: wrong
+    error_message: "'wrong' does not match"
+  - data:
+      integer_over_ten_or_string_na: false
+    error_message: False is not valid under any of the given schemas

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -131,6 +131,11 @@ class JsonSchemaTestCase(unittest.TestCase):
 
         self.externalFileTest("jsonschema_type_inheritance.yaml")
 
+    def test_class_inheritance(self):
+        """Tests that a class definition's is_a slot is correctly accounted for."""
+
+        self.externalFileTest("jsonschema_class_inheritance.yaml", {'not_closed': False, 'include_range_class_descendants': True})
+
     def test_top_class_identifier(self):
         """Test that an identifier slot on the top_class becomes a required
         property in the JSON Schema."""
@@ -246,7 +251,7 @@ class JsonSchemaTestCase(unittest.TestCase):
     #
     # **********************************************************
 
-    def externalFileTest(self, file: str) -> None:
+    def externalFileTest(self, file: str, generator_args={'not_closed': False}) -> None:
         with open(env.input_path(file)) as f:
             test_definition = yaml.safe_load(f)
 
@@ -254,6 +259,7 @@ class JsonSchemaTestCase(unittest.TestCase):
             yaml.dump(test_definition["schema"]),
             test_definition.get("json_schema", {}),
             test_definition.get("data_cases", []),
+            generator_args=generator_args
         )
 
     def assertSchemaValidates(
@@ -261,8 +267,9 @@ class JsonSchemaTestCase(unittest.TestCase):
         schema: Union[str, SchemaDefinition],
         expected_json_schema_subset={},
         data_cases=[],
+        generator_args={},
     ):
-        generator = JsonSchemaGenerator(schema, not_closed=False)
+        generator = JsonSchemaGenerator(schema, **generator_args)
         json_schema = json.loads(generator.serialize())
 
         self.assertDictSubset(expected_json_schema_subset, json_schema)

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -143,25 +143,13 @@ class JsonSchemaTestCase(unittest.TestCase):
         self.externalFileTest("jsonschema_top_class_identifier.yaml")
 
     def test_value_constraints(self):
-        with open(env.input_path("jsonschema_value_constraints.yaml")) as f:
-            test_def = yaml.safe_load(f)
-
-        generator = JsonSchemaGenerator(
-            yaml.dump(test_def["schema"]), stacktrace=True, not_closed=False
-        )
-        json_schema = json.loads(generator.serialize())
-
-        for data_case in test_def.get("data_cases", []):
-            data = data_case["data"]
-            with self.subTest(data=data):
-                if "error_message" in data_case:
-                    self.assertRaisesRegex(
-                        jsonschema.ValidationError,
-                        data_case["error_message"],
-                        lambda: jsonschema.validate(data, json_schema),
-                    )
-                else:
-                    jsonschema.validate(data, json_schema)
+        """Test the translation of metaslots that constrain values.
+        
+        Tests the translation of equals_string, equals_number, pattern, maximum_value,
+        and minimum_value metaslots. Additionally contains one test case that verifies
+        these work with multiple ranges as well.
+        """
+        self.externalFileTest("jsonschema_value_constraints.yaml")
 
     def test_rules(self):
         """Tests translation of various types of class rules.
@@ -271,6 +259,7 @@ class JsonSchemaTestCase(unittest.TestCase):
     ):
         generator = JsonSchemaGenerator(schema, **generator_args)
         json_schema = json.loads(generator.serialize())
+        print(generator.serialize())
 
         self.assertDictSubset(expected_json_schema_subset, json_schema)
 

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -262,7 +262,7 @@ class JsonSchemaTestCase(unittest.TestCase):
         expected_json_schema_subset={},
         data_cases=[],
     ):
-        generator = JsonSchemaGenerator(schema)
+        generator = JsonSchemaGenerator(schema, not_closed=False)
         json_schema = json.loads(generator.serialize())
 
         self.assertDictSubset(expected_json_schema_subset, json_schema)

--- a/tests/test_issues/input/issue_177.yaml
+++ b/tests/test_issues/input/issue_177.yaml
@@ -8,6 +8,7 @@ types:
     base: int
     uri: xsd:int
 
+default_range: string
 
 classes:
   c1:


### PR DESCRIPTION
The primary goal of this was to fix #1421. Fundamentally these changes just simplify the handling of `any_of`, `exactly_one_of`, `all_of`, and `none_of` metaslots so that cases where a `range` is specified within are not treated as special cases. 

While I was in there I backfilled some test cases around non-inlined and inlined-as-list collections (including cases with non-string keys -- previously there was an implicit assumption that keys were always strings), the multiple descendant matching case mentioned in https://github.com/linkml/linkml/pull/1342, and boolean expressions that combine ranges and value constraints. 