### PR TITLE
Generate permissible JSON schema for empty enum

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -319,10 +319,11 @@ class JsonSchemaGenerator(Generator):
         enum_schema = JsonSchema(
             {
                 "type": "string",
-                "enum": permissible_values_texts,
                 "description": be(enum.description),
             }
         )
+        if permissible_values_texts:
+            enum_schema["enum"] = permissible_values_texts
         self.top_level_schema.add_def(enum.name, enum_schema)
 
     def get_type_info_for_slot_subschema(


### PR DESCRIPTION
This patch changes the JSON schema generator such that it creates an unrestricted schema for enums for which no permissible values are specified in LinkML (which may be the case if a reachability query is specified instead).

We are running into this issue in the context of [dynamic enums](https://linkml.io/linkml/schemas/enums.html#dynamic-enums). The documentation says

> At this time, tooling support for dynamic enums is maturing, but you can still go ahead and use them in your schemas. The default behavior will be too permissive – however, you still gain additional clarity in your schema documentation.

However, currently, the JSON schema generator does not create permissible schemas, it creates schemas for which no values can be provided at all (`"enum" : []`).