### PR TITLE
Add pre-commit config with black, ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+  - id: codespell
+    additional_dependencies:
+      - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+default_language_version:
+  python: python3
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-toml
+  - id: trailing-whitespace
+- repo: https://github.com/psf/black
+  rev: 23.7.0
+  hooks:
+  - id: black
+    args: ['--target-version', 'py38']
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.0.278
+  hooks:
+  - id: ruff
+    args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,12 +147,12 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.codespell]
 # TODO: bring in tests in too
-skip = '.git,*.pdf,*.svg,tests,pyproject.toml,*.dill'
+skip = '.git,*.pdf,*.svg,./tests,pyproject.toml,*.dill'
 # Ignore table where words could be split across rows
 # Ignore shortcut specifications like [Ff]alse
 ignore-regex = '(\|.*\|.*\|.*\||\[[A-Z][a-z]\][a-z][a-z])'
-#
 ignore-words-list = 'mater,connexion,infarction'
+quiet-level = 3
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ enable = true
 vcs = "git"
 style = "pep440"
 
-[tool.poetry.scripts]    
+[tool.poetry.scripts]
 gen-jsonld-context = "linkml.generators.jsonldcontextgen:cli"
 gen-prefix-map = "linkml.generators.prefixmapgen:cli"
 gen-csv = "linkml.generators.csvgen:cli"
@@ -170,6 +170,8 @@ select = [
   "F",  # Pyflakes
   "I",  # isort
 ]
+# Assume Python 3.8
+target-version = "py38"
 
 [tool.ruff.per-file-ignores]
 # These templates can have long lines


### PR DESCRIPTION
@pkalita-lbl This is a follow-up of your #1520 which added extended checks to CI/tox. 

With [pre-commit](https://pre-commit.com/) code can be tested (and fixed) before the commit and before it hits CI-testing.

Installation and use is simple even on Windows. The following commands were run in the root directory of the git clone. They show the typical steps including installation, update and running all checks (AKA "hooks").
```bash
$ pipx install pre-commit
'pre-commit' already seems to be installed. Not modifying existing installation in...

$ pre-commit install
pre-commit installed at .git\hooks\pre-commit

$ pre-commit autoupdate
[https://github.com/pre-commit/pre-commit-hooks] already up to date!
[https://github.com/psf/black] already up to date!
[https://github.com/astral-sh/ruff-pre-commit] already up to date!

$ pre-commit run
```

Pre-commit runs by default only for staged files. To check all files:
```bash
$ pre-commit run --all-files
```

To run only one specific hook, for example ruff, use:
```bash
$ pre-commit run ruff
```

To commit with failing checks pre-commit can be skipped by `--no-verify`. For example:
```bash
$ git commit . -m 'quick fix' --no-verify
```
~~I intentionally left out `codespell` because I found it to noisy. But in principle it can also run as a pre-commit hook.~~ (see update below)
