### PR TITLE
Allow non-object types in JSON Schema generated from unconstrained classes

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -189,7 +189,7 @@ class JsonSchemaGenerator(Generator):
 
         self.top_level_schema = JsonSchema(
             {
-                "$schema": "http://json-schema.org/draft-07/schema#",
+                "$schema": "https://json-schema.org/draft/2019-09/schema",
                 "$id": self.schema.id,
                 "metamodel_version": metamodel_version,
                 "version": self.schema.version if self.schema.version else None,

--- a/linkml/linter/linter.py
+++ b/linkml/linter/linter.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import lru_cache
@@ -38,7 +37,7 @@ def get_named_config(name: str) -> Dict[str, Any]:
 @lru_cache
 def get_metamodel_validator() -> jsonschema.Validator:
     meta_json_gen = JsonSchemaGenerator(LOCAL_METAMODEL_YAML_FILE, not_closed=False)
-    meta_json_schema = json.loads(meta_json_gen.serialize())
+    meta_json_schema = meta_json_gen.generate()
     validator = jsonschema.Draft7Validator(meta_json_schema)
     return validator
 

--- a/linkml/linter/linter.py
+++ b/linkml/linter/linter.py
@@ -38,7 +38,8 @@ def get_named_config(name: str) -> Dict[str, Any]:
 def get_metamodel_validator() -> jsonschema.Validator:
     meta_json_gen = JsonSchemaGenerator(LOCAL_METAMODEL_YAML_FILE, not_closed=False)
     meta_json_schema = meta_json_gen.generate()
-    validator = jsonschema.Draft7Validator(meta_json_schema)
+    validator_cls = jsonschema.validators.validator_for(meta_json_schema, default=jsonschema.Draft7Validator)
+    validator = validator_cls(meta_json_schema, format_checker=validator_cls.FORMAT_CHECKER)
     return validator
 
 

--- a/linkml/validator/plugins/jsonschema_validation_plugin.py
+++ b/linkml/validator/plugins/jsonschema_validation_plugin.py
@@ -1,7 +1,6 @@
 import os
 from typing import Any, Iterator, Optional
 
-import jsonschema
 from jsonschema.exceptions import best_match
 
 from linkml.validator.plugins.validation_plugin import ValidationPlugin
@@ -41,12 +40,11 @@ class JsonschemaValidationPlugin(ValidationPlugin):
         :return: Iterator over validation results
         :rtype: Iterator[ValidationResult]
         """
-        json_schema = context.json_schema(
+        validator = context.json_schema_validator(
             closed=self.closed,
             include_range_class_descendants=self.include_range_class_descendants,
             path_override=self.json_schema_path,
         )
-        validator = jsonschema.Draft7Validator(json_schema, format_checker=jsonschema.Draft7Validator.FORMAT_CHECKER)
         for error in validator.iter_errors(instance):
             best_error = best_match([error])
             yield ValidationResult(

--- a/linkml/validator/validation_context.py
+++ b/linkml/validator/validation_context.py
@@ -3,6 +3,7 @@ import os
 from functools import lru_cache
 from typing import Optional
 
+import jsonschema
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import SchemaDefinition
 
@@ -29,26 +30,29 @@ class ValidationContext:
         return self._target_class
 
     @lru_cache
-    def json_schema(
+    def json_schema_validator(
         self,
         *,
         closed: bool,
         include_range_class_descendants: bool,
         path_override: Optional[os.PathLike] = None,
-    ):
+    ) -> jsonschema.Validator:
         if path_override:
             with open(path_override) as json_schema_file:
-                return json.load(json_schema_file)
+                json_schema = json.load(json_schema_file)
+        else:
+            not_closed = not closed
+            jsonschema_gen = JsonSchemaGenerator(
+                schema=self._schema,
+                mergeimports=True,
+                top_class=self._target_class,
+                not_closed=not_closed,
+                include_range_class_descendants=include_range_class_descendants,
+            )
+            json_schema = jsonschema_gen.generate()
 
-        not_closed = not closed
-        jsonschema_gen = JsonSchemaGenerator(
-            schema=self._schema,
-            mergeimports=True,
-            top_class=self._target_class,
-            not_closed=not_closed,
-            include_range_class_descendants=include_range_class_descendants,
-        )
-        return jsonschema_gen.generate()
+        validator_cls = jsonschema.validators.validator_for(json_schema, default=jsonschema.Draft7Validator)
+        return validator_cls(json_schema, format_checker=validator_cls.FORMAT_CHECKER)
 
     def pydantic_model(self, *, closed: bool):
         module = self._pydantic_module(closed=closed)

--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -105,7 +105,8 @@ class JsonSchemaDataValidator(DataValidator):
         jsonschema_obj = _generate_jsonschema(
             self._hashable_schema, target_class_name, closed, self.include_range_class_descendants
         )
-        validator = jsonschema.Draft7Validator(jsonschema_obj, format_checker=jsonschema.Draft7Validator.FORMAT_CHECKER)
+        validator_cls = jsonschema.validators.validator_for(jsonschema_obj, default=jsonschema.Draft7Validator)
+        validator = validator_cls(jsonschema_obj, format_checker=validator_cls.FORMAT_CHECKER)
         for error in validator.iter_errors(data):
             best_error = best_match([error])
             # TODO: This should return some kind of standard validation result

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -113,7 +113,7 @@ def test_compliance_cases(kitchen_sink_path, input_path, subtests):
                 jsonschema.validate(
                     dataset,
                     schema,
-                    format_checker=jsonschema.Draft7Validator.FORMAT_CHECKER,
+                    format_checker=jsonschema.Draft201909Validator.FORMAT_CHECKER,
                 )
 
             if expected_valid:

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -65,7 +65,16 @@ def test_class_uri_any(kitchen_sink_path, subtests):
     See also https://github.com/linkml/linkml/issues/579
     """
 
-    assert_schema_validates(subtests, kitchen_sink_path, {"$defs": {"AnyObject": {"additionalProperties": True}}})
+    expected_json_schema_subset = {"$defs": {"AnyObject": {"additionalProperties": True}}}
+    data_cases = [
+        {"data": {"metadata": {"anything": {"goes": "here"}}}},
+        {"data": {"metadata": "anything goes here"}},
+        {"data": {"metadata": 0}},
+        {"data": {"metadata": None}},
+        {"data": {"metadata": True}},
+        {"data": {"metadata": ["array", "not", "allowed"]}, "error_message": "is not of type"},
+    ]
+    assert_schema_validates(subtests, kitchen_sink_path, expected_json_schema_subset, data_cases)
 
 
 def test_compliance_cases(kitchen_sink_path, input_path, subtests):

--- a/tests/test_issues/__snapshots__/issue_120.json
+++ b/tests/test_issues/__snapshots__/issue_120.json
@@ -27,7 +27,7 @@
         }
     },
     "$id": "http://example.org/sample/example1",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "metamodel_version": "1.7.0",
     "title": "example1",

--- a/tests/test_issues/__snapshots__/issue_177.json
+++ b/tests/test_issues/__snapshots__/issue_177.json
@@ -27,7 +27,7 @@
         }
     },
     "$id": "http://example.org/tests/issue177",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "description": "",
     "metamodel_version": "1.7.0",

--- a/tests/test_issues/__snapshots__/issue_202.json.schema
+++ b/tests/test_issues/__snapshots__/issue_202.json.schema
@@ -14,7 +14,7 @@
         }
     },
     "$id": "http://example.org/sample/example1",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "metamodel_version": "1.7.0",
     "title": "example1",

--- a/tests/test_issues/__snapshots__/issue_239.json
+++ b/tests/test_issues/__snapshots__/issue_239.json
@@ -43,7 +43,7 @@
         }
     },
     "$id": "http://example.org/sample/types",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "metamodel_version": "1.7.0",
     "title": "types",

--- a/tests/test_issues/__snapshots__/linkml_issue_388.owl
+++ b/tests/test_issues/__snapshots__/linkml_issue_388.owl
@@ -8,26 +8,26 @@
 this:C2 a owl:Class ;
     rdfs:label "C2" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty this:a ],
         [ a owl:Restriction ;
             owl:allValuesFrom this:my_int ;
             owl:onProperty this:a ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty this:a ] ;
     skos:inScheme <https://w3id.org/linkml/examples/personinfo> .
 
 this:C3 a owl:Class ;
     rdfs:label "C3" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty this:a ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty this:a ],
         [ a owl:Restriction ;
             owl:allValuesFrom this:C1 ;
+            owl:onProperty this:a ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty this:a ] ;
     skos:inScheme <https://w3id.org/linkml/examples/personinfo> .
 
@@ -37,10 +37,10 @@ this:C1 a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty this:a ],
         [ a owl:Restriction ;
-            owl:allValuesFrom this:my_str ;
+            owl:maxCardinality 1 ;
             owl:onProperty this:a ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom this:my_str ;
             owl:onProperty this:a ] ;
     skos:inScheme <https://w3id.org/linkml/examples/personinfo> .
 

--- a/tests/test_issues/__snapshots__/linkml_issue_388.schema.json
+++ b/tests/test_issues/__snapshots__/linkml_issue_388.schema.json
@@ -38,7 +38,7 @@
         }
     },
     "$id": "https://w3id.org/linkml/examples/personinfo",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "metamodel_version": "1.7.0",
     "title": "personinfo",

--- a/tests/test_issues/__snapshots__/linkml_issue_388.ttl
+++ b/tests/test_issues/__snapshots__/linkml_issue_388.ttl
@@ -6,12 +6,12 @@
 <https://example.org/this/personinfo> a linkml:SchemaDefinition ;
     sh:declare [ sh:namespace <https://example.org/this/> ;
             sh:prefix "this" ],
-        [ sh:namespace <https://example.org/other/> ;
-            sh:prefix "other" ],
         [ sh:namespace linkml: ;
             sh:prefix "linkml" ],
         [ sh:namespace xsd: ;
-            sh:prefix "xsd" ] ;
+            sh:prefix "xsd" ],
+        [ sh:namespace <https://example.org/other/> ;
+            sh:prefix "other" ] ;
     linkml:classes <https://example.org/this/C1>,
         <https://example.org/this/C2>,
         <https://example.org/this/C3> ;

--- a/tests/test_scripts/__snapshots__/genjsonschema/meta.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/meta.json
@@ -7913,7 +7913,7 @@
         }
     },
     "$id": "https://w3id.org/linkml/meta",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "description": "A collection of definitions that make up a schema or a data model.",
     "metamodel_version": "1.7.0",

--- a/tests/test_scripts/__snapshots__/genjsonschema/meta.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/meta.json
@@ -871,13 +871,25 @@
             "additionalProperties": true,
             "description": "",
             "title": "AnyValue",
-            "type": "object"
+            "type": [
+                "null",
+                "boolean",
+                "object",
+                "number",
+                "string"
+            ]
         },
         "Anything": {
             "additionalProperties": true,
             "description": "",
             "title": "Anything",
-            "type": "object"
+            "type": [
+                "null",
+                "boolean",
+                "object",
+                "number",
+                "string"
+            ]
         },
         "ClassDefinition": {
             "additionalProperties": false,

--- a/tests/test_scripts/__snapshots__/genjsonschema/meta_inline.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/meta_inline.json
@@ -7913,7 +7913,7 @@
         }
     },
     "$id": "https://w3id.org/linkml/meta",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "description": "A collection of definitions that make up a schema or a data model.",
     "metamodel_version": "1.7.0",

--- a/tests/test_scripts/__snapshots__/genjsonschema/meta_inline.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/meta_inline.json
@@ -871,13 +871,25 @@
             "additionalProperties": true,
             "description": "",
             "title": "AnyValue",
-            "type": "object"
+            "type": [
+                "null",
+                "boolean",
+                "object",
+                "number",
+                "string"
+            ]
         },
         "Anything": {
             "additionalProperties": true,
             "description": "",
             "title": "Anything",
-            "type": "object"
+            "type": [
+                "null",
+                "boolean",
+                "object",
+                "number",
+                "string"
+            ]
         },
         "ClassDefinition": {
             "additionalProperties": false,

--- a/tests/test_scripts/__snapshots__/genjsonschema/roottest.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/roottest.json
@@ -14,7 +14,7 @@
         }
     },
     "$id": "http://example.org/tests/issue177",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "description": "",
     "metamodel_version": "1.7.0",

--- a/tests/test_scripts/__snapshots__/genjsonschema/roottest2.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/roottest2.json
@@ -14,7 +14,7 @@
         }
     },
     "$id": "http://example.org/tests/issue177",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "description": "",
     "metamodel_version": "1.7.0",

--- a/tests/test_scripts/__snapshots__/genjsonschema/roottest3.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/roottest3.json
@@ -14,7 +14,7 @@
         }
     },
     "$id": "http://example.org/tests/issue177",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": false,
     "description": "",
     "metamodel_version": "1.7.0",

--- a/tests/test_scripts/__snapshots__/genjsonschema/roottest4.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/roottest4.json
@@ -14,7 +14,7 @@
         }
     },
     "$id": "http://example.org/tests/issue177",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "additionalProperties": true,
     "description": "",
     "metamodel_version": "1.7.0",


### PR DESCRIPTION
Fixes #1691 

The root cause of the issue lies in a metamodel change in the 1.6 release. [This commit](https://github.com/linkml/linkml-model/commit/799b549be473f9628f2ddc297f4d71dd6a181034) changed the range of an annotation value from string to a class with `class_uri: linkml:Any`. 

When interpreting a class with `class_uri: linkml:Any`, the JSON Schema generator previously asserted that the value must be an **object**, albeit one with any attributes. For example, with this schema (abridged):

```yaml
# schema.yaml
classes:
  Anything:
    class_uri: linkml:Any
  MyClass:
    tree_root: true
    attributes:
      anything:
        range: Anything
```

This instance was considered valid:

```yaml
# data-valid.yaml
anything:
  a: 1
  b: 
    c: hello
```

However this instance was considered invalid:

```yaml
# data-invalid.yaml
anything: no good
```

With these changes the JSON Schema generator will produce JSON Schema that admits **any** scalar type (object, string, number, boolean, or null) as the value for a range marked with `class_uri: linkml:Any`, and so both of the above instances would be considered valid. Likewise this means that the pre-1.6 behavior of allowing simple strings as an annotation `value` is allowed again. 

These changes also do a little cleanup where a utility class was previously inheriting from `UserDict` instead of `dict`, even though we weren't actually using any of the features of `UserDict`. On the contrary there were some edge cases where passing a `UserDict` subclass to the `jsonschema` library functions was problematic. 

* * *

### Update

The compliance test suite identified an issue with the initial fix. Namely when a LinkML schema contains:

```yaml
s1:
  range: Any  # A class with class_uri: linkml:Any
  any_of:
    - range: D  # Just some other class
    - range: integer
```

The test expects for validation to fail on an instance like:

```yaml
s1: some string
```

Since the `any_of` range union is more specific than the `range` itself that makes sense. That LinkML schema gets translated pretty directly into JSON Schema that looks like:

```json
"s1": {
  "$ref": "#/$defs/Any",
  "anyOf": [
    { "$ref": "#/$defs/D" }, 
    { "type": "integer" }
  ]
}
```

The crucial piece of the puzzle here is that the JSON Schema generator has been specifying that the output it generates is compatible with JSON Schema Draft 7 (i.e. `"$schema": "http://json-schema.org/draft-07/schema#"`). However the Draft 7 spec says that when `$ref` is seen in a subschema then its sibling keywords (`anyOf` in the above example) are **not** processed. 

So before these changes the `"$ref": "#/$defs/Any"` was checking for an object with any keys. If it found a string instead (as in the above example), it failed and then stopped without checking the `anyOf` subschema. Which means the test was passing, but not exactly for the right reason.

With the initial fix the `"$ref": "#/$defs/Any"` checks for any scalar type. A string passes that check, but it still stops without checking the `anyOf`. Fortunately the JSON Schema authors seem to also realize the limitation of this, and in the JSON Schema Draft 2019-09 spec they changed it so that the sibling keywords of `$ref` are checked as well (https://json-schema.org/draft/2019-09/release-notes#core-vocabulary).

So the final change here is to update the JSON Schema generator to advertise that this later version of the spec should be used in validation (i.e. `"$schema": "https://json-schema.org/draft/2019-09/schema"`). Previously in our validation code we used to hardcode the use of a Draft 7 validator. These changes update that to choose a validator based on what the JSON Schema itself asserts ([see also](https://python-jsonschema.readthedocs.io/en/stable/api/jsonschema/validators/#jsonschema.validators.validator_for)). With that final change when the JSON Schema of the above example is encountered the `"$ref": "#/$defs/Any"` part still passes validation for a string, but the `anyOf` subschema _is also_ checked and it fails as expected.

A number of test snapshot files also had to be updated as a consequence of changing the JSON Schema generator output.