### PR TITLE
Improve tutorial 02 (add docu for tree_root)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@ output/
 docs/_sources
 docs/_modules
 docs/_images
-docs/_build/
-docs/source/
+docs/_build
 
 # Jekyll
 Gemfile.lock

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 apidocs:
-	pipenv run sphinx-apidoc -o ./ ../linkml
+	poetry run sphinx-apidoc -o ./ ../linkml
 
 deploy:
 	cp -pr _build/html/* ../docs/

--- a/docs/data/csvs.md
+++ b/docs/data/csvs.md
@@ -2,7 +2,7 @@
 
 LinkML can support both complex interlinked normalized relational data as well as flat/denormalized data as typically found in spreadsheets and in CSVs used by data scientists.
 
-Our philosophy is "always have a schema" even when working with simple tabular data
+Our philosophy is "always have a schema" even when working with simple tabular data.
 
 ## Conversion
 
@@ -17,7 +17,7 @@ if your schema has a certain "shape" and you provide sufficient hints.
 
 ### Container objects
 
-See [part 2 of the tutorial](../intro/tutorial02) for more on container objects.
+See [part 2 of the tutorial](../intro/tutorial02) for an introduction to container objects.
 
 To serialize your data objects as TSVs, it's assumed that you have a
 class in your schema that serves the role of *container*. It can be
@@ -38,7 +38,7 @@ their best to guess the index slot and the container, but if there is
 no unambiguous choice, then have to provide these using the following
 arguments:
 
-```
+```text
   -C, --target-class TEXT         name of class in datamodel that the root
                                   node instantiates
 
@@ -58,13 +58,9 @@ Note that currently serializing the person objects won't work, as the Person cla
 
 The [json-flattener/](https://github.com/cmungall/json-flattener/) library is used to do on-the-fly denormalizations. For example:
 
- - multivalued slots are serialized using a `|` separator
- - nested slots are flattened to paths, e.g if Container has a slot persons, and Person has a slot name, then the path with be `persons_name`
+* multivalued slots are serialized using a `|` separator
+* nested slots are flattened to paths, e.g if Container has a slot persons, and Person has a slot name, then the path with be `persons_name`
 
 ## Inference of schemas from tabular data
 
 Use `generalize-tsv` command in the [schema-automator](https://github.com/linkml/schema-automator)
-
-
-
-

--- a/docs/intro/tutorial01.md
+++ b/docs/intro/tutorial01.md
@@ -4,7 +4,6 @@ We assume that you already have LinkML [installed](install)
 
 For the purposes of this tutorial, the simplest setup is to use a virtual environment, and then install linkml:
 
-
 <!-- NO_EXECUTE -->
 ```bash
 mkdir linkml-tutorial
@@ -62,6 +61,7 @@ gen-json-schema personinfo.yaml
 ```
 
 Outputs:
+
 ```json
 {
    "$defs": {
@@ -110,14 +110,11 @@ Let's create an example data file. The file will contain an *instance* of the cl
 
 data.yaml:
 
-```yaml
-id: ORCID:1234
-full_name: Clark Kent
-age: "32"
-phone: 555-555-5555
+```{literalinclude} ../../examples/tutorial/tutorial01/data.yaml
+:language: yaml
 ```
 
-note the values of all these fields are strings, even age; we will later return
+Note the values of all these fields are strings, even age; we will later return
 to this example and show how we could model this more naturally as a number.
 
 Validate:
@@ -132,12 +129,8 @@ To see an example of data not validating:
 
 bad-data.yaml:
 
-```yaml
-id: ORCID:1234
-full_name: Clark Kent
-age: "32"
-phone: 555-555-5555
-made_up_field: hello
+```{literalinclude} ../../examples/tutorial/tutorial01/bad-data.yaml
+:language: yaml
 ```
 
 <!-- FAIL -->
@@ -151,22 +144,17 @@ This should report an error to the effect that `made_up_field` is not allowed.
 
 One of the advantages of LinkML is the same datamodel can be used for multiple expressions of the same data, for example:
 
- * YAML/JSON
- * TSVs/spreadsheets
- * RDF
- * Relational Databases
+* YAML/JSON
+* TSVs/spreadsheets
+* RDF
+* Relational Databases
 
 There are various complexities involved in going between these, but YAML and JSON are basically interchangeable with LinkML
 
 data.json:
 
-```json
-{
- "id": "ORCID:1234",
- "full_name": "Clark Kent",
- "age": "32",
- "phone": "555-555-5555"
-}
+```{literalinclude} ../../examples/tutorial/tutorial01/data.json
+:language: json
 ```
 
 This will validate in the same way as the equivalent YAML file:
@@ -174,7 +162,6 @@ This will validate in the same way as the equivalent YAML file:
 ```bash
 linkml-validate -s personinfo.yaml data.json
 ```
-
 
 ## Converting to RDF
 
@@ -189,14 +176,9 @@ linkml-convert -s personinfo.yaml data.yaml -o data.ttl
 This will produce an RDF/turtle file as follows
 
 <!-- MATCHES data.ttl -->
-```turtle
-@prefix ns1: <https://w3id.org/linkml/examples/personinfo/> .
 
-[] a ns1:Person ;
-    ns1:age "32" ;
-    ns1:full_name "Clark Kent" ;
-    ns1:id "ORCID:1234" ;
-    ns1:phone "555-555-5555" .
+```{literalinclude} ../../examples/tutorial/tutorial01/data.ttl
+:language: turtle
 ```
 
 If you are not familiar with RDF that's OK! RDF is just one of the possible ways of working with LinkML.

--- a/docs/intro/tutorial01.md
+++ b/docs/intro/tutorial01.md
@@ -29,25 +29,8 @@ First create a file
 
 personinfo.yaml:
 
-```yaml
-id: https://w3id.org/linkml/examples/personinfo
-name: personinfo
-prefixes:
-  linkml: https://w3id.org/linkml/
-  personinfo: https://w3id.org/linkml/examples/personinfo
-imports:
-  - linkml:types
-default_range: string
-default_prefix: personinfo
-
-classes:
-  Person:
-    attributes:
-      id:
-      full_name:
-      aliases:
-      phone:
-      age:
+```{literalinclude} ../../examples/tutorial/tutorial01/personinfo.yaml
+:language: yaml
 ```
 
 (note that all files are available in the [examples/tutorial](https://github.com/linkml/linkml/tree/main/examples/tutorial) folder of this repository)
@@ -62,44 +45,8 @@ gen-json-schema personinfo.yaml
 
 Outputs:
 
-```json
-{
-   "$defs": {
-      "Person": {
-         "additionalProperties": false,
-         "description": "",
-         "properties": {
-            "age": {
-               "type": "string"
-            },
-            "aliases": {
-               "type": "string"
-            },
-            "full_name": {
-               "type": "string"
-            },
-            "id": {
-               "type": "string"
-            },
-            "phone": {
-               "type": "string"
-            }
-         },
-         "required": [],
-         "title": "Person",
-         "type": "object"
-      }
-   },
-   "$id": "https://w3id.org/linkml/examples/personinfo",
-   "$schema": "http://json-schema.org/draft-07/schema#",
-   "additionalProperties": true,
-   "metamodel_version": "1.7.0",
-   "properties": {},
-   "required": [],
-   "title": "personinfo",
-   "type": "object",
-   "version": null
-}
+```{literalinclude} ../../examples/tutorial/tutorial01/personinfo.json
+:language: yaml
 ```
 
 Don't worry if you don't know much about JSON-Schema. This is just an illustration that LinkML can be used in combination with a number of frameworks.
@@ -168,17 +115,21 @@ linkml-validate -s personinfo.yaml data.json
 You can use the linkml convert tool to convert your data to other formats, including RDF:
 
 ```bash
-linkml-convert -s personinfo.yaml data.yaml -o data.ttl
+linkml-convert -s personinfo.yaml data.yaml -t ttl
 ```
 
-(Note the converter uses the suffix to determine that RDF/turtle is required, but you can be explicit by setting `-t`)
-
-This will produce an RDF/turtle file as follows
+This will produce RDF/turtle output as follows
 
 <!-- MATCHES data.ttl -->
 
 ```{literalinclude} ../../examples/tutorial/tutorial01/data.ttl
 :language: turtle
+```
+
+To write the RDF/turtle output directly to a file use
+
+```bash
+linkml-convert -s personinfo.yaml data.yaml -o data.ttl
 ```
 
 If you are not familiar with RDF that's OK! RDF is just one of the possible ways of working with LinkML.

--- a/docs/intro/tutorial02.md
+++ b/docs/intro/tutorial02.md
@@ -29,7 +29,7 @@ data.yaml:
 :language: yaml
 ```
 
-In [Working with Data](../data/working-with-data) we will learn how to express the same data in TSV format.
+In [Working with Data](../data/csvs) we will learn how to express such data in TSV format.
 
 ## Nesting lists of objects
 

--- a/docs/intro/tutorial02.md
+++ b/docs/intro/tutorial02.md
@@ -1,29 +1,35 @@
 # Part 2: Adding a container object
 
-In part 1 of this tutorial we created a schema for describing people,
+In part 1 of this tutorial we created a schema for describing a person,
 and showed how we could use this to validate YAML or JSON files with a
 single person instance.
+In this tutorial we address collections and hierarchy.
 
-In practice our data files will rarely be at the level of a single instance. Instead we might have a file that contains a *list* of people, or a more complex document that contains a variety of different heterogeneous objects.
+In practice our data will typically contain multiple instances, for example we might want to describe a *list* of persons (people).
+How do we express that? We need a way to group the instances together.
+For this purpose, we can define a class with a multivalued slot and use `range` to specify the type of the object we want to collect.
+
+More complex data are also often hierarchical.
+In order to express hierarchies, multivalued slots alone are not enough.
+We also need a way to mark which class is the root of our hierarchy.
+In LinkML, the `tree_root` slot is used to designate a class as the root of a tree structure.
+Only one class in a schema can be set as root.
+If more than one class is marked as `tree_root`, a validation error will occur.
+
+Marking one class to serve as the root of the tree (as "container" of the other classes) is especially important when serializing and deserializing data.
+The class marked as `tree_root` will be the top-level object in the serialized data.
 
 ## Example data file
 
-Let's start with a simple data file that contains more than one instance of person. We choose to structure this as a YAML/JSON dictionary, with an "index slot" called `persons`:
+Let's start with a simple data file that contains more than one instance of person. We choose to structure this as a YAML/JSON dictionary, with an **index slot** called `persons`:
 
 data.yaml:
 
-```yaml
-persons:
-  - id: ORCID:1234
-    full_name: Clark Kent
-    age: 32
-    phone: 555-555-5555
-  - id: ORCID:4567
-    full_name: Lois Lane
-    age: 33
+```{literalinclude} ../../examples/tutorial/tutorial02/data.yaml
+:language: yaml
 ```
 
-(later on we will see how to express this same thing as a TSV)
+In [Working with Data](../data/working-with-data) we will learn how to express the same data in TSV format.
 
 ## Nesting lists of objects
 
@@ -31,67 +37,44 @@ We can describe this data using the following schema.
 
 personinfo.yaml:
 
-```yaml
-id: https://w3id.org/linkml/examples/personinfo
-name: personinfo
-prefixes:
-  linkml: https://w3id.org/linkml/
-imports:
-  - linkml:types
-default_range: string
-  
-classes:
-  Person:
-    attributes:
-      id:
-      full_name:
-      aliases:
-      phone:
-      age:
-        range: integer
-  Container:
-    tree_root: true
-    attributes:
-      persons:
-        multivalued: true
-        inlined_as_list: true
-        range: Person
+```{literalinclude} ../../examples/tutorial/tutorial02/personinfo.yaml
+:language: yaml
 ```
 
-This time we are modeling age as an integer. We use the construct
-``range`` to state that the values of ``age`` must be integers.
+We introduce a class called `Container`.
+This doesn't necessarily reflect a "real world" entity in our domain, it's just a convenient holder for our data.
+Right now the container has only a single attribute/slot called "persons" because it just need to holding instances of `Person`.
+But it could hold other kinds of data, too.
 
-We introduce a class called `Container`. This doesn't necessarily
-reflect a "real world" entity in our domain, it's just a convenient
-holder for our data.
+The `Container` class has three crucial characteristics:
 
-Right now it is holding instances of `Person` but it could hold other kinds of data.
+- it is *multivalued* - i.e. it holds a list
+- it is *inlined* - i.e. the values are nested underneath the container
+- the *range* is Person - i.e. the expected values in the data are persons (people)
 
-The container has a single attribute/slot called "persons". This has 3
-crucial characteristics:
+Moreover, the `Container` class is also marked as root class of our model.
+In this simple schema setting `tree_root` is not strictly necessary.
+LinkML is able to infer that the class `Container` is the root class because it is not referenced as a range in any other class.
+However, it is good practice to nevertheless mark the root class explicitly.
 
- - it is *multivalued* - i.e. it holds a list
- - the *range* is Person - i.e. the expected values in the data should be people
- - it is *inlined* - i.e. the values are nested underneath the container
-
-Later on we will explore these in more detail
+Later on we will explore these in more detail.
 
 ## Validating
 
 We can validate this to make sure we got it right:
 
 ```bash
-linkml-validate -s personinfo.yaml data.yaml 
+linkml-validate -s personinfo.yaml data.yaml
 ```
 
 This should report no errors.
 
 ## Visualizing
 
-We can use yUML to visualize the schema. The `gen-yuml` command can generate REST URLs that can be fed into
+We can use yUML to visualize the schema. The `gen-yuml` command can generate REST URLs that can be fed into:
 
 ```bash
-gen-yuml -f yuml personinfo.yaml 
+gen-yuml -f yuml personinfo.yaml
 ```
 
 Outputs:
@@ -104,7 +87,7 @@ Which renders as:
 
 ![img](https://yuml.me/diagram/nofunky;dir:TB/class/[Container]++-%20persons%200..*>[Person|id:string%20%3F;full_name:string%20%3F;aliases:string%20%3F;phone:string%20%3F;age:string%20%3F],[Container])
 
-You can also generate a png directly
+You can also generate a png directly:
 
 ```bash
 gen-yuml -f png personinfo.yaml  > personinfo.png
@@ -121,10 +104,12 @@ gen-yuml -f png personinfo.yaml  > personinfo.png
 
 ## Further reading
 
-* Metamodel Specification
-   * [multivalued](https://w3id.org/linkml/multivalued) slot
-   * [range](https://w3id.org/linkml/range) slot   
+- Metamodel Specification
+  - [tree_root](https://w3id.org/linkml/tree_root) slot
+  - [multivalued](https://w3id.org/linkml/multivalued) slot
+  - [inlined_as_list](https://w3id.org/linkml/inlined_as_list) slot
+  - [range](https://w3id.org/linkml/range) slot
 
 ## Next
 
-Next we will explore how to add constraints to the schema
+Next we will explore how to add constraints to the schema.

--- a/examples/tutorial/tutorial01/data.json
+++ b/examples/tutorial/tutorial01/data.json
@@ -1,6 +1,6 @@
 {
  "id": "ORCID:1234",
  "full_name": "Clark Kent",
- "age": 32,
+ "age": "32",
  "phone": "555-555-5555"
 }

--- a/examples/tutorial/tutorial01/data.ttl
+++ b/examples/tutorial/tutorial01/data.ttl
@@ -5,4 +5,3 @@
     ns1:full_name "Clark Kent" ;
     ns1:id "ORCID:1234" ;
     ns1:phone "555-555-5555" .
-

--- a/examples/tutorial/tutorial01/data.ttl
+++ b/examples/tutorial/tutorial01/data.ttl
@@ -1,7 +1,7 @@
-@prefix ns1: <https://w3id.org/linkml/examples/personinfo/> .
+@prefix personinfo: <https://w3id.org/linkml/examples/personinfo> .
 
-[] a ns1:dict ;
-    ns1:age "32" ;
-    ns1:full_name "Clark Kent" ;
-    ns1:id "ORCID:1234" ;
-    ns1:phone "555-555-5555" .
+[] a personinfo:Person ;
+    personinfo:age "32" ;
+    personinfo:full_name "Clark Kent" ;
+    personinfo:id "ORCID:1234" ;
+    personinfo:phone "555-555-5555" .

--- a/examples/tutorial/tutorial01/personinfo.json
+++ b/examples/tutorial/tutorial01/personinfo.json
@@ -1,0 +1,34 @@
+{
+    "$defs": {
+        "Person": {
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+                "age": {
+                    "type": "string"
+                },
+                "aliases": {
+                    "type": "string"
+                },
+                "full_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                }
+            },
+            "title": "Person",
+            "type": "object"
+        }
+    },
+    "$id": "https://w3id.org/linkml/examples/personinfo",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": true,
+    "metamodel_version": "1.7.0",
+    "title": "personinfo",
+    "type": "object",
+    "version": null
+}

--- a/examples/tutorial/tutorial01/personinfo.yaml
+++ b/examples/tutorial/tutorial01/personinfo.yaml
@@ -2,9 +2,11 @@ id: https://w3id.org/linkml/examples/personinfo
 name: personinfo
 prefixes:
   linkml: https://w3id.org/linkml/
+  personinfo: https://w3id.org/linkml/examples/personinfo
 imports:
   - linkml:types
 default_range: string
+default_prefix: personinfo
 
 classes:
   Person:

--- a/examples/tutorial/tutorial02/data.yaml
+++ b/examples/tutorial/tutorial02/data.yaml
@@ -1,8 +1,8 @@
 persons:
   - id: ORCID:1234
     full_name: Clark Kent
-    age: 32
+    age: "32"
     phone: 555-555-5555
   - id: ORCID:4567
     full_name: Lois Lane
-    age: 33
+    age: "33"

--- a/examples/tutorial/tutorial02/personinfo.yaml
+++ b/examples/tutorial/tutorial02/personinfo.yaml
@@ -16,6 +16,7 @@ classes:
       age:
         range: integer
   Container:
+    tree_root: true
     attributes:
       persons:
         multivalued: true


### PR DESCRIPTION
- Document `tree_note` in tutorial 02
- Add more explanations and links to tutorial 02
- Fix example data for tutorial 01 & 02 to make validation pass
  - Correcting the example data fixed also #683.
- Replace copies of example data in the tutorial text by `literalinclude`s to avoid diverging of data in example data directory vs. tutorial text. This PR addresses only tutorial 01 & 02)
- Since I edited Tutorial 01 I also fixed #1043.

Closes #1046
Closes #683
Closes #1043