### PR TITLE
Make pyshacl an `extra`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,7 +75,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --no-interaction --no-root -E tests
 
       #----------------------------------------------
       # install pydantic

--- a/poetry.lock
+++ b/poetry.lock
@@ -804,7 +804,7 @@ files = [
 name = "html5lib"
 version = "1.1"
 description = "HTML parser based on the WHATWG HTML specification"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
     {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
@@ -1582,7 +1582,7 @@ et-xmlfile = "*"
 name = "owlrl"
 version = "6.0.2"
 description = "OWL-RL and RDFS based RDF Closure inferencing for Python"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "owlrl-6.0.2-py3-none-any.whl", hash = "sha256:57eca06b221edbbc682376c8d42e2ddffc99f61e82c0da02e26735592f08bacc"},
@@ -1760,7 +1760,7 @@ refresh = ["bioregistry[refresh] (>=0.10.0,<0.11.0)", "rdflib[refresh] (>=6.2.0,
 name = "prettytable"
 version = "3.9.0"
 description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "prettytable-3.9.0-py3-none-any.whl", hash = "sha256:a71292ab7769a5de274b146b276ce938786f56c31cf7cea88b6f3775d82fe8c8"},
@@ -1970,7 +1970,7 @@ testing = ["covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytes
 name = "pyshacl"
 version = "0.25.0"
 description = "Python SHACL Validator"
-optional = false
+optional = true
 python-versions = ">=3.8.1,<4.0.0"
 files = [
     {file = "pyshacl-0.25.0-py3-none-any.whl", hash = "sha256:716b65397486b1a306efefd018d772d3c112a3828ea4e1be27aae16aee524243"},
@@ -3389,7 +3389,11 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+shacl = ["pyshacl"]
+tests = ["pyshacl"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "00653b00c25e13aefd83f591bba9da988d67a5a13e84bcdaea4ab4be2c04e556"
+content-hash = "12a333885dc43482828d4438efc5a2ebba97f80de020359dceb08703542188b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ requests = ">=2.22"
 sqlalchemy = ">=1.4.31"
 watchdog = ">=0.9.0"
 typing-extensions = {version = "^4.5.0", python = "3.7"}
+pyshacl = { version = "^0.25.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 chardet = "*"
@@ -144,8 +145,9 @@ pytest = "^7.4.0"
 pytest-subtests = "^0.11.0"
 numpy = ">=1.24.3"
 
-[tool.poetry.group.shacl.dependencies]
-pyshacl = "^0.25.0"
+[tool.poetry.extras]
+shacl = ["pyshacl"]
+tests = ["pyshacl"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]


### PR DESCRIPTION
Noticed this while doing https://github.com/linkml/linkml/pull/1991

`pyshacl` is currently in its own (required) poetry group. 

Poetry groups are only visible when installing with poetry -- ie. they are invisible to pip. the docs say:

> Dependency groups, other than the implicit main group, must only contain dependencies you need in your development process. Installing them is only possible by using Poetry.
> 
> To declare a set of dependencies, which add additional functionality to the project during runtime, use [extras](https://python-poetry.org/docs/pyproject/#extras) instead. Extras can be installed by the end user using pip.

If one builds an sdist, one will notice that `pyshacl` is not present in the `PKG-INFO`, which is what pip will use to source dependencies.

the `pyshacl` package is only used in one place in validators, but nonetheless it seems like that's intended to be an optional package available at runtime. 

This PR changes it to be an `extra`, so one installs it like `pip install linkml[shacl]` (or `poetry install -E shacl`. 

I also added it to a `tests` extra group, so that we might gradually work towards https://github.com/linkml/linkml/issues/1784 where all formats have their own extras group, and one can install everything like `pip install linkml[all]` or whatever, and we also can install for tests like `pip install linkml[tests]`. 

with this PR, the `PKG-INFO` has these extra lines:

```
Provides-Extra: shacl
Provides-Extra: tests
...
Requires-Dist: pyshacl (>=0.25.0,<0.26.0) ; extra == "shacl" or extra == "tests"
```

## Caveats

This means that you need to do `poetry install -E tests` when installing (rather than just `poetry install`. this is imo a good thing, because it may gradually make it possible for people who *do* use poetry to install from the lockfile without needing to install all testing and docs dependencies if they don't want to.