### PR TITLE
Cast rdflib `Namespace` instances to strings when used as `base` for contextgen 

### DIFF
--- a/linkml/generators/prefixmapgen.py
+++ b/linkml/generators/prefixmapgen.py
@@ -59,7 +59,7 @@ class PrefixGenerator(Generator):
             if self.default_ns:
                 self.emit_prefixes.add(self.default_ns)
 
-    def end_schema(self, base: Optional[str, Namespace] = None, output: Optional[str] = None, **_) -> None:
+    def end_schema(self, base: Optional[Union[str, Namespace]] = None, output: Optional[str] = None, **_) -> None:
         context = JsonObj()
         if base:
             base = str(base)

--- a/linkml/generators/prefixmapgen.py
+++ b/linkml/generators/prefixmapgen.py
@@ -6,14 +6,14 @@ Generate JSON-LD contexts
 import csv
 import os
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Set
+from typing import Dict, Optional, Set, Union
 
 import click
 from jsonasobj2 import JsonObj, as_json
 from linkml_runtime.linkml_model.meta import ClassDefinition, SlotDefinition
 from linkml_runtime.linkml_model.types import SHEX
 from linkml_runtime.utils.formatutils import camelcase
-from rdflib import XSD
+from rdflib import XSD, Namespace
 
 from linkml._version import __version__
 from linkml.utils.generator import Generator, shared_arguments
@@ -35,7 +35,7 @@ class PrefixGenerator(Generator):
     default_ns: str = None
     context_body: Dict = field(default_factory=lambda: dict())
     slot_class_maps: Dict = field(default_factory=lambda: dict())
-    base: str = None
+    base: Optional[Union[str, Namespace]] = None
 
     def __post_init__(self):
         super().__post_init__()
@@ -59,9 +59,10 @@ class PrefixGenerator(Generator):
             if self.default_ns:
                 self.emit_prefixes.add(self.default_ns)
 
-    def end_schema(self, base: Optional[str] = None, output: Optional[str] = None, **_) -> None:
+    def end_schema(self, base: Optional[str, Namespace] = None, output: Optional[str] = None, **_) -> None:
         context = JsonObj()
         if base:
+            base = str(base)
             if "://" not in base:
                 self.context_body["@base"] = os.path.relpath(base, os.path.dirname(self.schema.source_file))
             else:

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -1,7 +1,7 @@
-import pdb
 import re
-from linkml.generators.jsonldcontextgen import ContextGenerator
+
 from linkml import LOCAL_TYPES_YAML_FILE, METAMODEL_NAMESPACE
+from linkml.generators.jsonldcontextgen import ContextGenerator
 
 
 def test_context(kitchen_sink_path):

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -19,17 +19,3 @@ def test_rdflib_string_handling():
     generated = ContextGenerator(LOCAL_TYPES_YAML_FILE).serialize(base=METAMODEL_NAMESPACE)
     assert not re.search(r"http:/[^/]", generated)
     assert not re.search(r"https:/[^/]", generated)
-
-
-def test_model_field_usage(tmp_path):
-    """
-    When a field is allowed in both the generator instantiation and serialization method,
-    use the instance field when the serialization arg isn't provided
-    """
-    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, base=METAMODEL_NAMESPACE).serialize()
-    assert "@base" in generated
-
-    output_path = tmp_path.with_suffix(".context.json")
-    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, output=str(output_path)).serialize(base=METAMODEL_NAMESPACE)
-    assert generated is None
-    assert output_path.exists()

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -19,3 +19,17 @@ def test_rdflib_string_handling():
     generated = ContextGenerator(LOCAL_TYPES_YAML_FILE).serialize(base=METAMODEL_NAMESPACE)
     assert not re.search(r"http:/[^/]", generated)
     assert not re.search(r"https:/[^/]", generated)
+
+
+def test_model_field_usage(tmp_path):
+    """
+    When a field is allowed in both the generator instantiation and serialization method,
+    use the instance field when the serialization arg isn't provided
+    """
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, base=METAMODEL_NAMESPACE).serialize()
+    assert "@base" in generated
+
+    output_path = tmp_path.with_suffix(".context.json")
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, output=str(output_path)).serialize(base=METAMODEL_NAMESPACE)
+    assert generated is None
+    assert output_path.exists()

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -1,6 +1,21 @@
+import pdb
+import re
 from linkml.generators.jsonldcontextgen import ContextGenerator
+from linkml import LOCAL_TYPES_YAML_FILE, METAMODEL_NAMESPACE
 
 
 def test_context(kitchen_sink_path):
     """json schema"""
     ContextGenerator(kitchen_sink_path).serialize()
+
+
+def test_rdflib_string_handling():
+    """
+    Ensure that we don't make mistakes expecting rdflib stringlike-classes to behave
+    like strings!
+
+    Eg. :class:`rdflib.Namespace` inherits from ``str`` , but overrides the ``contains`` method
+    """
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE).serialize(base=METAMODEL_NAMESPACE)
+    assert not re.search(r"http:/[^/]", generated)
+    assert not re.search(r"https:/[^/]", generated)


### PR DESCRIPTION
So what's the deal with the `@base` [being](https://github.com/sneakers-the-rat/linkml/blob/2e7fac785f59ecded70768b737be2e18a158dadb/tests/test_base/__snapshots__/types.context.jsonld#L13) `"https:/w3id.org/linkml"` in https://github.com/linkml/linkml/pull/1976 ?

That's no string! that's an `rdflib.Namespace` object! 

`Namespace` overrides `__contains__`: https://github.com/RDFLib/rdflib/blob/98346657aaea6bad23fe574b7e575d8fbc002da7/rdflib/namespace/__init__.py#L175 so the check `'://' in base` always fails. 

cast to a string and make the type annotations correct.

also override `serialize` and add `base` because otherwise there's no way to know it's an allowable parameter to `serialize`. would b cool to have a docstring but 🤷 