### PR TITLE
Fix 1666 - Dont use callables for generated pydantic field defaults

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -125,7 +125,7 @@ class {{ c.name }}
     {%- endif %}
     {% for attr in c.attributes.values() if c.attributes -%}
     {{attr.name}}: {{ attr.annotations['python_range'].value }} = Field(
-    {%- if predefined_slot_values[c.name][attr.name] -%}
+    {%- if predefined_slot_values[c.name][attr.name] is string -%}
         {{ predefined_slot_values[c.name][attr.name] }}
     {%- elif (attr.required or attr.identifier or attr.key) -%}
         ...
@@ -177,7 +177,7 @@ class {{ c.name }}
     {%- endif %}
     {% for attr in c.attributes.values() if c.attributes -%}
     {{attr.name}}: {{ attr.annotations['python_range'].value }} = Field(
-    {%- if predefined_slot_values[c.name][attr.name] -%}
+    {%- if predefined_slot_values[c.name][attr.name] is string -%}
         {{ predefined_slot_values[c.name][attr.name] }}
     {%- elif (attr.required or attr.identifier or attr.key) -%}
         ...

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -125,7 +125,7 @@ class {{ c.name }}
     {%- endif %}
     {% for attr in c.attributes.values() if c.attributes -%}
     {{attr.name}}: {{ attr.annotations['python_range'].value }} = Field(
-    {%- if predefined_slot_values[c.name][attr.name] is string -%}
+    {%- if predefined_slot_values[c.name][attr.name] is not callable -%}
         {{ predefined_slot_values[c.name][attr.name] }}
     {%- elif (attr.required or attr.identifier or attr.key) -%}
         ...
@@ -177,7 +177,7 @@ class {{ c.name }}
     {%- endif %}
     {% for attr in c.attributes.values() if c.attributes -%}
     {{attr.name}}: {{ attr.annotations['python_range'].value }} = Field(
-    {%- if predefined_slot_values[c.name][attr.name] is string -%}
+    {%- if predefined_slot_values[c.name][attr.name] is not callable -%}
         {{ predefined_slot_values[c.name][attr.name] }}
     {%- elif (attr.required or attr.identifier or attr.key) -%}
         ...

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -356,7 +356,8 @@ classes:
         range: string
       values:
         name: values
-        range: string
+        range: integer
+        ifabsent: int(1)
     """
     gen = PydanticGenerator(bad_schema, package=PACKAGE)
     code = gen.serialize()
@@ -365,3 +366,7 @@ classes:
     # doesn't generate a field like
     # keys: Optional[str] = Field(<built-in method keys of dict object at 0x10f1f13c0>)
     mod = compile_python(code, PACKAGE)
+
+    # and we check that we haven't lost defaults when they are set
+    assert mod.BadClass.model_fields['keys'].default is None
+    assert mod.BadClass.model_fields['values'].default == 1

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -1,5 +1,6 @@
 import pytest
 import yaml
+from importlib.metadata import version
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SlotDefinition
@@ -369,5 +370,10 @@ classes:
     mod = compile_python(code, PACKAGE)
 
     # and we check that we haven't lost defaults when they are set
-    assert mod.BadClass.model_fields["keys"].default is None
-    assert mod.BadClass.model_fields["values"].default == 1
+    pydantic_major_version = int(version('pydantic').split('.')[0])
+    if pydantic_major_version >= 2:
+        assert mod.BadClass.model_fields["keys"].default is None
+        assert mod.BadClass.model_fields["values"].default == 1
+    else:
+        assert mod.BadClass.__fields__["keys"].default is None
+        assert mod.BadClass.__fields__["values"].default == 1

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -339,6 +339,7 @@ def test_pydantic_pattern(kitchen_sink_path, tmp_path, input_path):
     with pytest.raises(ValidationError):
         module.Person(id="01", name="x")
 
+
 def test_pydantic_template_1666():
     """
     Regression test for https://github.com/linkml/linkml/issues/1666
@@ -368,5 +369,5 @@ classes:
     mod = compile_python(code, PACKAGE)
 
     # and we check that we haven't lost defaults when they are set
-    assert mod.BadClass.model_fields['keys'].default is None
-    assert mod.BadClass.model_fields['values'].default == 1
+    assert mod.BadClass.model_fields["keys"].default is None
+    assert mod.BadClass.model_fields["values"].default == 1

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -338,3 +338,30 @@ def test_pydantic_pattern(kitchen_sink_path, tmp_path, input_path):
     assert p1.name == "John Doe"
     with pytest.raises(ValidationError):
         module.Person(id="01", name="x")
+
+def test_pydantic_template_1666():
+    """
+    Regression test for https://github.com/linkml/linkml/issues/1666
+    """
+    bad_schema = """
+name: BadSchema
+id: BadSchema
+imports:
+- linkml:types
+classes:
+  BadClass:
+    attributes:
+      keys:
+        name: keys
+        range: string
+      values:
+        name: values
+        range: string
+    """
+    gen = PydanticGenerator(bad_schema, package=PACKAGE)
+    code = gen.serialize()
+    # test fails here if "is_string" check not applied
+    # so the test is just that this completes successfully and
+    # doesn't generate a field like
+    # keys: Optional[str] = Field(<built-in method keys of dict object at 0x10f1f13c0>)
+    mod = compile_python(code, PACKAGE)

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -1,6 +1,7 @@
+from importlib.metadata import version
+
 import pytest
 import yaml
-from importlib.metadata import version
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SlotDefinition
@@ -370,7 +371,7 @@ classes:
     mod = compile_python(code, PACKAGE)
 
     # and we check that we haven't lost defaults when they are set
-    pydantic_major_version = int(version('pydantic').split('.')[0])
+    pydantic_major_version = int(version("pydantic").split(".")[0])
     if pydantic_major_version >= 2:
         assert mod.BadClass.model_fields["keys"].default is None
         assert mod.BadClass.model_fields["values"].default == 1


### PR DESCRIPTION
Fix: https://github.com/linkml/linkml/issues/1666

Bug is described in that issue, problem was that if a field had the same name as a method/attr of a python dict, it would get included as a field like:

```python
class MyClass(BaseModel):
    keys: Optional[str] = Field(<built-in method keys of dict object at 0x10f1f13c0>)
```

which is no good. Simple fix in the template and a regression test :)