### PR TITLE
Update jinja template for subset documentation

### DIFF
--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -1,7 +1,7 @@
 # Subset: {{ gen.name(element) }}
 
 {%- if header -%}
-{{header}}
+{{ header }}
 {%- endif -%}
 
 {% if element.description %}
@@ -13,17 +13,40 @@ _{{ element_description_line }}_
 
 URI: {{ gen.uri_link(element) }}
 
-
 {% include "common_metadata.md.jinja2" %}
 
+{% set classes_in_subset = [] %}
+{% set slots_in_subset = [] %}
+{% set enums_in_subset = [] %}
+
+{# Collect classes, slots, and enumerations in subset #}
+{% for c in gen.all_class_objects()|sort(attribute=sort_by) %}
+    {%- if element.name in c.in_subset %}
+        {% set _ = classes_in_subset.append(c) %}
+    {%- endif %}
+{% endfor %}
+
+{% for s in gen.all_slot_objects()|sort(attribute=sort_by) %}
+    {%- if element.name in s.in_subset %}
+        {% set _ = slots_in_subset.append(s) %}
+    {%- endif %}
+{% endfor %}
+
+{% for e in schemaview.all_enums().values() %}
+    {%- if element.name in e.in_subset %}
+        {% set _ = enums_in_subset.append(e) %}
+    {%- endif %}
+{% endfor %}
+
+{% if classes_in_subset %}
 ## Classes in subset
 
 | Class | Description |
 | --- | --- |
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
-{%- if element.name in c.in_subset -%}
-| {{gen.link(c)}} | {{c.description|enshorten}} |
-{% endif -%}
+    {%- if element.name in c.in_subset -%}
+        | {{gen.link(c)}} | {{c.description|enshorten}} |
+    {% endif -%}
 {% endfor %}
 
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
@@ -32,34 +55,46 @@ URI: {{ gen.uri_link(element) }}
 
 {{c.description}}
 
+{% set induced_slots = gen.class_induced_slots(c.name)|sort(attribute=sort_by) %}
+{%- if induced_slots|length > 0 %}
 | Name | Cardinality and Range  | Description  |
 | ---  | ---  | --- |
 {% for s in gen.class_induced_slots(c.name)|sort(attribute=sort_by) -%}
 {% if element.name in s.in_subset or element.name in schemaview.get_slot(s.name).in_subset -%}
 | {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{gen.link(s.range)}}  | {{s.description|enshorten}} {% if s.identifier %}**identifier**{% endif %}  |
-{% endif -%}
+{% endif %}
+{% endfor %}
+{%- endif %}
+
+{% endif %}
 {% endfor %}
 
-{% endif -%}
-{% endfor %}
+{% endif %}
 
+
+{% if slots_in_subset %}
 ## Slots in subset
 
 | Slot | Description |
 | --- | --- |
-{% for s in gen.all_slot_objects()|sort(attribute=sort_by) -%}
-{%- if element.name in s.in_subset -%}
-| {{gen.link(s)}} | {{s.description|enshorten}} |
-{% endif -%}
+{% for s in slots_in_subset|sort(attribute=sort_by) %}
+    {%- if element.name in s.in_subset %}
+        | {{ gen.link(s) }} | {{ s.description|enshorten }} |
+    {%- endif %}
 {% endfor %}
 
+{% endif %}
+
+
+{% if enums_in_subset %}
 ## Enumerations in subset
 
 | Enumeration | Description |
 | --- | --- |
-{% for e in schemaview.all_enums().values()|sort(attribute='name') -%}
-{%- if element.name in e.in_subset -%}
-| {{gen.link(e)}} | {{e.description|enshorten}} |
-{% endif -%}
+{% for e in enums_in_subset|sort(attribute='name') %}
+    {%- if element.name in e.in_subset %}
+        | {{ gen.link(e) }} | {{ e.description|enshorten }} |
+    {%- endif %}
 {% endfor %}
 
+{% endif %}

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -44,9 +44,9 @@ URI: {{ gen.uri_link(element) }}
 | Class | Description |
 | --- | --- |
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
-    {%- if element.name in c.in_subset -%}
-        | {{gen.link(c)}} | {{c.description|enshorten}} |
-    {% endif -%}
+{%- if element.name in c.in_subset -%}
+| {{gen.link(c)}} | {{c.description|enshorten}} |
+{% endif -%}
 {% endfor %}
 
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
@@ -55,21 +55,27 @@ URI: {{ gen.uri_link(element) }}
 
 {{c.description}}
 
-{% set induced_slots = gen.class_induced_slots(c.name)|sort(attribute=sort_by) %}
-{%- if induced_slots|length > 0 %}
+{%- set filtered_slots = [] -%}
+
+{%- for s in induced_slots|sort(attribute=sort_by) -%}
+    {%- if element.name in s.in_subset or element.name in schemaview.get_slot(s.name).in_subset -%}
+        {% set _ = filtered_slots.append(s) %}
+    {%- endif -%}
+{%- endfor %}
+
+{%- if filtered_slots|length > 0 -%}
 | Name | Cardinality and Range  | Description  |
 | ---  | ---  | --- |
-{% for s in gen.class_induced_slots(c.name)|sort(attribute=sort_by) -%}
-{% if element.name in s.in_subset or element.name in schemaview.get_slot(s.name).in_subset -%}
+{% for s in filtered_slots -%}
 | {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{gen.link(s.range)}}  | {{s.description|enshorten}} {% if s.identifier %}**identifier**{% endif %}  |
-{% endif %}
 {% endfor %}
 {%- endif %}
 
-{% endif %}
+
+{%- endif %}
 {% endfor %}
 
-{% endif %}
+{%- endif %}
 
 
 {% if slots_in_subset %}
@@ -77,13 +83,13 @@ URI: {{ gen.uri_link(element) }}
 
 | Slot | Description |
 | --- | --- |
-{% for s in slots_in_subset|sort(attribute=sort_by) %}
-    {%- if element.name in s.in_subset %}
-        | {{ gen.link(s) }} | {{ s.description|enshorten }} |
-    {%- endif %}
+{% for s in slots_in_subset|sort(attribute=sort_by) -%}
+{%- if element.name in s.in_subset -%}
+| {{ gen.link(s) }} | {{ s.description|enshorten }} |
+{%- endif %}
 {% endfor %}
 
-{% endif %}
+{%- endif %}
 
 
 {% if enums_in_subset %}
@@ -91,10 +97,10 @@ URI: {{ gen.uri_link(element) }}
 
 | Enumeration | Description |
 | --- | --- |
-{% for e in enums_in_subset|sort(attribute='name') %}
-    {%- if element.name in e.in_subset %}
-        | {{ gen.link(e) }} | {{ e.description|enshorten }} |
-    {%- endif %}
+{% for e in enums_in_subset|sort(attribute='name') -%}
+{%- if element.name in e.in_subset %}
+| {{ gen.link(e) }} | {{ e.description|enshorten }} |
+{%- endif %}
 {% endfor %}
 
-{% endif %}
+{%- endif %}

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -218,21 +218,11 @@ class DocGeneratorTestCase(unittest.TestCase):
             followed_by=["## Identifier and Mapping Information", "### Schema Source"],
         )
 
-        assert_mdfile_contains(
-            "SubsetB.md",
-            "## Slots in subset",
-            after="### Schema Source"
-        )
+        assert_mdfile_contains("SubsetB.md", "## Slots in subset", after="### Schema Source")
 
-        assert_mdfile_does_not_contain(
-            "SubsetB.md",
-            "## Classes in subset"
-        )
+        assert_mdfile_does_not_contain("SubsetB.md", "## Classes in subset")
 
-        assert_mdfile_does_not_contain(
-            "SubsetB.md",
-            "## Enumerations in subset"
-        )
+        assert_mdfile_does_not_contain("SubsetB.md", "## Enumerations in subset")
 
         # test internal links
         assert_mdfile_contains("ceo.md", "Range: [Person](Person.md)", after="Properties")

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -218,6 +218,22 @@ class DocGeneratorTestCase(unittest.TestCase):
             followed_by=["## Identifier and Mapping Information", "### Schema Source"],
         )
 
+        assert_mdfile_contains(
+            "SubsetB.md",
+            "## Slots in subset",
+            after="### Schema Source"
+        )
+
+        assert_mdfile_does_not_contain(
+            "SubsetB.md",
+            "## Classes in subset"
+        )
+
+        assert_mdfile_does_not_contain(
+            "SubsetB.md",
+            "## Enumerations in subset"
+        )
+
         # test internal links
         assert_mdfile_contains("ceo.md", "Range: [Person](Person.md)", after="Properties")
         # TODO: external links


### PR DESCRIPTION
The PR seeks to modify the jinja template that controls the behavior/rendering of subset markdown/web documentation pages so that _tables_ are only displayed if it is not empty.

For example, look at the subset documentation page for _MixsExtension_ subset on NMDC schema docs: https://microbiomedata.github.io/nmdc-schema/MixsExtension/

The new documentation page after applying the template from this PR:
<img width="1026" alt="Screen Shot 2023-08-11 at 11 33 19 AM" src="https://github.com/linkml/linkml/assets/20239224/10c0c18d-e77c-4c89-b787-a716c035aa08">