### PR TITLE
Correct import for sqlalchemy.pool.StaticPool

### DIFF
--- a/linkml/utils/sqlutils.py
+++ b/linkml/utils/sqlutils.py
@@ -18,10 +18,11 @@ from linkml_runtime.utils.formatutils import underscore
 from linkml_runtime.utils.introspection import package_schemaview
 from linkml_runtime.utils.yamlutils import YAMLRoot
 from pydantic import BaseModel
-from sqlalchemy import StaticPool, create_engine
+from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.associationproxy import _AssociationCollection
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from linkml._version import __version__
 from linkml.generators.pythongen import PythonGenerator


### PR DESCRIPTION
I found this error with:

```bash
$ linkml-sqldb dump --help
```
```pytb
Traceback (most recent call last):
  File "/Users/bendichter/opt/miniconda3/bin/linkml-sqldb", line 5, in <module>
    from linkml.utils.sqlutils import main
  File "/Users/bendichter/opt/miniconda3/lib/python3.9/site-packages/linkml/utils/sqlutils.py", line 21, in <module>
    from sqlalchemy import StaticPool, create_engine
ImportError: cannot import name 'StaticPool' from 'sqlalchemy' (/Users/bendichter/opt/miniconda3/lib/python3.9/site-packages/sqlalchemy/__init__.py)
```

It looks like the import pattern can be corrected. `from sqlalchemy.pool import StaticPool` works for me. I'm not sure why I am getting this error and it hasn't come up before. I have sqlalchemy 1.4.46 installed