### PR TITLE
[QoL] Make generating output optional in compliance tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -73,6 +73,9 @@ DEFAULT_MISMATCH_ACTION = eval(test_settings.get("DEFAULT_MISMATCH_ACTION", "Mis
 #  the final output
 USE_LOCAL_IMPORT_MAP = test_settings.getboolean("USE_LOCAL_IMPORT_MAP", False)
 
+# set by --with-output cli flag
+WITH_OUTPUT = False
+
 
 # Exception for use in script testing.  Global to prevent redefinition
 class CLIExitException(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from _pytest.assertion.util import _diff_text
 from linkml_runtime.linkml_model.meta import SchemaDefinition
 
+import tests
 from tests.utils.compare_rdf import compare_rdf
 from tests.utils.dirutils import are_dir_trees_equal
 
@@ -161,6 +162,9 @@ def pytest_addoption(parser):
         help="Generate new files into __snapshot__ directories instead of checking against existing files",
     )
     parser.addoption("--with-slow", action="store_true", help="include tests marked slow")
+    parser.addoption(
+        "--with-output", action="store_true", help="dump output in compliance test for richer debugging information"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -169,6 +173,10 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if item.get_closest_marker("slow"):
                 item.add_marker(skip_slow)
+
+
+def pytest_sessionstart(session: pytest.Session):
+    tests.WITH_OUTPUT = session.config.getoption("--with-output")
 
 
 def pytest_assertrepr_compare(config, op, left, right):

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
 
 import linkml_runtime
+from linkml_runtime.linkml_model import SchemaDefinition
 import pydantic
 import pytest
 import rdflib
@@ -43,6 +44,7 @@ from linkml.utils.sqlutils import SQLStore
 from linkml.validator import JsonschemaValidationPlugin, Validator
 from linkml.validator.plugins.shacl_validation_plugin import ShaclValidationPlugin
 from tests.output.types import Decimal
+import tests
 
 THIS_DIR = Path(__file__).parent
 OUTPUT_DIR = THIS_DIR / "output"
@@ -274,7 +276,8 @@ def _generate_framework_output(schema: Dict, framework: str, mappings: List = No
             gen_class, gen_args = gen_class
         else:
             gen_args = {}
-        gen = gen_class(schema=yaml.dump(schema), **gen_args)
+
+        gen = gen_class(schema=SchemaDefinition(**schema), **gen_args)
         if framework == JAVA:
             temp_dir = tempfile.TemporaryDirectory()
             gen.serialize(temp_dir.name)
@@ -486,32 +489,34 @@ def _make_schema(
             raise AssertionError(f"No core elements defined for for {schema_name}")
         for el in core_elements:
             stream.write(f"* [{el}](https://w3id.org/linkml/{el})\n")
-    # Write README for this schema combo
-    with open(out_dir / "README.md", "w", encoding="utf-8") as stream:
-        dlines = [x.strip() for x in schema["description"].split("\n")]
-        dlines = [x for x in dlines if not x.startswith(":")]
-        desc = "\n".join(dlines)
-        stream.write(f"# {schema_name.replace('test_', '')}\n\n")
-        stream.write(f"{desc}\n\n")
-        schema_minimal = deepcopy(schema)
-        builtin = [
-            tn
-            for tn, t in schema_minimal.get("types", {}).items()
-            if t.get("from_schema", None) == "https://w3id.org/linkml/types"
-        ]
-        for t in builtin:
-            del schema_minimal["types"][t]
-        if "imports" not in schema_minimal:
-            schema_minimal["imports"] = []
-        schema_minimal["imports"].append("linkml:types")
-        stream.write("## Schema\n\n")
-        stream.write("```yaml\n")
-        yaml.safe_dump(schema_minimal, stream, sort_keys=False)
-        stream.write("```\n\n")
-    with open(out_dir / "schema.yaml", "w", encoding="utf-8") as stream:
-        yaml.safe_dump(schema, stream, sort_keys=False)
-    with open(out_dir / "mappings.txt", "w", encoding="utf-8") as stream:
-        stream.write(str(mappings))
+
+    if tests.WITH_OUTPUT:
+        # Write README for this schema combo
+        with open(out_dir / "README.md", "w", encoding="utf-8") as stream:
+            dlines = [x.strip() for x in schema["description"].split("\n")]
+            dlines = [x for x in dlines if not x.startswith(":")]
+            desc = "\n".join(dlines)
+            stream.write(f"# {schema_name.replace('test_', '')}\n\n")
+            stream.write(f"{desc}\n\n")
+            schema_minimal = deepcopy(schema)
+            builtin = [
+                tn
+                for tn, t in schema_minimal.get("types", {}).items()
+                if t.get("from_schema", None) == "https://w3id.org/linkml/types"
+            ]
+            for t in builtin:
+                del schema_minimal["types"][t]
+            if "imports" not in schema_minimal:
+                schema_minimal["imports"] = []
+            schema_minimal["imports"].append("linkml:types")
+            stream.write("## Schema\n\n")
+            stream.write("```yaml\n")
+            yaml.safe_dump(schema_minimal, stream, sort_keys=False)
+            stream.write("```\n\n")
+        with open(out_dir / "schema.yaml", "w", encoding="utf-8") as stream:
+            yaml.safe_dump(schema, stream, sort_keys=False)
+        with open(out_dir / "mappings.txt", "w", encoding="utf-8") as stream:
+            stream.write(str(mappings))
     if not schema["name"]:
         raise ValueError(f"Schema name not set: {schema}")
     return schema, mappings
@@ -672,23 +677,24 @@ def check_data(
     feature = feature_dict[schema_name_to_feature[schema["name"]]]
     feature.num_tests += 1
     # TODO: avoid repeated rewrites of same object shared across frameworks
-    with open(out_dir / f"README.{data_name}.md", "w", encoding="utf-8") as stream:
-        stream.write(f"# {data_name}\n")
-        if description:
-            stream.write(f"_{description}_\n")
-        stream.write("\n## Schema:\n")
-        stream.write(" * [../schema.yaml](../schema.yaml)\n")
-        stream.write("\n## Object:\n")
-        stream.write("```yaml\n")
-        yaml.safe_dump(object_to_validate, stream)
-        stream.write("```\n")
-        stream.write("\nExpected behavior:\n\n")
-        if valid:
-            stream.write("* valid (frameworks must accept the data object)\n")
-        else:
-            stream.write("* invalid (frameworks must flag the data object)\n")
-    with open(out_dir / f"{data_name}.yaml", "w", encoding="utf-8") as stream:
-        yaml.safe_dump(object_to_validate, stream)
+    if tests.WITH_OUTPUT:
+        with open(out_dir / f"README.{data_name}.md", "w", encoding="utf-8") as stream:
+            stream.write(f"# {data_name}\n")
+            if description:
+                stream.write(f"_{description}_\n")
+            stream.write("\n## Schema:\n")
+            stream.write(" * [../schema.yaml](../schema.yaml)\n")
+            stream.write("\n## Object:\n")
+            stream.write("```yaml\n")
+            yaml.safe_dump(object_to_validate, stream)
+            stream.write("```\n")
+            stream.write("\nExpected behavior:\n\n")
+            if valid:
+                stream.write("* valid (frameworks must accept the data object)\n")
+            else:
+                stream.write("* invalid (frameworks must flag the data object)\n")
+        with open(out_dir / f"{data_name}.yaml", "w", encoding="utf-8") as stream:
+            yaml.safe_dump(object_to_validate, stream)
     notes = None
     plugins = []
     if isinstance(expected_behavior, tuple):


### PR DESCRIPTION
More test profiling :)

Writing and reading yaml turns out to be like really expensive when you do it thousands of times, who knew! 

Added another option (i know i am sorry) to be able to write the (very cool!) diagnostic output in the compliance tests.

This output is (as far as I can tell) not accessible in the CI runner, but is useful when you want to diagnose problems locally, so makes sense to me as a default option.

Did a little hacky monkeypatching to a module level variable to preserve the config option since you can't get access to the config fixtures from functions that aren't test functions, but it works. 

Total time before: 2200s (36.6m)
Total time after: 1620s (27m)
Difference: 580s (9.6m) (26%)