### PR TITLE
Pydantic generated models require importing Decimal

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -46,6 +46,7 @@ from enum import Enum
 {% if uses_numpy -%}
 import numpy as np
 {%- endif %}
+from decimal import Decimal
 from typing import List, Dict, Optional, Any, Union"""
     if pydantic_ver == "1":
         template += """

--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -146,6 +146,7 @@ classes:
     slots:
       - street
       - city
+      - altitude
 
   Concept:
     slots:
@@ -285,7 +286,7 @@ classes:
         range: class with spaces
   # these below two sub classes at the same depth have
   # been added to check if class hierarchy methods
-  # follow lexigraphic sorting
+  # follow lexicographic sorting
   Sub sub class 2:
     is_a: subclass test
   tub sub class 1:
@@ -383,7 +384,8 @@ slots:
   life_status:
     range: LifeStatusEnum
   cordialness:
-    
+  altitude:
+    range: decimal
 
 enums:
   FamilialRelationshipType:

--- a/tests/test_generators/input/kitchen_sink_inst_01.yaml
+++ b/tests/test_generators/input/kitchen_sink_inst_01.yaml
@@ -31,6 +31,7 @@ persons:
     addresses:
       - street: 1 foo street
         city: foo city
+        altitude: 923.3
 companies:
   - id: ROR:1
     name: foo

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -560,7 +560,7 @@ def test_fetch_slots_of_class(kitchen_sink_path, input_path):
 
     # test assertion for own attributes of a class
     actual_result = gen.get_direct_slot_names(cls)
-    expected_result = ["street", "city"]
+    expected_result = ["street", "city", "altitude"]
 
     assert expected_result == actual_result
 

--- a/tests/test_generators/test_javagen.py
+++ b/tests/test_generators/test_javagen.py
@@ -10,7 +10,7 @@ def test_javagen_records(kitchen_sink_path, tmp_path):
     gen.serialize(directory=str(tmp_path))
     assert_file_contains(
         tmp_path / "Address.java",
-        "public record Address(String street, String city)",
+        "public record Address(String street, String city, BigDecimal altitude)",
         after="package org.sink.kitchen",
     )
 


### PR DESCRIPTION
A schema containing the primitive type `range: decimal` requires that the Pydantic generated classes import `decimal.Decimal`. Added that to the template, added a decimal slot to the kitchen sink test, and updated expected test outputs on a couple of impacted. tests.