### PR TITLE
[wip] fixing context generator for `any_of` with `range`

### DIFF
--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -150,7 +150,7 @@ class ContextGenerator(Generator):
         else:
             slot_def = {}
             if not slot.usage_slot_name:
-                any_of_ranges = [any_of_el["range"] for any_of_el in slot.any_of]
+                any_of_ranges = [any_of_el.range for any_of_el in slot.any_of]
                 if slot.range in self.schema.classes or any(rng in self.schema.classes for rng in any_of_ranges):
                     slot_def["@type"] = "@id"
                 elif slot.range in self.schema.enums:

--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -150,7 +150,8 @@ class ContextGenerator(Generator):
         else:
             slot_def = {}
             if not slot.usage_slot_name:
-                if slot.range in self.schema.classes:
+                any_of_ranges = [any_of_el["range"] for any_of_el in slot.any_of]
+                if slot.range in self.schema.classes or any(rng in self.schema.classes for rng in any_of_ranges):
                     slot_def["@type"] = "@id"
                 elif slot.range in self.schema.enums:
                     slot_def["@context"] = ENUM_CONTEXT

--- a/tests/test_compliance/test_boolean_slot_compliance.py
+++ b/tests/test_compliance/test_boolean_slot_compliance.py
@@ -5,6 +5,7 @@ from typing import Optional
 import pytest
 
 from tests.test_compliance.helper import (
+    JSONLD_CONTEXT,
     JSON_SCHEMA,
     OWL,
     PYDANTIC,
@@ -100,6 +101,7 @@ def test_slot_any_of(framework, data_name, value, is_valid, use_any_type, use_de
                     "_mappings": {
                         PYDANTIC: f"{SLOT_S1}: Optional[Union[D, int]]",
                         JSON_SCHEMA: expected_json_schema,
+                        JSONLD_CONTEXT: {"s1": {"@type": "@id"}},
                     },
                 },
             },

--- a/tests/test_compliance/test_boolean_slot_compliance.py
+++ b/tests/test_compliance/test_boolean_slot_compliance.py
@@ -5,8 +5,8 @@ from typing import Optional
 import pytest
 
 from tests.test_compliance.helper import (
-    JSONLD_CONTEXT,
     JSON_SCHEMA,
+    JSONLD_CONTEXT,
     OWL,
     PYDANTIC,
     PYTHON_DATACLASSES,


### PR DESCRIPTION
fixies #1897 

I've tried to fix the context generator, but I'm actually not sure if my approach is correct. Should `slot_def["@type"] = "@id"` be added if any of the ranges from `any_of` are in `self.schema.classes`?