### PR TITLE
Delete `[` character that was truncating hyperlink text (fixes #1473)

### DIFF
--- a/docs/intro/overview.md
+++ b/docs/intro/overview.md
@@ -82,7 +82,7 @@ and transformations between different representations of the same
 data; for example, if your JSON documents need to work in concert with
 your relational database or graph store.
 
-LinkML has [many different generators for[existing
+LinkML has [many different generators for existing
 frameworks](../generators/index) that allow the translation of a LinkML
 schema to other frameworks:
 


### PR DESCRIPTION
### Status of branch

~~This branch is a WIP (work-in-progress). I will add documentation-related proposals (e.g. typo corrections) to it as I read the LinkML docs over the next few weeks. I'll remove the "WIP" prefix from the title and post a comment when I'm ready for someone to review it.~~

Review for review.

### Summary of changes

- Delete `[` character that was truncating hyperlink text (fixes #1473)