### PR TITLE
Add optimizations to reduce compliance test run time

### DIFF
--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -21,6 +21,7 @@ import re
 import sys
 from contextlib import redirect_stdout
 from dataclasses import dataclass, field
+from functools import lru_cache
 from io import StringIO
 from pathlib import Path
 from typing import Callable, ClassVar, Dict, List, Mapping, Optional, Set, TextIO, Type, Union, cast
@@ -56,6 +57,23 @@ from linkml.utils.typereferences import References
 
 DEFAULT_LOG_LEVEL: str = "WARNING"
 DEFAULT_LOG_LEVEL_INT: int = logging.WARNING
+
+
+@lru_cache
+def _resolved_metamodel(mergeimports):
+    if not os.path.exists(LOCAL_METAMODEL_YAML_FILE):
+        raise AssertionError(f"{LOCAL_METAMODEL_YAML_FILE} not found")
+
+    base_dir = str(Path(str(LOCAL_METAMODEL_YAML_FILE)).parent)
+    logging.debug(f"BASE={base_dir}")
+    metamodel = SchemaLoader(
+        LOCAL_METAMODEL_YAML_FILE,
+        importmap={"linkml": base_dir},
+        base_dir=base_dir,
+        mergeimports=mergeimports,
+    )
+    metamodel.resolve()
+    return metamodel
 
 
 @dataclass
@@ -172,18 +190,7 @@ class Generator(metaclass=abc.ABCMeta):
             self.source_file_date = None
             self.source_file_size = None
         if self.requires_metamodel:
-            if os.path.exists(LOCAL_METAMODEL_YAML_FILE):
-                base_dir = str(Path(str(LOCAL_METAMODEL_YAML_FILE)).parent)
-                logging.debug(f"BASE={base_dir}")
-                self.metamodel = SchemaLoader(
-                    LOCAL_METAMODEL_YAML_FILE,
-                    importmap={"linkml": base_dir},
-                    base_dir=base_dir,
-                    mergeimports=self.mergeimports,
-                )
-            else:
-                raise AssertionError(f"{LOCAL_METAMODEL_YAML_FILE} not found")
-            self.metamodel.resolve()
+            self.metamodel = _resolved_metamodel(self.mergeimports)
         schema = self.schema
         # TODO: remove aliasing
         self.emit_metadata = self.metadata


### PR DESCRIPTION
These changes:

* Cache the result of `SchemaLoader.resolve`-ing the metamodel in the `Generator` base class. This improves the performance of all tests using generators that require the metamodel. 
* In the compliance test suite, `https://w3id.org/linkml/types.yaml` is fetched once and the results are inlined into test schema. This only affects the compliance tests, but it saves a significant amount of time in making network requests.

This brings the build and test workflow time down from around 40 - 50 minutes to around 20 minutes. I'm sure there is more we could do, but I think this is a good enough start.