### PR TITLE
Codespell: config, workflog + some typos fixed

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -163,7 +163,7 @@ prefixes:
   qud: http://qudt.org/1.1/schema/qudt#
 ```
 
-The CURIE `wgs:lat` will exand to http://www.w3.org/2003/01/geo/wgs84_pos#lat.
+The CURIE `wgs:lat` will expand to http://www.w3.org/2003/01/geo/wgs84_pos#lat.
 
 * an external CURIE map specified via a [default_curi_maps](https://w3id.org/linkml/meta/default_curi_maps) section.
 

--- a/docs/faq/modeling.md
+++ b/docs/faq/modeling.md
@@ -80,7 +80,7 @@ types:
     uri: xsd:string
     base: str
     pattern: "^\\w+$"
-    description: A symbol is a string used as a shorthand identifier that is restriced to a subset of characters
+    description: A symbol is a string used as a shorthand identifier that is restricted to a subset of characters
 ```
 
 Some applications may choose to interpret this in particular ways. E.g. you may want to define all narrative text fields as being amenable to spellchecking, or machine learning natual language processing, or special kinds of indexing in ElasticSearch/Solr
@@ -332,7 +332,7 @@ Then this will translate as follows:
    * my_schema:MyClass
    * my_schema:my_slot
 
-Note in the RDF/OWL representation, seperate `rdfs:label` triples will be generated retaining the original human-friendly name.
+Note in the RDF/OWL representation, separate `rdfs:label` triples will be generated retaining the original human-friendly name.
 
 This has the advantage of keeping human-friendly nomenclature in the appropriate places without specifying redundant computer names and human names
 
@@ -504,7 +504,7 @@ Any element in a LinkML schema can have any number of *mappings* associated with
 
 Mappings are useful in a variety of ways including: 
 
-- they make your data and your schema more FAIR (Findable, Accessable, Reusable, and Interoperable)
+- they make your data and your schema more FAIR (Findable, Accessible, Reusable, and Interoperable)
 - when people use data that conforms to your model, and integrated with data that conforms to another model, they can use mappings between models to help automate data harmonization.  
 - mappings can provide links to other documentation sources for your model, allowing expertise to be shared between projects and not duplicated
 - mappings allow advanced users to reason over your model.
@@ -536,6 +536,6 @@ Depending on the answer, LinkML has different modeling constructs to help you, i
 
 - [range](https://w3id.org/linkml/range) constraints, which can refer to classes
 - the ability to assign a slot as an [identifier](https://w3id.org/linkml/identifier), allowing other objects to link to it
-- [inlining](https://w3id.org/linkml/inlining) which determins how relationships are serialized in formats like JSON
+- [inlining](https://w3id.org/linkml/inlining) which determines how relationships are serialized in formats like JSON
 
 Other more advanced constructs are also possible to allow you to treat relationships as first-class entities

--- a/docs/faq/why-linkml.md
+++ b/docs/faq/why-linkml.md
@@ -106,7 +106,7 @@ This has a number of advantages:
 
  - you make the intended meaning of your columns more transparent and explicit
  - your TSVs can be automatically translated to JSON-LD and RDF via the LinkML framework
- - it faciliates automated and semi-automated mapping between your data and other representations
+ - it facilitates automated and semi-automated mapping between your data and other representations
 
 There are a number of proposed frameworks for providing lightweight data dictionaries for your TSVs/spreadsheets:
 

--- a/docs/generators/python.rst
+++ b/docs/generators/python.rst
@@ -348,7 +348,7 @@ where we have defined four slot type permutations:
 
       ``opt_multi_integer: Optional[Union[int, List[int]]] = empty_list()``
 
-   -  The absence of a list property is always represented as an emtpy
+   -  The absence of a list property is always represented as an empty
       list:
       ``if self.opt_multi_integer is None:       self.opt_multi_integer = []``
 

--- a/docs/generators/python.rst
+++ b/docs/generators/python.rst
@@ -274,7 +274,7 @@ Four class variables are included in the generation: \*
 original definition \* ``type_model_uri`` - the URIRef of the type
 definition in the default LinkML namespace
 
-The python then emits a class definition for the ``Integers`` classe,
+The python then emits a class definition for the ``Integers`` class,
 where we have defined four slot type permutations:
 
 1) ``mand_integer`` - a single valued required type:

--- a/docs/generators/python.rst
+++ b/docs/generators/python.rst
@@ -1617,7 +1617,7 @@ a list of integers with a single value:
        my_entries = ListOfIntegers(17)
 
 Which would, if the class ``ListOfIntegers``\ ’s first variable was a
-multivalued slot with a range of intgers, result in
+multivalued slot with a range of integers, result in
 ``my_entries.v == [17]``. When dealing with classes, however, the
 following:
 
@@ -1634,7 +1634,7 @@ The final line in the ``__post_init__`` section:
 
        self._normalize_inlined_slot(slot_name="v1", slot_type=IdentifiedThreeElementClass, key_name="name", inlined_as_list=True, keyed=True)
 
-passes the remainder of the post initilization normalization to a
+passes the remainder of the post initialization normalization to a
 function defined in ``YAMLRoot``.
 
 The final case, Case 2.4 (Inlined as dictionary) is essentially the

--- a/docs/generators/sqlalchemy.rst
+++ b/docs/generators/sqlalchemy.rst
@@ -12,7 +12,7 @@ In principle, two styles of mappings are possible:
 
 1. Declarative, in which SQLA-style classes are generated, with
    combined mappings
-2. Imperative, in which seperate mappings are created for a
+2. Imperative, in which separate mappings are created for a
    pre-existing object model, such as one created by the existing
    python or pydantic generators
 

--- a/docs/howtos/model-measurements.md
+++ b/docs/howtos/model-measurements.md
@@ -53,7 +53,7 @@ We will work through a number of different alternatives, but all use the followi
 ```yaml
 id: https://w3id.org/linkml/howtos/measurements
 name: research_subject_measurements
-title: A demonstrator schema for measuing properties of research subjects
+title: A demonstrator schema for measuring properties of research subjects
 license: https://creativecommons.org/publicdomain/zero/1.0/
 
 prefixes:

--- a/docs/howtos/multidimensional-arrays.md
+++ b/docs/howtos/multidimensional-arrays.md
@@ -1,4 +1,4 @@
-# Multidimension Arrays
+# Multidimensional Arrays
 
 __NOTE__ This is an *experimental* feature of LinkML. It may be only
 partially implemented, and subject to change.
@@ -98,7 +98,7 @@ This representation is quite convenient for scientific computing. The underlying
 an N-dimensional (nested lists) in many languages:
 
 ```python
->>> measurments = yaml.safe_load(open("lolol.yaml"))
+>>> measurements = yaml.safe_load(open("lolol.yaml"))
 >>> measurements[0][0][0]
 111
 ```
@@ -266,7 +266,7 @@ This relies on a feature implemented in LinkML 1.5,
 [implements](https://w3id.org/linkml/implements). This provides
 information for tools to *interpret* the axes and elements.
 
-In particalar:
+In particular:
 
  - our `TemperatureMatrix` class *implements* `linkml:ThreeDimensionalArray`
  - the 3 axes class *implements* `linkml:OneDimensionalSeries`

--- a/docs/howtos/port-linkml.md
+++ b/docs/howtos/port-linkml.md
@@ -110,7 +110,7 @@ support for a target language via *bootstrapping*
 ### Step 1: Bootstrap metamodel data access classes
 
 Even if you intended to ultimately use the target language for doing
-code geneation, we strongly recommend you bootstrap by using the existing
+code generation, we strongly recommend you bootstrap by using the existing
 generators framework. This may take a small amount of Python coding,
 but the majority of this involves writing Jinja2 templates, so no Python expertise
 is required.
@@ -280,7 +280,7 @@ See: [gen-typescript](../generators/typescript)
 
 In contrast to the python approaches, this targets typescript *Interfaces* as the construct of choice in the target language
 
-Note that interfaces are "compiled away" but are used for static analyis and IDE support
+Note that interfaces are "compiled away" but are used for static analysis and IDE support
 
 This is being used to bootstrap a javascript runtime: [linkml-runtime.js](https://github.com/linkml/linkml-runtime.js)
 

--- a/docs/intro/tutorial08.md
+++ b/docs/intro/tutorial08.md
@@ -106,12 +106,12 @@ sqlschema
 
 ### GitHub Guides
 
-We recommend maintaing your source for your schema, plus all generated products in GitHub
+We recommend maintaining your source for your schema, plus all generated products in GitHub
 
 Some resources to help you:
 
 * [software carpentry guide](https://swcarpentry.github.io/git-novice/)
-* We hace created a [slide deck on GitHub](https://docs.google.com/presentation/u/0/d/1ydkB8y3cPYcDZYCT9DcENQk6gwWr0xR6/) for LinkML users
+* We have created a [slide deck on GitHub](https://docs.google.com/presentation/u/0/d/1ydkB8y3cPYcDZYCT9DcENQk6gwWr0xR6/) for LinkML users
 
 ### ProjectGen docs
 

--- a/docs/intro/tutorial09.md
+++ b/docs/intro/tutorial09.md
@@ -220,7 +220,7 @@ Database. Examples of ORMs are:
 The LinkML metamodel has aspects of OO modeling, so ORMs can be useful
 here. Note that ORMs can be divisive among developers, with some
 believe ORMs to be add unnecessary complexity, and others finding them
-indispensible. Use of ORMs is completely optional with LinkML, but if
+indispensable. Use of ORMs is completely optional with LinkML, but if
 you are using a RDBMS you may find them useful.
 
 Currently the only ORM directly supported in SQL Alchemy

--- a/docs/intro/tutorial10.md
+++ b/docs/intro/tutorial10.md
@@ -220,7 +220,7 @@ Database. Examples of ORMs are:
 The LinkML metamodel has aspects of OO modeling, so ORMs can be useful
 here. Note that ORMs can be divisive among developers, with some
 believe ORMs to be add unnecessary complexity, and others finding them
-indispensible. Use of ORMs is completely optional with LinkML, but if
+indispensable. Use of ORMs is completely optional with LinkML, but if
 you are using a RDBMS you may find them useful.
 
 Currently the only ORM directly supported in SQL Alchemy

--- a/docs/schemas/advanced.md
+++ b/docs/schemas/advanced.md
@@ -84,7 +84,7 @@ classes:
               pattern: "[0-9]{5}(-[0-9]{4})?"
             telephone:
               pattern: "^\\+1 "
-        description: USA and territories must have a specific regex patern for postal codes and phone numbers
+        description: USA and territories must have a specific regex pattern for postal codes and phone numbers
 ```
 
 See above for implementation status

--- a/docs/schemas/models.md
+++ b/docs/schemas/models.md
@@ -291,7 +291,7 @@ enums:
         meaning: GSSO:000385
 ```
 
-With the introduction of LinkML 1.3, LinkML supports *dynamic* or *intensional* enums,
+With the introduction of LinkML 1.3, LinkML supports *dynamic* or *intentional* enums,
 which allow enumerations to be derived from queries - e.g. to take all terms in a branch of
 an ontology.
 

--- a/docs/schemas/slots.md
+++ b/docs/schemas/slots.md
@@ -113,7 +113,7 @@ the range of an identifier can be any type, but it is a good idea to have these 
 A class must not have more than one identifier (asserted or derived). `identifier` marks the *primary* identifier.
 
 If you need to mark additional fields as unique, or a collection of slots that when considered as a tuple are unique, use
-`unique_keys` (see the [constraits](constraints.md) section of the docs).
+`unique_keys` (see the [constraints](constraints.md) section of the docs).
 
 ## Type designator
 

--- a/docs/schemas/uris-and-mappings.md
+++ b/docs/schemas/uris-and-mappings.md
@@ -8,7 +8,7 @@ URIs and IRIs are generalizations of URLs. URIs are used as identifiers in linke
 
 For example, in [schema.org](http://schema.org), the URI [http://schema.org/Person](http://schema.org/Person) is the identifier for the Person concept.
 
-URIs can be shortended as CURIEs (Compact URIs). Given a prefix declaration where we map `schema` to `http://schema.org/`, then we can use the CURIE `schema:Person` to denote the person concept.
+URIs can be shortened as CURIEs (Compact URIs). Given a prefix declaration where we map `schema` to `http://schema.org/`, then we can use the CURIE `schema:Person` to denote the person concept.
 
 For more on URIs and their importance in Linked Data, see
 

--- a/examples/PersonSchema/personinfo/jsonld/personinfo.jsonld
+++ b/examples/PersonSchema/personinfo/jsonld/personinfo.jsonld
@@ -222,7 +222,7 @@
       "definition_uri": "https://w3id.org/linkml/Objectidentifier",
       "description": "A URI or CURIE that represents an object in the model.",
       "comments": [
-        "Used for inheritence and type checking"
+        "Used for inheritance and type checking"
       ],
       "from_schema": "https://w3id.org/linkml/types",
       "imported_from": "linkml:types",

--- a/examples/prov-association.yaml
+++ b/examples/prov-association.yaml
@@ -23,7 +23,7 @@ classes:
     comments:
     - An instance of prov:Association provides additional descriptions about the binary
       prov:wasAssociatedWith relation from an prov:Activity to some prov:Agent that
-      had some responsiblity for it. For example, prov:baking prov:wasAssociatedWith prov:baker;
+      had some responsibility for it. For example, prov:baking prov:wasAssociatedWith prov:baker;
       prov:qualifiedAssociation [ a prov:Association; prov:agent prov:baker; prov:foo prov:bar
       ].
     description: An activity association is an assignment of responsibility to an

--- a/linkml/generators/PythonGenNotes.md
+++ b/linkml/generators/PythonGenNotes.md
@@ -122,7 +122,7 @@ the builtin type `int`.  Four class variables are included in the generation:
 * `type_name` - the non-mangled name assigned to the type in the original definition
 * `type_model_uri` - the URIRef of the type definition in the default LinkML namespace
 
-The python then emits a class definition for the `Integers` classe, where we have defined four slot type permutations:
+The python then emits a class definition for the `Integers` class, where we have defined four slot type permutations:
 
 1) `mand_integer` - a single valued required type:
 

--- a/linkml/generators/PythonGenNotes.md
+++ b/linkml/generators/PythonGenNotes.md
@@ -189,7 +189,7 @@ The python then emits a class definition for the `Integers` classe, where we hav
     
         `opt_multi_integer: Optional[Union[int, List[int]]] = empty_list()`
         
-    * The absence of a list property is always represented as an emtpy list:
+    * The absence of a list property is always represented as an empty list:
         ```        
         if self.opt_multi_integer is None:
             self.opt_multi_integer = []

--- a/linkml/generators/PythonGenNotes.md
+++ b/linkml/generators/PythonGenNotes.md
@@ -1232,7 +1232,7 @@ dictionary.  You can construct a list of integers with a single value:
 ```python
     my_entries = ListOfIntegers(17)
 ```
-Which would, if the class `ListOfIntegers`'s first variable was a multivalued slot with a range of intgers, result in
+Which would, if the class `ListOfIntegers`'s first variable was a multivalued slot with a range of integers, result in
 `my_entries.v == [17]`.  When dealing with classes, however, the following:
 ```python
     my_entries = ListOfClasses(dict(name='element1', value=17))
@@ -1243,7 +1243,7 @@ The final line in the `__post_init__` section:
 ```python
     self._normalize_inlined_slot(slot_name="v1", slot_type=IdentifiedThreeElementClass, key_name="name", inlined_as_list=True, keyed=True)
 ```
-passes the remainder of the post initilization normalization to a function defined in `YAMLRoot`.  
+passes the remainder of the post initialization normalization to a function defined in `YAMLRoot`.  
 
 
 The final case, Case 2.4 (Inlined as dictionary) is essentially the same, with the exception that the target type is

--- a/linkml/generators/common/type_designators.py
+++ b/linkml/generators/common/type_designators.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 def get_type_designator_value(sv: SchemaView, type_designator_slot: SlotDefinition, class_def: ClassDefinition) -> str:
     """
-        retuns the correct value for a type designator field for a given class, depending on its range
+        returns the correct value for a type designator field for a given class, depending on its range
         this implements the logic described in https://github.com/linkml/linkml/issues/945:
     """
     slot_types = set(sv.type_ancestors(type_designator_slot.range))
@@ -21,7 +21,7 @@ def get_type_designator_value(sv: SchemaView, type_designator_slot: SlotDefiniti
 
 def get_accepted_type_designator_values(sv: SchemaView, type_designator_slot: SlotDefinition, class_def: ClassDefinition) -> List[str]:
     """
-        retuns the accepted values for a type designator field for a given class, depending on its range
+        returns the accepted values for a type designator field for a given class, depending on its range
         this implements the logic described in https://github.com/linkml/linkml/issues/945:
     """
     accepted_uri_values = [

--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -275,7 +275,7 @@ class DocGenerator(Generator):
         Create a jinja2 template object for a given schema element type
 
         The default location for templates is in the linkml/docgen folder,
-        but this can be overriden
+        but this can be overridden
         :param element_type: e.g. class, enum, index, subset, ...
         :return:
         """
@@ -433,7 +433,7 @@ class DocGenerator(Generator):
         self, element: Definition, children: bool = True, **kwargs
     ) -> str:
         """
-        Show an element in the context of its is-a hierachy
+        Show an element in the context of its is-a hierarchy
 
         Limitations: currently only implemented for markdown (uses nested bullets)
 

--- a/linkml/generators/erdiagramgen.py
+++ b/linkml/generators/erdiagramgen.py
@@ -203,11 +203,11 @@ class ERDiagramGenerator(Generator):
         :param diagram: ER Diagram
         :return:
         """
-        ser = str(diagram)
+        er = str(diagram)
         if self.format == 'markdown':
-            return f'```mermaid\n{ser}\n```\n'
+            return f'```mermaid\n{er}\n```\n'
         else:
-            return ser
+            return er
 
     def add_class(self, class_name: ClassDefinitionName, diagram: ERDiagram) -> None:
         """

--- a/linkml/generators/linkmlgen.py
+++ b/linkml/generators/linkmlgen.py
@@ -39,7 +39,7 @@ class LinkmlGenerator(Generator):
         self.schemaview = SchemaView(self.schema, merge_imports=self.mergeimports)
 
     def materialize_classes(self) -> None:
-        """Materialize class slots from schema as attribues, in place"""
+        """Materialize class slots from schema as attributes, in place"""
         all_classes = self.schemaview.all_classes()
 
         for c_name, c_def in all_classes.items():

--- a/linkml/generators/prefixmapgen.py
+++ b/linkml/generators/prefixmapgen.py
@@ -44,7 +44,7 @@ class PrefixGenerator(Generator):
         super().__post_init__()
         if self.namespaces is None:
             raise TypeError(
-                "Schema text must be supplied to context generater.  Preparsed schema will not work"
+                "Schema text must be supplied to context generator.  Preparsed schema will not work"
             )
 
     def visit_schema(

--- a/linkml/generators/pythongen.py
+++ b/linkml/generators/pythongen.py
@@ -333,7 +333,7 @@ dataclasses._init_fn = dataclasses_init_fn_with_kwargs
                         )
                         # If we've got a parent slot and the range of the parent is the range of the child, the
                         # child slot is a subclass of the parent.  Otherwise, the child range has been overridden,
-                        # so the inheritence chain has been broken
+                        # so the inheritance chain has been broken
                         parent_pk = (
                             self.class_identifier(cls.is_a) if cls.is_a else None
                         )
@@ -517,7 +517,7 @@ dataclasses._init_fn = dataclasses_init_fn_with_kwargs
         """
         Generate the variable declarations for a dataclass.
 
-        :param cls: class containing variables to be rendered in inheritence hierarchy
+        :param cls: class containing variables to be rendered in inheritance hierarchy
         :return: variable declarations for target class and its ancestors
         """
         initializers = []
@@ -823,7 +823,7 @@ dataclasses._init_fn = dataclasses_init_fn_with_kwargs
                     f"if self.{aliased_slot_name} is not None and "
                     f"not isinstance(self.{aliased_slot_name}, {base_type_name}):"
                 )
-            # A really wierd case -- a class that has no properties
+            # A really weird case -- a class that has no properties
             if (
                 slot.range in self.schema.classes
                 and not self.schema.classes[slot.range].slots

--- a/linkml/generators/sparqlgen.py
+++ b/linkml/generators/sparqlgen.py
@@ -203,7 +203,7 @@ class SparqlGenerator(Generator):
 def cli(yamlfile, dir, **kwargs):
     """Generate SPARQL queries for validation
 
-    This will generate a directory of queries that cann be used for QC over a triplestore that
+    This will generate a directory of queries that can be used for QC over a triplestore that
     is conformant to the same LinkML schema.
 
     Each query in the directory will be of the form

--- a/linkml/utils/execute_tutorial.py
+++ b/linkml/utils/execute_tutorial.py
@@ -72,7 +72,7 @@ def execute_blocks(directory: str, blocks: List[Block]) -> List[str]:
                 cmd = cmd[0:pos]
                 if len(outpath) > 1:
                     raise Exception(
-                        f"Maximim 1 token after > in {block.content}. Got: {outpath}"
+                        f"Maximum 1 token after > in {block.content}. Got: {outpath}"
                     )
                 outpath = str(Path(directory, *outpath))
                 logging.info(f"OUTPATH = {outpath}")

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -251,7 +251,7 @@ class Generator(metaclass=abc.ABCMeta):
         """
         Generate output in the required format
 
-        :param kwargs: Generater specific parameters
+        :param kwargs: Generator specific parameters
         :return: Generated output
         """
         output = StringIO()

--- a/linkml/utils/schemasynopsis.py
+++ b/linkml/utils/schemasynopsis.py
@@ -239,7 +239,7 @@ class SchemaSynopsis:
 
         :param typ: element type
         :param k: element name
-        :param v: element deffinition
+        :param v: element definition
         :return:
         """
         if k != v.name:

--- a/notebooks/SQL-examples.ipynb
+++ b/notebooks/SQL-examples.ipynb
@@ -1393,7 +1393,7 @@
     "\n",
     "The PersonInfo schema has a class Container whose sole function is to contain all top level objects.\n",
     "\n",
-    "We will populate our container with our 100 artifical people."
+    "We will populate our container with our 100 artificial people."
    ]
   },
   {
@@ -1539,7 +1539,7 @@
     "\n",
     "Unfortunately there is no one single standard for object models in Python. Dataclasses and Pydantic have a lot of advantages over SQLA models, but they don't work as well in conjunction with the ORM.\n",
     "\n",
-    "To accomodate this, the LinkML python toolchain has bridging code that will map objects from one system to another."
+    "To accommodate this, the LinkML python toolchain has bridging code that will map objects from one system to another."
    ]
   },
   {

--- a/notebooks/context_issue.ipynb
+++ b/notebooks/context_issue.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "def fetch_pc_context(name: str) -> Optional[str]:\n",
     "    \"\"\"\n",
-    "    Retrive the prefixcommons JSON-LD entry for name\n",
+    "    Retrieve the prefixcommons JSON-LD entry for name\n",
     "    :param name: context name\n",
     "    :return: String representation of JSON-LD context\n",
     "    \"\"\"\n",

--- a/notebooks/enumerations.ipynb
+++ b/notebooks/enumerations.ipynb
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## The simplist form of a LinkML enumeration is a list of tag and (optional) values\n"
+    "## The simplest form of a LinkML enumeration is a list of tag and (optional) values\n"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,5 +148,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 [tool.codespell]
 # TODO: bring in tests in too
 skip = '.git,*.pdf,*.svg,tests'
+# Ignore table where words could be split across rows
+ignore-regex = '\|.*\|.*\|.*\|'
 #
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.codespell]
 # TODO: bring in tests in too
-skip = '.git,*.pdf,*.svg,tests'
+skip = '.git,*.pdf,*.svg,tests,pyproject.toml'
 # Ignore table where words could be split across rows
 # Ignore shortcut specifications like [Ff]alse
 ignore-regex = '(\|.*\|.*\|.*\||\[[A-Z][a-z]\][a-z][a-z])'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,4 +152,4 @@ skip = '.git,*.pdf,*.svg,tests,pyproject.toml'
 # Ignore shortcut specifications like [Ff]alse
 ignore-regex = '(\|.*\|.*\|.*\||\[[A-Z][a-z]\][a-z][a-z])'
 #
-# ignore-words-list = ''
+ignore-words-list = 'mater,connexion,infarction'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,3 +144,8 @@ docs = ["Sphinx", "sphinxcontrib-mermaid", "furo"]
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.codespell]
+skip = '.git,*.pdf,*.svg'
+#
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 # TODO: bring in tests in too
 skip = '.git,*.pdf,*.svg,tests'
 # Ignore table where words could be split across rows
-ignore-regex = '\|.*\|.*\|.*\|'
+# Ignore shortcut specifications like [Ff]alse
+ignore-regex = '(\|.*\|.*\|.*\||\[[A-Z][a-z]\][a-z][a-z])'
 #
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.codespell]
-skip = '.git,*.pdf,*.svg'
+# TODO: bring in tests in too
+skip = '.git,*.pdf,*.svg,tests'
 #
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.codespell]
 # TODO: bring in tests in too
-skip = '.git,*.pdf,*.svg,tests,pyproject.toml'
+skip = '.git,*.pdf,*.svg,tests,pyproject.toml,*.dill'
 # Ignore table where words could be split across rows
 # Ignore shortcut specifications like [Ff]alse
 ignore-regex = '(\|.*\|.*\|.*\||\[[A-Z][a-z]\][a-z][a-z])'


### PR DESCRIPTION
Currently I skip `tests/` entirely for codespell testing ~~but in the last commit I did add fixing of the most common typos. But I had to exclude the `tests/data/hp.dill` binary file so who knows -- may be fixing not thoroughly would bring some tests failures.  The last commit could be omitted then.~~