### PR TITLE
Pydanticgen: Inject imports, slots, and classes

### DIFF
--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -334,7 +334,7 @@ class PydanticGenerator(OOCodeGenerator):
         )
     
     """
-    imports: Optional[Dict[str, Union[Dict[str, str], List[Union[str, Dict[str, str]]]]]] = None
+    imports: Optional[Dict[str, Union[None, Dict[str, str], List[Union[str, Dict[str, str]]]]]] = None
     """
     Additional imports to inject into generated module. 
     

--- a/linkml/generators/pydanticgen.py
+++ b/linkml/generators/pydanticgen.py
@@ -1,10 +1,11 @@
+import inspect
 import logging
 import os
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Type, Union
 
 import click
 from jinja2 import Template
@@ -32,7 +33,9 @@ from linkml.utils.generator import shared_arguments
 from linkml.utils.ifabsent_functions import ifabsent_value_declaration
 
 
-def default_template(pydantic_ver: str = "1", extra_fields: str = "forbid") -> str:
+def default_template(
+    pydantic_ver: str = "1", extra_fields: str = "forbid", injected_classes: Optional[List[Union[Type, str]]] = None
+) -> str:
     """Constructs a default template for pydantic classes based on the version of pydantic"""
     ### HEADER ###
     template = """
@@ -62,7 +65,26 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-
+{% if imports is not none %}
+{%- for import_module, import_classes in imports.items() -%}
+{% if import_classes is none -%}
+import {{ import_module }}
+{% elif import_classes is mapping -%}
+import {{ import_module }} as {{ import_classes['as'] }}
+{% else -%}
+from {{ import_module }} import (
+    {% for imported_class in import_classes %}
+    {%- if imported_class is string -%}
+    {{ imported_class }}
+    {%- else -%}
+    {{ imported_class['name'] }} as {{ imported_class['as'] }}
+    {%- endif -%}
+    {%- if not loop.last %},{{ '\n    ' }}{% else %}{{ '\n' }}{%- endif -%}
+    {% endfor -%}
+)
+{% endif -%}
+{% endfor -%}
+{% endif %}
 metamodel_version = "{{metamodel_version}}"
 version = "{{version if version else None}}"
 """
@@ -79,7 +101,6 @@ class ConfiguredBaseModel(WeakRefShimBaseModel,
                 extra = '{extra_fields}',
                 arbitrary_types_allowed = True,
                 use_enum_values = True):
-    pass
 """
     else:
         template += f"""
@@ -90,8 +111,26 @@ class ConfiguredBaseModel(BaseModel):
         extra = '{extra_fields}',
         arbitrary_types_allowed=True,
         use_enum_values = True)
-    pass
 """
+
+    ### Fields injected into base model
+    template += """{% if injected_fields is not none %}
+    {% for field in injected_fields -%}
+    {{ field }}
+    {% endfor %}
+{% else %}
+    pass
+{% endif %}
+        """
+
+    ### Extra classes
+    if injected_classes is not None and len(injected_classes) > 0:
+        template += """{{ '\n\n' }}"""
+        for cls in injected_classes:
+            if isinstance(cls, str):
+                template += cls + "\n\n"
+            else:
+                template += inspect.getsource(cls) + "\n\n"
 
     ### ENUMS ###
     template += """
@@ -273,6 +312,67 @@ class PydanticGenerator(OOCodeGenerator):
     template_file: str = None
     extra_fields: str = "forbid"
     gen_mixin_inheritance: bool = True
+    injected_classes: Optional[List[Union[Type, str]]] = None
+    """
+    A list/tuple of classes to inject into the generated module.
+    
+    Accepts either live classes or strings. Live classes will have their source code
+    extracted with inspect.get - so they need to be standard python classes declared in a
+    source file (ie. the module they are contained in needs a ``__file__`` attr, 
+    see: :func:`inspect.getsource` )
+    """
+    injected_fields: Optional[List[str]] = None
+    """
+    A list/tuple of field strings to inject into the base class.
+    
+    Examples:
+    
+    .. code-block:: python
+
+        injected_fields = (
+            'object_id: Optional[str] = Field(None, description="Unique UUID for each object")',
+        )
+    
+    """
+    imports: Optional[Dict[str, Union[Dict[str, str], List[Union[str, Dict[str, str]]]]]] = None
+    """
+    Additional imports to inject into generated module. 
+    
+    A dictionary mapping a module to a list of objects to import. 
+    If the value of an entry is ``None`` , import the whole module.
+    
+    Import Aliases:
+    If the value of a module import is a dictionary with a key "as",
+    or a class is specified as a dictionary with a "name" and "as",
+    then the import is renamed like "from module import class as renamedClass".
+    
+    Examples:
+        
+    .. code-block:: python
+    
+        imports = {
+            'typing': ['Dict', 'List', 'Union'],
+            'types': None,
+            'numpy': {'as': 'np'},
+            'collections': [{'name': 'OrderedDict', 'as': 'odict'}]
+        }
+        
+    becomes:
+    
+    .. code-block:: python
+    
+        from typing import (
+            Dict,
+            List,
+            Union
+        )
+        import types
+        import numpy as np
+        from collections import (
+            OrderedDict as odict
+        )
+    
+    """
 
     # ObjectVars (identical to pythongen)
     gen_classvars: bool = True
@@ -567,7 +667,7 @@ class PydanticGenerator(OOCodeGenerator):
             with open(self.template_file) as template_file:
                 template_obj = Template(template_file.read())
         else:
-            template_obj = Template(default_template(self.pydantic_version, self.extra_fields))
+            template_obj = Template(default_template(self.pydantic_version, self.extra_fields, self.injected_classes))
 
         sv: SchemaView
         sv = self.schemaview
@@ -668,6 +768,8 @@ class PydanticGenerator(OOCodeGenerator):
             metamodel_version=self.schema.metamodel_version,
             version=self.schema.version,
             class_isa_plus_mixins=self.get_class_isa_plus_mixins(),
+            imports=self.imports,
+            injected_fields=self.injected_fields,
             uses_numpy=uses_numpy,
         )
         return code

--- a/tests/test_generators/conftest.py
+++ b/tests/test_generators/conftest.py
@@ -4,3 +4,10 @@ import pytest
 @pytest.fixture
 def kitchen_sink_path(input_path):
     return str(input_path("kitchen_sink.yaml"))
+
+
+class MyInjectedClass:
+    classattr: str = "hey"
+
+    def __init__(self, up: str = "doc"):
+        self.whats = up

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -1,4 +1,7 @@
+import inspect
+import typing
 from importlib.metadata import version
+from typing import Dict, List, Optional, Union
 
 import pytest
 import yaml
@@ -10,6 +13,8 @@ from pydantic import ValidationError
 
 from linkml.generators.pydanticgen import PydanticGenerator
 from linkml.utils.schema_builder import SchemaBuilder
+
+from .conftest import MyInjectedClass
 
 PACKAGE = "kitchen_sink"
 
@@ -595,3 +600,71 @@ classes:
     gen = PydanticGenerator(schema=unit_test_schema)
     with pytest.raises(NotImplementedError):
         gen.serialize()
+
+
+@pytest.mark.parametrize(
+    "imports,expected",
+    [
+        ({"typing": ["Dict", "List", "Union"]}, (("Dict", Dict), ("List", List), ("Union", Union))),
+        ({"typing": None}, (("typing", typing),)),
+        (
+            {"typing": [{"name": "Dict", "as": "DictRenamed"}, {"name": "List", "as": "ListRenamed"}]},
+            (("DictRenamed", Dict), ("ListRenamed", List)),
+        ),
+        ({"typing": {"as": "tp"}}, (("tp", typing),)),
+    ],
+)
+def test_inject_imports(kitchen_sink_path, tmp_path, input_path, imports, expected):
+    gen = PydanticGenerator(kitchen_sink_path, package=PACKAGE, imports=imports)
+    code = gen.serialize()
+    module = compile_python(code, PACKAGE)
+    for condition in expected:
+        assert hasattr(module, condition[0])
+        assert getattr(module, condition[0]) is condition[1]
+
+
+_StringClass = (
+    """class MyInjectedClass:\n    field: str = 'field'\n    def __init__(self):\n        self.apple = 'banana'"""
+)
+
+
+@pytest.mark.parametrize(
+    "inject,expected", ((MyInjectedClass, inspect.getsource(MyInjectedClass)), (_StringClass, _StringClass))
+)
+def test_inject_classes(kitchen_sink_path, tmp_path, input_path, inject, expected):
+    gen = PydanticGenerator(
+        kitchen_sink_path,
+        package=PACKAGE,
+        injected_classes=[inject],
+    )
+    code = gen.serialize()
+    module = compile_python(code, PACKAGE)
+    assert hasattr(module, "MyInjectedClass")
+    # can't do inspect on the compiled module since it doesn't have a file
+    assert expected in code
+
+
+@pytest.mark.parametrize(
+    "inject,name,type,default,description",
+    (
+        (
+            'object_id: Optional[str] = Field(None, description="Unique UUID for each object")',
+            "object_id",
+            Optional[str],
+            None,
+            "Unique UUID for each object",
+        ),
+    ),
+)
+def test_inject_field(kitchen_sink_path, tmp_path, input_path, inject, name, type, default, description):
+    gen = PydanticGenerator(kitchen_sink_path, package=PACKAGE, injected_fields=[inject])
+    code = gen.serialize()
+    module = compile_python(code, PACKAGE)
+
+    base = getattr(module, "ConfiguredBaseModel")
+
+    assert name in base.model_fields
+    field = base.model_fields[name]
+    assert field.annotation == type
+    assert field.default == default
+    assert field.description == description


### PR DESCRIPTION
Prerequisite of: https://github.com/linkml/linkml/pull/1887

This is both a step towards cleaning up the pydantic generator and a prerequisite to implementing arrays. 

There is one failing compliance test, but it is for the dataclass generator from code that i definitely didn't touch, so not sure what that's about. added tests pass, lmk if we need additional cases :)

## Motivation

As we try and make more complex models in pydantic, we need to expose more of the generation machinery to allow for custom behavior. Particularly for arrays, we'll need to optionally include extra accessory classes to handle the special type checking needed for the arrays, and we want to have flexibility to inject source code or imports to make that work, depending on the preference of the person doing the generation. We could continue to add extra special cases in the jinja template or generator, but even better would be to have more standardized hooks for each of the different components of a generated pydantic file. This will be needed in any sort of eventual plugin system, where we might want to have a plugin define what extra classes it provides, what additional imports it depends on, etc.

## Implementation

This PR does three things: 

### Inject Imports

Currently additional imports are handled as special cases - eg. https://github.com/linkml/linkml/blob/55cc87f8d8e62eb5456f4d3431180c0d1bd98d0b/linkml/generators/pydanticgen.py#L46-L48

An additional field `imports` is added to the `PydanticGenerator` with the admittedly complex signature:

```python
imports: Optional[Dict[str, Union[None, Dict[str, str], List[Union[str, Dict[str, str]]]]]] = None
```

This allows injecting four forms of imports:

* Modules: `{'typing': None}`
* Classes from modules: `{'typing': ['Dict', 'List']}`
* Aliased modules: `{'typing': {'as': 'tp'}`
* Aliased classes from modules: `{'typing': [{'name': 'Dict', 'as': 'AliasedDict'}]}`

So, for example:

```python
imports = {
    'typing': ['Dict', 'List', 'Union'],
    'types': None,
    'numpy': {'as': 'np'},
    'collections': [{'name': 'OrderedDict', 'as': 'odict'}]
}
```

yields

```python
from typing import (
    Dict,
    List,
    Union
)
import types
import numpy as np
from collections import (
    OrderedDict as odict
)
```

#### Caveats

This is still, to me, undesirably implicit, as it depends on passing a bunch of anonymous dicts and whatnot around, but I didn't want to go and add a bunch of `TypedDict`s and pydantic models in here since that isn't how the rest of the code is styled. I would be happy to do that though, since i really don't like the type of this field lol.

Another option would be to flatten the whole thing like:

```python
imports = [
  {'type': 'module', 'name': 'typing'},
  {'type': 'module', 'name': 'numpy', 'as': 'np'},
  {'type': 'class', 'name': 'Dict', 'from': 'typing', 'as': 'DictRenamed'}
]
```
what that gains in potential clarity it sacrifices in ergonomics. In the future if we choose to replace the existing imports within the template with a more generalized import system, we'll need to write logic to merge sets of imports, and it's sort of an open question to me which version is better

When I merge the PR for arrays i'll also remove the existing numpy import and replace it with a result of the array generation process which will indicate whether or not numpy needs to be imported.

### Inject Classes

An additional field is added to `PydanticGenerator`: 

```python
injected_classes: Optional[List[Union[Type, str]]] = None
```

So one is able to do:

```python
class MyClass:
    hey = 'what up'

string_class = """
class StringClass:
    this_one_is = 'a string'
"""

gen = PydanticGenerator(injected_classes = [MyClass, string_class])
```

and have them show up in the generated module.

This allows a live class definition or a string for a class definition to be injected into the resulting module. This will be necessary for arrays, but is also a useful thing in general: eg. currently the BaseModel is defined in the jinja template, but that is undesirable since it's not possible to introspect it at test time, so it can't be tested independently. 

Related to: https://github.com/orgs/linkml/discussions/1820 - we could have a `LinkMLMeta` class that contains all the extra properties that usually get dropped in the pydantic models. eg how i do this in `nwb-linkml` here: 

https://github.com/p2p-ld/nwb-linkml/blob/4ee97263ed4338a0cf76c19c23553038f85a9eae/nwb_linkml/src/nwb_linkml/generators/pydantic.py#L63-L66

https://github.com/p2p-ld/nwb-linkml/blob/4ee97263ed4338a0cf76c19c23553038f85a9eae/nwb_linkml/src/nwb_linkml/generators/pydantic.py#L483-L495

https://github.com/p2p-ld/nwb-linkml/blob/4ee97263ed4338a0cf76c19c23553038f85a9eae/nwb_linkml/src/nwb_linkml/generators/pydantic.py#L674-L675

#### Caveats

This is handled separately within the template string generation function, rather than in the template itself, because inspecting for the source code requires access to the python context where the object is imported. We could alternatively add an additional method to the `PydanticGenerator` that stringifies classes, but since the build order within `serialize` is a little complex I wasn't quite sure where that should go a priori. 

It's also a little delicate since in order for `inspect` to get the source code, the it has to be in a module with `__file__`, so eg. it can't be defined in an interactive session or other potential other weird cases, so that's why the ability to pass a pre-stringified class is present.

## Inject Slots to BaseModel

This one is super simple. Sometimes you want to have a field present on all the generated classes - eg. for `nwb-linkml` i needed to add a field to store the hdf5 path for every class, but more generally this would be how we add the `linkml_meta` slot to every model without special-casing it. 

A field is added to `PydanticGenerator` with signature:

```python
injected_fields: Optional[List[str]] = None
```

where additional fields can be injected to the basemodel such that

```python
gen = PydanticGenerator(injected_fields = (
            ['object_id: Optional[str] = Field(None, description="Unique UUID for each object")']
        )
```

results in 

```python
class ConfiguredBaseModel(BaseModel):
    model_config = ConfigDict(
        validate_assignment=True,
        validate_default=True,
        extra = 'forbid',
        arbitrary_types_allowed=True,
        use_enum_values = True)
        
    object_id: Optional[str] = Field(None, description="Unique UUID for each object")

```

This replaces the `pass` (but includes it if `injected_fields = None`


## Future cleanup

### Build stages with `Results` objects

Currently there is a relatively large amount of implicit behavior between the pydantic default template and the generator itself, so while I'm not touching it in this PR, this is a step towards one piece of that by making an explicit system to include imports - eg., in the future it might be nice to handle all imports this way, in particular by having discrete build stages for each of the classes/slots that yield a `BuildResult` that indicate what other classes and imports they depend on (this will be how arrays work).

### Unification with `dataclass` generator

I didn't try and port this to the `PythonGenerator` since it has a different inheritance lineage, but it might be nice to make a single `PythonGenerator` metaclass/mixin for all the python generators (eg. incl `SqlAlchemy`), renaming this one `DataclassGenerator`, to contain all the logic that is special to python generators like this.

### Modularize template

It would be nice to able to reuse common logic to make the generator more concise and less prone to errors. So for example, I couldn't reuse the logic to generate a model slot for `injected_fields` and thus could only accept a pre-formatted field string. It's also relatively difficult to tell the format of what should go into the jinja template - we lose all the structure of the `ClassDefinition` et al. classes and instead go into anonymous dictionary land.

It would be nice to instead 
- make use of jinja's [macro](https://jinja.palletsprojects.com/en/3.0.x/templates/#macros) and [import](https://jinja.palletsprojects.com/en/3.0.x/templates/#import) system, 
- break up each part of the template, such that
- each template module has an adjoining `dataclass` or pydantic model that defines the properties for that module.
