### PR TITLE
use typing version of Tuple, not class for 3.8 compat

### DIFF
--- a/linkml/utils/ifabsent_functions.py
+++ b/linkml/utils/ifabsent_functions.py
@@ -115,8 +115,8 @@ default_library: List[
 def isabsent_match(
     txt: Text,
 ) -> Union[
-    tuple[Match[str], bool, Callable[[Match[str], SchemaLoader, ClassDefinition, SlotDefinition], str]],
-    tuple[None, None, None],
+    Tuple[Match[str], bool, Callable[[Match[str], SchemaLoader, ClassDefinition, SlotDefinition], str]],
+    Tuple[None, None, None],
 ]:
     txt = str(txt)
     for pattern, postinit, f in default_library:


### PR DESCRIPTION
https://github.com/linkml/linkml/pull/1964 introduced type hints that use the `tuple` form rather than the `typing.Tuple` form, which breaks python3.8: https://github.com/linkml/linkml/actions/runs/8336780512/job/22814478512?pr=1887

the reason why CI didn't catch this in that PR is pretty funny, stay tuned...