### PR TITLE
linkml-lint: ignore dot files by default

### DIFF
--- a/tests/test_linter/test_cli.py
+++ b/tests/test_linter/test_cli.py
@@ -217,6 +217,108 @@ slots:
             self.assertIn(str(schema_b), result.stdout)
             self.assertIn("Slot has name 'a slot'", result.stdout)
 
+    def test_ignores_dot_file_in_directory_when_all_option_omitted(self):
+        schema_dir = Path("schemas")
+        schema_a = schema_dir / "schema_a.yaml"
+        schema_b = schema_dir / ".schema_b.yaml"
+        with self.runner.isolated_filesystem():
+            schema_dir.mkdir()
+            schema_a.write_text(
+                """
+id: http://example.org/test_a
+name: test_a
+
+classes:
+  person:
+    description: An individual human
+"""
+            )
+            schema_b.write_text(
+                """
+id: http://example.org/test_b
+name: test_b
+
+slots:
+  a slot:
+    description: A slot to hold thing
+"""
+            )
+
+            result = self.runner.invoke(main, [str(schema_dir)])
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn(str(schema_a), result.stdout)
+            self.assertIn("Class has name 'person'", result.stdout)
+            self.assertNotIn(str(schema_b), result.stdout)
+            self.assertNotIn("Slot has name 'a slot'", result.stdout)
+
+    def test_processes_dot_files_in_directory_when_a_option_provided(self):
+        schema_dir = Path("schemas")
+        schema_a = schema_dir / "schema_a.yaml"
+        schema_b = schema_dir / ".schema_b.yaml"
+        with self.runner.isolated_filesystem():
+            schema_dir.mkdir()
+            schema_a.write_text(
+                """
+id: http://example.org/test_a
+name: test_a
+
+classes:
+  person:
+    description: An individual human
+"""
+            )
+            schema_b.write_text(
+                """
+id: http://example.org/test_b
+name: test_b
+
+slots:
+  a slot:
+    description: A slot to hold thing
+"""
+            )
+
+            result = self.runner.invoke(main, ["-a", str(schema_dir)])
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn(str(schema_a), result.stdout)
+            self.assertIn("Class has name 'person'", result.stdout)
+            self.assertIn(str(schema_b), result.stdout)
+            self.assertIn("Slot has name 'a slot'", result.stdout)
+
+    def test_processes_dot_files_in_directory_when_all_option_provided(self):
+        schema_dir = Path("schemas")
+        schema_a = schema_dir / "schema_a.yaml"
+        schema_b = schema_dir / ".schema_b.yaml"
+        with self.runner.isolated_filesystem():
+            schema_dir.mkdir()
+            schema_a.write_text(
+                """
+id: http://example.org/test_a
+name: test_a
+
+classes:
+  person:
+    description: An individual human
+"""
+            )
+            schema_b.write_text(
+                """
+id: http://example.org/test_b
+name: test_b
+
+slots:
+  a slot:
+    description: A slot to hold thing
+"""
+            )
+
+            result = self.runner.invoke(main, ["--all", str(schema_dir)])
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn(str(schema_a), result.stdout)
+            self.assertIn("Class has name 'person'", result.stdout)
+            self.assertIn(str(schema_b), result.stdout)
+            self.assertIn("Slot has name 'a slot'", result.stdout)
+
     def test_validate_schema(self):
         with self.runner.isolated_filesystem():
             with open(SCHEMA_FILE, "w") as f:


### PR DESCRIPTION
Motivation:

The `.yml` / `.yaml` file extension indicates the contents is YAML. YAML is a common format and is used by some non-LinkML tools as their configuration file format.

A common convention on Unix-like systems is that configuration files start with a dot (`.`) character.  Therefore it is relatively common for applications to ignore or hide files that start with a dot when working with the contents of a directory.

Currently, when scanning a directory, linkml-lint will attempt to process all files that have `.yaml` or `.yml` as the file extension. This includes dot files.

While linkml-lint will avoid processing its own configuration file, it will attempt to process any YAML configuration files of other tools. This leads to the tool reporting problems even when the actual LinkML files are fine.

Modification:

Update `linkml-lint` so that, by default, it ignores files that start with a dot.  Introduce a new command-line option (`-a` or `--all`) that overrides this behaviour and includes dot files when scanning a directory.  In either case, linkml-lint avoids its own configuration files (if present).

Result:

When scanning for files in a directory, `linkml-lint` now ignores filenames that start with a dot unless a new command-line option (`-a` or `--all`) is specified.

Closes: #1827