### PR TITLE
[bugfix] generalize test for #494 after linkml-runtime 1.7.2

### DIFF
--- a/tests/test_issues/test_issue_494.py
+++ b/tests/test_issues/test_issue_494.py
@@ -14,7 +14,7 @@ def test_jsonschema_validation(input_path):
     with pytest.raises(
         RuntimeError,
         match="Multiple potential target "
-        r"classes found: \['Container', 'annotation'\]. "
+        r"classes found: \['(Container|annotation)', '(Container|annotation)'\]. "
         "Please specify a target using --target-class "
         "or by adding tree_root: true to the relevant class in the schema",
     ):


### PR DESCRIPTION
linkml-runtime 1.7.2 introduced a change to schemaview that changed the order of the import closure - https://github.com/linkml/linkml-runtime/pull/302

that changed the order of results and broke a `pytest.raises` regex match to a hardcoded list that was revealed in https://github.com/linkml/linkml/pull/1704#issuecomment-1960210701

slightly generalized the regex to allow the items to be in whatever position, since it's not important for the substance of the test