### PR TITLE
gen-json-schema: support taking JSON Schema `title` from `title` slot

### DIFF
--- a/tests/test_generators/input/jsonschema_class_title_from_title.yaml
+++ b/tests/test_generators/input/jsonschema_class_title_from_title.yaml
@@ -1,0 +1,30 @@
+schema:
+  id: https://example.org/test
+  name: MyTestSchema
+  title: "My Test Schema"
+
+  prefixes:
+    linkml: https://w3id.org/linkml/
+  imports:
+    - linkml:types
+  default_range: string
+
+  classes:
+    MyClass:
+      title: "My Class"
+      attributes:
+        my_slot:
+          range: MySubClass
+    MySubClass:
+      title: "My Sub-Class"
+      attributes:
+        my_inner_slot:
+
+json_schema:
+  title: My Test Schema
+  "$defs":
+    MyClass:
+      title: "My Class"
+    MySubClass:
+      title: "My Sub-Class"
+

--- a/tests/test_generators/input/jsonschema_enum_title_from_title.yaml
+++ b/tests/test_generators/input/jsonschema_enum_title_from_title.yaml
@@ -1,0 +1,29 @@
+schema:
+  id: https://example.org/test
+  name: MyTestSchema
+  title: "My Test Schema"
+
+  prefixes:
+    linkml: https://w3id.org/linkml/
+  imports:
+    - linkml:types
+  default_range: string
+
+  classes:
+    MyClass:
+      attributes:
+        my_slot:
+          range: MyEnum
+  enums:
+    MyEnum:
+      title: "My Enum"
+      permissible_values:
+        VALUE_1:
+        VALUE_2:
+        VALUE_3:
+
+json_schema:
+  "$defs":
+    MyEnum:
+      title: "My Enum"
+

--- a/tests/test_generators/input/jsonschema_slot_title_from_title.yaml
+++ b/tests/test_generators/input/jsonschema_slot_title_from_title.yaml
@@ -1,0 +1,23 @@
+schema:
+  id: https://example.org/test
+  name: MyTestSchema
+  title: "My Test Schema"
+
+  prefixes:
+    linkml: https://w3id.org/linkml/
+  imports:
+    - linkml:types
+  default_range: string
+
+  classes:
+    MyClass:
+      attributes:
+        my_slot:
+          title: "My Slot"
+
+json_schema:
+  "$defs":
+    MyClass:
+      properties:
+        my_slot:
+          title: "My Slot"

--- a/tests/test_generators/input/jsonschema_title_from_name.yaml
+++ b/tests/test_generators/input/jsonschema_title_from_name.yaml
@@ -1,0 +1,18 @@
+schema:
+  id: https://example.org/test
+  name: MyTestSchema
+  title: "My Test Schema"
+
+  prefixes:
+    linkml: https://w3id.org/linkml/
+  imports:
+    - linkml:types
+  default_range: string
+
+  classes:
+    MyClass:
+      attributes:
+        my_slot:
+
+json_schema:
+  title: MyTestSchema

--- a/tests/test_generators/input/jsonschema_title_from_name_missing_title.yaml
+++ b/tests/test_generators/input/jsonschema_title_from_name_missing_title.yaml
@@ -1,0 +1,17 @@
+schema:
+  id: https://example.org/test
+  name: MyTestSchema
+
+  prefixes:
+    linkml: https://w3id.org/linkml/
+  imports:
+    - linkml:types
+  default_range: integer
+
+  classes:
+    MyClass:
+      attributes:
+        my_slot:
+
+json_schema:
+  title: MyTestSchema

--- a/tests/test_generators/input/jsonschema_title_from_title.yaml
+++ b/tests/test_generators/input/jsonschema_title_from_title.yaml
@@ -1,0 +1,18 @@
+schema:
+  id: https://example.org/test
+  name: MyTestSchema
+  title: "My Test Schema"
+
+  prefixes:
+    linkml: https://w3id.org/linkml/
+  imports:
+    - linkml:types
+  default_range: integer
+
+  classes:
+    MyClass:
+      attributes:
+        my_slot:
+
+json_schema:
+  title: "My Test Schema"

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -272,6 +272,36 @@ def test_rule_inheritance(subtests, input_path):
     external_file_test(subtests, input_path("jsonschema_rule_inheritance.yaml"))
 
 
+def test_title_from_name_slot(subtests, input_path):
+    """Tests that the JSON Schema title is taken from name slot."""
+    external_file_test(subtests, input_path("jsonschema_title_from_name.yaml"))
+
+
+def test_title_from_name_slot_when_title_missing(subtests, input_path):
+    """Tests that the JSON Schema title is taken from name slot when title is missing."""
+    external_file_test(subtests, input_path("jsonschema_title_from_name_missing_title.yaml"), {"title_from": "title"})
+
+
+def test_schama_title_from_title_slot(subtests, input_path):
+    """Tests that the JSON Schema title is taken from title slot if option specified."""
+    external_file_test(subtests, input_path("jsonschema_title_from_title.yaml"), {"title_from": "title"})
+
+
+def test_class_title_from_title_slot(subtests, input_path):
+    """Tests that the class-based sub-schema title is taken from title slot if option specified."""
+    external_file_test(subtests, input_path("jsonschema_class_title_from_title.yaml"), {"title_from": "title"})
+
+
+def test_enum_title_from_title_slot(subtests, input_path):
+    """Tests that the enum-based sub-schema title is taken from title slot if option specified."""
+    external_file_test(subtests, input_path("jsonschema_enum_title_from_title.yaml"), {"title_from": "title"})
+
+
+def test_slot_title_from_title_slot(subtests, input_path):
+    """Tests that the slot-based sub-schema title is taken from title slot if option specified."""
+    external_file_test(subtests, input_path("jsonschema_slot_title_from_title.yaml"), {"title_from": "title"})
+
+
 # **********************************************************
 #
 #    Utility functions


### PR DESCRIPTION
Motivation:

JSON Schema supports `title` and `description` as a schema annotations, with the following description:

    Both of these keywords can be used to decorate a user interface with
    information about the data produced by this user interface. A title
    will preferably be short, whereas a description will provide
    explanation about the purpose of the instance described by this
    schema.

The nature of these annotations isn't specified; however, I'm assuming both JSON Schema annotations are usually natural language prose, with title following common conventions of the title of other creative works (such as books).

Currently gen-json-schema takes the LinkML schema's name slot as the corresponding JSON Schema's title annotation.

To me, this is not a perfect mapping, as a "name" (as with a LinkML schema-level slot) is an identifier and often just a single word, while a "title" is often a short descriptive phrase and typically includes multiple words. This distinction is, perhaps, reflected in the restrictions placed on the name slot:

    name – the schema name. Use only alphanumeric characters,
    underscores, and dashes

More specifically, a JSON Schema title value allows spaces while a LinkML name slot does not.

The same argument applies for the JSON Schema `title` annotations generated from LinkML classes and enums.  These currently use the class or enum name (respectively), although using these names as the title may be sub-optimal.

The JSON Schema generated for slots currently lacks any `title` annotation.

Modification:

Update gen-json-schema to accept an extra configuration option (`--title-from`) that controls how `title` annotations are generated. This takes two values `name` and `title`, with `name` being the default.

The `name` option provides backwards compatibility.  The generated output is identical to that produced before this patch.

The `title` option uses the LinkML `title` slot for the JSON Schema `title` annotation if the slot is present, otherwise it behaves as if the `name` option was specified.  This is true for JSON Schema generated from the LinkML Schema slots, classes, enums and slots.

Result:

The gen-json-schema command now includes the `--title-from` option that controls the support for generating JSON Schema `title` annotations from the LinkML schema `title` slot.

Closes: #1834