### PR TITLE
allow both UML class and ER diagrams in docgen

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -166,6 +166,7 @@ class DocGenerator(Generator):
         if self.example_directory:
             self.example_runner = ExampleRunner(input_directory=Path(self.example_directory))
         super().__post_init__()
+        self.logger = logging.getLogger(__name__)
         self.schemaview = SchemaView(self.schema, merge_imports=self.mergeimports)
 
     def serialize(self, directory: str = None) -> None:
@@ -581,8 +582,8 @@ class DocGenerator(Generator):
                 return erdgen.serialize_classes(class_names, follow_references=True, max_hops=2)
             else:
                 return erdgen.serialize()
-        elif self.diagram_type == DiagramType.uml_class_diagram:
-            raise NotImplementedError("This is currently handled in the jinja templates")
+        elif self.diagram_type.value == DiagramType.uml_class_diagram.value:
+            self.logger.info("This is currently handled in the jinja templates")
         else:
             raise NotImplementedError(f"Diagram type {self.diagram_type} not implemented")
 
@@ -854,13 +855,13 @@ class DocGenerator(Generator):
 @click.option(
     "--diagram-type",
     type=click.Choice([e.value for e in DiagramType]),
-    help="er_diagram is an experimental feature.",
+    help="Type of UML diagram to be rendered on class documentation pages.",
 )
 @click.option(
     "--include-top-level-diagram/--no-include-top-level-diagram",
     default=False,
     show_default=True,
-    help="EXPERIMENTAL: (ER diagram only) Include a diagram of the whole schema.",
+    help="Include ER diagram of the entire schema on index page.",
 )
 @click.option(
     "--sort-by",

--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -18,7 +18,14 @@ _{{ element_description_line }}_
 
 URI: {{ gen.uri_link(element) }}
 
+
+{% if diagram_type == "er_diagram" %}
+```{{ gen.mermaid_directive() }}
+{{ gen.mermaid_diagram([element.name]) }}
+```
+{% else %}
 {% include "class_diagram.md.jinja2" %}
+{% endif %}
 
 {% if schemaview.class_parents(element.name) or schemaview.class_children(element.name, mixins=False) %}
 

--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -1,8 +1,3 @@
-{% if diagram_type == "er_diagram" %}
-```{{ gen.mermaid_directive() }}
-{{ gen.mermaid_diagram([element.name]) }}
-```
-{% else %}
 {% if schemaview.class_parents(element.name) and schemaview.class_children(element.name) %}
 ```{{ gen.mermaid_directive() }}
  classDiagram
@@ -61,5 +56,4 @@
         {% endif %}
       {% endfor %}
 ```
-{% endif %}
 {% endif %}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -58,10 +58,10 @@ URI: {{ gen.uri_link(element) }}
 * Recommended: {{ element.recommended }}
 {% endif -%}
 {% if element.minimum_value is not none %}
-* Minimum Value: {{ element.minimum_value|float }}
+* Minimum Value: {{ element.minimum_value|int }}
 {% endif -%}
 {% if element.maximum_value is not none %}
-* Maximum Value: {{ element.maximum_value|float }}
+* Maximum Value: {{ element.maximum_value|int }}
 {% endif -%}
 {% if element.pattern %}
 * Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -58,10 +58,10 @@ URI: {{ gen.uri_link(element) }}
 * Recommended: {{ element.recommended }}
 {% endif -%}
 {% if element.minimum_value is not none %}
-* Minimum Value: {{ element.minimum_value|int }}
+* Minimum Value: {{ element.minimum_value|float }}
 {% endif -%}
 {% if element.maximum_value is not none %}
-* Maximum Value: {{ element.maximum_value|int }}
+* Maximum Value: {{ element.maximum_value|float }}
 {% endif -%}
 {% if element.pattern %}
 * Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -53,8 +53,6 @@ def assert_mdfile_contains(
                         subsequent_line = lines[j]
                         if len(todo) > 0 and todo[0] in subsequent_line:
                             todo = todo[1:]
-                            # if len(todo) == 0:
-                            #     return  # Found all elements in followed_by
                     if len(todo) > 0:
                         if not invert:
                             logging.error(f"Did not find: {todo}")

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -661,10 +661,7 @@ class DocGeneratorTestCase(unittest.TestCase):
 
     def test_uml_diagrams(self):
         gen = DocGenerator(
-            SCHEMA,
-            mergeimports=True,
-            diagram_type="er_diagram",
-            include_top_level_diagram=True
+            SCHEMA, mergeimports=True, diagram_type="er_diagram", include_top_level_diagram=True
         )
 
         md_temp_dir = tempfile.mkdtemp()
@@ -672,23 +669,25 @@ class DocGeneratorTestCase(unittest.TestCase):
         gen.serialize(directory=md_temp_dir)
 
         # check if ER diagram has been included at top level, i.e., on the index page
-        assert_mdfile_contains("index.md", 
-                               "## Schema Diagram", 
-                               after="Name: kitchen_sink", 
-                               followed_by=["```mermaid", "erDiagram"], 
-                               outdir=md_temp_dir
-                               )
+        assert_mdfile_contains(
+            "index.md",
+            "## Schema Diagram",
+            after="Name: kitchen_sink",
+            followed_by=["```mermaid", "erDiagram"],
+            outdir=md_temp_dir,
+        )
 
-        # pick a random class documentation markdown file and check if there 
+        # pick a random class documentation markdown file and check if there
         # is a mermaid ER diagram in it
-        assert_mdfile_contains("Person.md", 
-                               "# Class: Person", 
-                               followed_by=["```mermaid", "erDiagram", "Person"], 
-                               outdir=md_temp_dir
-                               )
-        
+        assert_mdfile_contains(
+            "Person.md",
+            "# Class: Person",
+            followed_by=["```mermaid", "erDiagram", "Person"],
+            outdir=md_temp_dir,
+        )
+
         shutil.rmtree(md_temp_dir)
-        
+
         gen = DocGenerator(
             SCHEMA,
             mergeimports=True,
@@ -699,13 +698,14 @@ class DocGeneratorTestCase(unittest.TestCase):
 
         gen.serialize(directory=md_temp_dir)
 
-        # pick a random class documentation markdown file and check if there 
+        # pick a random class documentation markdown file and check if there
         # is a mermaid class diagram in it
-        assert_mdfile_contains("Person.md", 
-                               "# Class: Person", 
-                               followed_by=["```mermaid", "classDiagram", "Person"], 
-                               outdir=md_temp_dir
-                               )
+        assert_mdfile_contains(
+            "Person.md",
+            "# Class: Person",
+            followed_by=["```mermaid", "classDiagram", "Person"],
+            outdir=md_temp_dir,
+        )
 
         shutil.rmtree(md_temp_dir)
 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -53,6 +53,8 @@ def assert_mdfile_contains(
                         subsequent_line = lines[j]
                         if len(todo) > 0 and todo[0] in subsequent_line:
                             todo = todo[1:]
+                            # if len(todo) == 0:
+                            #     return  # Found all elements in followed_by
                     if len(todo) > 0:
                         if not invert:
                             logging.error(f"Did not find: {todo}")
@@ -656,6 +658,56 @@ class DocGeneratorTestCase(unittest.TestCase):
         assert_mdfile_contains("index.md", "EmploymentEvent", after="BirthEvent")
 
         assert_mdfile_contains("index.md", "MarriageEvent", after="EmploymentEvent")
+
+    def test_uml_diagrams(self):
+        gen = DocGenerator(
+            SCHEMA,
+            mergeimports=True,
+            diagram_type="er_diagram",
+            include_top_level_diagram=True
+        )
+
+        md_temp_dir = tempfile.mkdtemp()
+
+        gen.serialize(directory=md_temp_dir)
+
+        # check if ER diagram has been included at top level, i.e., on the index page
+        assert_mdfile_contains("index.md", 
+                               "## Schema Diagram", 
+                               after="Name: kitchen_sink", 
+                               followed_by=["```mermaid", "erDiagram"], 
+                               outdir=md_temp_dir
+                               )
+
+        # pick a random class documentation markdown file and check if there 
+        # is a mermaid ER diagram in it
+        assert_mdfile_contains("Person.md", 
+                               "# Class: Person", 
+                               followed_by=["```mermaid", "erDiagram", "Person"], 
+                               outdir=md_temp_dir
+                               )
+        
+        shutil.rmtree(md_temp_dir)
+        
+        gen = DocGenerator(
+            SCHEMA,
+            mergeimports=True,
+            diagram_type="uml_class_diagram",
+        )
+
+        md_temp_dir = tempfile.mkdtemp()
+
+        gen.serialize(directory=md_temp_dir)
+
+        # pick a random class documentation markdown file and check if there 
+        # is a mermaid class diagram in it
+        assert_mdfile_contains("Person.md", 
+                               "# Class: Person", 
+                               followed_by=["```mermaid", "classDiagram", "Person"], 
+                               outdir=md_temp_dir
+                               )
+
+        shutil.rmtree(md_temp_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix issues that @Silvanoc was running into while trying to run the following command:

```
gen-doc --include-top-level-diagram --diagram-type uml_class_diagram
```

Error that he was running into:

```python
NotImplementedError: This is currently handled in the jinja templates
```