### PR TITLE
convert plantUML generator tests to `pytest`

### DIFF
--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -1,17 +1,11 @@
-import logging
 import os
-import shutil
-import tempfile
-import unittest
-from copy import copy
-from typing import List
+
+from xml.dom import minidom
+
+import pytest
 
 from linkml.generators.plantumlgen import PlantumlGenerator
-from tests.test_generators.environment import env
 
-SCHEMA = env.input_path("kitchen_sink.yaml")
-PLANTUML_OUT = env.expected_path("kitchen_sink.plantuml.md")
-SVG_DIR = env.expected_path("kitchen_sink_svg")
 
 MARKDOWN_HEADER = """@startuml
 """
@@ -45,114 +39,88 @@ DATASET2PERSON = """
 """
 
 
-def assert_svgfile_contains(
-    filename,
-    text,
-    after: str = None,
-    followed_by: List[str] = None,
-    outdir=SVG_DIR,
-    invert=False,
-) -> None:
-    found = False
-    is_after = False  # have we reached the after mark?
-    with open(os.path.join(outdir, filename)) as stream:
-        lines = stream.readlines()
-        for i in range(0, len(lines)):
-            line = lines[i]
-            if text in line:
-                if after is None:
-                    found = True
-                else:
-                    if is_after:
-                        found = True
-                if found and followed_by:
-                    todo = copy(followed_by)
-                    for j in range(i + 1, len(lines)):
-                        subsequent_line = lines[j]
-                        if len(todo) > 0 and todo[0] in subsequent_line:
-                            todo = todo[1:]
-                    if len(todo) > 0:
-                        if not invert:
-                            logging.error(f"Did not find: {todo}")
-                        assert invert
-                    else:
-                        return
-            if after is not None and after in line:
-                is_after = True
-    if not found and not invert:
-        logging.error(f"Failed to find {text} in {filename}")
-    if invert:
-        assert not found
-    else:
-        assert found
+@pytest.mark.parametrize(
+    "input_class,expected",
+    [
+        # check that plantUML header and footer are present
+        # for one class, like `Person`, extensible to other classes
+        ("Person", MARKDOWN_HEADER),
+        ("Person", MARKDOWN_FOOTER),
+        # check that expected plantUML class diagram blocks are present
+        # when diagrams are generated for different classes
+        ("Person", PERSON),
+        ("Dataset", DATASET2PERSON),
+        ("MedicalEvent", PERSON2MEDICALEVENT),
+        ("FamilialRelationship", FAMILIALRELATIONSHIP2PERSON),
+    ],
+)
+def test_serialize_selected(input_class, expected, kitchen_sink_path):
+    """Test serialization of select plantUML class diagrams from schema."""
+    generator = PlantumlGenerator(kitchen_sink_path)
+    plantuml = generator.serialize(classes=[input_class])
+
+    # check that the expected block/relationships are present
+    # in class-selected diagrams
+    assert expected in plantuml
+
+    # make sure that random classes like `MarriageEvent` which
+    # have no defined relationships with classes like `FamilialRelationship`
+    # have crept into class-selected diagrams
+    if input_class == "FamilialRelationship":
+        assert (
+            'class "MarriageEvent"' not in plantuml
+        ), f"MarriageEvent not reachable from {input_class}"
 
 
-class PlantumlDiagramGeneratorTestCase(unittest.TestCase):
-    """
-    Tests generation of PlantUML from LinkML schemas
-    """
+def test_serialize(kitchen_sink_path):
+    """Test serialization of complete plantUML class diagram from schema."""
+    generator = PlantumlGenerator(kitchen_sink_path)
+    plantuml = generator.serialize()
 
-    def test_serialize(self):
-        """Test default serialization (structural)"""
-        gen = PlantumlGenerator(SCHEMA)
-        plantuml = gen.serialize()
-        with open(PLANTUML_OUT, "w") as stream:
-            stream.write(plantuml)
-        self._in(MARKDOWN_HEADER, plantuml, "diagram header is missing")
-        self._in(MARKDOWN_FOOTER, plantuml, "diagram footer is missing")
-        self._in(PERSON, plantuml)
-        self._in(PERSON2MEDICALEVENT, plantuml)
-        self._in(FAMILIALRELATIONSHIP2PERSON, plantuml)
+    # check that plantUML start and end blocks are present
+    assert MARKDOWN_HEADER in plantuml
+    assert MARKDOWN_FOOTER in plantuml
 
-    def test_serialize_direct(self):
-        """Test default serialization (structural), no markdown block"""
-        gen = PlantumlGenerator(SCHEMA)
-        plantuml = gen.serialize()
-        self.assertNotIn("```", plantuml, "markdown header should not be present")
-        self._in(PERSON, plantuml)
-        self._in(PERSON2MEDICALEVENT, plantuml)
+    # check that Markdown code blocks are not present
+    assert "```" not in plantuml, "Markdown code block should not be present"
 
-    def test_serialize_selected(self):
-        """Test serialization of selected elements"""
-        gen = PlantumlGenerator(SCHEMA)
-        plantuml = gen.serialize(classes=["FamilialRelationship"])
-        self.assertNotIn("MarriageEvent", plantuml, "MarriageEvent not reachable from selected")
-        self._in(FAMILIALRELATIONSHIP2PERSON, plantuml, "dangling references should be included")
-
-    def test_generate_svg(self):
-        gen = PlantumlGenerator(SCHEMA)
-        svg_temp_dir = tempfile.mkdtemp()
-        gen.serialize(directory=svg_temp_dir)
-        assert_svgfile_contains(
-            "KitchenSink.svg",
-            "<svg xmlns=",
-            outdir=svg_temp_dir,
-        )
-        assert_svgfile_contains(
-            "KitchenSink.svg",
-            '<!--class FakeClass--><g id="elem_FakeClass">',
-            outdir=svg_temp_dir,
-        )
-        assert_svgfile_contains(
-            "KitchenSink.svg",
-            ">FakeClass</text>",
-            outdir=svg_temp_dir,
-        )
-        assert_svgfile_contains(
-            "KitchenSink.svg",
-            "<line style=",
-            outdir=svg_temp_dir,
-        )
-        assert_svgfile_contains(
-            "KitchenSink.svg",
-            "</svg>",
-            outdir=svg_temp_dir,
-        )
-        shutil.rmtree(svg_temp_dir)
-
-    def _in(self, s1, s2, message: str = None):
-        self.assertIn(s1.replace(" ", ""), s2.replace(" ", ""), message)
+    # check that classes like `MarriageEvent` are present
+    # in complete UML class diagram
+    assert "class \"MarriageEvent\"" in plantuml
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_generate_svg(tmp_path, kitchen_sink_path):
+    """Test the correctness of SVG rendering of plantUML diagram."""
+    generator = PlantumlGenerator(kitchen_sink_path)
+    generator.serialize(directory=tmp_path)
+
+    # name of SVG file will be inferred from schema name because
+    # we are passing a value to the directory argument
+    svg_file = tmp_path / "KitchenSink.svg"
+
+    # check that SVG file is generated correctly
+    assert svg_file.is_file()
+
+    svg_dom = minidom.parse(os.fspath(tmp_path / "KitchenSink.svg"))
+
+    classes_list = []   # list of all classes in schema
+    relationships_list = [] # list of all links/relationships in schema
+    groups = svg_dom.getElementsByTagName("g")
+    for group in groups:
+        id = group.getAttribute("id")
+        if id.startswith("elem_"):
+            class_name = id[len("elem_") :]
+            classes_list.append(class_name)
+        if id.startswith("link_"):
+            link_name = id[len("link_") :]
+            relationships_list.append(link_name)
+
+    assert "Person" in classes_list
+    assert "Dataset" in classes_list
+    assert "FamilialRelationship" in classes_list
+    assert "MedicalEvent" in classes_list
+
+    assert "Person_MedicalEvent" in relationships_list
+    assert "FamilialRelationship_Person" in relationships_list
+    assert "Dataset_Person" in relationships_list
+    assert "Dataset_MarriageEvent" not in relationships_list

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -84,7 +84,7 @@ def test_serialize(kitchen_sink_path):
 
     # check that classes like `MarriageEvent` are present
     # in complete UML class diagram
-    assert "class \"MarriageEvent\"" in plantuml
+    assert 'class "MarriageEvent"' in plantuml
 
 
 def test_generate_svg(tmp_path, kitchen_sink_path):
@@ -101,8 +101,8 @@ def test_generate_svg(tmp_path, kitchen_sink_path):
 
     svg_dom = minidom.parse(os.fspath(tmp_path / "KitchenSink.svg"))
 
-    classes_list = []   # list of all classes in schema
-    relationships_list = [] # list of all links/relationships in schema
+    classes_list = []  # list of all classes in schema
+    relationships_list = []  # list of all links/relationships in schema
     groups = svg_dom.getElementsByTagName("g")
     for group in groups:
         id = group.getAttribute("id")

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -1,11 +1,9 @@
 import os
-
 from xml.dom import minidom
 
 import pytest
 
 from linkml.generators.plantumlgen import PlantumlGenerator
-
 
 MARKDOWN_HEADER = """@startuml
 """

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -40,10 +40,6 @@ DATASET2PERSON = """
 @pytest.mark.parametrize(
     "input_class,expected",
     [
-        # check that plantUML header and footer are present
-        # for one class, like `Person`, extensible to other classes
-        ("Person", MARKDOWN_HEADER),
-        ("Person", MARKDOWN_FOOTER),
         # check that expected plantUML class diagram blocks are present
         # when diagrams are generated for different classes
         ("Person", PERSON),


### PR DESCRIPTION
The tests written for the plantUML generator were originally written in pytest. This PR seeks to convert those tests to pytest.