### PR TITLE
Add codecov config making coverage reports informational only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This adds a [codecov config file](https://docs.codecov.com/docs/codecov-yaml) which uses the `informational` [setting](https://docs.codecov.com/docs/commit-status#informational) to make it so that the same information will be reported in PRs as it is today, but it will no longer change the PR pass/fail status. 

The other option would be to fiddle around with the `target` and `threshold` [settings](https://docs.codecov.com/docs/commit-status#basic-configuration). However, given that as a project we've never really discussed or agreed on coverage standards (that I know of), I felt like using `informational` was a better approach for now.

Fixes #1633 