### PR TITLE
Adds support for using typeof to generate the typescript type if type.base is not set

### DIFF
--- a/linkml/generators/typescriptgen.py
+++ b/linkml/generators/typescriptgen.py
@@ -168,6 +168,8 @@ class TypescriptGenerator(OOCodeGenerator):
                 tsrange = "string"
                 if t.base and t.base in type_map:
                     tsrange = type_map[t.base]
+                elif t.typeof and t.typeof in type_map:
+                    tsrange = type_map[t.typeof]
                 else:
                     logging.warning(f"Unknown type.base: {t.name}")
                 if slot.multivalued:


### PR DESCRIPTION
This fix addresses https://github.com/monarch-initiative/monarch-app/issues/449, where custom types brought in from the oak similarity schema didn't get the correct typescript type.