### PR TITLE
Show headers for class, slot documentation pages similar to MIxS

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -1,4 +1,10 @@
-# Class: {{ gen.name(element) }}
+{%- if element.title -%}
+    {%- set title = element.title ~ ' (' ~ gen.name(element) ~ ')' -%}
+{%- else -%}
+    {%- set title = gen.name(element) -%}
+{%- endif -%}
+
+# Class: {{ title }}
 
 {%- if header -%}
 {{header}}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -1,4 +1,10 @@
-# Slot: {{ gen.name(element) }}
+{%- if element.title %}
+    {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
+{%- else %}
+    {%- set title = gen.name(element) -%}
+{%- endif -%}
+
+# Slot: {{ title }}
 
 {%- if header -%}
 {{header}}


### PR DESCRIPTION
Examples for the way in which we're making the headers for class and slot documentation pages for the MIxS docs is like below:
* https://genomicsstandardsconsortium.github.io/mixs/MigsBa/ (class doc page)
* https://genomicsstandardsconsortium.github.io/mixs/0000122/ (slot doc page)