### PR TITLE
can't populate container with sub-classes of range if the sub-classes use slots that are not assigned to the parent

### DIFF
--- a/tests/test_issues/input/linkml_issue_1608_data.yaml
+++ b/tests/test_issues/input/linkml_issue_1608_data.yaml
@@ -1,0 +1,10 @@
+vehicles:
+  - exterior_color: red
+    max_passengers: 4
+    type: Boat
+    waterline: 30.0
+  - exterior_color: blue
+    max_passengers: 5
+    type: Airplane
+    wingspan: 100.0
+

--- a/tests/test_issues/input/linkml_issue_1608_schema.yaml
+++ b/tests/test_issues/input/linkml_issue_1608_schema.yaml
@@ -1,0 +1,43 @@
+name: test_1608
+id: https://example.org/test_1608
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Database:
+    slots:
+      - vehicles
+  Vehicle:
+    slots:
+      - exterior_color
+      - max_passengers
+      - type
+  Boat:
+    is_a: Vehicle
+    slots:
+      - waterline
+  Airplane:
+    is_a: Vehicle
+    slots:
+      - wingspan
+slots:
+  exterior_color: { }
+  max_passengers:
+    range: integer
+  wingspan:
+    range: float
+    required: true
+  waterline:
+    range: float
+    required: true
+  vehicles:
+    range: Vehicle
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  type:
+    range: uriorcurie
+    slot_uri: rdf:type
+    designates_type: true
+    required: true

--- a/tests/test_issues/test_linkml_issue_1608.py
+++ b/tests/test_issues/test_linkml_issue_1608.py
@@ -1,0 +1,43 @@
+import os
+import pprint
+
+import yaml
+from linkml_runtime import SchemaView
+from linkml_runtime.dumpers import yaml_dumper
+from linkml_runtime.loaders import yaml_loader
+
+from linkml.generators import PythonGenerator
+
+import importlib
+
+from linkml.validators import JsonSchemaDataValidator
+
+schema_file = "input/linkml_issue_1608_schema.yaml"
+data_file = "input/linkml_issue_1608_data.yaml"
+# output_dir = "../output"
+schema_python_source_file_name = "linkml_issue_1608_schema.py"
+model_dir = "model"
+schema_python_source_file_path = os.path.join(model_dir, schema_python_source_file_name)
+
+
+def test_heterogeneous_collection():
+    # read a schema YAML file and prepare for compilation to python
+    pg = PythonGenerator(schema_file)
+    # compile the YAML to python, in a string
+    python_source_text = pg.serialize()
+    # write the generated python string to a file
+    with open(schema_python_source_file_path, 'w') as f:
+        f.write(python_source_text)
+    # dynamically import the generated python module into this namespace
+    database_class = getattr(importlib.import_module("tests.test_issues.model.linkml_issue_1608_schema"), "Database")
+
+    # read a YAML data file and instantiate it against the dynamically loaded Database class
+    # this performs SOME validation
+    database_instance = yaml_loader.loads(data_file, target_class=database_class)
+
+    print("\n")
+    print(yaml_dumper.dumps(database_instance))
+
+    # additional validation if necessary
+    jv = JsonSchemaDataValidator(schema_file)
+    jv.validate_object(database_instance, target_class=database_class)


### PR DESCRIPTION
I was under the impression that a LinkML collection (Class `Database` in this case), which might correspond to one MongoDB collection, could use an aggregating slot (`vehicles`) to aggregate all of the subclasses of the named range (`Vehicle`)

This would be very useful for minimizing the number of collections in the NMDC MongoDB, but allowing dDifferent kinds of metabolomics `SampleOperation`s to be aggregated in one collection, or for both `Studies` and `SampleCollectionConsortium`s to be aggregated in a single `ResearchInitiative` collection.

In this test case, LinkML `yaml_loader.loads` doesn't seem to like instantiating `Boat` and an `Airplane` instances, because they each use a slot that is not associated with the parent, `Vehicle`