### PR TITLE
Add option to assert equivalentClass between a class and its class_uri

### DIFF
--- a/tests/test_generators/test_owlgen.py
+++ b/tests/test_generators/test_owlgen.py
@@ -123,6 +123,35 @@ class OwlGeneratorTestCase(unittest.TestCase):
         for t in expected:
             self.assertIn(t, triples)
 
+    def test_equivalent_uris(self):
+        """
+        Test behavior of asserting owl:equivalentClass between a class
+        and its corresponding class_uri
+        """
+        sb = SchemaBuilder()
+        sb.add_class('MyPerson',
+                     class_uri='schema:Person',
+                     slots=[SlotDefinition("name", slot_uri="schema:name")])
+        sb.add_defaults()
+        sb.add_prefix("schema", "http://schema.org/")
+        schema = sb.schema
+        gen = OwlSchemaGenerator(
+            schema=schema,
+            mergeimports=False,
+            metaclasses=False,
+            type_objects=False,
+            assert_equivalent_classes=True
+        )
+        owl = gen.serialize()
+        with open(OWL_OUTPUT, "w", encoding="UTF-8") as stream:
+            stream.write(owl)
+        graph = Graph()
+        graph.parse(OWL_OUTPUT)
+        assert (
+            URIRef('http://example.org/test-schema/MyPerson'),
+            OWL.equivalentClass,
+            URIRef('http://schema.org/Person')
+        ) in graph
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the ability to add an equivalentClass between a class and its class_uri.

Addresses concern raised in https://github.com/linkml/linkml/issues/932

Currently the class_uri is added as a `skos:exactMatch` by default.

When running gen-owl with `--assert-equivalent-classes` flag, the default behavior is changed and there is an `owl:equivalentClass` between class and its class_uri.

Happy to tweak this PR further as needed and appropriate :) 