### PR TITLE
Add timeout to requests

### DIFF
--- a/linkml/__init__.py
+++ b/linkml/__init__.py
@@ -71,3 +71,10 @@ BIOLINK_MODEL_URI = "https://w3id.org/biolink/biolink-model"
 BIOLINK_MODEL_PYTHON_LOC = "biolink.model"
 
 TurtleSerializer.roundtrip_prefixes = [""]
+
+REQUESTS_TIMEOUT = 10
+"""
+Time (in seconds) to wait before failing a network request
+
+See: https://docs.python-requests.org/en/latest/user/advanced/#timeouts
+"""

--- a/linkml/generators/plantumlgen.py
+++ b/linkml/generators/plantumlgen.py
@@ -19,6 +19,7 @@ from linkml_runtime.linkml_model.meta import (
 )
 from linkml_runtime.utils.formatutils import camelcase, underscore
 
+from linkml import REQUESTS_TIMEOUT
 from linkml._version import __version__
 from linkml.utils.generator import Generator, shared_arguments
 
@@ -101,7 +102,7 @@ class PlantumlGenerator(Generator):
                 camelcase(sorted(classes)[0] if classes else self.schema.name) + file_suffix,
             )
             if load_image:
-                resp = requests.get(plantuml_url, stream=True)
+                resp = requests.get(plantuml_url, stream=True, timeout=REQUESTS_TIMEOUT)
                 if resp.ok:
                     with open(self.output_file_name, "wb") as f:
                         for chunk in resp.iter_content(chunk_size=2048):

--- a/linkml/generators/yumlgen.py
+++ b/linkml/generators/yumlgen.py
@@ -14,6 +14,7 @@ from linkml_runtime.linkml_model.meta import ClassDefinition, ClassDefinitionNam
 from linkml_runtime.utils.formatutils import camelcase, underscore
 from rdflib import Namespace
 
+from linkml import REQUESTS_TIMEOUT
 from linkml.utils.generator import Generator, shared_arguments
 
 yuml_is_a = "^-"
@@ -95,10 +96,10 @@ class YumlGenerator(Generator):
                 payload = "dsl_text=" + (",".join(yumlclassdef))
                 payload = payload.replace("%3F", "?").replace("%2B", "+")
                 url = "https://yuml.me/diagram/plain/class/"
-                resp = requests.post(url, data=payload)
+                resp = requests.post(url, data=payload, timeout=REQUESTS_TIMEOUT)
                 if resp.ok:
                     filename = resp.text.strip().replace(".svg", file_suffix)
-                    resp = requests.get(f"https://yuml.me/{filename}", stream=True)
+                    resp = requests.get(f"https://yuml.me/{filename}", stream=True, timeout=REQUESTS_TIMEOUT)
                     with open(self.output_file_name, "wb") as f:
                         for chunk in resp.iter_content(chunk_size=2048):
                             f.write(chunk)


### PR DESCRIPTION
Related to: https://github.com/linkml/linkml/issues/1917

Requests [recommends](https://docs.python-requests.org/en/latest/user/advanced/#timeouts) that all requests have a timeout. Without an explicit timeout, requests to an unresponsive server will hang indefinitely.

Couldn't find if there was any place that configuration was set via eg. environment variables, so i just added the timeout value as a top-level module variable along with other constant-like things. Set it to 10 seconds, but obvi that can be whatever.

Didn't add to requests in tests, because those should use recorded network traffic rather than real network requests except when checking API consistency. No extra tests bc the test failures are sporadic, and i don't think we need to simulate an unresponsive server necessarily.