### PR TITLE
Linter: add patterns in config for classes and slots 

### DIFF
--- a/docs/schemas/linter.md
+++ b/docs/schemas/linter.md
@@ -105,6 +105,8 @@ Enforce standard naming conventions: CamelCase for classes, snake_case for slots
 
 **Additional Configuration**
 * `permissible_values_upper_case`: If `true`, permissible values will be checked for UPPER_SNAKE, otherwise snake_case. Default: `false`.
+* `class_pattern`: If specified, permissible format pattern for classes can be provided either as one of the following pattern `snake`, `uppersnake`, `camel`, `uppercamel`, `kebab` or as regular expression (e.g. `"[a-z][_a-z0-9]+"` for snake case)
+* `slot_pattern`: If specified, permissible format pattern for slots can be provided in analogy to `class_pattern`.
 
 ### tree_root_class
 

--- a/linkml/linter/config/datamodel/config.py
+++ b/linkml/linter/config/datamodel/config.py
@@ -232,10 +232,18 @@ class StandardNamingConfig(RuleConfig):
 
     level: Union[str, "RuleLevel"] = None
     permissible_values_upper_case: Optional[Union[bool, Bool]] = None
+    slot_pattern: Optional[str] = None
+    class_pattern: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self.permissible_values_upper_case is not None and not isinstance(self.permissible_values_upper_case, Bool):
             self.permissible_values_upper_case = Bool(self.permissible_values_upper_case)
+
+        if self.class_pattern is not None and not isinstance(self.class_pattern, str):
+            self.class_pattern = str(self.class_pattern)
+
+        if self.slot_pattern is not None and not isinstance(self.slot_pattern, str):
+            self.slot_pattern = str(self.slot_pattern)
 
         super().__post_init__(**kwargs)
 

--- a/linkml/linter/rules.py
+++ b/linkml/linter/rules.py
@@ -219,8 +219,17 @@ class StandardNamingRule(LinterRule):
         self.config = config
 
     def check(self, schema_view: SchemaView, fix: bool = False) -> Iterable[LinterProblem]:
-        class_pattern = self.PATTERNS["uppercamel"]
-        slot_pattern = self.PATTERNS["snake"]
+        class_pattern = (
+            self.PATTERNS["uppercamel"]
+            if not self.config.class_pattern
+            else self.PATTERNS.get(self.config.class_pattern, re.compile(self.config.class_pattern))
+        )
+        slot_pattern = (
+            self.PATTERNS["snake"]
+            if not self.config.slot_pattern
+            else self.PATTERNS.get(self.config.slot_pattern, re.compile(self.config.slot_pattern))
+        )
+
         enum_pattern = self.PATTERNS["uppercamel"]
         permissible_value_pattern = (
             self.PATTERNS["uppersnake"] if self.config.permissible_values_upper_case else self.PATTERNS["snake"]

--- a/tests/test_linter/test_rule_standard_naming.py
+++ b/tests/test_linter/test_rule_standard_naming.py
@@ -82,3 +82,61 @@ class TestStandardNamingRule(unittest.TestCase):
         self.assertIn("Enum has name 'bad_enum'", messages)
         self.assertIn("Permissible value of Enum 'bad_enum' has name 'good_lower_pv'", messages)
         self.assertIn("Permissible value of Enum 'bad_enum' has name 'great_lower_pv'", messages)
+
+    def test_standard_naming_slot_pattern(self):
+        config = StandardNamingConfig(level=RuleLevel.error.text, slot_pattern="uppercamel")
+
+        rule = StandardNamingRule(config)
+        problems = list(rule.check(self.schema_view))
+
+        self.assertEqual(len(problems), 10)
+
+        messages = [p.message for p in problems]
+        self.assertIn("Class has name 'bad class'", messages)
+        self.assertIn("Class has name '0worseclass'", messages)
+        # BadSlot no longer bad
+        self.assertIn("Slot has name 'worse slot'", messages)
+        self.assertIn("Permissible value of Enum 'GoodEnumWithBadPV' has name 'Bad_PV'", messages)
+        self.assertIn(
+            "Permissible value of Enum 'GoodEnumUpperPV' has name 'GOOD_UPPER_PV'",
+            messages,
+        )
+        self.assertIn(
+            "Permissible value of Enum 'GoodEnumUpperPV' has name 'GREAT_UPPER_PV'",
+            messages,
+        )
+        self.assertIn(
+            "Permissible value of Enum 'GoodEnumBadUpperPV' has name 'GOOD_UPPER_PV'",
+            messages,
+        )
+        self.assertIn("Enum has name 'bad_enum'", messages)
+
+    def test_standard_naming_class_pattern(self):
+        config = StandardNamingConfig(level=RuleLevel.error.text, class_pattern=r"[_a-z0-9]+")
+
+        rule = StandardNamingRule(config)
+        problems = list(rule.check(self.schema_view))
+
+        self.assertEqual(len(problems), 9)
+
+        messages = [p.message for p in problems]
+        print(messages)
+        self.assertIn("Class has name 'GoodClass'", messages)
+        self.assertIn("Class has name 'bad class'", messages)
+        # '0worseclass' now longer bad in the context of the given regular expression
+        self.assertIn("Slot has name 'BadSlot'", messages)
+        self.assertIn("Slot has name 'worse slot'", messages)
+        self.assertIn("Permissible value of Enum 'GoodEnumWithBadPV' has name 'Bad_PV'", messages)
+        self.assertIn(
+            "Permissible value of Enum 'GoodEnumUpperPV' has name 'GOOD_UPPER_PV'",
+            messages,
+        )
+        self.assertIn(
+            "Permissible value of Enum 'GoodEnumUpperPV' has name 'GREAT_UPPER_PV'",
+            messages,
+        )
+        self.assertIn(
+            "Permissible value of Enum 'GoodEnumBadUpperPV' has name 'GOOD_UPPER_PV'",
+            messages,
+        )
+        self.assertIn("Enum has name 'bad_enum'", messages)


### PR DESCRIPTION
closes #1978

Proposes the following two features:

- add `class_pattern` and `slot_pattern` as additional, optional configuration in the `standard_naming` _linter_ rule
- enable patterns defined in `LinterRule` as well as regular expressions

here is an example of what the config for the _linter_ would/could look like

```
extends: recommended
rules:
  standard_naming:
    level: error
    slot_pattern: camel  
    class_pattern: "[A-Z][a-zA-Z0-9]+"
```

Would something in this direction be acceptable? I'd be happy to adopt, if necessary. 