### PR TITLE
Fix issues identified by Ruff v0.0.284

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -304,11 +304,11 @@ class JsonSchemaGenerator(Generator):
         # support other pv_formula
 
         def extract_permissible_text(pv):
-            if type(pv) is str:
+            if isinstance(pv, str):
                 return pv
-            if type(pv) is PermissibleValue:
+            if isinstance(pv, PermissibleValue):
                 return pv.text.code
-            if type(pv) is PermissibleValueText:
+            if isinstance(pv, PermissibleValueText):
                 return pv
             raise ValueError(f"Invalid permissible value in enum {enum}: {pv}")
 

--- a/tests/test_issues/test_linkml_issue_723.py
+++ b/tests/test_issues/test_linkml_issue_723.py
@@ -93,8 +93,8 @@ def test_plain_dataclasses():
     assert p.status.value == StatusEnumDC.ALIVE.value
     assert p.status.value == "ALIVE"
     assert p.status != "ALIVE"
-    assert type(p.status) == StatusEnumDC
-    assert type(p.status.value) == str
+    assert isinstance(p.status, StatusEnumDC)
+    assert isinstance(p.status.value, str)
 
 
 def test_raises(pythongen_module):


### PR DESCRIPTION
Ruff [v0.0.283](https://github.com/astral-sh/ruff/releases/tag/v0.0.283) was released on 2023-08-08. That release updates an existing rule ([E721](https://beta.ruff.rs/docs/rules/type-comparison/)) to catch constructs that it didn't previously. These changes fix up our code to pass linting against the latest Ruff release (v0.0.284).