### PR TITLE
Include python version in CI cache key

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
       # install dependencies if cache does not exist


### PR DESCRIPTION
OK this is pretty funny.

I have been wondering for awhile why there would be some bugs related to python version incompatibility that would only sporadically show themselves in CI. 

Eg. https://github.com/linkml/linkml/pull/1989 should have been spotted in https://github.com/linkml/linkml/pull/1964 , but it didn't, what gives!?

Take a look at the python version that pytest reports in the (alleged) python 3.8 test: https://github.com/linkml/linkml/actions/runs/8267528787/job/22618158448#step:11:12

```
platform linux -- Python 3.10.13, pytest-7.4.4, pluggy-1.4.0
```

what in tarnation!??!!?

since we are caching *the whole venv* rather than just `site-packages`, we also restore the python binaries in that venv over whatever we had installed in the prior python install step.

PR adds python version to the cache key, so each python version should have its own cache - ie. its own version of python lmao. 

doh! 🤦