### PR TITLE
Replace `JsonSchemaDataValidator` with `Validator` in `ExampleRunner`

### DIFF
--- a/linkml/validator/validator.py
+++ b/linkml/validator/validator.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator, List, Optional, TextIO, Union
 
@@ -95,7 +96,7 @@ class Validator:
         if not self._validation_plugins:
             return []
 
-        context = ValidationContext(self._schema, target_class)
+        context = self._context(target_class)
 
         for plugin in self._validation_plugins:
             plugin.pre_process(context)
@@ -117,3 +118,7 @@ class Validator:
 
         for plugin in self._validation_plugins:
             plugin.post_process(context)
+
+    @lru_cache
+    def _context(self, target_class: Optional[str] = None) -> ValidationContext:
+        return ValidationContext(self._schema, target_class)


### PR DESCRIPTION
Fixes #1743 

This is just a basic swap-out of the old `JsonSchemaDataValidator` class with the new `Validator` class in `ExampleRunner`. Down the road we could consider adding options to the `ExampleRunner` class and corresponding `linkml-run-examples` CLI to allow customizing the underlying `Validator` instance. But for now you get the same default `Validator` that you get when running `linkml-validate` without any extra configuration.

I also confirmed that the issue being discussed here no longer happens with these changes: https://github.com/microbiomedata/nmdc-schema/pull/1428#issuecomment-1847760668. The current path from `linkml-run-examples` CLI invocation to JSON Schema generation is a bit circuitous. I didn't pinpoint exactly where it's going awry, but it emanates from the way that `JsonSchemaDataValidator` caches artifacts. Obviously with these changes that code path is no longer executed via `linkml-run-examples`.

cc: @turbomam @brynnz22 @aclum