### PR TITLE
Fix some typos

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -26,7 +26,7 @@ There are two cases you need to consider while writing your unit test. The first
 To run a single test file using `pytest`:
 
 ```python
-poetry run pytset tests/test_issues/test_linkml_issue_NNN.py
+poetry run pytest tests/test_issues/test_linkml_issue_NNN.py
 ```
 
 You can run the full test suite in the following way:

--- a/docs/developers/tool-developer-guide.rst
+++ b/docs/developers/tool-developer-guide.rst
@@ -1,4 +1,4 @@
-Tool Implementor Guide
+Tool Implementer Guide
 ======================
 
 This guide is for developers of *generic* LinkML tools that operate

--- a/docs/faq/why-linkml.md
+++ b/docs/faq/why-linkml.md
@@ -10,7 +10,7 @@ All data follows some kind of schema or data model, whether it is explicitly art
  * you have a knowledge graph in Neo4J
  * you are working with linked data in RDF
 
-LinkML is designed to be flexible enough to cover all these use cases, allowing for lighweight semantic data dictionaries for tabular data, through rich interlinked schemas for knowledge graphs and triplestores
+LinkML is designed to be flexible enough to cover all these use cases, allowing for lightweight semantic data dictionaries for tabular data, through rich interlinked schemas for knowledge graphs and triplestores
 
 ## My data is a simple spreadsheet/TSV, why should I use LinkML?
 

--- a/docs/schemas/index.rst
+++ b/docs/schemas/index.rst
@@ -8,7 +8,7 @@ create a schema in order to model your data.
 
 Note that the formal specification for LinkML can be found at
 `<https://w3id.org/linkml/specification>`_. This formal specification
-is aimed at implementors and not users. General users of LinkML should
+is aimed at implementers and not users. General users of LinkML should
 use the guide below.
 
 .. toctree::

--- a/docs/schemas/models.md
+++ b/docs/schemas/models.md
@@ -171,7 +171,7 @@ slots:
     range: Address
 ```
 
-You can then re-use these in your class definitions. For example, if your `Person` class has a `name` slot, just list it:
+You can then reuse these in your class definitions. For example, if your `Person` class has a `name` slot, just list it:
 
 ```yaml
 classes:

--- a/docs/specifications/linkml-spec.md
+++ b/docs/specifications/linkml-spec.md
@@ -6,7 +6,7 @@ The LinkML specification has a permanent URL:
 
 Note the specification is hosted on the [linkml-model](https://github.com/linkml/linkml-model) repository.
 
-This specification is aimed at implementors of LinkML tools rather
+This specification is aimed at implementers of LinkML tools rather
 than general users. It is more formal in its language than this main LinkML guide.
 
 The specification is in the following parts:


### PR DESCRIPTION
- spotted fresh typo in https://linkml.io/linkml/contributing/contributing.html `pytset` and decided to fix
- apparently codespell found more , not sure why action (https://github.com/linkml/linkml/actions/runs/6188045401/job/16799203411#step:8:1) didn't pick them up.
   - I did go with fixing for `implementer` since that one also was used already:
```
❯ git grep -i implementer
tests/test_biolink_model/input/biolink-model.yaml:      implementers should use one of the more specific subtypes of this generic property.
tests/test_biolink_model/input/biolink-model.yaml:      implementer can identify.  Performing a rigorous analysis of upstream data providers is expected; every effort
```