### PR TITLE
Perf: Mark shex generator as slow, skip except for gh actions runner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,7 +102,7 @@ jobs:
       #----------------------------------------------
       - name: Generate coverage results
         run: |
-          poetry run coverage run -m pytest --slow
+          poetry run coverage run -m pytest --with-slow
           poetry run coverage xml
           poetry run coverage report -m
         shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,7 +102,7 @@ jobs:
       #----------------------------------------------
       - name: Generate coverage results
         run: |
-          poetry run coverage run -m pytest
+          poetry run coverage run -m pytest --slow
           poetry run coverage xml
           poetry run coverage report -m
         shell: bash

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -59,6 +59,16 @@ runs the entire test suite with the new test case that you added, on that test c
 Note: You will see a number of issues which are named `test_issue_NNN.py`. The numbers and convention for those
 issues are with reference to the old [biolinkml](https://github.com/biolink/biolinkml) issue numbering convention.
 
+#### Marks
+
+Use marks to run or exclude groups of tests:
+
+- `network` - (currently unused in CI) - tests marked as requiring network access/making network requests in order to succeed. 
+- `slow` - tests that are necessary to test technical correctness but are sufficiently long that it's worth excluding them during routine development/when running tests locally. 
+  By default, tests marked `slow` are not run, and require the `--with-slow` flag to run. Slow tests are included in the CI testing action. Typical use is to do most development
+  work without running `slow` tests, and then running the full test suite `--with-slow` before submitting or merging a pull request.
+- `skip`, `xfail` - see [skip and xfail docs](https://docs.pytest.org/en/latest/how-to/skipping.html)
+
 #### General Tips
 
 * Always make sure to use `assert` statements to compare the expected value with the actual value, rather than simply printing or logging the expected and actual values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,8 @@ filterwarnings = [
   "ignore:.*_pytestfixturefunction is not defined in namespace:UserWarning"
 ]
 markers = [
-  "network: mark tests that make external network requests"
+  "network: mark tests that make external network requests",
+  "slow: mark test as slow to run"
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,11 +160,7 @@ def pytest_addoption(parser):
         action="store_true",
         help="Generate new files into __snapshot__ directories instead of checking against existing files",
     )
-    parser.addoption(
-        "--slow",
-        action="store_true",
-        help="include tests marked slow"
-    )
+    parser.addoption("--slow", action="store_true", help="include tests marked slow")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,12 +160,12 @@ def pytest_addoption(parser):
         action="store_true",
         help="Generate new files into __snapshot__ directories instead of checking against existing files",
     )
-    parser.addoption("--slow", action="store_true", help="include tests marked slow")
+    parser.addoption("--with-slow", action="store_true", help="include tests marked slow")
 
 
 def pytest_collection_modifyitems(config, items):
-    if not config.getoption("--slow"):
-        skip_slow = pytest.mark.skip(reason="need --slow option to run")
+    if not config.getoption("--with-slow"):
+        skip_slow = pytest.mark.skip(reason="need --with-slow option to run")
         for item in items:
             if item.get_closest_marker("slow"):
                 item.add_marker(skip_slow)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,6 +160,19 @@ def pytest_addoption(parser):
         action="store_true",
         help="Generate new files into __snapshot__ directories instead of checking against existing files",
     )
+    parser.addoption(
+        "--slow",
+        action="store_true",
+        help="include tests marked slow"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--slow"):
+        skip_slow = pytest.mark.skip(reason="need --slow option to run")
+        for item in items:
+            if item.get_closest_marker("slow"):
+                item.add_marker(skip_slow)
 
 
 def pytest_assertrepr_compare(config, op, left, right):

--- a/tests/test_scripts/test_gen_shex.py
+++ b/tests/test_scripts/test_gen_shex.py
@@ -17,6 +17,7 @@ def test_help():
     assert "Generate a ShEx Schema for a  LinkML model" in result.output
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "arguments,snapshot_file",
     [


### PR DESCRIPTION
Continuing from https://github.com/linkml/linkml-runtime/pull/296 trying to improve DX

`test_scripts/test_gen_shex.py:gen_meta` singlehandedly takes 7 minutes (out of 50 total) because it's doing a gigantic rdflib graph equality test. 

Mark this as slow and only run on gh actions test runner. 