### PR TITLE
Emit a warning from JsonSchemaGenerator when the top_class option doesn't correspond to an actual class name

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -181,6 +181,10 @@ class JsonSchemaGenerator(Generator):
 
         super().__post_init__()
 
+        if self.top_class:
+            if self.schemaview.get_class(self.top_class) is None:
+                logging.warning(f"No class in schema named {self.top_class}")
+
     def start_schema(self, inline: bool = False) -> JsonSchema:
         self.inline = inline
 

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -246,6 +246,11 @@ def test_empty_inlined_as_dict_objects(subtests, input_path):
     external_file_test(subtests, input_path("jsonschema_empty_inlined_as_dict_objects.yaml"))
 
 
+def test_missing_top_class(input_path, caplog):
+    JsonSchemaGenerator(input_path("kitchen_sink.yaml"), top_class="NotARealClass")
+    assert "No class in schema named NotARealClass" in caplog.text
+
+
 # **********************************************************
 #
 #    Utility functions


### PR DESCRIPTION
Fixes #1175 