### PR TITLE
Use `-->` for for class-to-class relationships based on slots

### DIFF
--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -13,7 +13,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --|> {{ s.range }} : {{ gen.name(s) }}
+          {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -27,7 +27,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --|> {{ s.range }} : {{ gen.name(s) }}
+          {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -41,7 +41,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --|> {{ s.range }} : {{ gen.name(s) }}
+          {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -52,7 +52,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --|> {{ s.range }} : {{ gen.name(s) }}
+          {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
         {% endif %}
       {% endfor %}
 ```


### PR DESCRIPTION
Arrowheads in Mermaid class diagrams between classes that are related by slots should be the non-solid directed arrow/link.

Mermaid [syntax](https://mermaid.js.org/syntax/classDiagram.html) for that kind of an arrow: `-->`