### PR TITLE
Fix typo in return for is{{interface}}

### DIFF
--- a/linkml/generators/typescriptgen.py
+++ b/linkml/generators/typescriptgen.py
@@ -84,11 +84,11 @@ export function is{{gen.name(c)}}(o: object): o is {{gen.name(c)}} {
     {%- set rcs = gen.required_slots(c) %}
     {%- set comp = "&&" if rcs else "||" %}
     {%- set cs = rcs if rcs else view.class_slots(c.name, direct=False) %}
-    return {
+    return (
         {%- for sn in cs %}
         '{{sn}}' in o {%- if not loop.last %} {{comp}}{% endif -%}
         {%- endfor %}
-    }
+    )
 }
 
 export function to{{gen.name(c)}}(o: {{gen.name(c)}}): {{gen.name(c)}} {


### PR DESCRIPTION
Sorry, I just noticed a fairly significant error in the return for one of the generated utilities. I had a bracket { instead of a parens (.