### PR TITLE
Fix broken enum and subset URI links

### DIFF
--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -7,7 +7,7 @@ _{{ element_description_line }}_
 {% endfor %}
 {% endif %}
 
-URI: {{ gen.uri_link(element) }}
+URI: {{ gen.link(element) }}
 
 {% if element.permissible_values -%}
 ## Permissible Values

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -11,7 +11,7 @@ _{{ element_description_line }}_
 {% endfor %}
 {% endif %}
 
-URI: {{ gen.uri_link(element) }}
+URI: {{ gen.link(element) }}
 
 {% include "common_metadata.md.jinja2" %}
 


### PR DESCRIPTION
This PR is a fix for issue #1682 

The docgen method responsible for rendering resolvable uri links is [uri_link()](https://github.com/linkml/linkml/blob/main/linkml/generators/docgen.py#L346-L358) which depends on [uri()](https://github.com/linkml/linkml/blob/main/linkml/generators/docgen.py#L334-L344) which has special handling for enums and subsets because the underlying SchemaView method [get_uri()](https://github.com/linkml/linkml-runtime/blob/main/linkml_runtime/utils/schemaview.py#L904-L941) does not know how to make URIs for enums/subsets.

Ultimately, `uri_link()` should be the one method which handles the resolving/rendering of element URIs but that will require fixes in linkml-model/linkml-runtime, so until then, this can be a temporary fix for issue #1682 