### PR TITLE
Poetry extras removal

### DIFF
--- a/.github/workflows/check_external_links.yaml
+++ b/.github/workflows/check_external_links.yaml
@@ -25,7 +25,7 @@ jobs:
           version: 1.3.2
 
       - name: install
-        run: poetry install -E docs
+        run: poetry install
 
       - name: Build documentation.
         run: |

--- a/.github/workflows/doc_pages.yaml
+++ b/.github/workflows/doc_pages.yaml
@@ -23,7 +23,7 @@ jobs:
           version: 1.3.2
 
       - name: install
-        run: poetry install -E docs
+        run: poetry install
 
       - name: Build documentation.
         run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -3479,10 +3479,7 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
-[extras]
-docs = []
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "04e767bb80274b79637e2337c1cd3fec52921b54339fc04688d30861209a0534"
+content-hash = "70256ae2488d1bea4ee1dc8e8f80dfe32b97877bd81c9a554ac5e5a3f8032adf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,12 +144,8 @@ pytest = "^7.4.0"
 pytest-subtests = "^0.11.0"
 numpy = ">=1.24.3"
 
-
 [tool.poetry.group.shacl.dependencies]
 pyshacl = "^0.25.0"
-
-[tool.poetry.extras]
-docs = ["Sphinx", "sphinxcontrib-mermaid", "furo"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]


### PR DESCRIPTION
Running poetry check gives:

```
(.venv) λ poetry check
Error: Cannot find dependency "Sphinx" for extra "docs" in main dependencies.
Error: Cannot find dependency "sphinxcontrib-mermaid" for extra "docs" in main dependencies.
Error: Cannot find dependency "furo" for extra "docs" in main dependencies.
```

I propose to remove the extra-section. In a normal `poetry install` the packages in extras are already installed. 

What was the purpose of extras? Should it enable using pip for a developer install? This does not work because the whole dependency specification in `pyproject.toml` is using a the poetry-specific style. 

In two CI jobs the extra option was used although it was doing nothing more than a standard `poetry install`.

This PR also updates the lock-file but does not change any version.
