### PR TITLE
Traverse class ancestors looking for rules to apply in JSON Schema output

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -83,7 +83,9 @@ class JsonSchema(UserDict):
                 lax_cls["required"].remove(identifier_name)
                 self["$defs"][canonical_name + self.OPTIONAL_IDENTIFIER_SUFFIX] = lax_cls
 
-    def add_property(self, name: str, subschema: "JsonSchema", required: bool = False) -> None:
+    def add_property(
+        self, name: str, subschema: "JsonSchema", *, value_required: bool = False, value_disallowed: bool = False
+    ) -> None:
         canonical_name = underscore(name)
 
         if "properties" not in self:
@@ -91,11 +93,31 @@ class JsonSchema(UserDict):
 
         self["properties"][canonical_name] = subschema
 
-        if required:
+        if value_required:
             if "required" not in self:
                 self["required"] = []
 
             self["required"].append(canonical_name)
+
+        # JSON Schema does not have a very natural way to express that a property cannot be present.
+        # The apparent best way to do it is to use:
+        # {
+        #   properties: {
+        #     foo: ...
+        #   },
+        #   not: {
+        #     required: ['foo']
+        #   }
+        # }
+        # The {required: [foo]} subschema evaluates to true if the foo property is present with any
+        # value. Wrapping that in a `not` keyword inverts that condition.
+        if value_disallowed:
+            if "not" not in self:
+                self["not"] = {}
+            if "required" not in self["not"]:
+                self["not"]["required"] = []
+
+            self["not"]["required"].append(canonical_name)
 
     def add_keyword(self, keyword: str, value: Any):
         if value is None:
@@ -220,42 +242,44 @@ class JsonSchemaGenerator(Generator):
             self.handle_class_slot(subschema=class_subschema, cls=cls, slot=slot_definition)
 
         rule_subschemas = []
-        for rule in cls.rules:
-            subschema = JsonSchema()
+        for ancestor_class_name in self.schemaview.class_ancestors(cls.name):
+            ancestor_class = self.schemaview.get_class(ancestor_class_name)
+            for rule in ancestor_class.rules:
+                subschema = JsonSchema()
 
-            open_world = rule.open_world
-            if open_world is None:
-                open_world = False
+                open_world = rule.open_world
+                if open_world is None:
+                    open_world = False
 
-            if_subschema = self.get_subschema_for_anonymous_class(rule.preconditions, properties_required=True)
-            if if_subschema:
-                subschema["if"] = if_subschema
-
-            then_subschema = self.get_subschema_for_anonymous_class(
-                rule.postconditions, properties_required=not open_world
-            )
-            if then_subschema:
-                subschema["then"] = then_subschema
-
-            # same as required requirements as postconditions?
-            else_subschema = self.get_subschema_for_anonymous_class(
-                rule.elseconditions, properties_required=not open_world
-            )
-            if else_subschema:
-                subschema["else"] = else_subschema
-
-            rule_subschemas.append(subschema)
-
-            if rule.bidirectional:
-                inverse_subschema = JsonSchema()
-
-                if then_subschema:
-                    inverse_subschema["if"] = then_subschema
-
+                if_subschema = self.get_subschema_for_anonymous_class(rule.preconditions, properties_required=True)
                 if if_subschema:
-                    inverse_subschema["then"] = if_subschema
+                    subschema["if"] = if_subschema
 
-                rule_subschemas.append(inverse_subschema)
+                then_subschema = self.get_subschema_for_anonymous_class(
+                    rule.postconditions, properties_required=not open_world
+                )
+                if then_subschema:
+                    subschema["then"] = then_subschema
+
+                # same as required requirements as postconditions?
+                else_subschema = self.get_subschema_for_anonymous_class(
+                    rule.elseconditions, properties_required=not open_world
+                )
+                if else_subschema:
+                    subschema["else"] = else_subschema
+
+                rule_subschemas.append(subschema)
+
+                if rule.bidirectional:
+                    inverse_subschema = JsonSchema()
+
+                    if then_subschema:
+                        inverse_subschema["if"] = then_subschema
+
+                    if if_subschema:
+                        inverse_subschema["then"] = if_subschema
+
+                    rule_subschemas.append(inverse_subschema)
 
         if len(rule_subschemas) == 1:
             class_subschema.update(rule_subschemas[0])
@@ -285,20 +309,20 @@ class JsonSchemaGenerator(Generator):
         subschema = JsonSchema()
         for slot in cls.slot_conditions.values():
             prop = self.get_subschema_for_slot(slot, omit_type=True)
+            value_required = False
+            value_disallowed = False
             if slot.value_presence:
                 if slot.value_presence == PresenceEnum(PresenceEnum.PRESENT):
-                    this_properties_required = True
+                    value_required = True
                 elif slot.value_presence == PresenceEnum(PresenceEnum.ABSENT):
-                    this_properties_required = False
-                    # make the slot unsatisfiable
-                    prop["enum"] = []
-                else:
-                    this_properties_required = False
+                    value_disallowed = True
             elif slot.required is not None:
-                this_properties_required = slot.required
+                value_required = slot.required
             else:
-                this_properties_required = properties_required
-            subschema.add_property(self.aliased_slot_name(slot), prop, this_properties_required)
+                value_required = properties_required
+            subschema.add_property(
+                self.aliased_slot_name(slot), prop, value_required=value_required, value_disallowed=value_disallowed
+            )
 
         if cls.any_of is not None and len(cls.any_of) > 0:
             subschema["anyOf"] = [self.get_subschema_for_anonymous_class(c, properties_required) for c in cls.any_of]
@@ -343,7 +367,9 @@ class JsonSchemaGenerator(Generator):
             enum_schema["enum"] = permissible_values_texts
         self.top_level_schema.add_def(enum.name, enum_schema)
 
-    def get_type_info_for_slot_subschema(self, slot: AnonymousSlotExpression) -> Tuple[str, str, Union[str, List[str]]]:
+    def get_type_info_for_slot_subschema(
+        self, slot: Union[SlotDefinition, AnonymousSlotExpression]
+    ) -> Tuple[str, str, Union[str, List[str]]]:
         # JSON Schema type (https://json-schema.org/understanding-json-schema/reference/type.html)
         typ = None
         # Reference to a JSON schema entity (https://json-schema.org/understanding-json-schema/structuring.html#ref)
@@ -379,7 +405,7 @@ class JsonSchemaGenerator(Generator):
 
         return (typ, fmt, reference)
 
-    def get_value_constraints_for_slot(self, slot: Union[AnonymousSlotExpression, None]) -> JsonSchema:
+    def get_value_constraints_for_slot(self, slot: Union[SlotDefinition, AnonymousSlotExpression, None]) -> JsonSchema:
         if slot is None:
             return JsonSchema()
 
@@ -397,11 +423,6 @@ class JsonSchemaGenerator(Generator):
         constraints.add_keyword("maximum", slot.maximum_value)
         constraints.add_keyword("const", slot.equals_string)
         constraints.add_keyword("const", slot.equals_number)
-        if slot.value_presence:
-            if slot.value_presence == PresenceEnum(PresenceEnum.PRESENT):
-                constraints.add_keyword("required", True)
-            elif slot.value_presence == PresenceEnum(PresenceEnum.ABSENT):
-                constraints.add_keyword("enum", [])
         return constraints
 
     def get_subschema_for_slot(self, slot: SlotDefinition, omit_type: bool = False) -> JsonSchema:
@@ -503,11 +524,16 @@ class JsonSchemaGenerator(Generator):
 
     def handle_class_slot(self, subschema: JsonSchema, cls: ClassDefinition, slot: SlotDefinition) -> None:
         class_id_slot = self.schemaview.get_identifier_slot(cls.name, use_key=True)
-        slot_is_required = slot.required or slot == class_id_slot
+        value_required = (
+            slot.required or slot == class_id_slot or slot.value_presence == PresenceEnum(PresenceEnum.PRESENT)
+        )
+        value_disallowed = slot.value_presence == PresenceEnum(PresenceEnum.ABSENT)
 
         aliased_slot_name = self.aliased_slot_name(slot)
         prop = self.get_subschema_for_slot(slot)
-        subschema.add_property(aliased_slot_name, prop, slot_is_required)
+        subschema.add_property(
+            aliased_slot_name, prop, value_required=value_required, value_disallowed=value_disallowed
+        )
 
         if slot.designates_type:
             type_value = get_type_designator_value(self.schemaview, slot, cls)

--- a/tests/test_generators/input/jsonschema_required_slot_condition_in_rule.yaml
+++ b/tests/test_generators/input/jsonschema_required_slot_condition_in_rule.yaml
@@ -11,6 +11,9 @@ schema:
   slots:
     drivers_license_number:
     role:
+    gas_money:
+      range: float
+      required: true
 
   classes:
     CarOccupant:
@@ -18,8 +21,12 @@ schema:
       slots:
         - role
         - drivers_license_number
+        - gas_money
       rules:
         - title: drivers need licenses
+          description: >-
+            this rule verifies that a slot can be flipped from non-required to required in a
+            postcondition and that asserting required: false in the elsecondition is a no-op.
           preconditions:
             slot_conditions:
               role:
@@ -32,16 +39,44 @@ schema:
             slot_conditions:
               drivers_license_number:
                 required: false
+        - title: driver doesn't have to pay for gas
+          description: >-
+            this rule verifies that a slot can be flipped from required to non-required in a
+            postcondition and that asserting required: true in the elsecondition is a no-op.
+          preconditions:
+            slot_conditions:
+              role:
+                equals_string: driver
+          postconditions:
+            slot_conditions:
+              gas_money:
+                required: false
+          elseconditions:
+            slot_conditions:
+              gas_money:
+                required: true
 
 data_cases:
   - data:
       role: driver
       drivers_license_number: ABC123
+      gas_money: 10.0
   - data:
       role: driver
-    error_message: "required"
+      gas_money: 10.0
+    error_message: "drivers_license_number"
+# TODO: Making a slot NOT required in a rule doesn't currently work
+# https://github.com/linkml/linkml/issues/1803
+#  - data:
+#      role: driver
+#      drivers_license_number: ABC123
   - data:
       role: passenger
       drivers_license_number: ABC123
+      gas_money: 10.0
   - data:
       role: passenger
+      gas_money: 10.0
+  - data:
+      role: passenger
+    error_message: "gas_money"

--- a/tests/test_generators/input/jsonschema_rule_inheritance.yaml
+++ b/tests/test_generators/input/jsonschema_rule_inheritance.yaml
@@ -1,0 +1,43 @@
+schema:
+  id: https://example.org/test
+  name: test
+
+  prefixes:
+    linkml: https://w3id.org/linkml/
+  imports:
+    - linkml:types
+
+  default_range: integer
+
+  classes:
+    MyClass:
+      attributes:
+        a:
+        b:
+      rules:
+        - description: if a is big then b is small
+          preconditions:
+            slot_conditions:
+              a:
+                minimum_value: 100
+          postconditions:
+            slot_conditions:
+              b:
+                maximum_value: 10
+    MySubClass:
+      is_a: MyClass
+      tree_root: true
+      attributes:
+        c:
+
+data_cases:
+  - data:
+      a: 1000
+      b: 1
+  - data:
+      a: 1
+      b: 1000
+  - data:
+      a: 1000
+      b: 2000
+    error_message: "2000 is greater than the maximum"

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -257,6 +257,12 @@ def test_missing_top_class(input_path, caplog):
     assert "No class in schema named NotARealClass" in caplog.text
 
 
+def test_rule_inheritance(subtests, input_path):
+    """Tests that rules are inherited from superclasses"""
+
+    external_file_test(subtests, input_path("jsonschema_rule_inheritance.yaml"))
+
+
 # **********************************************************
 #
 #    Utility functions


### PR DESCRIPTION
These changes might warrant a bit of discussion. 

You can see a use case described in #1802. In that very simple scenario I think it seems intuitive that `MySubClass` would inherit the `rules` defined on `MyClass`. However it becomes murky if _both_ `MySubClass` and `MyClass` define `rules`. Should it be additive and all `rules` from both levels of the hierarchy apply? Should the subclass `rules` replace the superclass `rules`? Should a subclass be allowed to remove the `rules` of a superclass without adding any of its own? Or maybe all of this is going against the metamodel because [`rules`](https://github.com/linkml/linkml-model/blob/f953f6b224960b4e12d071906264e4c4fa47935e/linkml_model/model/schema/meta.yaml#L1186-L1194) is not marked with `inherited: true` in the first place? 

Separately these changes also clean up the way `value_presence` is translated into JSON Schema. Previously the generator emitted `enum: []` when it encountered `value_presence: ABSENT`. It also emitted this when encountering `value_presence: PRESENT`:
```json
"properties": {
  "my_slot": {
     "required": true
  }
}
```
Both of these are non-standard JSON Schema ([`enum` should not be empty](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2) and [`required` must be an array of strings](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3)), and a strict JSON Schema validator would not accept it. Admittedly, making fields required is one of _the most annoying things_ about JSON Schema because it doesn't follow the same patterns as other keywords (like `minimum` or `pattern`, for example). It also makes it really awkward to express "a value is not permitted" (a la `value_presence: ABSENT`). As far as I can tell the most standard way to do it looks like this:
```json
{
  "properties": {
    "value_must_be_present": {
      "type": "string"
    },
    "value_must_be_absent": {
      "type": "string"
    }
  },
  "required": [
    "value_must_be_present",
  ],
  "not": {
    "required": ["value_must_be_absent"]
  },
  "title": "test",
  "type": "object"
}
```
The `"required": ["value_must_be_absent"]` subschema evaluates to True if the `value_must_be_absent` field has any value and wrapping that in a `not` keyword inverts that. So it really is saying "no value is allowed" despite looking like it's saying it's simply not required. Again, `required` in JSON Schema is extremely unintuitive. 

In fleshing out some of those `required` keyword changes I tried adding some additional test cases to an existing test and realized we're not handling this one: https://github.com/linkml/linkml/issues/1803. That one could be a bit icky to figure out.

I didn't realize at the outset that I was going to be making two somewhat unrelated sets of changes in this branch. If it makes sense to split out the `rules` stuff from the `value_presence` stuff I can do that.

Fixes #1802 