### PR TITLE
[contextgen] Honor parameterization in generator instance, expose parameters to `serialize`

### DIFF
--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -91,16 +91,16 @@ class ContextGenerator(Generator):
         model: Optional[bool] = None,
         **_,
     ) -> None:
-        # if base is None:
-        #     base = self.base
-        # if output is None:
-        #     output = self.output
-        # if prefixes is None:
-        #     prefixes = self.prefixes
-        # if flatprefixes is None:
-        #     flatprefixes = self.flatprefixes
-        # if model is None:
-        #     model = self.model
+        if base is None:
+            base = self.base
+        if output is None:
+            output = self.output
+        if prefixes is None:
+            prefixes = self.prefixes
+        if flatprefixes is None:
+            flatprefixes = self.flatprefixes
+        if model is None:
+            model = self.model
 
         context = JsonObj()
         if self.emit_metadata:
@@ -188,8 +188,18 @@ class ContextGenerator(Generator):
         if slot_def:
             self.context_body[underscore(aliased_slot_name)] = slot_def
 
-    def serialize(self, base: Optional[Union[str, Namespace]] = None, **kwargs) -> str:
-        return super().serialize(base=base, **kwargs)
+    def serialize(
+        self,
+        base: Optional[Union[str, Namespace]] = None,
+        output: Optional[str] = None,
+        prefixes: Optional[bool] = None,
+        flatprefixes: Optional[bool] = None,
+        model: Optional[bool] = None,
+        **kwargs,
+    ) -> str:
+        return super().serialize(
+            base=base, output=output, prefixes=prefixes, flatprefixes=flatprefixes, model=model, **kwargs
+        )
 
 
 @shared_arguments(ContextGenerator)

--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -86,13 +86,22 @@ class ContextGenerator(Generator):
         self,
         base: Optional[Union[str, Namespace]] = None,
         output: Optional[str] = None,
-        prefixes: Optional[bool] = True,
-        flatprefixes: Optional[bool] = False,
-        model: Optional[bool] = True,
+        prefixes: Optional[bool] = None,
+        flatprefixes: Optional[bool] = None,
+        model: Optional[bool] = None,
         **_,
     ) -> None:
-        if model is None:
-            model = self.model
+        # if base is None:
+        #     base = self.base
+        # if output is None:
+        #     output = self.output
+        # if prefixes is None:
+        #     prefixes = self.prefixes
+        # if flatprefixes is None:
+        #     flatprefixes = self.flatprefixes
+        # if model is None:
+        #     model = self.model
+
         context = JsonObj()
         if self.emit_metadata:
             comments = JsonObj()

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -1,6 +1,6 @@
 import re
 
-from linkml import LOCAL_TYPES_YAML_FILE, METAMODEL_NAMESPACE, LOCAL_ANNOTATIONS_YAML_FILE
+from linkml import LOCAL_ANNOTATIONS_YAML_FILE, LOCAL_TYPES_YAML_FILE, METAMODEL_NAMESPACE
 from linkml.generators.jsonldcontextgen import ContextGenerator
 
 
@@ -31,7 +31,7 @@ def test_model_field_usage(tmp_path):
 
     output_path = tmp_path.with_suffix(".context.json")
     generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, output=str(output_path)).serialize()
-    assert generated is None
+    assert generated == ""
     assert output_path.exists()
 
     generated = ContextGenerator(LOCAL_ANNOTATIONS_YAML_FILE, model=False).serialize()

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -1,6 +1,6 @@
 import re
 
-from linkml import LOCAL_TYPES_YAML_FILE, METAMODEL_NAMESPACE
+from linkml import LOCAL_TYPES_YAML_FILE, METAMODEL_NAMESPACE, LOCAL_ANNOTATIONS_YAML_FILE
 from linkml.generators.jsonldcontextgen import ContextGenerator
 
 
@@ -19,3 +19,26 @@ def test_rdflib_string_handling():
     generated = ContextGenerator(LOCAL_TYPES_YAML_FILE).serialize(base=METAMODEL_NAMESPACE)
     assert not re.search(r"http:/[^/]", generated)
     assert not re.search(r"https:/[^/]", generated)
+
+
+def test_model_field_usage(tmp_path):
+    """
+    When a field is allowed in both the generator instantiation and serialization method,
+    use the instance field when the serialization arg isn't provided
+    """
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, base=METAMODEL_NAMESPACE).serialize()
+    assert "@base" in generated
+
+    output_path = tmp_path.with_suffix(".context.json")
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, output=str(output_path)).serialize()
+    assert generated is None
+    assert output_path.exists()
+
+    generated = ContextGenerator(LOCAL_ANNOTATIONS_YAML_FILE, model=False).serialize()
+    assert "value" not in generated
+
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, prefixes=False).serialize()
+    assert "shex" not in generated
+
+    _ = ContextGenerator(LOCAL_ANNOTATIONS_YAML_FILE, flatprefixes=True).serialize()
+    # FIXME: Not sure how to test this

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -1,7 +1,7 @@
-import pdb
 import re
-from linkml.generators.jsonldcontextgen import ContextGenerator
+
 from linkml import LOCAL_TYPES_YAML_FILE, METAMODEL_NAMESPACE
+from linkml.generators.jsonldcontextgen import ContextGenerator
 
 
 def test_context(kitchen_sink_path):

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -19,17 +19,3 @@ def test_rdflib_string_handling():
     generated = ContextGenerator(LOCAL_TYPES_YAML_FILE).serialize(base=METAMODEL_NAMESPACE)
     assert not re.search(r"http:/[^/]", generated)
     assert not re.search(r"https:/[^/]", generated)
-
-
-def test_model_field_usage(tmp_path):
-    """
-    When a field is allowed in both the generator instantiation and serialization method,
-    use the instance field when the serialization arg isn't provided
-    """
-    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, base=METAMODEL_NAMESPACE).serialize()
-    assert "@base" in generated
-
-    output_path = tmp_path.with_suffix(".context.json")
-    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, output=str(output_path)).serialize(base=METAMODEL_NAMESPACE)
-    assert generated is None
-    assert output_path.exists()

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -19,3 +19,17 @@ def test_rdflib_string_handling():
     generated = ContextGenerator(LOCAL_TYPES_YAML_FILE).serialize(base=METAMODEL_NAMESPACE)
     assert not re.search(r"http:/[^/]", generated)
     assert not re.search(r"https:/[^/]", generated)
+
+
+def test_model_field_usage(tmp_path):
+    """
+    When a field is allowed in both the generator instantiation and serialization method,
+    use the instance field when the serialization arg isn't provided
+    """
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, base=METAMODEL_NAMESPACE).serialize()
+    assert "@base" in generated
+
+    output_path = tmp_path.with_suffix(".context.json")
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE, output=str(output_path)).serialize(base=METAMODEL_NAMESPACE)
+    assert generated is None
+    assert output_path.exists()

--- a/tests/test_generators/test_contextgen.py
+++ b/tests/test_generators/test_contextgen.py
@@ -1,6 +1,21 @@
+import pdb
+import re
 from linkml.generators.jsonldcontextgen import ContextGenerator
+from linkml import LOCAL_TYPES_YAML_FILE, METAMODEL_NAMESPACE
 
 
 def test_context(kitchen_sink_path):
     """json schema"""
     ContextGenerator(kitchen_sink_path).serialize()
+
+
+def test_rdflib_string_handling():
+    """
+    Ensure that we don't make mistakes expecting rdflib stringlike-classes to behave
+    like strings!
+
+    Eg. :class:`rdflib.Namespace` inherits from ``str`` , but overrides the ``contains`` method
+    """
+    generated = ContextGenerator(LOCAL_TYPES_YAML_FILE).serialize(base=METAMODEL_NAMESPACE)
+    assert not re.search(r"http:/[^/]", generated)
+    assert not re.search(r"https:/[^/]", generated)


### PR DESCRIPTION
Builds on https://github.com/linkml/linkml/pull/1982

Noticed that the contextgen advertises parameters in its dataclass fields that it then ignores during serialization.

If those fields exist, they should do something!

set all args to default `None` and use instance attributes as defaults instead of method args as defaults - parameters can be set in the instance body, but overridden when calling `serialize`