### PR TITLE
Fix JsonSchemaDataValidator interaction with example runner

### DIFF
--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -38,6 +38,12 @@ def _generate_jsonschema(schema, top_class, closed):
     ).generate()
 
 
+class JsonSchemaDataValidatorError(Exception):
+    def __init__(self, validation_messages: List[str]) -> None:
+        super().__init__("\n".join(validation_messages))
+        self.validation_messages = validation_messages
+
+
 @dataclass
 class JsonSchemaDataValidator(DataValidator):
     """
@@ -60,7 +66,7 @@ class JsonSchemaDataValidator(DataValidator):
 
     def validate_object(
         self, data: YAMLRoot, target_class: Type[YAMLRoot] = None, closed: bool = True
-    ) -> List[str]:
+    ) -> None:
         """
         validates instance data against a schema
 
@@ -72,11 +78,11 @@ class JsonSchemaDataValidator(DataValidator):
         if target_class is None:
             target_class = type(data)
         inst_dict = as_simple_dict(data)
-        return self.validate_dict(inst_dict, target_class.class_name, closed)
+        self.validate_dict(inst_dict, target_class.class_name, closed)
 
     def validate_dict(
         self, data: dict, target_class: ClassDefinitionName = None, closed: bool = True
-    ) -> List[str]:
+    ) -> None:
         """
         validates instance data against a schema
 
@@ -86,7 +92,8 @@ class JsonSchemaDataValidator(DataValidator):
         :return:
         """
         results = list(self.iter_validate_dict(data, target_class, closed))
-        return results or None
+        if results:
+            raise JsonSchemaDataValidatorError(results)
 
     def iter_validate_dict(
         self, data: dict, target_class_name: ClassDefinitionName = None, closed: bool = True

--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -89,16 +89,16 @@ class JsonSchemaDataValidator(DataValidator):
         return results or None
 
     def iter_validate_dict(
-        self, data: dict, target_class: ClassDefinitionName = None, closed: bool = True
+        self, data: dict, target_class_name: ClassDefinitionName = None, closed: bool = True
     ) -> Iterable[str]:
         if self.schema is None:
             raise ValueError(f"schema object must be set")
-        if target_class is None:
+        if target_class_name is None:
             roots = [c.name for c in self.schema.classes.values() if c.tree_root]
             if len(roots) != 1:
                 raise ValueError(f"Cannot determine tree root: {roots}")
-            target_class = roots[0]
-        jsonschema_obj = _generate_jsonschema(self._hashable_schema, target_class, closed)
+            target_class_name = roots[0]
+        jsonschema_obj = _generate_jsonschema(self._hashable_schema, target_class_name, closed)
         validator = jsonschema.Draft7Validator(
             jsonschema_obj, format_checker=jsonschema.Draft7Validator.FORMAT_CHECKER
         )
@@ -186,7 +186,7 @@ def cli(
     validator = JsonSchemaDataValidator(schema)
     error_count = 0
     for error in validator.iter_validate_dict(
-        data_as_dict, target_class=py_target_class
+        data_as_dict, target_class_name=py_target_class.class_name
     ):
         error_count += 1
         click.echo(click.style("\u2717 ", fg="red") + error)

--- a/linkml/workspaces/example_runner.py
+++ b/linkml/workspaces/example_runner.py
@@ -189,7 +189,7 @@ class ExampleRunner:
                 except Exception as e:
                     success = False
                     if not counter_examples:
-                        raise ValueError(f"Example {input_example} failed validation: {e}")
+                        raise ValueError(f"Example {input_example} failed validation:\n{e}")
                 if counter_examples:
                     if success:
                         raise ValueError(f"Counter example {input_example} succeeded validation")


### PR DESCRIPTION
Follow up to #1502.

The changes in the previous PR did in fact mess up `linkml-run-examples`. These changes restore the previous behavior where `JsonSchemaDataValidator.validate_object` and `JsonSchemaDataValidator.validate_dict` raise an exception if validation problems are found. There seemed to be a handful of places in the `linkml` code itself that relied on that behavior, so it seems like it would be safer to not change that contract. The methods will still validate the entire instance data (as opposed to stopping on the first failure) and make all the validation failure messages available through the exception.

These changes also fix a bug where there was some confusion over passing a `ClassDefinition` vs `ClassDefinitionName`.