### PR TITLE
Foreign keys should be of same type as the primary key they reference

### DIFF
--- a/linkml/generators/sqltablegen.py
+++ b/linkml/generators/sqltablegen.py
@@ -220,8 +220,12 @@ class SQLTableGenerator(Generator):
             schema = SchemaLoader(data=self.schema).resolve()
 
         if range in schema.classes:
-            # FKs treated as Text
-            return Text()
+            # FK type should be the same as the identifier of the foreign key
+            fk = SchemaView(schema).get_identifier_slot(range)
+            if fk:
+                return self.get_sql_range(fk, schema)
+            else:
+                return Text()
         if range in schema.enums:
             e = schema.enums[range]
             if e.permissible_values is not None:

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -511,7 +511,7 @@ def test_cardinality(framework, multivalued, required, data_name, value):
     else:
         sqlite = (
             'CREATE TABLE "C_s1" ('
-            '   "C_id" TEXT,'
+            '   "C_id" INTEGER,'
             f"   s1 TEXT {sql_nullable},"
             '   PRIMARY KEY ("C_id", s1),'
             '   FOREIGN KEY("C_id") REFERENCES "C" (id)'

--- a/tests/test_generators/input/personinfo.yaml
+++ b/tests/test_generators/input/personinfo.yaml
@@ -126,7 +126,10 @@ classes:
   ProcedureConcept:
     is_a: Concept
       
-
+  IntegerPrimaryKeyObject:
+    slots:
+      - int_id
+    
   Relationship:
     slots:
       - started_at_time
@@ -178,6 +181,10 @@ slots:
   id:
     identifier: true
     slot_uri: schema:identifier
+  int_id:
+    identifier: true
+    slot_uri: schema:int_identifier
+    range: integer
   name:
     slot_uri: schema:name
   description:

--- a/tests/test_generators/test_sqltablegen.py
+++ b/tests/test_generators/test_sqltablegen.py
@@ -5,7 +5,7 @@ import pytest
 from linkml_runtime.linkml_model.meta import SlotDefinition
 from linkml_runtime.utils.introspection import package_schemaview
 from linkml_runtime.utils.schemaview import SchemaView
-from sqlalchemy.sql.sqltypes import Enum, Text
+from sqlalchemy.sql.sqltypes import Enum, Integer, Text
 
 from linkml.generators.sqltablegen import SQLTableGenerator
 from linkml.utils.schema_builder import SchemaBuilder
@@ -151,6 +151,8 @@ def test_get_sql_range(schema):
 
     case_3_slot = SlotDefinition(name="NonExistentSlot", range="NonExistentRange")
 
+    case_4_slot = SlotDefinition(name="ForeignKeySlot", range="IntegerPrimaryKeyObject")
+
     # Slot range in list of schema classes
     actual_1_output = gen.get_sql_range(case_1_slot)
 
@@ -160,9 +162,13 @@ def test_get_sql_range(schema):
     # Slot not present in schema
     actual_3_output = gen.get_sql_range(case_3_slot)
 
+    # foreign key slot type
+    actual_4_output = gen.get_sql_range(case_4_slot)
+
     assert isinstance(actual_1_output, Text)
     assert isinstance(actual_2_output, Enum)
     assert isinstance(actual_3_output, Text)
+    assert isinstance(actual_4_output, Integer)
 
 
 def test_get_foreign_key(schema):


### PR DESCRIPTION
Ran into the same issue as linkml/linkml/#1407 -- if you have a schema like:

```YAML
ClassA:
   attributes:
      id:
          identifier: true
          range: integer
ClassB:
   attributes:
      other_model:
         range: ClassA
```

This was generating a foreign key on ClassB of type text in all SQL derivatives, even though the key that references is an integer. This pull request switches it so foreign keys are specified by the datatype of the identifier they link to. 