### PR TITLE
Add slot definitions for Tutorial 7

### DIFF
--- a/docs/intro/tutorial07.md
+++ b/docs/intro/tutorial07.md
@@ -333,6 +333,8 @@ slots:
   id:
     identifier: true
   full_name:
+  related_to:
+  relationship_type:
 
 enums:
   FamilialRelationshipType:


### PR DESCRIPTION
This PR closes #1383 where the `related_to` and `relationship_type` slots were referenced by classes without being formally added to the slot definition.