### PR TITLE
remove tab in biolink model

### DIFF
--- a/tests/test_biolink_model/input/biolink-model.yaml
+++ b/tests/test_biolink_model/input/biolink-model.yaml
@@ -5520,7 +5520,7 @@ classes:
   chemical role:
     is_a: attribute
     description: >-
-      	A role played by the molecular entity or part thereof within a chemical context.
+        A role played by the molecular entity or part thereof within a chemical context.
     id_prefixes:
       - CHEBI
     exact_mappings:


### PR DESCRIPTION
the tiniest PR in the world.

re: https://github.com/linkml/linkml-runtime/pull/306

if yamllib (rather than pure python pyyaml) tries to read a multiline string that starts with a `\t` it chokes.

replace `\t` with two spaces