### PR TITLE
Include mixin classes in JSON schema definitions

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -225,7 +225,7 @@ class JsonSchemaGenerator(Generator):
         )
 
     def handle_class(self, cls: ClassDefinition) -> None:
-        if cls.mixin or cls.abstract:
+        if cls.abstract:
             return
 
         subschema_type = "object"


### PR DESCRIPTION
This fixes a problem that was discovered while working on https://github.com/psychoinformatics-de/datalad-concepts/pull/44/commits/d8bb1f1e9f84610d57865e3a52fb9266e1c4e414

Specifically, the JSON schema output generated from that linkml schema referenced any base classes that were not abstract, but did not include definitions for mixin classes.

This change aligns the criterion to exclude abstract, but not mixin classes.

It may be possible to exclude the references to mixin classes in the JSON schema output, and thereby be able to continue to exclude definitions for mixin classes too. However, an attempt to address this in `get_type_info_for_slot_subschema()` was not fully successful for me, but was impacted by generator parameterization.

Apologies for not including a test case, I am not yet familiar with a suitable development setup.