### PR TITLE
Add option to generate Pydantic v2

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -304,11 +304,11 @@ class JsonSchemaGenerator(Generator):
         # support other pv_formula
 
         def extract_permissible_text(pv):
-            if type(pv) is str:
+            if isinstance(pv, str):
                 return pv
-            if type(pv) is PermissibleValue:
+            if isinstance(pv, PermissibleValue):
                 return pv.text.code
-            if type(pv) is PermissibleValueText:
+            if isinstance(pv, PermissibleValueText):
                 return pv
             raise ValueError(f"Invalid permissible value in enum {enum}: {pv}")
 

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -30,7 +30,11 @@ from linkml.generators.oocodegen import OOCodeGenerator
 from linkml.utils.generator import shared_arguments
 from linkml.utils.ifabsent_functions import ifabsent_value_declaration
 
-default_template = """
+
+def default_template(pydantic_ver: str = "1") -> str:
+    """Constructs a default template for pydantic classes based on the version of pydantic"""
+    ### HEADER ###
+    template = """
 {#-
 
   Jinja2 Template for a pydantic classes
@@ -40,7 +44,6 @@ from datetime import datetime, date
 from enum import Enum
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, Field
-from linkml_runtime.linkml_model import Decimal
 import sys
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -50,7 +53,10 @@ else:
 
 metamodel_version = "{{metamodel_version}}"
 version = "{{version if version else None}}"
-
+"""
+    ### BASE MODEL ###
+    if pydantic_ver == "1":
+        template += """
 class WeakRefShimBaseModel(BaseModel):
    __slots__ = '__weakref__'
 
@@ -62,7 +68,19 @@ class ConfiguredBaseModel(WeakRefShimBaseModel,
                 arbitrary_types_allowed = True,
                 use_enum_values = True):
     pass
-
+""" 
+    else:
+        template += """
+class ConfiguredBaseModel(BaseModel,
+                validate_assignment = True,
+                validate_default = True,
+                extra = {% if allow_extra %}'allow'{% else %}'forbid'{% endif %},
+                arbitrary_types_allowed = True,
+                use_enum_values = True):
+    pass
+"""
+    ### ENUMS ###
+    template += """
 {% for e in enums.values() %}
 class {{ e.name }}(str, Enum):
     {% if e.description -%}
@@ -80,7 +98,9 @@ class {{ e.name }}(str, Enum):
     dummy = "dummy"
     {% endif %}
 {% endfor %}
-
+"""
+    ### CLASSES ###
+    template += """
 {%- for c in schema.classes.values() %}
 class {{ c.name }}
     {%- if class_isa_plus_mixins[c.name] -%}
@@ -111,15 +131,26 @@ class {{ c.name }}
     {% else -%}
     None
     {% endfor %}
-
 {% endfor %}
-
+"""
+    ### FWD REFS / REBUILD MODEL ###
+    if pydantic_ver == "1":
+        template += """
 # Update forward refs
 # see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
 {% for c in schema.classes.values() -%}
 {{ c.name }}.update_forward_refs()
 {% endfor %}
 """
+    else:
+        template += """
+# Model rebuild
+# see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
+{% for c in schema.classes.values() -%}
+{{ c.name }}.model_rebuild()
+{% endfor %}    
+"""
+    return template
 
 
 def _get_pyrange(t: TypeDefinition, sv: SchemaView) -> str:
@@ -147,11 +178,12 @@ class PydanticGenerator(OOCodeGenerator):
 
     # ClassVar overrides
     generatorname = os.path.basename(__file__)
-    generatorversion = "0.0.1"
+    generatorversion = "0.0.2"
     valid_formats = ["pydantic"]
     file_extension = "py"
 
     # ObjectVars
+    pydantic_version: str = field(default_factory=lambda: "1")
     template_file: str = None
     allow_extra: bool = field(default_factory=lambda: False)
     gen_mixin_inheritance: bool = field(default_factory=lambda: True)
@@ -441,7 +473,7 @@ class PydanticGenerator(OOCodeGenerator):
             with open(self.template_file) as template_file:
                 template_obj = Template(template_file.read())
         else:
-            template_obj = Template(default_template)
+            template_obj = Template(default_template(self.pydantic_version))
 
         sv: SchemaView
         sv = self.schemaview
@@ -547,6 +579,7 @@ class PydanticGenerator(OOCodeGenerator):
 
 @shared_arguments(PydanticGenerator)
 @click.option("--template_file", help="Optional jinja2 template to use for class generation")
+@click.option("--pydantic_version", help="Pydantic version to use (1 or 2)", default="1")
 @click.version_option(__version__, "-V", "--version")
 @click.command()
 def cli(
@@ -557,18 +590,25 @@ def cli(
     genmeta=False,
     classvars=True,
     slots=True,
+    pydantic_version="1",
     **args,
 ):
     """Generate pydantic classes to represent a LinkML model"""
+
+    if pydantic_version not in ["1", "2"]:
+        raise ValueError(f"pydantic_version must be 1 or 2, not {pydantic_version}")
+    
     gen = PydanticGenerator(
         yamlfile,
         template_file=template_file,
+        pydantic_version=pydantic_version,
         emit_metadata=head,
         genmeta=genmeta,
         gen_classvars=classvars,
         gen_slots=slots,
         **args,
     )
+    
     print(gen.serialize())
 
 

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -579,7 +579,7 @@ class PydanticGenerator(OOCodeGenerator):
 
 @shared_arguments(PydanticGenerator)
 @click.option("--template_file", help="Optional jinja2 template to use for class generation")
-@click.option("--pydantic_version", help="Pydantic version to use (1 or 2)", default="1")
+@click.option("--pydantic_version", type=click.Choice(["1", "2"]), default="1", help="Pydantic version to use (1 or 2)")
 @click.version_option(__version__, "-V", "--version")
 @click.command()
 def cli(
@@ -594,10 +594,6 @@ def cli(
     **args,
 ):
     """Generate pydantic classes to represent a LinkML model"""
-
-    if pydantic_version not in ["1", "2"]:
-        raise ValueError(f"pydantic_version must be 1 or 2, not {pydantic_version}")
-
     gen = PydanticGenerator(
         yamlfile,
         template_file=template_file,
@@ -608,7 +604,6 @@ def cli(
         gen_slots=slots,
         **args,
     )
-
     print(gen.serialize())
 
 

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -579,7 +579,12 @@ class PydanticGenerator(OOCodeGenerator):
 
 @shared_arguments(PydanticGenerator)
 @click.option("--template_file", help="Optional jinja2 template to use for class generation")
-@click.option("--pydantic_version", type=click.Choice(["1", "2"]), default="1", help="Pydantic version to use (1 or 2)")
+@click.option(
+    "--pydantic_version",
+    type=click.Choice(["1", "2"]),
+    default="1",
+    help="Pydantic version to use (1 or 2)",
+)
 @click.version_option(__version__, "-V", "--version")
 @click.command()
 def cli(

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -68,7 +68,7 @@ class ConfiguredBaseModel(WeakRefShimBaseModel,
                 arbitrary_types_allowed = True,
                 use_enum_values = True):
     pass
-""" 
+"""
     else:
         template += """
 class ConfiguredBaseModel(BaseModel,
@@ -597,7 +597,7 @@ def cli(
 
     if pydantic_version not in ["1", "2"]:
         raise ValueError(f"pydantic_version must be 1 or 2, not {pydantic_version}")
-    
+
     gen = PydanticGenerator(
         yamlfile,
         template_file=template_file,
@@ -608,7 +608,7 @@ def cli(
         gen_slots=slots,
         **args,
     )
-    
+
     print(gen.serialize())
 
 

--- a/tests/test_issues/test_linkml_issue_723.py
+++ b/tests/test_issues/test_linkml_issue_723.py
@@ -93,8 +93,8 @@ def test_plain_dataclasses():
     assert p.status.value == StatusEnumDC.ALIVE.value
     assert p.status.value == "ALIVE"
     assert p.status != "ALIVE"
-    assert type(p.status) == StatusEnumDC
-    assert type(p.status.value) == str
+    assert isinstance(p.status, StatusEnumDC)
+    assert isinstance(p.status.value, str)
 
 
 def test_raises(pythongen_module):


### PR DESCRIPTION
Addresses #1545 

There aren't too many significant [changes](https://docs.pydantic.dev/latest/migration/) between v1 and v2

This PR proposes a new flag for the `gen-pydantic` command (currently `--pydantic_version [1|2]`, but open to suggestions) which leads to small changes in the default template (now a function returning a string)

Note this PR doesn't (yet) update Linkml's dependency on Pydantic to ^2.0, only allows model generation in v2