### PR TITLE
Add util functions for typescript in generator

### DIFF
--- a/linkml/generators/typescriptgen.py
+++ b/linkml/generators/typescriptgen.py
@@ -79,6 +79,7 @@ export interface {{gen.name(c)}} {%- if parents %} extends {{parents|join(', ')}
     {%- endfor %}
 }
 
+{% if gen.gen_type_utils %}
 export function is{{gen.name(c)}}(o: object): o is {{gen.name(c)}} {
     {%- set rcs = gen.required_slots(c) %}
     {%- set comp = "&&" if rcs else "||" %}
@@ -98,6 +99,7 @@ export function to{{gen.name(c)}}(o: {{gen.name(c)}}): {{gen.name(c)}} {
         {%- endfor %}
     }
 }
+{% endif %}
 {% endfor %}
 """
 
@@ -113,6 +115,9 @@ class TypescriptGenerator(OOCodeGenerator):
     generatorversion = "0.0.1"
     valid_formats = ["text"]
     uses_schemaloader = False
+
+    # ObjectVars
+    gen_type_utils: bool = False
 
     def serialize(self) -> str:
         """Serialize a schema to typescript string"""
@@ -255,13 +260,15 @@ class TypescriptGenerator(OOCodeGenerator):
 
 @shared_arguments(TypescriptGenerator)
 @click.version_option(__version__, "-V", "--version")
+@click.option("--gen-type-utils/", "-u", help="Generate Type checking utils", is_flag=True)
 @click.command()
-def cli(yamlfile, **args):
+def cli(yamlfile, gen_type_utils=False, **args):
     """Generate typescript interfaces and types
 
     See https://github.com/linkml/linkml-runtime.js
     """
-    gen = TypescriptGenerator(yamlfile, **args)
+    gen = TypescriptGenerator(yamlfile, gen_type_utils=gen_type_utils, **args)
+    # print(gen.serialize(gen_utils=gen_utils))
     print(gen.serialize())
 
 

--- a/linkml/generators/typescriptgen.py
+++ b/linkml/generators/typescriptgen.py
@@ -70,7 +70,7 @@ export enum {{e.name}} {
 {%- endif -%}
 {% set parents = gen.parents(c) %}
 export interface {{gen.name(c)}} {%- if parents %} extends {{parents|join(', ')}} {%- endif %} {
-    {%- for sn in view.class_slots(c.name, direct=False) %}
+    {%- for sn in view.class_slots(c.name, direct=not(gen.include_induced_slots)) %}
     {% set s = view.induced_slot(sn, c.name) %}
     {%- if s.description -%}
     /** {{s.description}} */
@@ -118,6 +118,7 @@ class TypescriptGenerator(OOCodeGenerator):
 
     # ObjectVars
     gen_type_utils: bool = False
+    include_induced_slots: bool = False
 
     def serialize(self) -> str:
         """Serialize a schema to typescript string"""
@@ -261,14 +262,16 @@ class TypescriptGenerator(OOCodeGenerator):
 @shared_arguments(TypescriptGenerator)
 @click.version_option(__version__, "-V", "--version")
 @click.option("--gen-type-utils/", "-u", help="Generate Type checking utils", is_flag=True)
+@click.option("--include-induced-slots/", help="Generate slots induced through inheritance", is_flag=True)
 @click.command()
-def cli(yamlfile, gen_type_utils=False, **args):
+def cli(yamlfile, gen_type_utils=False, include_induced_slots=False, **args):
     """Generate typescript interfaces and types
 
     See https://github.com/linkml/linkml-runtime.js
     """
-    gen = TypescriptGenerator(yamlfile, gen_type_utils=gen_type_utils, **args)
-    # print(gen.serialize(gen_utils=gen_utils))
+    gen = TypescriptGenerator(
+        yamlfile, gen_type_utils=gen_type_utils, include_induced_slots=include_induced_slots, **args
+    )
     print(gen.serialize())
 
 

--- a/linkml/generators/typescriptgen.py
+++ b/linkml/generators/typescriptgen.py
@@ -72,16 +72,14 @@ export interface {{gen.name(c)}} {%- if parents %} extends {{parents|join(', ')}
 }
 
 export function is{{gen.name(c)}}(o: object): o is {{gen.name(c)}} {
-    {%- set rcs = gen.decorate_strings(gen.required_slots(c), '"', '" in o') %}
-    {%- if rcs %}
+    {%- set rcs = gen.required_slots(c) %}
+    {%- set comp = "&&" if rcs else "||" %}
+    {%- set cs = rcs if rcs else view.class_slots(c.name, direct=False) %}
     return {
-        {{rcs|join(" &&\n        ")}}
+        {%- for sn in cs %}
+        "{{sn}}" in o {%- if not loop.last %} {{comp}}{% endif -%}
+        {%- endfor %}
     }
-    {%- else %}
-    return {
-        {{gen.decorate_strings(view.class_slots(c.name, direct=False), '"', '" in o')|join(" ||\n        ")}}
-     }
-    {%- endif %}
 }
 
 export function to{{gen.name(c)}}(o: {{gen.name(c)}}): {{gen.name(c)}} {
@@ -212,10 +210,6 @@ class TypescriptGenerator(OOCodeGenerator):
 
     def required_slots(self, cls: ClassDefinition) -> List[SlotDefinitionName]:
         return [s for s in self.schemaview.class_slots(cls.name) if self.schemaview.induced_slot(s, cls.name).required]
-
-    @staticmethod
-    def decorate_strings(ss: [str], pre: str, post: str) -> [str]:
-        return [f"{pre}{s}{post}" for s in ss]
 
 
 @shared_arguments(TypescriptGenerator)

--- a/tests/test_generators/test_typescriptgen.py
+++ b/tests/test_generators/test_typescriptgen.py
@@ -26,11 +26,17 @@ def test_required_slots():
     description = SlotDefinition(name="description", multivalued=False, range="string")
     sb.add_class("Person", slots=[id, description])
     schema = sb.schema
-    tss = TypescriptGenerator(schema, mergeimports=True).serialize()
+    tss = TypescriptGenerator(schema, gen_type_utils=True, mergeimports=True).serialize()
     assert "id: string" in tss
     assert "'id' in o" in tss
     assert "description?: string" in tss
     assert "description: o.description ?? ''" in tss
+
+    tss = TypescriptGenerator(schema, mergeimports=True).serialize()
+    assert "id: string" in tss
+    assert "'id' in o" not in tss
+    assert "description?: string" in tss
+    assert "description: o.description ?? ''" not in tss
 
 
 def test_mutlivalued_string():
@@ -42,11 +48,17 @@ def test_mutlivalued_string():
     descriptions = SlotDefinition(name="descriptions", multivalued=True, range="string", required=True)
     sb.add_class("Person", slots=[aliases, descriptions])
     schema = sb.schema
-    tss = TypescriptGenerator(schema, mergeimports=True).serialize()
+    tss = TypescriptGenerator(schema, gen_type_utils=True, mergeimports=True).serialize()
     assert "aliases?: string[]" in tss
     assert "descriptions: string[]" in tss
     assert "'descriptions' in o" in tss
     assert "descriptions: o.descriptions ?? []" in tss
+
+    tss = TypescriptGenerator(schema, mergeimports=True).serialize()
+    assert "aliases?: string[]" in tss
+    assert "descriptions: string[]" in tss
+    assert "'descriptions' in o" not in tss
+    assert "descriptions: o.descriptions ?? []" not in tss
 
 
 def test_enums():

--- a/tests/test_generators/test_typescriptgen.py
+++ b/tests/test_generators/test_typescriptgen.py
@@ -28,7 +28,9 @@ def test_required_slots():
     schema = sb.schema
     tss = TypescriptGenerator(schema, mergeimports=True).serialize()
     assert "id: string" in tss
+    assert "'id' in o" in tss
     assert "description?: string" in tss
+    assert "description: o.description ?? ''" in tss
 
 
 def test_mutlivalued_string():
@@ -37,10 +39,14 @@ def test_mutlivalued_string():
     sb = SchemaBuilder("test")
     sb.add_defaults()
     aliases = SlotDefinition(name="aliases", multivalued=True, range="string")
-    sb.add_class("Person", slots=[aliases])
+    descriptions = SlotDefinition(name="descriptions", multivalued=True, range="string", required=True)
+    sb.add_class("Person", slots=[aliases, descriptions])
     schema = sb.schema
     tss = TypescriptGenerator(schema, mergeimports=True).serialize()
     assert "aliases?: string[]" in tss
+    assert "descriptions: string[]" in tss
+    assert "'descriptions' in o" in tss
+    assert "descriptions: o.descriptions ?? []" in tss
 
 
 def test_enums():


### PR DESCRIPTION
This implements the utility functions in typescript that I mentioned in #1782. This is based on how I use these in a web app I've based on my schema. I'd appreciate any thoughts and feedback on whether I should manage this differently. It's important to remember that typescript compiles out all types during runtime, so types are only checked at compile-time. These helper functions can be used to ensure we conform to the interfaces during runtime.