### PR TITLE
Add optional argument `--use-class-uris` to `gen-doc`

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -150,6 +150,7 @@ class DocGenerator(Generator):
     gen_slots: bool = field(default_factory=lambda: True)
     no_types_dir: bool = field(default_factory=lambda: False)
     use_slot_uris: bool = field(default_factory=lambda: False)
+    use_class_uris: bool = field(default_factory=lambda: False)
     hierarchical_class_view: bool = field(default_factory=lambda: False)
 
     def __post_init__(self):
@@ -331,6 +332,13 @@ class DocGenerator(Generator):
                     return curie.split(":")[1]
 
             return underscore(element.name)
+        elif type(element).class_name == "class_definition":
+            if self.use_class_uris:
+                curie = self.schemaview.get_uri(element)
+                if curie:
+                    return curie.split(":")[1]
+                
+            return camelcase(element.name)
         else:
             return camelcase(element.name)
 
@@ -374,6 +382,10 @@ class DocGenerator(Generator):
         if self._is_external(e):
             return self.uri_link(e)
         elif isinstance(e, ClassDefinition):
+            if self.use_class_uris:
+                curie = self.schemaview.get_uri(e)
+                if curie is not None:
+                    return self._markdown_link(n=curie.split(":")[1], name=e.name)
             return self._markdown_link(camelcase(e.name))
         elif isinstance(e, EnumDefinition):
             return self._markdown_link(camelcase(e.name))
@@ -474,7 +486,7 @@ class DocGenerator(Generator):
     ) -> str:
         indent = " " * depth * 4
 
-        if self.use_slot_uris:
+        if self.use_slot_uris or self.use_class_uris:
             name = self.schemaview.get_element(element).name
         else:
             name = self.name(element)
@@ -879,6 +891,11 @@ class DocGenerator(Generator):
     help="Use IDs from slot_uri instead of names",
 )
 @click.option(
+    "--use-class-uris/--no-use-class-uris",
+    default=False,
+    help="Use IDs from class_uri instead of names",
+)
+@click.option(
     "--hierarchical-class-view/--no-hierarchical-class-view",
     default=True,
     help="Render class table on index page in a hierarchically indented view",
@@ -889,7 +906,7 @@ class DocGenerator(Generator):
 )
 @click.version_option(__version__, "-V", "--version")
 @click.command()
-def cli(yamlfile, directory, index_name, dialect, template_directory, use_slot_uris, hierarchical_class_view, **args):
+def cli(yamlfile, directory, index_name, dialect, template_directory, use_slot_uris, use_class_uris, hierarchical_class_view, **args):
     """Generate documentation folder from a LinkML YAML schema
 
     Currently a default set of templates for markdown is provided (see the
@@ -915,6 +932,7 @@ def cli(yamlfile, directory, index_name, dialect, template_directory, use_slot_u
         dialect=dialect,
         template_directory=template_directory,
         use_slot_uris=use_slot_uris,
+        use_class_uris=use_class_uris,
         hierarchical_class_view=hierarchical_class_view,
         index_name=index_name,
         **args,

--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -1,7 +1,11 @@
-{%- if element.title -%}
-    {%- set title = element.title ~ ' (' ~ gen.name(element) ~ ')' -%}
-{%- else -%}
-    {%- set title = gen.name(element) -%}
+{%- if element.title %}
+    {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
+{%- else %}
+    {%- if gen.use_class_uris -%}
+        {%- set title = element.name -%}
+    {%- else -%}
+        {%- set title = gen.name(element) -%}
+    {%- endif -%}
 {%- endif -%}
 
 # Class: {{ title }}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -1,7 +1,11 @@
 {%- if element.title %}
     {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
 {%- else %}
-    {%- set title = gen.name(element) -%}
+    {%- if gen.use_slot_uris -%}
+        {%- set title = element.name -%}
+    {%- else -%}
+        {%- set title = gen.name(element) -%}
+    {%- endif -%}
 {%- endif -%}
 
 # Slot: {{ title }}

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -608,7 +608,7 @@ def test_use_slot_uris(kitchen_sink_path, input_path, tmp_path):
     gen.serialize(directory=str(tmp_path))
 
     # this is a markdown file created from slot_uri
-    assert_mdfile_contains(tmp_path / "actedOnBehalfOf.md", "Slot: actedOnBehalfOf")
+    assert_mdfile_contains(tmp_path / "actedOnBehalfOf.md", "Slot: acted on behalf of")
 
     # check label and link of documents in inheritance tree
     # A.md
@@ -621,6 +621,26 @@ def test_use_slot_uris(kitchen_sink_path, input_path, tmp_path):
         after="[tree_slot_A](A.md)",
         # followed_by="* [tree_slot_C](C.md) [ [mixin_slot_I](mixin_slot_I.md)]",
     )
+
+
+def test_use_class_uris(kitchen_sink_path, input_path, tmp_path):
+    tdir = input_path("docgen_html_templates")
+    gen = DocGenerator(
+        kitchen_sink_path,
+        mergeimports=True,
+        no_types_dir=True,
+        template_directory=str(tdir),
+        use_class_uris=True,
+    )
+
+    gen.serialize(directory=str(tmp_path))
+
+    # this is a markdown file created from class_uri
+    assert_mdfile_contains(tmp_path / "Any.md", "Class: AnyObject")
+
+    # check that the classes table on index page has correct class names and
+    # are linked to the correct class doc pages
+    assert_mdfile_contains(tmp_path / "index.md", "[AnyObject](Any.md)")
 
 
 def test_hierarchical_class_view(kitchen_sink_path, tmp_path):


### PR DESCRIPTION
Fixes #1672 

This PR enables the usage of an optional argument `--use-class-uris` on `gen-doc`. The request came out of a use case in the MIxS schema where users wanted the URLs to the documentation pages to be created based on the URI portions of the classes/slots.

Until now we had the ability to create/resolve slot (term) documentation pages based on their URIs, but not classes.