### PR TITLE
Format with Black v24

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Reformat with black and isort
 ef566b7942153a2f29b626976bf04d15854f3cf1
+# Format with Black 24
+bcb7c5c615120873b36dee16cfcb007e002e3833

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: trailing-whitespace
     exclude: __snapshots__
 - repo: https://github.com/psf/black
-  rev: 23.7.0
+  rev: 24.1.1
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/linkml/generators/csvgen.py
+++ b/linkml/generators/csvgen.py
@@ -1,6 +1,7 @@
 """
 Generate CSVs
 """
+
 import os
 import sys
 from csv import DictWriter

--- a/linkml/generators/dotgen.py
+++ b/linkml/generators/dotgen.py
@@ -1,6 +1,7 @@
 """
 Generate dotfiles
 """
+
 import os
 from dataclasses import dataclass
 from typing import List, Optional

--- a/linkml/generators/golrgen.py
+++ b/linkml/generators/golrgen.py
@@ -6,6 +6,7 @@ These can be converted to solr schema-xml, and used in amigo-bbop tools
 See the golr-views directory in this repo for examples
 
 """
+
 import os
 from dataclasses import dataclass
 from typing import List, Optional

--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -2,6 +2,7 @@
 Generate JSON-LD contexts
 
 """
+
 import os
 import re
 from dataclasses import dataclass, field

--- a/linkml/generators/jsonldgen.py
+++ b/linkml/generators/jsonldgen.py
@@ -1,6 +1,7 @@
 """ Generate JSONld
 
 """
+
 import os
 from copy import deepcopy
 from dataclasses import dataclass
@@ -99,13 +100,15 @@ class JSONLDGenerator(Generator):
             return (
                 ClassDefinitionName(camelcase(node))
                 if node in self.schema.classes
-                else SlotDefinitionName(underscore(node))
-                if node in self.schema.slots
-                else SubsetDefinitionName(camelcase(node))
-                if node in self.schema.subsets
-                else TypeDefinitionName(underscore(node))
-                if node in self.schema.types
-                else None
+                else (
+                    SlotDefinitionName(underscore(node))
+                    if node in self.schema.slots
+                    else (
+                        SubsetDefinitionName(camelcase(node))
+                        if node in self.schema.subsets
+                        else TypeDefinitionName(underscore(node)) if node in self.schema.types else None
+                    )
+                )
             )
         return None
 

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -456,11 +456,11 @@ class MarkdownGenerator(Generator):
         filename = (
             self.formatted_element_name(obj)
             if isinstance(obj, ClassDefinition)
-            else underscore(obj.name)
-            if isinstance(obj, SlotDefinition)
-            else underscore(obj.name)
-            if isinstance(obj, EnumDefinition)
-            else camelcase(obj.name)
+            else (
+                underscore(obj.name)
+                if isinstance(obj, SlotDefinition)
+                else underscore(obj.name) if isinstance(obj, EnumDefinition) else camelcase(obj.name)
+            )
         )
         subdir = "/types" if isinstance(obj, TypeDefinition) and not self.no_types_dir else ""
         return f"{self.directory}{subdir}/{filename}.md"

--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -1,4 +1,5 @@
 """Generate OWL ontology representation of a LinkML schema."""
+
 import logging
 import os
 from collections import defaultdict

--- a/linkml/generators/plantumlgen.py
+++ b/linkml/generators/plantumlgen.py
@@ -3,6 +3,7 @@
 https://plantuml.com/
 
 """
+
 import base64
 import os
 import zlib

--- a/linkml/generators/prefixmapgen.py
+++ b/linkml/generators/prefixmapgen.py
@@ -2,6 +2,7 @@
 Generate JSON-LD contexts
 
 """
+
 import csv
 import os
 from dataclasses import dataclass, field

--- a/linkml/generators/rdfgen.py
+++ b/linkml/generators/rdfgen.py
@@ -4,6 +4,7 @@ YAML Schema to RDF Generator
 Generate a JSON LD representation of the model
 
 """
+
 import os
 import urllib.parse as urlparse
 from dataclasses import dataclass, field

--- a/linkml/generators/shexgen.py
+++ b/linkml/generators/shexgen.py
@@ -1,6 +1,7 @@
 """Generate ShEx definition of a model
 
 """
+
 import os
 import urllib.parse as urlparse
 from dataclasses import dataclass, field

--- a/linkml/generators/sqlddlgen.py
+++ b/linkml/generators/sqlddlgen.py
@@ -1,4 +1,5 @@
 """DEPRECATED: Use SQLTableGenerator instead"""
+
 import logging
 import os
 from contextlib import redirect_stdout

--- a/linkml/generators/summarygen.py
+++ b/linkml/generators/summarygen.py
@@ -1,6 +1,7 @@
 """Generate Summary Spreadsheets
 
 """
+
 import os
 import sys
 from csv import DictWriter

--- a/linkml/generators/yamlgen.py
+++ b/linkml/generators/yamlgen.py
@@ -1,6 +1,7 @@
 """Validate linkml input and optionally emit completely resolved biolink yaml output
 
 """
+
 import os
 from dataclasses import dataclass, field
 

--- a/linkml/generators/yumlgen.py
+++ b/linkml/generators/yumlgen.py
@@ -3,6 +3,7 @@
 https://yuml.me/diagram/scruffy/class/samples
 
 """
+
 import os
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Set, cast

--- a/linkml/transformers/logical_model_transformer.py
+++ b/linkml/transformers/logical_model_transformer.py
@@ -12,6 +12,7 @@ of constraints in both classes hold.
 These logical constraints are then simplified by translating to disjunctive normal form,
 and applying simplification rules.
 """
+
 import logging
 from copy import deepcopy
 from dataclasses import dataclass

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -14,6 +14,7 @@ New generators should always using the latter approach
 See: https://github.com/linkml/linkml/issues/923
 
 """
+
 import abc
 import logging
 import os
@@ -453,9 +454,11 @@ class Generator(metaclass=abc.ABCMeta):
         return (
             None
             if element.is_a is None
-            else self.schema.classes[element.is_a]
-            if isinstance(element, ClassDefinition)
-            else self.schema.slots[element.is_a]
+            else (
+                self.schema.classes[element.is_a]
+                if isinstance(element, ClassDefinition)
+                else self.schema.slots[element.is_a]
+            )
         )
 
     def ancestors(self, element: Union[ClassDefinition, SlotDefinition]) -> List[ElementName]:

--- a/linkml/utils/ifabsent_functions.py
+++ b/linkml/utils/ifabsent_functions.py
@@ -113,7 +113,13 @@ default_library: List[
 
 def isabsent_match(
     txt: Text,
-) -> Optional[Tuple[Match[str], bool, Callable[[Match[str], SchemaLoader, ClassDefinition, SlotDefinition], str],]]:
+) -> Optional[
+    Tuple[
+        Match[str],
+        bool,
+        Callable[[Match[str], SchemaLoader, ClassDefinition, SlotDefinition], str],
+    ]
+]:
     txt = str(txt)
     for pattern, postinit, f in default_library:
         m = re.match(pattern + "$", txt)

--- a/linkml/utils/schemasynopsis.py
+++ b/linkml/utils/schemasynopsis.py
@@ -120,13 +120,11 @@ class SchemaSynopsis:
         self.add_ref(
             SlotType,
             k,
-            ClassType
-            if v.range in self.schema.classes
-            else EnumType
-            if v.range in self.schema.enums
-            else TypeType
-            if v.range in self.schema.types
-            else None,
+            (
+                ClassType
+                if v.range in self.schema.classes
+                else EnumType if v.range in self.schema.enums else TypeType if v.range in self.schema.types else None
+            ),
             v.range,
         )
 

--- a/linkml/validator/__init__.py
+++ b/linkml/validator/__init__.py
@@ -3,6 +3,7 @@ The ``linkml.validator`` package contains a new LinkML validation framework that
 than the ``linkml.validators`` package. While that package still exists, it may become deprecated
 in the future.
 """
+
 import os
 from pathlib import Path
 from typing import Any, Optional, Union

--- a/linkml/validator/loaders/__init__.py
+++ b/linkml/validator/loaders/__init__.py
@@ -4,6 +4,7 @@ instance from a source. Instances of these classes are passed to
 :meth:`linkml.validator.Validator.validate_source` and
 :meth:`linkml.validator.Validator.iter_results_from_source`
 """
+
 import os
 from typing import Union
 

--- a/linkml/validator/validator.py
+++ b/linkml/validator/validator.py
@@ -29,7 +29,7 @@ class Validator:
         schema: Union[str, dict, TextIO, Path, SchemaDefinition],
         validation_plugins: Optional[List[ValidationPlugin]] = None,
         *,
-        strict: bool = False
+        strict: bool = False,
     ) -> None:
         if isinstance(schema, Path):
             schema = str(schema)

--- a/linkml/workspaces/example_runner.py
+++ b/linkml/workspaces/example_runner.py
@@ -1,6 +1,7 @@
 """Iterate through all examples in a folder testing them for validity.
 
 """
+
 import glob
 import json
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ quiet-level = 3
 
 [tool.black]
 line-length = 120
-target-versions = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311"]
 force-exclude = '''
 /(
   # default exclude

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -1,4 +1,5 @@
 """Helper for compliance tests. See README.md for more information."""
+
 import csv
 import enum
 import json

--- a/tests/test_compliance/test_annotation_compliance.py
+++ b/tests/test_compliance/test_annotation_compliance.py
@@ -3,6 +3,7 @@
 Note these tests differ from other compliance tests in that
 there is no instance data to test.
 """
+
 from copy import copy
 from typing import Any, Dict, Optional
 

--- a/tests/test_compliance/test_boolean_slot_compliance.py
+++ b/tests/test_compliance/test_boolean_slot_compliance.py
@@ -1,4 +1,5 @@
 """Constants for boolean slots tests (any_of, all_of, etc)."""
+
 from typing import Optional
 
 import pytest
@@ -1391,9 +1392,9 @@ def test_min_max(framework, min_val, max_val, equals_number: Optional[int], valu
                     "maximum_value": max_val,
                     "equals_number": equals_number,
                     "_mappings": {
-                        PYDANTIC: f"{SLOT_S1}: int = Field(..., ge={min_val}, le={max_val})"
-                        if not equals_number
-                        else ""
+                        PYDANTIC: (
+                            f"{SLOT_S1}: int = Field(..., ge={min_val}, le={max_val})" if not equals_number else ""
+                        )
                     },
                 },
             },

--- a/tests/test_compliance/test_compliance.py
+++ b/tests/test_compliance/test_compliance.py
@@ -1,4 +1,5 @@
 """Constants for compliance tests. See README.md for more information."""
+
 from tests.test_compliance.helper import (
     JAVA,
     JSON_SCHEMA,

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -1,4 +1,5 @@
 """Compliance tests for core constructs."""
+
 import unicodedata
 
 import pytest

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -5,6 +5,7 @@ import unicodedata
 import pytest
 from _decimal import Decimal
 from linkml_runtime.utils.formatutils import underscore
+from pydantic.version import VERSION as PYDANTIC_VERSION
 
 from tests.test_compliance.helper import (
     JSON_SCHEMA,
@@ -33,6 +34,8 @@ from tests.test_compliance.test_compliance import (
     SLOT_S2,
     SLOT_S3,
 )
+
+IS_PYDANTIC_V1 = PYDANTIC_VERSION[0] == "1"
 
 
 @pytest.mark.parametrize(
@@ -339,6 +342,8 @@ def test_date_types(framework, linkml_type, example_value, is_valid):
         if linkml_type == "time" and "." in example_value and is_valid:
             expected_behavior = ValidationBehavior.FALSE_POSITIVE
     if framework == PYDANTIC:
+        if not IS_PYDANTIC_V1 and linkml_type == "datetime" and example_value == "2021-01-01":
+            expected_behavior = ValidationBehavior.COERCES
         if linkml_type == "time" and is_valid is False:
             expected_behavior = ValidationBehavior.INCOMPLETE
         if linkml_type == "date" and is_valid is False and example_value.startswith("2021"):

--- a/tests/test_compliance/test_designates_type_compliance.py
+++ b/tests/test_compliance/test_designates_type_compliance.py
@@ -44,7 +44,7 @@ def test_designates_type(framework, description, type_range, object, is_valid, o
     """
     Tests behavior of designates_type.
 
-    This creates a schema consisting of a *constainer* class that has a multivalued slot *entities*,
+    This creates a schema consisting of a *container* class that has a multivalued slot *entities*,
     with a range of C1. C1 has a slot *type* that designates the type of the entity.  C1a and C1b
     are subclasses of C1.
 
@@ -80,9 +80,11 @@ def test_designates_type(framework, description, type_range, object, is_valid, o
                     "designates_type": True,
                     "range": type_range,
                     "_mappings": {
-                        PYDANTIC: f'{SLOT_TYPE}: Literal["{CLASS_C1}"] = Field("{CLASS_C1}")'
-                        if type_range == "string"
-                        else "",
+                        PYDANTIC: (
+                            f'{SLOT_TYPE}: Literal["{CLASS_C1}"] = Field("{CLASS_C1}")'
+                            if type_range == "string"
+                            else ""
+                        ),
                     },
                 },
             },

--- a/tests/test_compliance/test_enum_compliance.py
+++ b/tests/test_compliance/test_enum_compliance.py
@@ -3,6 +3,7 @@ Tests for enum compliance.
 
  - TODO: dynamic enums
 """
+
 import re
 from copy import deepcopy
 

--- a/tests/test_compliance/test_inheritance_compliance.py
+++ b/tests/test_compliance/test_inheritance_compliance.py
@@ -1,4 +1,5 @@
 """Tests involving inheritance (is_a) and related constructs."""
+
 import pytest
 
 from tests.test_compliance.helper import (

--- a/tests/test_compliance/test_inlined_compliance.py
+++ b/tests/test_compliance/test_inlined_compliance.py
@@ -4,6 +4,7 @@ Tests that make use of linkml:inlined and related constructs.
 
 - TODO: dict normalization, SimpleDicts and CompactDicts
 """
+
 import pytest
 
 from tests.test_compliance.helper import (

--- a/tests/test_compliance/test_metadata_compliance.py
+++ b/tests/test_compliance/test_metadata_compliance.py
@@ -5,6 +5,7 @@ These typically do not include meaningful instance tests since metadata does not
 
 - TODO: license slot
 """
+
 from copy import deepcopy
 
 import pytest

--- a/tests/test_data/model/personinfo.py
+++ b/tests/test_data/model/personinfo.py
@@ -134,9 +134,9 @@ class Person(NamedThing):
     age_in_years: Optional[int] = None
     gender: Optional[Union[str, "GenderType"]] = None
     current_address: Optional[Union[dict, "Address"]] = None
-    has_employment_history: Optional[
-        Union[Union[dict, "EmploymentEvent"], List[Union[dict, "EmploymentEvent"]]]
-    ] = empty_list()
+    has_employment_history: Optional[Union[Union[dict, "EmploymentEvent"], List[Union[dict, "EmploymentEvent"]]]] = (
+        empty_list()
+    )
     has_familial_relationships: Optional[
         Union[
             Union[dict, "FamilialRelationship"],

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -3,6 +3,7 @@ Tests generation of markdown and similar documents
 
 Note that docgen replaces markdowngen
 """
+
 import logging
 import os
 from collections import Counter

--- a/tests/test_issues/test_tccm_issues.py
+++ b/tests/test_issues/test_tccm_issues.py
@@ -1,4 +1,5 @@
 """ Unit tests for issues encountered in the TCCM model generation """
+
 import logging
 
 import pytest

--- a/tests/test_utils/test_generator.py
+++ b/tests/test_utils/test_generator.py
@@ -13,6 +13,7 @@ https://stackoverflow.com/questions/52099029/change-in-behaviour-of-dataclasses
 If these tests are reinstated then it will be necessary to create distinct subClasses of TestGenerator
 
 """
+
 import logging
 import os
 from dataclasses import dataclass, field

--- a/tests/test_utils/test_schemasynopsis.py
+++ b/tests/test_utils/test_schemasynopsis.py
@@ -1,4 +1,5 @@
 """ Tests for various parts of the schema synopsis file """
+
 from pathlib import Path
 from typing import Union
 

--- a/tests/test_workspaces/test_example_runner.py
+++ b/tests/test_workspaces/test_example_runner.py
@@ -5,6 +5,7 @@ Test example runner using a simulated setup.
  - input/examples
  - input/counter_examples
 """
+
 import pytest
 from linkml_runtime import SchemaView
 from prefixmaps.io.parser import load_multi_context

--- a/tests/utils/filters.py
+++ b/tests/utils/filters.py
@@ -1,4 +1,5 @@
 """ Metadata filters for test cases -- various tools to remove metadata from output """
+
 import re
 
 from jsonasobj2 import as_json, loads

--- a/tests/utils/generatortestcase.py
+++ b/tests/utils/generatortestcase.py
@@ -35,7 +35,7 @@ class GeneratorTestCase(TestEnvironmentTestCase):
         filtr: Optional[Callable[[str], str]] = None,
         comparator: Callable[[str, str], str] = None,
         output_name: Optional[str] = None,
-        yaml_file: Optional[str] = None
+        yaml_file: Optional[str] = None,
     ) -> None:
         """Invoke generator specified in gen
 
@@ -78,7 +78,7 @@ class GeneratorTestCase(TestEnvironmentTestCase):
         subdir: Optional[str] = None,
         generator_args: Optional[dict] = None,
         serialize_args: Optional[dict] = None,
-        input_file: Optional[str] = None
+        input_file: Optional[str] = None,
     ) -> None:
         """
         Generate an output directory using the appropriate command and then compare the target with the source


### PR DESCRIPTION
### Context

Since we don't pin the version of Black used by tox, we get the latest version on each CI run. This isn't necessarily a bad thing. But Black just released a new major version (24.1.0) which changes some style rules. This is what's causing recent PRs and merges to `main` to fail.

The failing Black check was also masking a test failure in the compliance test suite. When we run our tests with Pydantic 2 that also gets the latest Pydantic version. They just released [Pydantic 2.6](https://docs.pydantic.dev/latest/changelog/#v260-2024-01-23) which [loosens a restriction on how datetimes are parsed](https://github.com/pydantic/pydantic/issues/8363).

### Summary of changes

* Reformat code according to Black v24
* Update pre-commit config to also use Black v24 (unlike tox, this version _must_ be pinned)
* Fix a Black config error flagged by the new version
* Update `test_core_compliance.py` to mark the "yyyy-MM-dd" datetime case as a "coerce"