### PR TITLE
remove rdflib_shim from __init__.py

### DIFF
--- a/linkml/__init__.py
+++ b/linkml/__init__.py
@@ -1,12 +1,9 @@
 import os
 import sys
 
-import rdflib_shim
 from linkml_runtime.linkml_model import linkml_files
 from linkml_runtime.linkml_model.linkml_files import Format, Source
 from rdflib.plugins.serializers.turtle import TurtleSerializer
-
-shim = rdflib_shim.RDFLIB_SHIM
 
 assert sys.version_info > (
     3,


### PR DESCRIPTION
rdflib_shim is no longer needed in linkml and was removed from pyproject.toml, however the import statement was never removed. This snuck through because one of the other requirements still pulls in rdflib_shim so no import error is raised.