### PR TITLE
feat(converters): add option include descendants

### DIFF
--- a/linkml/utils/converter.py
+++ b/linkml/utils/converter.py
@@ -67,6 +67,14 @@ from linkml.utils.datautils import (
     help="Infer missing slot values",
 )
 @click.option("--context", "-c", multiple=True, help="path to JSON-LD context file")
+@click.option(
+    "--include-range-class-descendants/--no-range-class-descendants",
+    default=False,
+    show_default=False,
+    help="""
+When handling range constraints, include all descendants of the range class instead of just the range class
+""",
+)
 @click.version_option(__version__, "-V", "--version")
 @click.argument("input")
 def cli(
@@ -83,6 +91,7 @@ def cli(
     validate=None,
     infer=None,
     index_slot=None,
+    include_range_class_descendants=False,
 ) -> None:
     """
     Converts instance data to and from different LinkML Runtime serialization formats.
@@ -151,7 +160,9 @@ def cli(
                 "--schema must be passed in order to validate. Suppress with --no-validate"
             )
         # TODO: use validator framework
-        validation.validate_object(obj, schema)
+        validation.validate_object(
+            obj, schema, include_range_class_descendants=include_range_class_descendants
+        )
 
     output_format = _get_format(output, output_format, default="json")
     if output_format == "json-ld":

--- a/linkml/utils/validation.py
+++ b/linkml/utils/validation.py
@@ -22,6 +22,7 @@ def validate_object(
     schema: Union[str, TextIO, SchemaDefinition],
     target_class: Type[YAMLRoot] = None,
     closed: bool = True,
+    include_range_class_descendants=False,
 ):
     """
     validates instance data against a schema
@@ -41,6 +42,7 @@ def validate_object(
         mergeimports=True,
         top_class=target_class.class_name,
         not_closed=not_closed,
+        include_range_class_descendants=include_range_class_descendants,
     ).serialize(not_closed=not_closed)
     jsonschema_obj = json.loads(jsonschemastr)
     return jsonschema.validate(

--- a/tests/test_utils/input/Person-01.yaml
+++ b/tests/test_utils/input/Person-01.yaml
@@ -1,0 +1,15 @@
+id: P:004
+name: eventful life
+has_events:
+  - employed_at: ROR:1
+    started_at_time: "2019-01-01"
+    is_current: true
+  - started_at_time: "2023-01-01"
+    in_location: GEO:1234
+    diagnosis:
+      id: CODE:P1789
+      name: hypertension
+    procedure:
+      id: CODE:P1846
+      name: valve repair
+

--- a/tests/test_utils/input/animals.yaml
+++ b/tests/test_utils/input/animals.yaml
@@ -1,0 +1,7 @@
+animals:
+  - animal_family: Dog
+    max_age: "17 years"
+    breed: Golden Retriever
+  - animal_family: Ant
+    max_age: "7 years"
+    venom: true

--- a/tests/test_utils/input/schema7.yaml
+++ b/tests/test_utils/input/schema7.yaml
@@ -1,0 +1,36 @@
+id: https://example.org/descendants
+name: Test_descendants
+imports:
+  - linkml:types
+prefixes:
+  linkml: https://w3id.org/linkml/
+classes:
+  Animal:
+    slots:
+      - animal_family
+    attributes:
+      max_age:
+        range: string
+  Dog:
+    is_a: Animal
+    slots:
+      - animal_family
+      - breed
+  Ant:
+    is_a: Animal
+    slots:
+      - animal_family
+      - venom
+  Container:
+    attributes:
+      animals:
+        multivalued: true
+        range: Animal
+slots:
+  animal_family:
+    range: string
+    designates_type: true
+  breed:
+    range: string
+  venom:
+    range: boolean


### PR DESCRIPTION
"gen-json-schema" and "linkml-validate" have the option "--include-range-class-descendants" so that children of a class specified in a range are added to the generated JSON-Schema as allowed classes.

This patch adds a similar option to "linkml-convert", with the same result in the JSON-Schema being used for validation as the equally named option for "gen-json-schema" and "linkml-validate".

Closes #1629 