### PR TITLE
Test Stub for Issue 163

### DIFF
--- a/tests/test_issues/__snapshots__/issue_163d.ttl
+++ b/tests/test_issues/__snapshots__/issue_163d.ttl
@@ -1,0 +1,256 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix linkml: <https://w3id.org/linkml/> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shex: <http://www.w3.org/ns/shex#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/example163c> a linkml:SchemaDefinition ;
+    dcterms:license "https://creativecommons.org/publicdomain/zero/1.0/" ;
+    sh:declare [ sh:namespace linkml: ;
+            sh:prefix "linkml" ],
+        [ sh:namespace <http://example.org/> ;
+            sh:prefix "ex" ] ;
+    linkml:classes <http://example.org/C1> ;
+    linkml:default_prefix "ex" ;
+    linkml:default_range <http://example.org/string> ;
+    linkml:generation_date "2023-09-21T06:28:58"^^xsd:dateTime ;
+    linkml:id <http://example.org/sample/example163c> ;
+    linkml:imports linkml:types ;
+    linkml:metamodel_version "1.7.0" ;
+    linkml:source_file "issue_163d.yaml" ;
+    linkml:source_file_date "2023-09-21T05:38:21"^^xsd:dateTime ;
+    linkml:source_file_size 239 ;
+    linkml:types <http://example.org/boolean>,
+        <http://example.org/curie>,
+        <http://example.org/date>,
+        <http://example.org/date_or_datetime>,
+        <http://example.org/datetime>,
+        <http://example.org/decimal>,
+        <http://example.org/double>,
+        <http://example.org/float>,
+        <http://example.org/integer>,
+        <http://example.org/jsonpath>,
+        <http://example.org/jsonpointer>,
+        <http://example.org/ncname>,
+        <http://example.org/nodeidentifier>,
+        <http://example.org/objectidentifier>,
+        <http://example.org/sparqlpath>,
+        <http://example.org/string>,
+        <http://example.org/time>,
+        <http://example.org/uri>,
+        <http://example.org/uriorcurie> .
+
+<http://example.org/boolean> a linkml:TypeDefinition ;
+    skos:definition "A binary (true or false) value" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"boolean\"." ;
+    skos:exactMatch schema:Boolean ;
+    skos:inScheme linkml:types ;
+    linkml:base "Bool" ;
+    linkml:definition_uri linkml:Boolean ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "bool" ;
+    linkml:uri xsd:boolean .
+
+<http://example.org/curie> a linkml:TypeDefinition ;
+    dcterms:conformsTo "https://www.w3.org/TR/curie/" ;
+    skos:definition "a compact URI" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"curie\"." ;
+    skos:inScheme linkml:types ;
+    skos:note "in RDF serializations this MUST be expanded to a URI",
+        "in non-RDF serializations MAY be serialized as the compact representation" ;
+    linkml:base "Curie" ;
+    linkml:definition_uri linkml:Curie ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:string .
+
+<http://example.org/date> a linkml:TypeDefinition ;
+    skos:definition "a date (year, month and day) in an idealized calendar" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date\".",
+        "URI is dateTime because OWL reasoners don't work with straight date or time" ;
+    skos:exactMatch schema:Date ;
+    skos:inScheme linkml:types ;
+    linkml:base "XSDDate" ;
+    linkml:definition_uri linkml:Date ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:date .
+
+<http://example.org/date_or_datetime> a linkml:TypeDefinition ;
+    skos:definition "Either a date or a datetime" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date_or_datetime\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "str" ;
+    linkml:definition_uri linkml:DateOrDatetime ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri linkml:DateOrDatetime .
+
+<http://example.org/datetime> a linkml:TypeDefinition ;
+    skos:definition "The combination of a date and time" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"datetime\"." ;
+    skos:exactMatch schema:DateTime ;
+    skos:inScheme linkml:types ;
+    linkml:base "XSDDateTime" ;
+    linkml:definition_uri linkml:Datetime ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:dateTime .
+
+<http://example.org/decimal> a linkml:TypeDefinition ;
+    skos:broadMatch schema:Number ;
+    skos:definition "A real number with arbitrary precision that conforms to the xsd:decimal specification" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"decimal\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "Decimal" ;
+    linkml:definition_uri linkml:Decimal ;
+    linkml:imported_from "linkml:types" ;
+    linkml:uri xsd:decimal .
+
+<http://example.org/double> a linkml:TypeDefinition ;
+    skos:closeMatch schema:Float ;
+    skos:definition "A real number that conforms to the xsd:double specification" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"double\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "float" ;
+    linkml:definition_uri linkml:Double ;
+    linkml:imported_from "linkml:types" ;
+    linkml:uri xsd:double .
+
+<http://example.org/float> a linkml:TypeDefinition ;
+    skos:definition "A real number that conforms to the xsd:float specification" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"float\"." ;
+    skos:exactMatch schema:Float ;
+    skos:inScheme linkml:types ;
+    linkml:base "float" ;
+    linkml:definition_uri linkml:Float ;
+    linkml:imported_from "linkml:types" ;
+    linkml:uri xsd:float .
+
+<http://example.org/integer> a linkml:TypeDefinition ;
+    skos:definition "An integer" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"integer\"." ;
+    skos:exactMatch schema:Integer ;
+    skos:inScheme linkml:types ;
+    linkml:base "int" ;
+    linkml:definition_uri linkml:Integer ;
+    linkml:imported_from "linkml:types" ;
+    linkml:uri xsd:integer .
+
+<http://example.org/jsonpath> a linkml:TypeDefinition ;
+    dcterms:conformsTo "https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html" ;
+    skos:definition "A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpath\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "str" ;
+    linkml:definition_uri linkml:Jsonpath ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:string .
+
+<http://example.org/jsonpointer> a linkml:TypeDefinition ;
+    dcterms:conformsTo "https://datatracker.ietf.org/doc/html/rfc6901" ;
+    skos:definition "A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to a valid object within the current instance document when encoded in tree form." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpointer\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "str" ;
+    linkml:definition_uri linkml:Jsonpointer ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:string .
+
+<http://example.org/ncname> a linkml:TypeDefinition ;
+    skos:definition "Prefix part of CURIE" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"ncname\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "NCName" ;
+    linkml:definition_uri linkml:Ncname ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:string .
+
+<http://example.org/nodeidentifier> a linkml:TypeDefinition ;
+    skos:definition "A URI, CURIE or BNODE that represents a node in a model." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"nodeidentifier\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "NodeIdentifier" ;
+    linkml:definition_uri linkml:Nodeidentifier ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri shex:nonLiteral .
+
+<http://example.org/objectidentifier> a linkml:TypeDefinition ;
+    skos:definition "A URI or CURIE that represents an object in the model." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"objectidentifier\"." ;
+    skos:inScheme linkml:types ;
+    skos:note "Used for inheritance and type checking" ;
+    linkml:base "ElementIdentifier" ;
+    linkml:definition_uri linkml:Objectidentifier ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri shex:iri .
+
+<http://example.org/sparqlpath> a linkml:TypeDefinition ;
+    dcterms:conformsTo "https://www.w3.org/TR/sparql11-query/#propertypaths" ;
+    skos:definition "A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF." ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"sparqlpath\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "str" ;
+    linkml:definition_uri linkml:Sparqlpath ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:string .
+
+<http://example.org/time> a linkml:TypeDefinition ;
+    skos:definition "A time object represents a (local) time of day, independent of any particular day" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"time\".",
+        "URI is dateTime because OWL reasoners do not work with straight date or time" ;
+    skos:exactMatch schema:Time ;
+    skos:inScheme linkml:types ;
+    linkml:base "XSDTime" ;
+    linkml:definition_uri linkml:Time ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:time .
+
+<http://example.org/uri> a linkml:TypeDefinition ;
+    dcterms:conformsTo "https://www.ietf.org/rfc/rfc3987.txt" ;
+    skos:closeMatch schema:URL ;
+    skos:definition "a complete URI" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uri\"." ;
+    skos:inScheme linkml:types ;
+    skos:note "in RDF serializations a slot with range of uri is treated as a literal or type xsd:anyURI unless it is an identifier or a reference to an identifier, in which case it is translated directly to a node" ;
+    linkml:base "URI" ;
+    linkml:definition_uri linkml:Uri ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:anyURI .
+
+<http://example.org/uriorcurie> a linkml:TypeDefinition ;
+    skos:definition "a URI or a CURIE" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uriorcurie\"." ;
+    skos:inScheme linkml:types ;
+    linkml:base "URIorCURIE" ;
+    linkml:definition_uri linkml:Uriorcurie ;
+    linkml:imported_from "linkml:types" ;
+    linkml:repr "str" ;
+    linkml:uri xsd:anyURI .
+
+<http://example.org/string> a linkml:TypeDefinition ;
+    skos:definition "A character string" ;
+    skos:editorialNote "In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.   If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"string\"." ;
+    skos:exactMatch schema:Text ;
+    skos:inScheme linkml:types ;
+    linkml:base "str" ;
+    linkml:definition_uri linkml:String ;
+    linkml:imported_from "linkml:types" ;
+    linkml:uri xsd:string .
+
+<http://example.org/C1> a linkml:ClassDefinition ;
+    skos:exactMatch <http://example.org/mapping1> ;
+    skos:inScheme <http://example.org/sample/example163c> ;
+    linkml:class_uri <http://example.org/C1> ;
+    linkml:definition_uri <http://example.org/C1> ;
+    linkml:slot_usage [ ] .

--- a/tests/test_issues/__snapshots__/issue_163d.ttl
+++ b/tests/test_issues/__snapshots__/issue_163d.ttl
@@ -6,7 +6,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://example.org/example163c> a linkml:SchemaDefinition ;
+<http://example.org/example163d> a linkml:SchemaDefinition ;
     dcterms:license "https://creativecommons.org/publicdomain/zero/1.0/" ;
     sh:declare [ sh:namespace linkml: ;
             sh:prefix "linkml" ],
@@ -15,12 +15,12 @@
     linkml:classes <http://example.org/C1> ;
     linkml:default_prefix "ex" ;
     linkml:default_range <http://example.org/string> ;
-    linkml:generation_date "2023-09-21T06:28:58"^^xsd:dateTime ;
-    linkml:id <http://example.org/sample/example163c> ;
+    linkml:generation_date "2023-09-21T07:30:23"^^xsd:dateTime ;
+    linkml:id <http://example.org/sample/example163d> ;
     linkml:imports linkml:types ;
     linkml:metamodel_version "1.7.0" ;
     linkml:source_file "issue_163d.yaml" ;
-    linkml:source_file_date "2023-09-21T05:38:21"^^xsd:dateTime ;
+    linkml:source_file_date "2023-09-21T06:49:28"^^xsd:dateTime ;
     linkml:source_file_size 239 ;
     linkml:types <http://example.org/boolean>,
         <http://example.org/curie>,
@@ -250,7 +250,7 @@
 
 <http://example.org/C1> a linkml:ClassDefinition ;
     skos:exactMatch <http://example.org/mapping1> ;
-    skos:inScheme <http://example.org/sample/example163c> ;
+    skos:inScheme <http://example.org/sample/example163d> ;
     linkml:class_uri <http://example.org/C1> ;
     linkml:definition_uri <http://example.org/C1> ;
     linkml:slot_usage [ ] .

--- a/tests/test_issues/input/issue_163d.yaml
+++ b/tests/test_issues/input/issue_163d.yaml
@@ -1,0 +1,17 @@
+id: http://example.org/sample/example163d
+
+prefixes:
+  ex: http://example.org/
+  linkml: https://w3id.org/linkml/
+
+default_prefix: ex
+default_range: string
+
+imports:
+  - linkml:types
+
+
+classes:
+  c1:
+    exact_mappings:
+      - ex:mapping1

--- a/tests/test_issues/test_issue_163.py
+++ b/tests/test_issues/test_issue_163.py
@@ -2,6 +2,7 @@ from rdflib import Graph, URIRef
 from rdflib.namespace import OWL, RDF
 
 from linkml.generators.owlgen import OwlSchemaGenerator
+from linkml.generators.rdfgen import RDFGenerator
 
 
 def test_issue_owl_namespace(input_path, snapshot):
@@ -34,3 +35,10 @@ def test_aliases(input_path, snapshot):
     """Make sure aliases work"""
     output = OwlSchemaGenerator(input_path("issue_163c.yaml")).serialize()
     assert output == snapshot("issue_163c.owl")
+
+
+def test_issue_genrdf_exact_mappings(input_path, snapshot):
+    """Make sure that exact_mappings curies are correctly converted in rdfgen"""
+    output = RDFGenerator(input_path("issue_163d.yaml")).serialize()
+    expected = snapshot("issue_163d.ttl")
+    assert output == expected


### PR DESCRIPTION
This PR adds an additional issue test for #163 that more specifically identifies the curie namespace mapping issue in the rdf generator. Namely, that curies listed in `exact_meanings` are not correctly mapped to an IRI.

~~This PR is also waiting on a few fixes that I think are underway in for #1567 to drop the `decode` from calls to serialize in rdflib so the CI will fail. I'll merge in those changes once available.~~

Tests passed, so it looks like the decode issue was just something I saw locally. This should be good to go.