### PR TITLE
Add option to JsonschemaValidationPlugin to provide pre-generated JSON Schema

### DIFF
--- a/linkml/validator/plugins/jsonschema_validation_plugin.py
+++ b/linkml/validator/plugins/jsonschema_validation_plugin.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterator
+import os
+from typing import Any, Iterator, Optional
 
 import jsonschema
 from jsonschema.exceptions import best_match
@@ -11,16 +12,25 @@ from linkml.validator.validation_context import ValidationContext
 class JsonschemaValidationPlugin(ValidationPlugin):
     """A validation plugin which validates instances using a JSON Schema validator."""
 
-    def __init__(self, closed: bool = False, strict: bool = False) -> None:
+    def __init__(
+        self,
+        closed: bool = False,
+        strict: bool = False,
+        json_schema_path: Optional[os.PathLike] = None,
+    ) -> None:
         """Constructor method
 
         :param closed: If True, additional properties are not allowed on instances.
             Defaults to False.
         :param strict: If true, stop validating after the first validation problem
             is found. Defaults to False.
+        :param json_schema_path: If provided, JSON Schema will not be generated from the schema,
+            instead it will be read from this path. In this case the value of the `closed` argument
+            is disregarded and the open- or closed-ness of the existing JSON Schema is taken as-is.
         """
         self.closed = closed
         self.strict = strict
+        self.json_schema_path = json_schema_path
 
     def process(self, instance: Any, context: ValidationContext) -> Iterator[ValidationResult]:
         """Perform JSON Schema validation on the provided instance
@@ -30,7 +40,7 @@ class JsonschemaValidationPlugin(ValidationPlugin):
         :return: Iterator over validation results
         :rtype: Iterator[ValidationResult]
         """
-        json_schema = context.json_schema(closed=self.closed)
+        json_schema = context.json_schema(closed=self.closed, path_override=self.json_schema_path)
         validator = jsonschema.Draft7Validator(
             json_schema, format_checker=jsonschema.Draft7Validator.FORMAT_CHECKER
         )

--- a/linkml/validator/validation_context.py
+++ b/linkml/validator/validation_context.py
@@ -1,4 +1,7 @@
+import json
+import os
 from functools import lru_cache
+from typing import Optional
 
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import SchemaDefinition
@@ -25,7 +28,11 @@ class ValidationContext:
         return hash((self.schema.id, self.target_class))
 
     @lru_cache
-    def json_schema(self, *, closed):
+    def json_schema(self, *, closed: bool, path_override: Optional[os.PathLike] = None):
+        if path_override:
+            with open(path_override) as json_schema_file:
+                return json.load(json_schema_file)
+
         not_closed = not closed
         jsonschema_gen = JsonSchemaGenerator(
             schema=self.schema,

--- a/tests/test_validator/test_jsonschema_validation_plugin.py
+++ b/tests/test_validator/test_jsonschema_validation_plugin.py
@@ -1,43 +1,73 @@
-import unittest
-from pathlib import Path
+import json
 
+import pytest
 from linkml_runtime.linkml_model import SchemaDefinition
 from linkml_runtime.loaders import yaml_loader
 
 from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.validation_context import ValidationContext
 
-PERSONINFO_SCHEMA = str(Path(__file__).parent / "input/personinfo.yaml")
+
+@pytest.fixture
+def validation_context(input_path) -> ValidationContext:
+    schema = yaml_loader.load(input_path("personinfo.yaml"), SchemaDefinition)
+    return ValidationContext(schema, "Person")
 
 
-class TestJsonschemaValidationPlugin(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        schema = yaml_loader.load(PERSONINFO_SCHEMA, SchemaDefinition)
-        cls._context = ValidationContext(schema, "Person")
+def test_valid_instance(validation_context):
+    plugin = JsonschemaValidationPlugin()
+    instance = {"id": "1", "full_name": "Person One"}
+    result_iter = plugin.process(instance, validation_context)
+    with pytest.raises(StopIteration):
+        next(result_iter)
 
-    def test_valid_instance(self):
-        plugin = JsonschemaValidationPlugin()
-        instance = {"id": "1", "full_name": "Person One"}
-        result_iter = plugin.process(instance, self._context)
-        self.assertRaises(StopIteration, lambda: next(result_iter))
 
-    def test_invalid_instance(self):
-        plugin = JsonschemaValidationPlugin()
-        instance = {"id": "1", "full_name": "Person One", "phone": "555-CALL-NOW"}
-        result_iter = plugin.process(instance, self._context)
-        self.assertIn("'555-CALL-NOW' does not match", next(result_iter).message)
-        self.assertRaises(StopIteration, lambda: next(result_iter))
+def test_invalid_instance(validation_context):
+    plugin = JsonschemaValidationPlugin()
+    instance = {"id": "1", "full_name": "Person One", "phone": "555-CALL-NOW"}
+    result_iter = plugin.process(instance, validation_context)
+    assert "'555-CALL-NOW' does not match" in next(result_iter).message
+    with pytest.raises(StopIteration):
+        next(result_iter)
 
-    def test_invalid_instance_closed(self):
-        plugin = JsonschemaValidationPlugin(closed=True)
-        instance = {
-            "id": "1",
-            "full_name": "Person One",
-            "whoops": "my bad",
-        }
-        result_iter = plugin.process(instance, self._context)
-        message = next(result_iter).message
-        self.assertIn("Additional properties", message)
-        self.assertIn("whoops", message)
-        self.assertRaises(StopIteration, lambda: next(result_iter))
+
+def test_invalid_instance_closed(validation_context):
+    plugin = JsonschemaValidationPlugin(closed=True)
+    instance = {
+        "id": "1",
+        "full_name": "Person One",
+        "whoops": "my bad",
+    }
+    result_iter = plugin.process(instance, validation_context)
+    message = next(result_iter).message
+    assert "Additional properties" in message
+    assert "whoops" in message
+    with pytest.raises(StopIteration):
+        next(result_iter)
+
+
+def test_path_override(validation_context, tmp_file_factory):
+    cached_json_schema = tmp_file_factory(
+        "schema.json",
+        json.dumps(
+            {
+                "$schema": "https://json-schema.org/draft/2019-09/schema",
+                "type": "object",
+                "properties": {"a": {"type": "number"}},
+                "required": ["a"],
+            }
+        ),
+    )
+    plugin = JsonschemaValidationPlugin(json_schema_path=cached_json_schema)
+
+    # with the cached json schema path provided, we're *not* validating against personinfo anymore
+    invalid_instance = {"id": "1", "full_name": "Person One"}
+    result_iter = plugin.process(invalid_instance, validation_context)
+    message = next(result_iter).message
+    assert "required property" in message
+    assert "a" in message
+
+    valid_instance = {"a": 1}
+    result_iter = plugin.process(valid_instance, validation_context)
+    with pytest.raises(StopIteration):
+        next(result_iter)


### PR DESCRIPTION
This is a bare-bones solution to fix #1659. From a user perspective, if they're using the CLI they would need a config file that looks something like:

```yaml
plugins:
  JsonschemaValidationPlugin:
    json_schema_path: some-cached-schema.json
```
