### PR TITLE
Add debug logs to doc-gen

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -192,52 +192,65 @@ class DocGenerator(Generator):
             "diagram_type": self.diagram_type.value if self.diagram_type else None,
             "include_top_level_diagram": self.include_top_level_diagram,
         }
+        self.logger.debug("Processing Index")
         template = self._get_template("index")
         out_str = template.render(gen=self, schema=sv.schema, schemaview=sv, **template_vars)
         self._write(out_str, directory, self.index_name)
         if self._is_single_file_format(self.format):
             self.logger.info(f"{self.format} is a single-page format, skipping non-index elements")
             return
+        self.logger.debug("Processing Schemas...")
         template = self._get_template("schema")
         for schema_name in sv.imports_closure():
+            self.logger.debug(f"  Generating doc for {schema_name}")
             imported_schema = sv.schema_map.get(schema_name)
             out_str = template.render(gen=self, schema=imported_schema, schemaview=sv, **template_vars)
             self._write(out_str, directory, imported_schema.name)
+        self.logger.debug("Processing Classes...")
         template = self._get_template("class")
         for cn, c in sv.all_classes().items():
             if self._is_external(c):
                 continue
             n = self.name(c)
+            self.logger.debug(f"  Generating doc for {n}")
             out_str = template.render(gen=self, element=c, schemaview=sv, **template_vars)
             self._write(out_str, directory, n)
+        self.logger.debug("Processing Slots...")
         template = self._get_template("slot")
         for sn, s in sv.all_slots().items():
             if self._is_external(s):
                 continue
             n = self.name(s)
+            self.logger.debug(f"  Generating doc for {n}")
             s = sv.induced_slot(sn)
             out_str = template.render(gen=self, element=s, schemaview=sv, **template_vars)
             self._write(out_str, directory, n)
+        self.logger.debug("Processing Enums...")
         template = self._get_template("enum")
         for en, e in sv.all_enums().items():
             if self._is_external(e):
                 continue
             n = self.name(e)
+            self.logger.debug(f"  Generating doc for {n}")
             out_str = template.render(gen=self, element=e, schemaview=sv, **template_vars)
             self._write(out_str, directory, n)
+        self.logger.debug("Processing Types...")
         template = self._get_template("type")
         for tn, t in sv.all_types().items():
             if self._exclude_type(t):
                 continue
             n = self.name(t)
+            self.logger.debug(f"  Generating doc for {n}")
             t = sv.induced_type(tn)
             out_str = template.render(gen=self, element=t, schemaview=sv, **template_vars)
             self._write(out_str, directory, n)
+        self.logger.debug("Processing Subsets...")
         template = self._get_template("subset")
         for _, s in sv.all_subsets().items():
             if self._is_external(c):
                 continue
             n = self.name(s)
+            self.logger.debug(f"  Generating doc for {n}")
             out_str = template.render(gen=self, element=s, schemaview=sv, **template_vars)
             self._write(out_str, directory, n)
 
@@ -253,6 +266,7 @@ class DocGenerator(Generator):
         path = Path(directory)
         path.mkdir(parents=True, exist_ok=True)
         file_name = f"{name}.{self._file_suffix()}"
+        self.logger.debug(f"  Writing file: {file_name}")
         with open(path / file_name, "w", encoding="UTF-8") as stream:
             stream.write(out_str)
 


### PR DESCRIPTION
This adds debug logs to allow for monitoring progress and debugging issues while generating documentation.

Without these logs, if you have an error in your template or a problematic data condition in your schema, it's not entirely clear what file or object `doc-gen` was processing when it ran into the problem. `--stacktrace`  helps somewhat, but without knowing what was being processed at the time, it's still difficult to solve the issue.

For example, if I have the following line that prints a link to a domain in a custom `class.md.jinja2`:
```
| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | direct | {{ gen.link(slot.domain) }}
```

and run `gen-doc` on the following schema:

```yaml
id: https://w3id.org/linkml/examples/personinfo
name: personinfo
prefixes:
  linkml: https://w3id.org/linkml/
  personinfo: https://w3id.org/linkml/examples/personinfo
imports:
  - linkml:types
default_range: string
default_prefix: personinfo

classes:
  Person_001:
    attributes:
      full_name_001:
  Person_002:
    attributes:
      full_name_002:
      parent_002:
        domain: Person_01 # <-- Notice the typo - it should be 001 instead of 01
  Person_003:
    attributes:
      full_name_003:
```

You get the following error which makes it difficult to notice that the issue lies the definition of `Person_002`:
```
$ poetry run gen-doc --stacktrace test.yaml -d out
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../Library/Caches/pypoetry/virtualenvs/linkml-F93wx90z-py3.11/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../Library/Caches/pypoetry/virtualenvs/linkml-F93wx90z-py3.11/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File ".../Library/Caches/pypoetry/virtualenvs/linkml-F93wx90z-py3.11/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../Library/Caches/pypoetry/virtualenvs/linkml-F93wx90z-py3.11/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../localenv/devenv/src/linkml/linkml/generators/docgen.py", line 977, in cli
    print(gen.serialize())
          ^^^^^^^^^^^^^^^
  File ".../src/linkml/linkml/generators/docgen.py", line 214, in serialize
    out_str = template.render(gen=self, element=c, schemaview=sv, **template_vars)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../Library/Caches/pypoetry/virtualenvs/linkml-F93wx90z-py3.11/lib/python3.11/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File ".../Library/Caches/pypoetry/virtualenvs/linkml-F93wx90z-py3.11/lib/python3.11/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File ".../src/linkml/linkml/generators/docgen/class.md.jinja2", line 71, in top-level template code
    | {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | direct | {{ gen.link(slot.domain) }}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../src/linkml/linkml/generators/docgen.py", line 397, in link
    if self._is_external(e):
       ^^^^^^^^^^^^^^^^^^^^
  File ".../src/linkml/linkml/generators/docgen.py", line 433, in _is_external
    if element.from_schema == "https://w3id.org/linkml/types" and not self.genmeta:
```

With this change, the problematic object becomes more obvious even without `--stacktrace`:

```
$ poetry run gen-doc --log_level DEBUG test.yaml -d out
INFO:root:Using SchemaView with im=None
INFO:root:Importing linkml:types as .../src/linkml-runtime/linkml_runtime/linkml_model/model/schema/types from source ../linkml-runtime/test.yaml; base_dir=None
DEBUG:linkml.generators.docgen:Processing Index
DEBUG:linkml.generators.docgen:  Writing file: index.md
DEBUG:linkml.generators.docgen:Processing Schemas...
DEBUG:linkml.generators.docgen:  Generating doc for personinfo
DEBUG:linkml.generators.docgen:  Writing file: personinfo.md
DEBUG:linkml.generators.docgen:Processing Classes...
DEBUG:linkml.generators.docgen:  Generating doc for Person001
DEBUG:linkml.generators.docgen:  Writing file: Person001.md
DEBUG:linkml.generators.docgen:  Generating doc for Person002
AttributeError: 'NoneType' object has no attribute 'from_schema'
```