### PR TITLE
Fix the rendering of date and time fields in Java code

### DIFF
--- a/linkml/generators/javagen.py
+++ b/linkml/generators/javagen.py
@@ -45,9 +45,9 @@ TYPEMAP = {
     "xsd:float": "Float",
     "xsd:double": "Double",
     "xsd:boolean": "boolean",
-    "xds:dateTime": "ZonedDateTime",
-    "xds:date": "LocalDateTime",
-    "xds:time": "Instant",
+    "xsd:dateTime": "ZonedDateTime",
+    "xsd:date": "LocalDateTime",
+    "xsd:time": "Instant",
     "xsd:anyURI": "String",
     "xsd:decimal": "BigDecimal",
 }

--- a/linkml/generators/javagen.py
+++ b/linkml/generators/javagen.py
@@ -46,7 +46,7 @@ TYPEMAP = {
     "xsd:double": "Double",
     "xsd:boolean": "boolean",
     "xsd:dateTime": "ZonedDateTime",
-    "xsd:date": "LocalDateTime",
+    "xsd:date": "LocalDate",
     "xsd:time": "Instant",
     "xsd:anyURI": "String",
     "xsd:decimal": "BigDecimal",

--- a/linkml/generators/javagen/java_record_template.jinja2
+++ b/linkml/generators/javagen/java_record_template.jinja2
@@ -5,8 +5,8 @@ package {{ doc.package }};
 import java.math.BigDecimal;{% endif -%}
 {% if f.range.startswith('Instant') %}
 import java.time.Instant;{% endif -%}
-{% if f.range.startswith('LocalDateTime') %}
-import java.time.LocalDateTime;{% endif -%}
+{% if f.range.startswith('LocalDate') %}
+import java.time.LocalDate;{% endif -%}
 {% if f.range.startswith('ZonedDateTime') %}
 import java.time.ZonedDateTime;{% endif -%}
 {% if f.range.startswith('List') %}

--- a/tests/test_generators/test_javagen.py
+++ b/tests/test_generators/test_javagen.py
@@ -1,23 +1,7 @@
 from linkml.generators.javagen import JavaGenerator
+from tests.utils.fileutils import assert_file_contains
 
 PACKAGE = "org.sink.kitchen"
-
-
-# TODO: move this somewhere reusable
-def assert_file_contains(filename, text, after=None, description=None) -> None:
-    found = False
-    is_after = False  # have we reached the after mark?
-    with open(filename) as stream:
-        for line in stream.readlines():
-            if text in line:
-                if after is None:
-                    found = True
-                else:
-                    if is_after:
-                        found = True
-            if after is not None and after in line:
-                is_after = True
-    assert found
 
 
 def test_javagen_records(kitchen_sink_path, tmp_path):

--- a/tests/test_issues/test_linkml_issue_1525.py
+++ b/tests/test_issues/test_linkml_issue_1525.py
@@ -1,0 +1,38 @@
+from linkml.generators.javagen import JavaGenerator
+from tests.utils.fileutils import assert_file_contains
+
+schema_str = """
+id: http://example.com/person
+name: datetest
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+
+classes:
+  SomethingWithDate:
+    slots:
+      - date_and_time
+      - date_only
+      - time_only
+
+slots:
+  date_and_time:
+    range: datetime
+  date_only:
+    range: date
+  time_only:
+    range: time
+"""
+
+
+def test_javagen_with_date_slots(tmp_path):
+    """
+    Check that date and time slots are rendered with the correct types in Java code.
+
+    See https://github.com/linkml/linkml/issues/1525.
+    """
+    JavaGenerator(schema_str).serialize(directory=str(tmp_path))
+    assert_file_contains(tmp_path / "SomethingWithDate.java", "ZonedDateTime dateAndTime")
+    assert_file_contains(tmp_path / "SomethingWithDate.java", "LocalDateTime dateOnly")
+    assert_file_contains(tmp_path / "SomethingWithDate.java", "Instant timeOnly")

--- a/tests/test_issues/test_linkml_issue_1525.py
+++ b/tests/test_issues/test_linkml_issue_1525.py
@@ -34,5 +34,5 @@ def test_javagen_with_date_slots(tmp_path):
     """
     JavaGenerator(schema_str).serialize(directory=str(tmp_path))
     assert_file_contains(tmp_path / "SomethingWithDate.java", "ZonedDateTime dateAndTime")
-    assert_file_contains(tmp_path / "SomethingWithDate.java", "LocalDateTime dateOnly")
+    assert_file_contains(tmp_path / "SomethingWithDate.java", "LocalDate dateOnly")
     assert_file_contains(tmp_path / "SomethingWithDate.java", "Instant timeOnly")

--- a/tests/utils/fileutils.py
+++ b/tests/utils/fileutils.py
@@ -1,0 +1,21 @@
+def assert_file_contains(filename, text, after=None) -> None:
+    """
+    Check that a file contains a specific bit of text in a line, and raise an assertion failure if it does not.
+
+    :param filename: the name of the file to be checked
+    :param text: the motif that must be present in the file
+    :param after: if present, the text to search for must appear after a line containing this
+    """
+    found = False
+    is_after = False
+    with open(filename) as stream:
+        for line in stream.readlines():
+            if text in line:
+                if after is None:
+                    found = True
+                else:
+                    if is_after:
+                        found = True
+            if after is not None and after in line:
+                is_after = True
+    assert found


### PR DESCRIPTION
This PR ensures that the Java code generator renders date- and time-ranged slots as appropriately typed Java fields:

* `datetime` -> `java.time.ZonedDateTime`
* `date` -> `java.time.LocalDate`
* `time` -> `java.time.Instant`

instead of being systematically rendered as `String`-typed fields.

closes #1525 