### PR TITLE
Total length of data validation formula <= 255 characters for uncorrutped Excel file generation

### DIFF
--- a/docs/generators/excel.rst
+++ b/docs/generators/excel.rst
@@ -33,15 +33,15 @@ that is of enum type will have associated drop downs for all cells corresponding
 Note: It works best for "flat" or denormalized schemas.
 
 Caveat:
-One of the features of ``gen-doc`` is that it has the ability to add Data Validation to columns 
+One of the features of ``gen-excel`` is that it has the ability to add Data Validation to columns 
 that have a range of an enumeration type in the form of dropdowns. A caveat within Microsoft Excel 
 is that the Data Validation list formula is limited to 255 characters, meaning, if the length of 
-all strings (permissible values) in your enumeration exceed 255 characters (combined), then it will 
-result in the creation of a "corrputed" Excel file. You will notice this when you try to open up 
-the Excel file, and Excel will prompt you with an error message saying: *We found a problem with some 
-content in 'xyz.xlsx'. Do you want us to try to recover as much as we can?* In order to avoid any 
-warning pop ups, we are simply turning off dropdown Data Validation for columns constrained by 
-enumerations with total length > 255 characters.
+all strings (permissible values) in your enumeration exceed 255 characters (combined, with separators), 
+then it will result in the creation of a "corrputed" Excel file. You will notice this when you try to 
+open up the Excel file, and Excel will prompt you with an error message saying: *We found a problem 
+with some content in 'xyz.xlsx'. Do you want us to try to recover as much as we can?* In order to 
+avoid any warning pop ups, we are simply turning off dropdown Data Validation for columns constrained 
+by enumerations with total length > 255 characters.
 
 Additional validation support to be added:
 

--- a/linkml/generators/excelgen.py
+++ b/linkml/generators/excelgen.py
@@ -67,10 +67,15 @@ class ExcelGenerator(Generator):
                     if s.range in enum_list:
                         pv_list = list(sv.get_enum(s.range).permissible_values.keys())
 
-                        # Check if the total length of permissible values is <= 255 characters
-                        enum_length = sum(len(value) for value in pv_list)
+                        # Data Validation formula to be applied to the column and
+                        # which will be used to create the dropdown
+                        dv_formula = f'"{",".join(pv_list)}"'
+
+                        # Check if the total length of the data validation formula
+                        # including the separators is <= 255 characters
+                        enum_length = len(dv_formula)
                         if enum_length <= 255:
-                            self.column_enum_validation(workbook, cls_name, s.name, pv_list)
+                            self.column_enum_validation(workbook, cls_name, s.name, dv_formula)
                         else:
                             self.logger.warning(
                                 f"'{s.range}' has permissible values with total "
@@ -103,7 +108,7 @@ class ExcelGenerator(Generator):
         workbook: Workbook,
         worksheet_name: str,
         column_name: str,
-        dropdown_values: List[str],
+        dv_formula: str,
     ) -> None:
         """
         Get worksheet by name and add a dropdown to a specific column in it
@@ -112,7 +117,7 @@ class ExcelGenerator(Generator):
         :param workbook: The workbook to which the worksheet should be added.
         :param worksheet_name: Name of the worksheet to add the column dropdown to.
         :param column_name: Name of the worksheet column to add the dropdown to.
-        :param dropdown_values: List of dropdown values to add to a column in a worksheet.
+        :param dv_formula: Validation formula (as a literal) to be used for the dropdown.
         """
         worksheet = workbook[worksheet_name]
 
@@ -121,7 +126,7 @@ class ExcelGenerator(Generator):
         column_letter = get_column_letter(column_number)
 
         # Create the data validation object and set the dropdown values
-        dv = DataValidation(type="list", formula1=f'"{",".join(dropdown_values)}"', allow_blank=True)
+        dv = DataValidation(type="list", formula1=dv_formula, allow_blank=True)
 
         worksheet.add_data_validation(dv)
 


### PR DESCRIPTION
According to the documentation from MS Excel (can't find the official documentation page from MS): https://stackoverflow.com/questions/70302650/how-to-add-more-than-255-characters-in-a-data-validation-in-xlsxwriter-python, the total length of the data validation formula, and not just the elements in it (that are separated by `,`) must be <= 255 characters.