### PR TITLE
additional tests for patterns, mixins, and abstract classes.

### DIFF
--- a/docs/generators/owl.rst
+++ b/docs/generators/owl.rst
@@ -10,7 +10,7 @@ Overview
 --------
 
 Web Ontology Language
-`OWL <https://www.w3.org/TR/2012/REC-owl2-overview-20121211/>`__ is
+`OWL <https://www.w3.org/TR/2012/REC-owl2-overview-20121211/>`_ is a
 modeling language used to author ontologies.
 
 OWL is used for building *ontologies*, whereas LinkML is a *schema*
@@ -137,8 +137,8 @@ Using ``--mixins-as-expressions`` gives:
       (mixins some HasAlias) SubClassOf: aliases only xsd:string, ...
     ...
 
-Semantics of mappings
-^^^^^^^^^^^^^^^^^^^^^
+Semantics of mapping from LinkML
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Generated OWL should be a faithful open-world rendering of the LinkML schema. This means that it may not be
 *complete* for the purposes of data validation. If a slot is not required, then an OWL reasoner will infer
@@ -150,6 +150,18 @@ like Protege, this can be an intuitive way of debugging errors with your schema.
 
 Note that currently only a subset of LinkML rules can be expressed as OWL. In future, we may
 add support to generate auxhiliary SWRL files including rules.
+
+Pitfalls
+^^^^^^^^
+
+Many OWL tools such as those based on the OWL API are intended to consume a [profile](https://www.w3.org/TR/owl2-profiles/)
+of OWL called OWL-DL. It's relatively easy to create LinkML that can't be *directly* expressed in
+OWL-DL, and the resulting RDF triples are said to be [OWL Full](https://www.w3.org/TR/owl2-overview/#Semantics).
+
+For example, if you have slots in your schema that have an `Any`
+range, then there is no direct translation of that slot to an OWL-DL
+property, since each property needs to explicitly commit to being a
+`DatatypeProperty` or `ObjectProperty` in OWL-DL.
 
 Other examples
 ^^^^^^^^^^^^^^

--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -687,6 +687,14 @@ class OwlSchemaGenerator(Generator):
                 eq_uris = [URIRef(self.schemaview.expand_curie(s)) for s in equals_string_in]
                 owl_exprs.append(self._union_of(eq_uris))
         for constraint_prop, constraint_val in constraints.items():
+            if is_literal is not None and not is_literal:
+                # In LinkML, it is permissible to have a literal constraints on slots that refer to
+                # other objects. E.g. a pattern on a in_organization slot which refers to an Organization
+                # will be applied to the id of that Organization.
+                # To support this in OWL we would need to change this to a complex expression - for
+                # now we will skip this.
+                # See: https://github.com/linkml/linkml/issues/1841
+                continue
             if constraint_val is not None:
                 owl_types.add(RDFS.Literal)
                 dr = BNode()

--- a/tests/test_compliance/test_compliance.py
+++ b/tests/test_compliance/test_compliance.py
@@ -16,6 +16,7 @@ from tests.test_compliance.helper import (
 CLASS_CONTAINER = "Container"
 CLASS_C = "C"
 CLASS_D = "D"
+CLASS_D1 = "D1"
 CLASS_X = "X"
 CLASS_Y = "Y"
 CLASS_Z = "Z"

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -274,6 +274,10 @@ def test_any_type(framework, example_value):
         ("uriorcurie", "X 1", False),
         ("uriorcurie", "X 1:1", False),
         # ("uriorcurie", "X:1 2", False),
+        ("curie", "X:1", True),
+        ("curie", "X.Y:A1", True),
+        ("curie", "X 1", False),
+        ("curie", "X 1:A1", False),
     ],
 )
 @pytest.mark.parametrize("framework", CORE_FRAMEWORKS)
@@ -287,6 +291,9 @@ def test_uri_types(framework, linkml_type, example_value, is_valid):
     :param is_valid: whether the value is valid
     :return:
     """
+    if example_value == "X:1":
+        if framework in [PYTHON_DATACLASSES, SHACL, SHEX, OWL, SQL_DDL_SQLITE]:
+            pytest.skip("Incorrectly flagged as invalid")
     classes = {
         CLASS_C: {
             "attributes": {
@@ -296,7 +303,6 @@ def test_uri_types(framework, linkml_type, example_value, is_valid):
             }
         },
     }
-    coerced = False
     expected_behavior = ValidationBehavior.IMPLEMENTS
     if not is_valid and framework in [PYDANTIC, JSON_SCHEMA]:
         expected_behavior = ValidationBehavior.INCOMPLETE
@@ -315,7 +321,6 @@ def test_uri_types(framework, linkml_type, example_value, is_valid):
         is_valid,
         expected_behavior=expected_behavior,
         target_class=CLASS_C,
-        coerced=coerced,
         description="uris and curies",
     )
 


### PR DESCRIPTION
Ensure owlgen doesn't pun when literal constraints are applied
to slots that are translated to ObjectProperties. Fixes #1841
