### PR TITLE
[pydanticgen] Replace classmethod-property chain with init subclass

### DIFF
--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -59,12 +59,17 @@ class TemplateModel(BaseModel):
         )
 
     if int(PYDANTIC_VERSION[0]) < 2:
-
-        @classmethod
-        @property
-        def model_fields(cls) -> Dict[str, Any]:
-            """In pydantic 1, simulate pydantic 2 behavior"""
-            return cls.__fields__
+        # simulate pydantic 2's model_fields behavior
+        # without using classmethod + property decorators
+        # see:
+        # - https://docs.python.org/3/whatsnew/3.11.html#language-builtins
+        # - https://github.com/python/cpython/issues/89519
+        # and:
+        # - https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
+        # for this version.
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            cls.model_fields = cls.__fields__
 
         @overload
         def model_dump(self, mode: Literal["python"] = "python") -> dict: ...

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -7,7 +7,7 @@ from pydantic.version import VERSION as PYDANTIC_VERSION
 if int(PYDANTIC_VERSION[0]) >= 2:
     from pydantic import computed_field
 else:
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:  # pragma: no cover
         from pydantic.fields import ModelField
 
 

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Generator, List, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, List, Literal, Optional, Union, overload
 
 from jinja2 import Environment, PackageLoader
 from pydantic import BaseModel, Field
@@ -6,6 +6,9 @@ from pydantic.version import VERSION as PYDANTIC_VERSION
 
 if int(PYDANTIC_VERSION[0]) >= 2:
     from pydantic import computed_field
+else:
+    if TYPE_CHECKING:
+        from pydantic.fields import ModelField
 
 
 class TemplateModel(BaseModel):
@@ -67,6 +70,8 @@ class TemplateModel(BaseModel):
         # and:
         # - https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
         # for this version.
+        model_fields: ClassVar[Dict[str, "ModelField"]]
+
         def __init_subclass__(cls, **kwargs):
             super().__init_subclass__(**kwargs)
             cls.model_fields = cls.__fields__
@@ -140,7 +145,7 @@ class PydanticBaseModel(TemplateModel):
     """
     fields: Optional[List[str]] = None
     """
-    Extra fields that are typically injected into the base model via 
+    Extra fields that are typically injected into the base model via
     :attr:`~linkml.generators.pydanticgen.PydanticGenerator.injected_fields`
     """
 
@@ -162,13 +167,13 @@ class PydanticAttribute(TemplateModel):
     annotations: Optional[dict] = None
     """
     Of the form::
-    
-        annotations = {'python_range': {'value': 'int'}} 
-    
+
+        annotations = {'python_range': {'value': 'int'}}
+
     .. todo::
-    
+
         simplify when refactoring pydanticgen, should just be a string or a model
-    
+
     """
     title: Optional[str] = None
     description: Optional[str] = None


### PR DESCRIPTION
I am not sure why this didn't fail during https://github.com/linkml/linkml/pull/1927

But tests were failing in python 3.8, for https://github.com/linkml/linkml/pull/1957 eg: https://github.com/linkml/linkml/actions/runs/8168000823/job/22329414024?pr=1957

and it turns out that chaining `@classmethod` and `@property` both
- was not implemented until python 3.9, and
- was deprecated in 3.11

See:
 - https://docs.python.org/3/whatsnew/3.11.html#language-builtins
 - https://github.com/python/cpython/issues/89519

So this just replaces that with `__init_subclass__` that adds `model_fields` as a class attr on subclass creation. All we're trying to do is add an alias for `__fields__` in pydantic 1...