### PR TITLE
Fix conversion to JSON-LD

### DIFF
--- a/linkml/utils/converter.py
+++ b/linkml/utils/converter.py
@@ -159,8 +159,6 @@ def cli(
             else:
                 raise Exception("Must pass in context OR schema for RDF output")
         outargs["contexts"] = list(context)
-        outargs["fmt"] = "json-ld"
-        outargs["schemaview"] = sv
     if output_format == "rdf" or output_format == "ttl":
         if sv is None:
             raise Exception(f"Must pass schema arg")

--- a/linkml/utils/datautils.py
+++ b/linkml/utils/datautils.py
@@ -27,7 +27,7 @@ dumpers_loaders = {
     "json": (JSONDumper, JSONLoader),
     "rdf": (RDFLibDumper, RDFLibLoader),
     "ttl": (RDFLibDumper, RDFLibLoader),
-    "json-ld": (RDFLibDumper, RDFLibLoader),
+    "json-ld": (JSONDumper, JSONLoader),
     "csv": (CSVDumper, CSVLoader),
     "tsv": (CSVDumper, CSVLoader),
 }


### PR DESCRIPTION
Data conversion from YAML to JSON-LD fails apparently because the wrong dumper is being used. This PR assigns the JSONDumper for JSON-LD.

See throughout analysis in [this Slack thread](https://obo-communitygroup.slack.com/archives/C04EU7JL1NF/p1683709581053169).

Fixes #1481 