### PR TITLE
Ensure that logging level is set correctly in Generator CLIs

### DIFF
--- a/linkml/generators/projectgen.py
+++ b/linkml/generators/projectgen.py
@@ -23,6 +23,7 @@ from linkml.generators.pythongen import PythonGenerator
 from linkml.generators.shaclgen import ShaclGenerator
 from linkml.generators.shexgen import ShExGenerator
 from linkml.generators.sqlddlgen import SQLDDLGenerator
+from linkml.utils.cli_utils import log_level_option
 from linkml.utils.generator import Generator
 
 PATH_FSTRING = str
@@ -103,7 +104,7 @@ class ProjectGenerator:
             all_schemas = [schema_path]
         else:
             all_schemas = get_local_imports(schema_path, os.path.dirname(schema_path))
-        print(f"ALL_SCHEMAS = {all_schemas}")
+        logging.debug(f"ALL_SCHEMAS = {all_schemas}")
         for gen_name, (gen_cls, gen_path_fmt, default_gen_args) in GEN_MAP.items():
             if config.includes is not None and config.includes != [] and gen_name not in config.includes:
                 logging.info(f"Skipping {gen_name} as not in inclusion list: {config.includes}")
@@ -178,6 +179,7 @@ class ProjectGenerator:
     show_default=True,
     help="Merge imports into source file",
 )
+@log_level_option
 @click.argument("yamlfile")
 @click.version_option(__version__, "-V", "--version")
 def cli(
@@ -221,7 +223,6 @@ def cli(
             top_class: Container
 
     """
-    logging.basicConfig(level=logging.INFO)
     project_config = ProjectConfiguration()
     if config_file is not None:
         for k, v in yaml.safe_load(config_file).items():

--- a/linkml/utils/cli_utils.py
+++ b/linkml/utils/cli_utils.py
@@ -1,0 +1,25 @@
+import logging
+
+import click
+
+LOG_LEVEL_STRINGS = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
+DEFAULT_LOG_LEVEL: str = "WARNING"
+DEFAULT_LOG_LEVEL_INT: int = logging.WARNING
+
+
+def log_level_option(fn):
+    def callback(ctx, param, value):
+        log_level_string = value.upper()
+        log_level_int = getattr(logging, log_level_string, None)
+        if not isinstance(log_level_int, int):
+            raise ValueError(f"Invalid log level: {log_level_string}")
+        logging.basicConfig(level=log_level_int)
+
+    return click.option(
+        "--log_level",
+        type=click.Choice(LOG_LEVEL_STRINGS),
+        help="Logging level",
+        default=DEFAULT_LOG_LEVEL,
+        show_default=True,
+        callback=callback,
+    )(fn)


### PR DESCRIPTION
Fixes #1689 

These changes ensure that the logging level is set correctly in the `Generator` subclass CLIs (via the `shared_arguments` decorator) and the `ProjectGenerator` CLI (via a new `--log_level` option).

### Problem assessment

* For `Generator` subclasses using the `shared_arguments` decorator, there was simply a bug in the old `_log_level_string_to_int` function. For some unknown reason it was trying to look up log levels by only the first letter of a string (e.g. `W` instead of `WARNING`). When that inevitably failed, it fell back to `INFO`. 
* Additionally `shared_arguments` has both a `--log_level` option and a `--verbose` option, both of which call `logging.basicConfig`. It's important to note that calling this function is a no-op when called a second time unless the `force` argument is provided (see: https://docs.python.org/3/library/logging.html#logging.basicConfig).  Since the `log_level_callback` is called first, the calls to `logging.basicConfig` in `verbosity_callback` weren't doing anything.
* For the `ProjectGenerator` CLI, the `INFO` level was hardcoded.

### Summary of changes

* I refactored the `--log_level` option into a separate module that both `shared_arguments` and `ProjectGenerator` can use. Its callback now correctly looks up levels by name and applies them.
* I added `force=True` to the `logging.basicConfig` in the callback for the `--verbose` option. I also added a note to the help that `--verbose` takes precedence over the `--log_level` option.


### Tasks for later
* We might still want to be more diligent about using non-root loggers. That may have some benefits overall, but I'm not quite sure yet what our strategy should be.
* I made a quick attempt at writing tests for this, but it's tricky since `pytest` does it's own log capturing and level-setting. So for now I just interactively tested.
* Some generators are still not totally silent. A few of the older ones have some `print` statements that _seem_ unnecessary: https://github.com/linkml/linkml/blob/776cafd14d7d655643ecb67e176608e9481294d9/linkml/generators/csvgen.py#L48-L51
  Something to take a closer look at later.