### PR TITLE
Ensure `source_file` is populated on SchemaDefinition when it is loaded by Validator

### DIFF
--- a/linkml/validator/validator.py
+++ b/linkml/validator/validator.py
@@ -36,7 +36,7 @@ class Validator:
             self._schema = schema
         else:
             self._schema: SchemaDefinition = yaml_loader.load(schema, SchemaDefinition)
-        if isinstance(schema, str):
+        if "\n" not in schema and isinstance(schema, str):
             self._schema.source_file = schema
         self._validation_plugins = validation_plugins
         self.strict = strict

--- a/linkml/validator/validator.py
+++ b/linkml/validator/validator.py
@@ -36,7 +36,7 @@ class Validator:
             self._schema = schema
         else:
             self._schema: SchemaDefinition = yaml_loader.load(schema, SchemaDefinition)
-        if "\n" not in schema and isinstance(schema, str):
+        if isinstance(schema, str) and "\n" not in schema:
             self._schema.source_file = schema
         self._validation_plugins = validation_plugins
         self.strict = strict

--- a/linkml/validator/validator.py
+++ b/linkml/validator/validator.py
@@ -36,6 +36,8 @@ class Validator:
             self._schema = schema
         else:
             self._schema: SchemaDefinition = yaml_loader.load(schema, SchemaDefinition)
+        if isinstance(schema, str):
+            self._schema.source_file = schema
         self._validation_plugins = validation_plugins
         self.strict = strict
 


### PR DESCRIPTION
Fixes #1694 

`SchemaView` does this [additional bit of work](https://github.com/linkml/linkml-runtime/blob/1feeb089a42a51272354b928cb93f7da911a2d3d/linkml_runtime/utils/schemaview.py#L71-L77) where it modifies the `source_file` slot of a `SchemaDefinition` if it loads it from a file.

In the `Validator` we load the schema (_not_ via `SchemaView`) on initialization. We don't create a `SchemaView` until it's needed for actual validation, and when we do we're handing `SchemaView` a `SchemaDefinition` object, not a path. So in order to get relative local imports to work, `Validator` needs to perform the same schema modification after it loads it from a file and before it later hands it off to `SchemaView`.