### PR TITLE
Add explicit record for Chris  to unify him with cmungall in mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Chris Mungall <cjm@berkeleybop.org>
+Harold Solbrig <solbrig@jhu.edu>
+Harshad Hegde <hegdehb@gmail.com> <hrshdhgd@users.noreply.github.com>
+Deepak Unni <deepak.unni3@gmail.com>
+Deepak Unni <deepak.unni3@gmail.com> <deepakunni3@users.noreply.github.com>


### PR DESCRIPTION
While at it -- unified a few others.

With this change it looks like

    ❯ git shortlog -sn | head
       599	Chris Mungall
       347	Sujay Patil
       250	Patrick Kalita
       243	GitHub Action
       131	Harold Solbrig
        87	Sierra Taylor Moxon
        81	Harshad Hegde
        44	Kevin Schaper
        42	Sierra Moxon
        32	David Linke

instead of

    ❯ git shortlog -sn | head
       347	Sujay Patil
       302	Chris Mungall
       297	cmungall
       250	Patrick Kalita
       243	GitHub Action
        87	Sierra Taylor Moxon
        75	hsolbrig
        56	Harold Solbrig
        44	Kevin Schaper
        42	Harshad

someone might want to copy it to some other repos.