### PR TITLE
Adding --use-native-uris option to owlgen.

### DIFF
--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -1219,6 +1219,12 @@ class OwlSchemaGenerator(Generator):
     show_default=True,
     help="If true, then mixins are represented as existential expressions",
 )
+@click.option(
+    "--use-native-uris/--no-use-native-uris",
+    default=True,
+    show_default=True,
+    help="Use model URIs rather than class/slot URIs",
+)
 @click.version_option(__version__, "-V", "--version")
 def cli(yamlfile, metadata_profile: str, **kwargs):
     """Generate an OWL representation of a LinkML model
@@ -1238,7 +1244,8 @@ def cli(yamlfile, metadata_profile: str, **kwargs):
         metadata_profiles = [MetadataProfile(metadata_profile)]
     else:
         metadata_profiles = [MetadataProfile.linkml]
-    print(OwlSchemaGenerator(yamlfile, metadata_profiles=metadata_profiles, **kwargs).serialize(**kwargs))
+    gen = OwlSchemaGenerator(yamlfile, metadata_profiles=metadata_profiles, **kwargs)
+    print(gen.serialize(**kwargs))
 
 
 if __name__ == "__main__":

--- a/tests/test_generators/test_owlgen.py
+++ b/tests/test_generators/test_owlgen.py
@@ -1,5 +1,6 @@
+import pytest
 from linkml_runtime.linkml_model import SlotDefinition
-from rdflib import RDFS, SKOS, Graph, Literal, Namespace, URIRef
+from rdflib import RDFS, SKOS, Graph, Literal, Namespace
 from rdflib.collection import Collection
 from rdflib.namespace import OWL, RDF
 
@@ -10,15 +11,26 @@ SYMP = Namespace("http://purl.obolibrary.org/obo/SYMP_")
 KS = Namespace("https://w3id.org/linkml/tests/kitchen_sink/")
 LINKML = Namespace("https://w3id.org/linkml/")
 BIZ = Namespace("https://example.org/bizcodes/")
+EX = Namespace("http://example.org/test-schema/")
+SCHEMA = Namespace("http://schema.org/")
 
 
-def test_owlgen(kitchen_sink_path):
+@pytest.mark.parametrize(
+    "metaclasses,type_objects",
+    [
+        (False, False),
+        (True, False),
+        (False, True),
+        (True, True),
+    ],
+)
+def test_owlgen(kitchen_sink_path, metaclasses, type_objects):
     """tests generation of owl schema-style ontologies"""
     owl = OwlSchemaGenerator(
         kitchen_sink_path,
         mergeimports=False,
-        metaclasses=False,
-        type_objects=False,
+        metaclasses=metaclasses,
+        type_objects=type_objects,
         ontology_uri_suffix=".owl.ttl",
     ).serialize()
     g = Graph()
@@ -27,7 +39,14 @@ def test_owlgen(kitchen_sink_path):
     assert len(owl_classes) > 10
     for c in owl_classes:
         types = list(g.objects(c, RDF.type))
-        assert types == [OWL.Class]
+        assert OWL.Class in types
+        if metaclasses:
+            # TODO: make this stricter;
+            # ClassDefinitions should be of type ClassDefinition
+            # PVs should be of the enum type
+            assert len(types) == 2
+        else:
+            assert len(types) == 1
     assert KS.MedicalEvent in owl_classes
     # test that enums are treated as classes
     assert KS.EmploymentEventType in owl_classes
@@ -35,12 +54,23 @@ def test_owlgen(kitchen_sink_path):
     assert len(owl_object_properties) > 10
     for p in owl_object_properties:
         types = list(g.objects(p, RDF.type))
-        assert types == [OWL.ObjectProperty]
+        assert OWL.ObjectProperty in types
+        if metaclasses:
+            assert len(types) == 2
+        else:
+            assert len(types) == 1
     owl_datatype_properties = list(g.subjects(RDF.type, OWL.DatatypeProperty))
-    assert len(owl_datatype_properties) > 10
+    if type_objects:
+        assert owl_datatype_properties == []
+    else:
+        assert len(owl_datatype_properties) > 10
     for p in owl_datatype_properties:
         types = list(g.objects(p, RDF.type))
-        assert types == [OWL.DatatypeProperty]
+        assert OWL.DatatypeProperty in types
+        if metaclasses:
+            assert len(types) == 2
+        else:
+            assert len(types) == 1
     # check that definitions are present, and use the default profile
     assert Literal("A person, living or dead") in g.objects(KS.Person, SKOS.definition)
     # test enums
@@ -69,64 +99,141 @@ def test_rdfs_profile(kitchen_sink_path):
     assert Literal("A person, living or dead") in g.objects(KS.Person, RDFS.comment)
 
 
-def test_definition_uris():
-    """
-    Tests behavior of assigning URIs to classes and slots
-
-    In future this will be paramterizable as per:
-    https://github.com/linkml/linkml/issues/932
-    """
-    sb = SchemaBuilder()
-    sb.add_class(
-        "MyPerson",
-        class_uri="schema:Person",
-        slots=[SlotDefinition("name", slot_uri="schema:name")],
-    )
-    sb.add_defaults()
-    sb.add_prefix("schema", "http://schema.org/")
-    schema = sb.schema
-    gen = OwlSchemaGenerator(schema, mergeimports=False, metaclasses=False, type_objects=False)
-    owl = gen.serialize()
-    g = Graph()
-    g.parse(data=owl)
-    triples = list(g.triples((None, None, None)))
-    expected = [
+@pytest.mark.parametrize(
+    "description,metadata_profiles,use_native_uris,metaclasses,assert_equivalent_classes,expected",
+    [
         (
-            URIRef("http://example.org/test-schema/MyPerson"),
-            URIRef("http://www.w3.org/2004/02/skos/core#exactMatch"),
-            URIRef("http://schema.org/Person"),
-        )
-    ]
-    for t in expected:
-        assert t in triples
-
-
-def test_equivalent_uris():
+            "default is model (native) URIs and SKOS for matches",
+            [],
+            True,
+            False,
+            False,
+            [
+                (
+                    EX.MyPerson,
+                    RDFS.label,
+                    Literal("MyPerson"),
+                ),
+                (
+                    EX.MyPerson,
+                    SKOS.definition,
+                    Literal("A person"),
+                ),
+                (
+                    EX.MyPerson,
+                    SKOS.exactMatch,
+                    SCHEMA.Person,
+                ),
+                (
+                    EX.name,
+                    RDFS.label,
+                    Literal("name"),
+                ),
+            ],
+        ),
+        (
+            "non-native_uris",
+            [],
+            False,
+            False,
+            False,
+            [
+                (
+                    SCHEMA.Person,
+                    RDFS.label,
+                    Literal("MyPerson"),
+                ),
+                (
+                    SCHEMA.Person,
+                    SKOS.exactMatch,
+                    EX.MyPerson,
+                ),
+                (
+                    SCHEMA.name,
+                    RDFS.label,
+                    Literal("name"),
+                ),
+            ],
+        ),
+        (
+            "native_uris and OWL for matches",
+            [],
+            True,
+            False,
+            True,
+            [
+                (
+                    EX.MyPerson,
+                    RDFS.label,
+                    Literal("MyPerson"),
+                ),
+                (
+                    EX.MyPerson,
+                    OWL.equivalentClass,
+                    SCHEMA.Person,
+                ),
+            ],
+        ),
+        (
+            "RDFS profile",
+            [MetadataProfile.rdfs],
+            True,
+            False,
+            False,
+            [
+                (
+                    EX.MyPerson,
+                    RDFS.label,
+                    Literal("MyPerson"),
+                ),
+                (
+                    EX.MyPerson,
+                    RDFS.comment,
+                    Literal("A person"),
+                ),
+                (
+                    EX.MyPerson,
+                    SKOS.exactMatch,
+                    SCHEMA.Person,
+                ),
+            ],
+        ),
+    ],
+)
+def test_definition_uris(
+    description, metadata_profiles, use_native_uris, metaclasses, assert_equivalent_classes, expected
+):
     """
-    Test behavior of asserting owl:equivalentClass between a class
-    and its corresponding class_uri
+    Tests behavior of assigning URIs to classes and slots.
     """
     sb = SchemaBuilder()
     sb.add_class(
         "MyPerson",
         class_uri="schema:Person",
+        description="A person",
         slots=[SlotDefinition("name", slot_uri="schema:name")],
     )
     sb.add_defaults()
     sb.add_prefix("schema", "http://schema.org/")
     schema = sb.schema
     gen = OwlSchemaGenerator(
-        schema=schema,
+        schema,
+        metadata_profiles=metadata_profiles,
         mergeimports=False,
-        metaclasses=False,
+        metaclasses=metaclasses,
         type_objects=False,
-        assert_equivalent_classes=True,
+        use_native_uris=use_native_uris,
+        assert_equivalent_classes=assert_equivalent_classes,
     )
     owl = gen.serialize()
-    graph = Graph()
-    graph.parse(data=owl)
-    assert (
-        URIRef("http://example.org/test-schema/MyPerson"),
-        OWL.equivalentClass,
-        URIRef("http://schema.org/Person"),
-    ) in graph
+    print(owl)
+    g = Graph()
+    g.parse(data=owl)
+    triples = list(g.triples((None, None, None)))
+    for t in expected:
+        assert t in triples
+    if metadata_profiles == [MetadataProfile.rdfs]:
+        owl_classes = list(g.subjects(RDF.type, OWL.Class))
+        for c in owl_classes:
+            # check not using the default metadata profile
+            assert list(g.objects(c, SKOS.definition)) == []


### PR DESCRIPTION
Fixes #1842

Note that native URIs is still the default.

This PR also makes owlgen tests for comprehensive
using pytest parametrization.
