### PR TITLE
Update snapshots with changes from latest metamodel

### DIFF
--- a/tests/test_issues/__snapshots__/issue_167b.yaml
+++ b/tests/test_issues/__snapshots__/issue_167b.yaml
@@ -23,6 +23,10 @@ types:
     name: string
     definition_uri: https://w3id.org/linkml/String
     description: A character string
+    notes:
+    - In RDF serializations, a slot with range of string is treated as a literal or
+      type xsd:string.   If you are authoring schemas in LinkML YAML, the type is
+      referenced with the lower case "string".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -33,6 +37,9 @@ types:
     name: integer
     definition_uri: https://w3id.org/linkml/Integer
     description: An integer
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "integer".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -43,6 +50,9 @@ types:
     name: boolean
     definition_uri: https://w3id.org/linkml/Boolean
     description: A binary (true or false) value
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "boolean".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -54,6 +64,9 @@ types:
     name: float
     definition_uri: https://w3id.org/linkml/Float
     description: A real number that conforms to the xsd:float specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "float".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -64,6 +77,9 @@ types:
     name: double
     definition_uri: https://w3id.org/linkml/Double
     description: A real number that conforms to the xsd:double specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "double".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     close_mappings:
@@ -75,6 +91,9 @@ types:
     definition_uri: https://w3id.org/linkml/Decimal
     description: A real number with arbitrary precision that conforms to the xsd:decimal
       specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "decimal".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     broad_mappings:
@@ -88,6 +107,8 @@ types:
       particular day
     notes:
     - URI is dateTime because OWL reasoners do not work with straight date or time
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "time".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -101,6 +122,8 @@ types:
     description: a date (year, month and day) in an idealized calendar
     notes:
     - URI is dateTime because OWL reasoners don't work with straight date or time
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "date".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -112,6 +135,9 @@ types:
     name: datetime
     definition_uri: https://w3id.org/linkml/Datetime
     description: The combination of a date and time
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "datetime".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -123,6 +149,9 @@ types:
     name: date_or_datetime
     definition_uri: https://w3id.org/linkml/DateOrDatetime
     description: Either a date or a datetime
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "date_or_datetime".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: str
@@ -132,6 +161,9 @@ types:
     name: uriorcurie
     definition_uri: https://w3id.org/linkml/Uriorcurie
     description: a URI or a CURIE
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "uriorcurie".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: URIorCURIE
@@ -142,6 +174,9 @@ types:
     definition_uri: https://w3id.org/linkml/Curie
     conforms_to: https://www.w3.org/TR/curie/
     description: a compact URI
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "curie".
     comments:
     - in RDF serializations this MUST be expanded to a URI
     - in non-RDF serializations MAY be serialized as the compact representation
@@ -155,6 +190,9 @@ types:
     definition_uri: https://w3id.org/linkml/Uri
     conforms_to: https://www.ietf.org/rfc/rfc3987.txt
     description: a complete URI
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "uri".
     comments:
     - in RDF serializations a slot with range of uri is treated as a literal or type
       xsd:anyURI unless it is an identifier or a reference to an identifier, in which
@@ -170,6 +208,9 @@ types:
     name: ncname
     definition_uri: https://w3id.org/linkml/Ncname
     description: Prefix part of CURIE
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "ncname".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: NCName
@@ -179,6 +220,9 @@ types:
     name: objectidentifier
     definition_uri: https://w3id.org/linkml/Objectidentifier
     description: A URI or CURIE that represents an object in the model.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "objectidentifier".
     comments:
     - Used for inheritance and type checking
     from_schema: https://w3id.org/linkml/types
@@ -190,6 +234,9 @@ types:
     name: nodeidentifier
     definition_uri: https://w3id.org/linkml/Nodeidentifier
     description: A URI, CURIE or BNODE that represents a node in a model.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "nodeidentifier".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: NodeIdentifier
@@ -202,6 +249,9 @@ types:
     description: A string encoding a JSON Pointer. The value of the string MUST conform
       to JSON Point syntax and SHOULD dereference to a valid object within the current
       instance document when encoded in tree form.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "jsonpointer".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: str
@@ -214,6 +264,9 @@ types:
     description: A string encoding a JSON Path. The value of the string MUST conform
       to JSON Point syntax and SHOULD dereference to zero or more valid objects within
       the current instance document when encoded in tree form.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "jsonpath".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: str
@@ -226,6 +279,9 @@ types:
     description: A string encoding a SPARQL Property Path. The value of the string
       MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects
       within the current instance document when encoded as RDF.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "sparqlpath".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: str

--- a/tests/test_issues/__snapshots__/issue_namespace.ttl
+++ b/tests/test_issues/__snapshots__/issue_namespace.ttl
@@ -8,21 +8,21 @@
     rdfs:label "Biolink_Model" ;
     dct:description "Entity and association taxonomy and datamodel for life-sciences data" ;
     linkml:classes [ a linkml:ClassDefinition ;
-            rdfs:label "NamedThing" ;
-            dct:description "a databased entity or concept/class" ;
-            linkml:class_uri "https://w3id.org/biolink/vocab/NamedThing" ;
-            linkml:definition_uri "https://w3id.org/biolink/vocab/NamedThing" ;
-            linkml:from_schema "https://w3id.org/biolink/biolink-model" ;
-            linkml:slot_usage [ ] ;
-            linkml:slots "id",
-                "name" ],
-        [ a linkml:ClassDefinition ;
             rdfs:label "AnatomicalEntity" ;
             biolink:subclass_of <uberon:0001062> ;
             linkml:class_uri "https://w3id.org/biolink/vocab/AnatomicalEntity" ;
             linkml:definition_uri "https://w3id.org/biolink/vocab/AnatomicalEntity" ;
             linkml:from_schema "https://w3id.org/biolink/biolink-model" ;
             linkml:is_a "NamedThing" ;
+            linkml:slot_usage [ ] ;
+            linkml:slots "id",
+                "name" ],
+        [ a linkml:ClassDefinition ;
+            rdfs:label "NamedThing" ;
+            dct:description "a databased entity or concept/class" ;
+            linkml:class_uri "https://w3id.org/biolink/vocab/NamedThing" ;
+            linkml:definition_uri "https://w3id.org/biolink/vocab/NamedThing" ;
+            linkml:from_schema "https://w3id.org/biolink/biolink-model" ;
             linkml:slot_usage [ ] ;
             linkml:slots "id",
                 "name" ] ;
@@ -42,26 +42,26 @@
     linkml:imports "linkml:types" ;
     linkml:license "https://creativecommons.org/publicdomain/zero/1.0/" ;
     linkml:metamodel_version "1.7.0" ;
-    linkml:prefixes [ linkml:prefix_prefix "wgs" ;
-            linkml:prefix_reference "http://www.w3.org/2003/01/geo/wgs84_pos" ],
-        [ linkml:prefix_prefix "SIO" ;
-            linkml:prefix_reference "http://semanticscience.org/resource/SIO_" ],
-        [ linkml:prefix_prefix "skos" ;
-            linkml:prefix_reference "http://www.w3.org/2004/02/skos/core#" ],
+    linkml:prefixes [ linkml:prefix_prefix "linkml" ;
+            linkml:prefix_reference "https://w3id.org/linkml/" ],
         [ linkml:prefix_prefix "UMLSST" ;
             linkml:prefix_reference "https://uts-ws.nlm.nih.gov/rest/semantic-network/semantic-network/current/STY/" ],
-        [ linkml:prefix_prefix "OBAN" ;
-            linkml:prefix_reference "http://purl.org/oban/" ],
+        [ linkml:prefix_prefix "qud" ;
+            linkml:prefix_reference "http://qudt.org/1.1/schema/qudt#" ],
         [ linkml:prefix_prefix "biolink" ;
             linkml:prefix_reference "https://w3id.org/biolink/vocab/" ],
-        [ linkml:prefix_prefix "linkml" ;
-            linkml:prefix_reference "https://w3id.org/linkml/" ],
-        [ linkml:prefix_prefix "UMLSSC" ;
-            linkml:prefix_reference "https://uts-ws.nlm.nih.gov/rest/semantic-network/semantic-network/current/TUI/" ],
+        [ linkml:prefix_prefix "skos" ;
+            linkml:prefix_reference "http://www.w3.org/2004/02/skos/core#" ],
+        [ linkml:prefix_prefix "SIO" ;
+            linkml:prefix_reference "http://semanticscience.org/resource/SIO_" ],
         [ linkml:prefix_prefix "UMLSSG" ;
             linkml:prefix_reference "https://uts-ws.nlm.nih.gov/rest/semantic-network/semantic-network/current/GROUP/" ],
-        [ linkml:prefix_prefix "qud" ;
-            linkml:prefix_reference "http://qudt.org/1.1/schema/qudt#" ] ;
+        [ linkml:prefix_prefix "UMLSSC" ;
+            linkml:prefix_reference "https://uts-ws.nlm.nih.gov/rest/semantic-network/semantic-network/current/TUI/" ],
+        [ linkml:prefix_prefix "wgs" ;
+            linkml:prefix_reference "http://www.w3.org/2003/01/geo/wgs84_pos" ],
+        [ linkml:prefix_prefix "OBAN" ;
+            linkml:prefix_reference "http://purl.org/oban/" ] ;
     linkml:slots [ a linkml:SlotDefinition ;
             rdfs:label "name" ;
             linkml:definition_uri "https://w3id.org/biolink/vocab/name" ;
@@ -84,59 +84,17 @@
             linkml:required true ;
             linkml:slot_uri "https://w3id.org/biolink/vocab/id" ] ;
     linkml:source_file "issue_namespace.yaml" ;
-    linkml:source_file_date "2022-04-06T12:03:11" ;
-    linkml:source_file_size 1583 ;
+    linkml:source_file_date "2000-01-01T00:00:00" ;
+    linkml:source_file_size 1 ;
     linkml:types [ a linkml:TypeDefinition ;
-            rdfs:label "time" ;
-            dct:description "A time object represents a (local) time of day, independent of any particular day" ;
-            linkml:base "XSDTime" ;
-            linkml:definition_uri "https://w3id.org/linkml/Time" ;
-            linkml:exact_mappings "schema:Time" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:notes "URI is dateTime because OWL reasoners do not work with straight date or time" ;
-            linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#time" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "decimal" ;
-            dct:description "A real number with arbitrary precision that conforms to the xsd:decimal specification" ;
-            linkml:base "Decimal" ;
-            linkml:broad_mappings "schema:Number" ;
-            linkml:definition_uri "https://w3id.org/linkml/Decimal" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#decimal" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "objectidentifier" ;
-            dct:description "A URI or CURIE that represents an object in the model." ;
-            linkml:base "ElementIdentifier" ;
-            linkml:comments "Used for inheritance and type checking" ;
-            linkml:definition_uri "https://w3id.org/linkml/Objectidentifier" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/ns/shex#iri" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "curie" ;
-            dct:description "a compact URI" ;
-            linkml:base "Curie" ;
-            linkml:comments "in RDF serializations this MUST be expanded to a URI",
-                "in non-RDF serializations MAY be serialized as the compact representation" ;
-            linkml:conforms_to "https://www.w3.org/TR/curie/" ;
-            linkml:definition_uri "https://w3id.org/linkml/Curie" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "jsonpath" ;
-            dct:description "A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form." ;
+            rdfs:label "string" ;
+            dct:description "A character string" ;
             linkml:base "str" ;
-            linkml:conforms_to "https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html" ;
-            linkml:definition_uri "https://w3id.org/linkml/Jsonpath" ;
+            linkml:definition_uri "https://w3id.org/linkml/String" ;
+            linkml:exact_mappings "schema:Text" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
-            linkml:repr "str" ;
+            linkml:notes "In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.   If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"string\"." ;
             linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
         [ a linkml:TypeDefinition ;
             rdfs:label "double" ;
@@ -146,82 +104,18 @@
             linkml:definition_uri "https://w3id.org/linkml/Double" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"double\"." ;
             linkml:uri "http://www.w3.org/2001/XMLSchema#double" ],
         [ a linkml:TypeDefinition ;
-            rdfs:label "identifier_type" ;
-            dct:description "A string that is intended to uniquely identify a thing May be URI in full or compact (CURIE) form" ;
-            linkml:base "ElementIdentifier" ;
-            linkml:definition_uri "https://w3id.org/biolink/vocab/IdentifierType" ;
-            linkml:from_schema "https://w3id.org/biolink/biolink-model" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#anyURI" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "float" ;
-            dct:description "A real number that conforms to the xsd:float specification" ;
-            linkml:base "float" ;
-            linkml:definition_uri "https://w3id.org/linkml/Float" ;
-            linkml:exact_mappings "schema:Float" ;
+            rdfs:label "decimal" ;
+            dct:description "A real number with arbitrary precision that conforms to the xsd:decimal specification" ;
+            linkml:base "Decimal" ;
+            linkml:broad_mappings "schema:Number" ;
+            linkml:definition_uri "https://w3id.org/linkml/Decimal" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#float" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "boolean" ;
-            dct:description "A binary (true or false) value" ;
-            linkml:base "Bool" ;
-            linkml:definition_uri "https://w3id.org/linkml/Boolean" ;
-            linkml:exact_mappings "schema:Boolean" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:repr "bool" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#boolean" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "date" ;
-            dct:description "a date (year, month and day) in an idealized calendar" ;
-            linkml:base "XSDDate" ;
-            linkml:definition_uri "https://w3id.org/linkml/Date" ;
-            linkml:exact_mappings "schema:Date" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:notes "URI is dateTime because OWL reasoners don't work with straight date or time" ;
-            linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#date" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "nodeidentifier" ;
-            dct:description "A URI, CURIE or BNODE that represents a node in a model." ;
-            linkml:base "NodeIdentifier" ;
-            linkml:definition_uri "https://w3id.org/linkml/Nodeidentifier" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/ns/shex#nonLiteral" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "sparqlpath" ;
-            dct:description "A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF." ;
-            linkml:base "str" ;
-            linkml:conforms_to "https://www.w3.org/TR/sparql11-query/#propertypaths" ;
-            linkml:definition_uri "https://w3id.org/linkml/Sparqlpath" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "datetime" ;
-            dct:description "The combination of a date and time" ;
-            linkml:base "XSDDateTime" ;
-            linkml:definition_uri "https://w3id.org/linkml/Datetime" ;
-            linkml:exact_mappings "schema:DateTime" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#dateTime" ],
-        [ a linkml:TypeDefinition ;
-            rdfs:label "uriorcurie" ;
-            dct:description "a URI or a CURIE" ;
-            linkml:base "URIorCURIE" ;
-            linkml:definition_uri "https://w3id.org/linkml/Uriorcurie" ;
-            linkml:from_schema "https://w3id.org/linkml/types" ;
-            linkml:imported_from "linkml:types" ;
-            linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#anyURI" ],
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"decimal\"." ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#decimal" ],
         [ a linkml:TypeDefinition ;
             rdfs:label "uri" ;
             dct:description "a complete URI" ;
@@ -232,26 +126,74 @@
             linkml:definition_uri "https://w3id.org/linkml/Uri" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uri\"." ;
             linkml:repr "str" ;
             linkml:uri "http://www.w3.org/2001/XMLSchema#anyURI" ],
         [ a linkml:TypeDefinition ;
-            rdfs:label "string" ;
-            dct:description "A character string" ;
-            linkml:base "str" ;
-            linkml:definition_uri "https://w3id.org/linkml/String" ;
-            linkml:exact_mappings "schema:Text" ;
+            rdfs:label "boolean" ;
+            dct:description "A binary (true or false) value" ;
+            linkml:base "Bool" ;
+            linkml:definition_uri "https://w3id.org/linkml/Boolean" ;
+            linkml:exact_mappings "schema:Boolean" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"boolean\"." ;
+            linkml:repr "bool" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#boolean" ],
         [ a linkml:TypeDefinition ;
-            rdfs:label "integer" ;
-            dct:description "An integer" ;
-            linkml:base "int" ;
-            linkml:definition_uri "https://w3id.org/linkml/Integer" ;
-            linkml:exact_mappings "schema:Integer" ;
+            rdfs:label "objectidentifier" ;
+            dct:description "A URI or CURIE that represents an object in the model." ;
+            linkml:base "ElementIdentifier" ;
+            linkml:comments "Used for inheritance and type checking" ;
+            linkml:definition_uri "https://w3id.org/linkml/Objectidentifier" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#integer" ],
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"objectidentifier\"." ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/ns/shex#iri" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "uriorcurie" ;
+            dct:description "a URI or a CURIE" ;
+            linkml:base "URIorCURIE" ;
+            linkml:definition_uri "https://w3id.org/linkml/Uriorcurie" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uriorcurie\"." ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#anyURI" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "time" ;
+            dct:description "A time object represents a (local) time of day, independent of any particular day" ;
+            linkml:base "XSDTime" ;
+            linkml:definition_uri "https://w3id.org/linkml/Time" ;
+            linkml:exact_mappings "schema:Time" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"time\".",
+                "URI is dateTime because OWL reasoners do not work with straight date or time" ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#time" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "float" ;
+            dct:description "A real number that conforms to the xsd:float specification" ;
+            linkml:base "float" ;
+            linkml:definition_uri "https://w3id.org/linkml/Float" ;
+            linkml:exact_mappings "schema:Float" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"float\"." ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#float" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "sparqlpath" ;
+            dct:description "A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF." ;
+            linkml:base "str" ;
+            linkml:conforms_to "https://www.w3.org/TR/sparql11-query/#propertypaths" ;
+            linkml:definition_uri "https://w3id.org/linkml/Sparqlpath" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"sparqlpath\"." ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
         [ a linkml:TypeDefinition ;
             rdfs:label "jsonpointer" ;
             dct:description "A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to a valid object within the current instance document when encoded in tree form." ;
@@ -260,6 +202,52 @@
             linkml:definition_uri "https://w3id.org/linkml/Jsonpointer" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpointer\"." ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "curie" ;
+            dct:description "a compact URI" ;
+            linkml:base "Curie" ;
+            linkml:comments "in RDF serializations this MUST be expanded to a URI",
+                "in non-RDF serializations MAY be serialized as the compact representation" ;
+            linkml:conforms_to "https://www.w3.org/TR/curie/" ;
+            linkml:definition_uri "https://w3id.org/linkml/Curie" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"curie\"." ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "datetime" ;
+            dct:description "The combination of a date and time" ;
+            linkml:base "XSDDateTime" ;
+            linkml:definition_uri "https://w3id.org/linkml/Datetime" ;
+            linkml:exact_mappings "schema:DateTime" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"datetime\"." ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#dateTime" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "nodeidentifier" ;
+            dct:description "A URI, CURIE or BNODE that represents a node in a model." ;
+            linkml:base "NodeIdentifier" ;
+            linkml:definition_uri "https://w3id.org/linkml/Nodeidentifier" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"nodeidentifier\"." ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/ns/shex#nonLiteral" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "jsonpath" ;
+            dct:description "A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form." ;
+            linkml:base "str" ;
+            linkml:conforms_to "https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html" ;
+            linkml:definition_uri "https://w3id.org/linkml/Jsonpath" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpath\"." ;
             linkml:repr "str" ;
             linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
         [ a linkml:TypeDefinition ;
@@ -269,8 +257,26 @@
             linkml:definition_uri "https://w3id.org/linkml/DateOrDatetime" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date_or_datetime\"." ;
             linkml:repr "str" ;
             linkml:uri "https://w3id.org/linkml/DateOrDatetime" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "identifier_type" ;
+            dct:description "A string that is intended to uniquely identify a thing May be URI in full or compact (CURIE) form" ;
+            linkml:base "ElementIdentifier" ;
+            linkml:definition_uri "https://w3id.org/biolink/vocab/IdentifierType" ;
+            linkml:from_schema "https://w3id.org/biolink/biolink-model" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#anyURI" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "integer" ;
+            dct:description "An integer" ;
+            linkml:base "int" ;
+            linkml:definition_uri "https://w3id.org/linkml/Integer" ;
+            linkml:exact_mappings "schema:Integer" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"integer\"." ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#integer" ],
         [ a linkml:TypeDefinition ;
             rdfs:label "ncname" ;
             dct:description "Prefix part of CURIE" ;
@@ -278,7 +284,20 @@
             linkml:definition_uri "https://w3id.org/linkml/Ncname" ;
             linkml:from_schema "https://w3id.org/linkml/types" ;
             linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"ncname\"." ;
             linkml:repr "str" ;
-            linkml:uri "http://www.w3.org/2001/XMLSchema#string" ] .
+            linkml:uri "http://www.w3.org/2001/XMLSchema#string" ],
+        [ a linkml:TypeDefinition ;
+            rdfs:label "date" ;
+            dct:description "a date (year, month and day) in an idealized calendar" ;
+            linkml:base "XSDDate" ;
+            linkml:definition_uri "https://w3id.org/linkml/Date" ;
+            linkml:exact_mappings "schema:Date" ;
+            linkml:from_schema "https://w3id.org/linkml/types" ;
+            linkml:imported_from "linkml:types" ;
+            linkml:notes "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date\".",
+                "URI is dateTime because OWL reasoners don't work with straight date or time" ;
+            linkml:repr "str" ;
+            linkml:uri "http://www.w3.org/2001/XMLSchema#date" ] .
 
 

--- a/tests/test_issues/__snapshots__/linkml_issue_384-False-False.owl
+++ b/tests/test_issues/__snapshots__/linkml_issue_384-False-False.owl
@@ -40,8 +40,8 @@
 <https://w3id.org/linkml/examples/personinfo/Person> a owl:Class ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/examples/personinfo/aliases> ],
+            owl:allValuesFrom <https://w3id.org/linkml/examples/personinfo/Person> ;
+            owl:onProperty <https://w3id.org/linkml/examples/personinfo/parent> ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onDataRange xsd:integer ;
@@ -51,8 +51,8 @@
             owl:onDataRange xsd:string ;
             owl:onProperty <https://w3id.org/linkml/examples/personinfo/phone> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/examples/personinfo/Person> ;
-            owl:onProperty <https://w3id.org/linkml/examples/personinfo/parent> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/examples/personinfo/aliases> ],
         <https://w3id.org/linkml/examples/personinfo/Thing> ;
     skos:exactMatch sdo:Person .
 

--- a/tests/test_issues/__snapshots__/linkml_issue_384-True-True.owl
+++ b/tests/test_issues/__snapshots__/linkml_issue_384-True-True.owl
@@ -23,12 +23,12 @@ linkml:TypeDefinition a owl:Class .
     rdfs:label "GeoObject" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass <https://w3id.org/linkml/examples/personinfo/GeoAge> ;
-            owl:onProperty <https://w3id.org/linkml/examples/personinfo/age> ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty <https://w3id.org/linkml/examples/personinfo/aliases> ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass <https://w3id.org/linkml/examples/personinfo/GeoAge> ;
+            owl:onProperty <https://w3id.org/linkml/examples/personinfo/age> ],
         <https://w3id.org/linkml/examples/personinfo/Thing> .
 
 linkml:topValue a owl:DatatypeProperty ;
@@ -38,18 +38,24 @@ linkml:topValue a owl:DatatypeProperty ;
         linkml:ClassDefinition ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/examples/personinfo/Organization> ;
+            owl:onProperty <https://w3id.org/linkml/examples/personinfo/parent> ],
+        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty <https://w3id.org/linkml/examples/personinfo/full_name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/examples/personinfo/Organization> ;
-            owl:onProperty <https://w3id.org/linkml/examples/personinfo/parent> ],
         <https://w3id.org/linkml/examples/personinfo/Thing> .
 
 <https://w3id.org/linkml/examples/personinfo/Person> a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/examples/personinfo/Person> ;
+            owl:onProperty <https://w3id.org/linkml/examples/personinfo/parent> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/linkml/examples/personinfo/aliases> ],
+        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty <https://w3id.org/linkml/examples/personinfo/phone> ],
@@ -57,12 +63,6 @@ linkml:topValue a owl:DatatypeProperty ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Integer ;
             owl:onProperty <https://w3id.org/linkml/examples/personinfo/age> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/examples/personinfo/Person> ;
-            owl:onProperty <https://w3id.org/linkml/examples/personinfo/parent> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/linkml/examples/personinfo/aliases> ],
         <https://w3id.org/linkml/examples/personinfo/Thing> ;
     skos:exactMatch sdo:Person .
 

--- a/tests/test_issues/__snapshots__/linkml_issue_384.ttl
+++ b/tests/test_issues/__snapshots__/linkml_issue_384.ttl
@@ -37,8 +37,8 @@
         <https://w3id.org/linkml/examples/personinfo/person__aliases>,
         <https://w3id.org/linkml/examples/personinfo/person__phone> ;
     linkml:source_file "linkml_issue_384.yaml" ;
-    linkml:source_file_date "2023-07-14T10:43:06"^^xsd:dateTime ;
-    linkml:source_file_size 1220 ;
+    linkml:source_file_date "2000-01-01T00:00:00"^^xsd:dateTime ;
+    linkml:source_file_size 1 ;
     linkml:types <https://w3id.org/linkml/examples/personinfo/boolean>,
         <https://w3id.org/linkml/examples/personinfo/curie>,
         <https://w3id.org/linkml/examples/personinfo/date>,
@@ -61,6 +61,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/boolean> a linkml:TypeDefinition ;
     skos:definition "A binary (true or false) value" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"boolean\"." ;
     skos:exactMatch schema:Boolean ;
     skos:inScheme linkml:types ;
     linkml:base "Bool" ;
@@ -72,6 +73,7 @@
 <https://w3id.org/linkml/examples/personinfo/curie> a linkml:TypeDefinition ;
     dcterms:conformsTo "https://www.w3.org/TR/curie/" ;
     skos:definition "a compact URI" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"curie\"." ;
     skos:inScheme linkml:types ;
     skos:note "in RDF serializations this MUST be expanded to a URI",
         "in non-RDF serializations MAY be serialized as the compact representation" ;
@@ -83,7 +85,8 @@
 
 <https://w3id.org/linkml/examples/personinfo/date> a linkml:TypeDefinition ;
     skos:definition "a date (year, month and day) in an idealized calendar" ;
-    skos:editorialNote "URI is dateTime because OWL reasoners don't work with straight date or time" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date\".",
+        "URI is dateTime because OWL reasoners don't work with straight date or time" ;
     skos:exactMatch schema:Date ;
     skos:inScheme linkml:types ;
     linkml:base "XSDDate" ;
@@ -94,6 +97,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/date_or_datetime> a linkml:TypeDefinition ;
     skos:definition "Either a date or a datetime" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date_or_datetime\"." ;
     skos:inScheme linkml:types ;
     linkml:base "str" ;
     linkml:definition_uri linkml:DateOrDatetime ;
@@ -103,6 +107,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/datetime> a linkml:TypeDefinition ;
     skos:definition "The combination of a date and time" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"datetime\"." ;
     skos:exactMatch schema:DateTime ;
     skos:inScheme linkml:types ;
     linkml:base "XSDDateTime" ;
@@ -114,6 +119,7 @@
 <https://w3id.org/linkml/examples/personinfo/decimal> a linkml:TypeDefinition ;
     skos:broadMatch schema:Number ;
     skos:definition "A real number with arbitrary precision that conforms to the xsd:decimal specification" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"decimal\"." ;
     skos:inScheme linkml:types ;
     linkml:base "Decimal" ;
     linkml:definition_uri linkml:Decimal ;
@@ -123,6 +129,7 @@
 <https://w3id.org/linkml/examples/personinfo/double> a linkml:TypeDefinition ;
     skos:closeMatch schema:Float ;
     skos:definition "A real number that conforms to the xsd:double specification" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"double\"." ;
     skos:inScheme linkml:types ;
     linkml:base "float" ;
     linkml:definition_uri linkml:Double ;
@@ -132,6 +139,7 @@
 <https://w3id.org/linkml/examples/personinfo/jsonpath> a linkml:TypeDefinition ;
     dcterms:conformsTo "https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html" ;
     skos:definition "A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpath\"." ;
     skos:inScheme linkml:types ;
     linkml:base "str" ;
     linkml:definition_uri linkml:Jsonpath ;
@@ -142,6 +150,7 @@
 <https://w3id.org/linkml/examples/personinfo/jsonpointer> a linkml:TypeDefinition ;
     dcterms:conformsTo "https://datatracker.ietf.org/doc/html/rfc6901" ;
     skos:definition "A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to a valid object within the current instance document when encoded in tree form." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpointer\"." ;
     skos:inScheme linkml:types ;
     linkml:base "str" ;
     linkml:definition_uri linkml:Jsonpointer ;
@@ -151,6 +160,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/ncname> a linkml:TypeDefinition ;
     skos:definition "Prefix part of CURIE" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"ncname\"." ;
     skos:inScheme linkml:types ;
     linkml:base "NCName" ;
     linkml:definition_uri linkml:Ncname ;
@@ -160,6 +170,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/nodeidentifier> a linkml:TypeDefinition ;
     skos:definition "A URI, CURIE or BNODE that represents a node in a model." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"nodeidentifier\"." ;
     skos:inScheme linkml:types ;
     linkml:base "NodeIdentifier" ;
     linkml:definition_uri linkml:Nodeidentifier ;
@@ -169,6 +180,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/objectidentifier> a linkml:TypeDefinition ;
     skos:definition "A URI or CURIE that represents an object in the model." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"objectidentifier\"." ;
     skos:inScheme linkml:types ;
     skos:note "Used for inheritance and type checking" ;
     linkml:base "ElementIdentifier" ;
@@ -180,6 +192,7 @@
 <https://w3id.org/linkml/examples/personinfo/sparqlpath> a linkml:TypeDefinition ;
     dcterms:conformsTo "https://www.w3.org/TR/sparql11-query/#propertypaths" ;
     skos:definition "A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"sparqlpath\"." ;
     skos:inScheme linkml:types ;
     linkml:base "str" ;
     linkml:definition_uri linkml:Sparqlpath ;
@@ -189,7 +202,8 @@
 
 <https://w3id.org/linkml/examples/personinfo/time> a linkml:TypeDefinition ;
     skos:definition "A time object represents a (local) time of day, independent of any particular day" ;
-    skos:editorialNote "URI is dateTime because OWL reasoners do not work with straight date or time" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"time\".",
+        "URI is dateTime because OWL reasoners do not work with straight date or time" ;
     skos:exactMatch schema:Time ;
     skos:inScheme linkml:types ;
     linkml:base "XSDTime" ;
@@ -202,6 +216,7 @@
     dcterms:conformsTo "https://www.ietf.org/rfc/rfc3987.txt" ;
     skos:closeMatch schema:URL ;
     skos:definition "a complete URI" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uri\"." ;
     skos:inScheme linkml:types ;
     skos:note "in RDF serializations a slot with range of uri is treated as a literal or type xsd:anyURI unless it is an identifier or a reference to an identifier, in which case it is translated directly to a node" ;
     linkml:base "URI" ;
@@ -212,6 +227,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/uriorcurie> a linkml:TypeDefinition ;
     skos:definition "a URI or a CURIE" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uriorcurie\"." ;
     skos:inScheme linkml:types ;
     linkml:base "URIorCURIE" ;
     linkml:definition_uri linkml:Uriorcurie ;
@@ -334,6 +350,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/float> a linkml:TypeDefinition ;
     skos:definition "A real number that conforms to the xsd:float specification" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"float\"." ;
     skos:exactMatch schema:Float ;
     skos:inScheme linkml:types ;
     linkml:base "float" ;
@@ -343,6 +360,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/integer> a linkml:TypeDefinition ;
     skos:definition "An integer" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"integer\"." ;
     skos:exactMatch schema:Integer ;
     skos:inScheme linkml:types ;
     linkml:base "int" ;
@@ -410,6 +428,7 @@
 
 <https://w3id.org/linkml/examples/personinfo/string> a linkml:TypeDefinition ;
     skos:definition "A character string" ;
+    skos:editorialNote "In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.   If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"string\"." ;
     skos:exactMatch schema:Text ;
     skos:inScheme linkml:types ;
     linkml:base "str" ;

--- a/tests/test_issues/__snapshots__/linkml_issue_384.yaml
+++ b/tests/test_issues/__snapshots__/linkml_issue_384.yaml
@@ -17,6 +17,10 @@ types:
     name: string
     definition_uri: https://w3id.org/linkml/String
     description: A character string
+    notes:
+    - In RDF serializations, a slot with range of string is treated as a literal or
+      type xsd:string.   If you are authoring schemas in LinkML YAML, the type is
+      referenced with the lower case "string".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -27,6 +31,9 @@ types:
     name: integer
     definition_uri: https://w3id.org/linkml/Integer
     description: An integer
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "integer".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -37,6 +44,9 @@ types:
     name: boolean
     definition_uri: https://w3id.org/linkml/Boolean
     description: A binary (true or false) value
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "boolean".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -48,6 +58,9 @@ types:
     name: float
     definition_uri: https://w3id.org/linkml/Float
     description: A real number that conforms to the xsd:float specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "float".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -58,6 +71,9 @@ types:
     name: double
     definition_uri: https://w3id.org/linkml/Double
     description: A real number that conforms to the xsd:double specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "double".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     close_mappings:
@@ -69,6 +85,9 @@ types:
     definition_uri: https://w3id.org/linkml/Decimal
     description: A real number with arbitrary precision that conforms to the xsd:decimal
       specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "decimal".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     broad_mappings:
@@ -82,6 +101,8 @@ types:
       particular day
     notes:
     - URI is dateTime because OWL reasoners do not work with straight date or time
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "time".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -95,6 +116,8 @@ types:
     description: a date (year, month and day) in an idealized calendar
     notes:
     - URI is dateTime because OWL reasoners don't work with straight date or time
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "date".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -106,6 +129,9 @@ types:
     name: datetime
     definition_uri: https://w3id.org/linkml/Datetime
     description: The combination of a date and time
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "datetime".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     exact_mappings:
@@ -117,6 +143,9 @@ types:
     name: date_or_datetime
     definition_uri: https://w3id.org/linkml/DateOrDatetime
     description: Either a date or a datetime
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "date_or_datetime".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: str
@@ -126,6 +155,9 @@ types:
     name: uriorcurie
     definition_uri: https://w3id.org/linkml/Uriorcurie
     description: a URI or a CURIE
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "uriorcurie".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: URIorCURIE
@@ -136,6 +168,9 @@ types:
     definition_uri: https://w3id.org/linkml/Curie
     conforms_to: https://www.w3.org/TR/curie/
     description: a compact URI
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "curie".
     comments:
     - in RDF serializations this MUST be expanded to a URI
     - in non-RDF serializations MAY be serialized as the compact representation
@@ -149,6 +184,9 @@ types:
     definition_uri: https://w3id.org/linkml/Uri
     conforms_to: https://www.ietf.org/rfc/rfc3987.txt
     description: a complete URI
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "uri".
     comments:
     - in RDF serializations a slot with range of uri is treated as a literal or type
       xsd:anyURI unless it is an identifier or a reference to an identifier, in which
@@ -164,6 +202,9 @@ types:
     name: ncname
     definition_uri: https://w3id.org/linkml/Ncname
     description: Prefix part of CURIE
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "ncname".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: NCName
@@ -173,6 +214,9 @@ types:
     name: objectidentifier
     definition_uri: https://w3id.org/linkml/Objectidentifier
     description: A URI or CURIE that represents an object in the model.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "objectidentifier".
     comments:
     - Used for inheritance and type checking
     from_schema: https://w3id.org/linkml/types
@@ -184,6 +228,9 @@ types:
     name: nodeidentifier
     definition_uri: https://w3id.org/linkml/Nodeidentifier
     description: A URI, CURIE or BNODE that represents a node in a model.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "nodeidentifier".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: NodeIdentifier
@@ -196,6 +243,9 @@ types:
     description: A string encoding a JSON Pointer. The value of the string MUST conform
       to JSON Point syntax and SHOULD dereference to a valid object within the current
       instance document when encoded in tree form.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "jsonpointer".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: str
@@ -208,6 +258,9 @@ types:
     description: A string encoding a JSON Path. The value of the string MUST conform
       to JSON Point syntax and SHOULD dereference to zero or more valid objects within
       the current instance document when encoded in tree form.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "jsonpath".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: str
@@ -220,6 +273,9 @@ types:
     description: A string encoding a SPARQL Property Path. The value of the string
       MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects
       within the current instance document when encoded as RDF.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "sparqlpath".
     from_schema: https://w3id.org/linkml/types
     imported_from: linkml:types
     base: str


### PR DESCRIPTION
The [latest change](https://github.com/linkml/linkml-model/commit/448146e53d5730b5e6735dac5ce40df205dd5681) to the metamodel has caused the expected output of some snapshot tests to change.

This represents a sort of loose, external dependency of these tests. We'll have to keep an eye out for often this happens and if it becomes onerous we might want to figure out how to make these tests more isolated. 