### PR TITLE
Pydantic gen pattern lists

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -145,7 +145,7 @@ class {{ c.name }}
     {% endfor %}
     {% for attr in c.attributes.values() if c.attributes -%}
     {%- if attr.pattern %}
-    @validator('{{attr.name}}')
+    @validator('{{attr.name}}', allow_reuse=True)
     def pattern_{{attr.name}}(cls, v):
         pattern=re.compile(r"{{attr.pattern}}")
         if isinstance(v,list):

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -49,8 +49,8 @@ from typing import List, Dict, Optional, Any, Union"""
 from pydantic import BaseModel as BaseModel, Field, validator"""
     else:
         template += """
-from pydantic import BaseModel as BaseModel, ConfigDict, field_validator, Field"""
-
+from pydantic import BaseModel as BaseModel, ConfigDict,  Field
+from pydantic.functional_validators import field_validator"""
     template += """
 import re
 import sys

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -44,10 +44,10 @@ from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
 from typing import List, Dict, Optional, Any, Union"""
-    if pydantic_ver == '1':
+    if pydantic_ver == "1":
         template += """
 from pydantic import BaseModel as BaseModel, Field, validator"""
-    elif pydantic_ver == '2':
+    elif pydantic_ver == "2":
         template += """
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator"""
     template += """

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -219,8 +219,7 @@ class {{ c.name }}
     {% endfor %}    
 {% endfor %}
 """
-        
-        
+
     ### FWD REFS / REBUILD MODEL ###
     if pydantic_ver == "1":
         template += """

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -44,13 +44,12 @@ from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
 from typing import List, Dict, Optional, Any, Union"""
-    if pydantic_ver == 1:
+    if pydantic_ver == '1':
         template += """
 from pydantic import BaseModel as BaseModel, Field, validator"""
-    else:
+    elif pydantic_ver == '2':
         template += """
-from pydantic import BaseModel as BaseModel, ConfigDict,  Field
-from pydantic.functional_validators import field_validator"""
+from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator"""
     template += """
 import re
 import sys

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -157,8 +157,6 @@ class {{ c.name }}
                 raise ValueError(f"Invalid {{attr.name}} format: {v}")
         return v
     {% endif -%}
-    {% else -%}
-    None
     {% endfor %}    
 {% endfor %}
 """
@@ -211,8 +209,6 @@ class {{ c.name }}
                 raise ValueError(f"Invalid {{attr.name}} format: {v}")
         return v
     {% endif -%}
-    {% else -%}
-    None
     {% endfor %}    
 {% endfor %}
 """

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -149,7 +149,6 @@ class {{ c.name }}
     def pattern_{{attr.name}}(cls, v):
         pattern=re.compile(r"{{attr.pattern}}")
         if isinstance(v,list):
-            # [raise ValueError(f"Invalid name format: {element}") for element in v if not pattern.match(element)]
             for element in v:
                 if not pattern.match(element):
                     raise ValueError(f"Invalid {{attr.name}} format: {element}")
@@ -204,7 +203,6 @@ class {{ c.name }}
     def pattern_{{attr.name}}(cls, v):
         pattern=re.compile(r"{{attr.pattern}}")
         if isinstance(v,list):
-            # [raise ValueError(f"Invalid name format: {element}") for element in v if not pattern.match(element)]
             for element in v:
                 if not pattern.match(element):
                     raise ValueError(f"Invalid {{attr.name}} format: {element}")

--- a/tests/test_compliance/test_pattern_compliance.py
+++ b/tests/test_compliance/test_pattern_compliance.py
@@ -54,7 +54,7 @@ def test_pattern(framework, schema_name, pattern, data_name, value):
     schema = validated_schema(test_pattern, schema_name, framework, classes=classes, core_elements=["pattern"])
     implementation_status = ValidationBehavior.IMPLEMENTS
     is_valid = bool(re.match(pattern, value))
-    if framework in [PYDANTIC, PYTHON_DATACLASSES, SQL_DDL_SQLITE]:
+    if framework in [PYTHON_DATACLASSES, SQL_DDL_SQLITE]:
         if not is_valid:
             implementation_status = ValidationBehavior.INCOMPLETE
     if framework == OWL:

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -333,7 +333,7 @@ def test_pydantic_pattern(kitchen_sink_path, tmp_path, input_path):
     gen = PydanticGenerator(kitchen_sink_path, package=PACKAGE)
     code = gen.serialize()
     module = compile_python(code, PACKAGE)
-    #scalar pattern enforcement
+    # scalar pattern enforcement
     p1 = module.Person(id="01", name="John Doe")
     assert p1.name == "John Doe"
     with pytest.raises(ValidationError):

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -329,10 +329,11 @@ def test_multiline_module(input_path):
 
 
 def test_pydantic_pattern(kitchen_sink_path, tmp_path, input_path):
-    """Generate pydantic classes"""
+    """Check if regex patterns are enforced. Only checks scalar case"""
     gen = PydanticGenerator(kitchen_sink_path, package=PACKAGE)
     code = gen.serialize()
     module = compile_python(code, PACKAGE)
+    #scalar pattern enforcement
     p1 = module.Person(id="01", name="John Doe")
     assert p1.name == "John Doe"
     with pytest.raises(ValidationError):


### PR DESCRIPTION
continues https://github.com/linkml/linkml/pull/1772

This PR corrects the previous attempt at regex support for both pydantic v1 and v2. It does this by adding validators to the jinja templating. The previous approach attempted to use only pattern key:values in the Fields, which causes pydantic to expect non-iterables.

"deep learnings":  the test "test_pattern_compliance.py" generated code for each tuple in
```
[
        ("complete_match", r"^\S+$", "no_ws", "ab"),
        ("complete_match", r"^\S+$", "ws", "a b"),
        ("partial_match", r"ab", "partial_ab", "abcd"),
        ("partial_match", r"ab", "complete_ab", "ab"),
        ("partial_match", r"ab", "ws", "a b"),
],
```
upon testing, this caused a duplicate validator error

adding allow_reuse=True to the decorator allowed for this to happen. Ultimately, we were able to remove PYDANTIC from the list of tested frameworks, as indicated here

https://obo-communitygroup.slack.com/archives/C04EU7JL1NF/p1701911088218449?thread_ts=1701887197.532469&cid=C04EU7JL1NF