### PR TITLE
Validation CLI improvements

### DIFF
--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -133,6 +133,11 @@ class JsonSchemaDataValidator(DataValidator):
     "--index-slot", "-S", help="top level slot. Required for CSV dumping/loading"
 )
 @click.option("--schema", "-s", help="Path to schema specified as LinkML yaml")
+@click.option(
+    "--exit-on-first-failure/--no-exit-on-first-failure", 
+    default=False,
+    help="Exit after the first validation failure is found. If not specified all validation failures are reported."
+)
 @click.argument("input")
 @click.version_option(__version__, "-V", "--version")
 def cli(
@@ -142,6 +147,7 @@ def cli(
     input_format=None,
     schema=None,
     index_slot=None,
+    exit_on_first_failure=False,
 ) -> None:
     """
     Validates instance data
@@ -195,6 +201,8 @@ def cli(
     ):
         error_count += 1
         click.echo(click.style("\u2717 ", fg="red") + error)
+        if exit_on_first_failure:
+            sys.exit(1)
 
     if not error_count:
         click.echo(click.style("\u2713 ", fg="green") + "No problems found")

--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -201,6 +201,7 @@ def cli(
     if not error_count:
         click.echo(click.style("\u2713 ", fg="green") + "No problems found")
 
+    sys.exit(0 if error_count == 0 else 1)
 
 if __name__ == "__main__":
     cli(sys.argv[1:])

--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -118,7 +118,6 @@ class JsonSchemaDataValidator(DataValidator):
 
 @click.command()
 @click.option("--module", "-m", help="Path to python datamodel module")
-@click.option("--output", "-o", help="Path to output file")
 @click.option(
     "--input-format",
     "-f",
@@ -140,7 +139,6 @@ def cli(
     input,
     module,
     target_class,
-    output=None,
     input_format=None,
     schema=None,
     index_slot=None,


### PR DESCRIPTION
These changes:

* Ensure that the `linkml-validate` CLI sets the exit code correctly base on whether issues were found
* Remove the `output` argument from `linkml-validate` to avoid confusion since it wasn't actually used anywhere
* Add a `--exit-on-first-failure` flag to `linkml-validate` to enable a "fail fast" mode