### PR TITLE
Fix Node Kind for Custom Class Ranges

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -162,7 +162,7 @@ class ShaclGenerator(Generator):
                         if sv.get_identifier_slot(r) is not None:
                             prop_pv(SH.nodeKind, SH.IRI)
                         else:
-                            prop_pv(SH.nodeKind, SH.BlankNode)
+                            prop_pv(SH.nodeKind, SH.BlankNodeOrIRI)
                     elif r in sv.all_types().values():
                         self._add_type(prop_pv, r)
                     elif r in sv.all_enums():

--- a/tests/test_biolink_model/output/biolink-model.model.owl.ttl
+++ b/tests/test_biolink_model/output/biolink-model.model.owl.ttl
@@ -1603,10 +1603,10 @@ biolink:CellLineToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "cell line to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:CellLine ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:CellLine ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -1623,13 +1623,13 @@ biolink:DrugToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "drug to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Drug ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:Drug ;
             owl:onProperty biolink:subject ],
         biolink:ChemicalEntityToEntityAssociationMixin ;
     skos:definition "An interaction between a drug and another entity" ;
@@ -1654,10 +1654,10 @@ biolink:EntityToOutcomeAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to outcome association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Outcome ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Outcome ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -1683,10 +1683,10 @@ biolink:MaterialSampleToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "material sample to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MaterialSample ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:MaterialSample ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -2826,32 +2826,32 @@ biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "anatomical entity to anatomical entity ontogenic association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
     skos:definition "A relationship between two anatomical entities where the relationship is ontogenic, i.e. the two entities are related by development. A number of different relationship types can be used to specify the precise nature of the relationship." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -2860,31 +2860,31 @@ biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "anatomical entity to anatomical entity part of association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
     skos:definition "A relationship between two anatomical entities where the relationship is mereological, i.e the two entities are related by parthood. This includes relationships between cellular components and cells, between cells and tissues, tissues and whole organisms" ;
@@ -2894,41 +2894,41 @@ biolink:Article a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "article" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:published_in ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:issue ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:iso_abbreviation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:issue ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:iso_abbreviation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:issue ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:published_in ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:published_in ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:iso_abbreviation ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:issue ],
         biolink:Publication ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -2937,22 +2937,22 @@ biolink:BehaviorToBehavioralFeatureAssociation a owl:Class,
     rdfs:label "behavior to behavioral feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:BehavioralFeature ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Behavior ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:BehavioralFeature ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin ;
     skos:definition "An association between an mixture behavior and a behavioral feature manifested by the individual exhibited or has exhibited the behavior." ;
@@ -2984,18 +2984,18 @@ biolink:Book a owl:Class,
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
+            owl:onProperty biolink:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         biolink:Publication ;
     skos:definition "This class may rarely be instantiated except if use cases of a given knowledge graph support its utility." ;
@@ -3114,13 +3114,13 @@ biolink:CellLineAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "cell line as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:CellLine ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation,
         biolink:EntityToDiseaseAssociationMixin,
@@ -3139,167 +3139,167 @@ biolink:ChemicalAffectsGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical affects gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object_context_qualifier ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:subject_context_qualifier ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:qualified_predicate ],
+            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
+            owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:object_part_qualifier ],
+            owl:onProperty biolink:object_direction_qualifier ],
         biolink:Association ;
     skos:definition "Describes an effect that a chemical has on a gene or gene product (e.g. an impact of on its abundance, activity, localization, processing, expression, etc.)" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3308,7 +3308,19 @@ biolink:ChemicalEntityAssessesNamedThingAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical entity assesses named thing association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -3317,23 +3329,11 @@ biolink:ChemicalEntityAssessesNamedThingAssociation a owl:Class,
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -3344,37 +3344,37 @@ biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:object_direction_qualifier ],
         biolink:Association ;
     skos:definition "A regulatory relationship between two genes" ;
@@ -3390,10 +3390,10 @@ biolink:ChemicalEntityToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical entity to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -3405,41 +3405,68 @@ biolink:ChemicalGeneInteractionAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical gene interaction association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
             owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
             owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_derivative_qualifier ],
@@ -3447,62 +3474,35 @@ biolink:ChemicalGeneInteractionAssociation a owl:Class,
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
             owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:object ],
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:object ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin ;
     skos:definition "describes a physical interaction between a chemical entity and a gene or gene product. Any biological or chemical effect resulting from such an interaction are out of scope, and covered by the ChemicalAffectsGeneAssociation type (e.g. impact of a chemical on the abundance, activity, structure, etc, of either participant in the interaction)" ;
@@ -3555,38 +3555,38 @@ biolink:ChemicalToChemicalDerivationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to chemical derivation association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:catalyst_qualifier ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:MacromolecularMachineMixin ;
+            owl:onProperty biolink:catalyst_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:catalyst_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MacromolecularMachineMixin ;
-            owl:onProperty biolink:catalyst_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:ChemicalToChemicalAssociation ;
     skos:definition """A causal relationship between two chemical entities, where the subject represents the upstream entity and the object represents the downstream. For any such association there is an implicit reaction:
   IF
@@ -3622,22 +3622,22 @@ biolink:ChemicalToPathwayAssociation a owl:Class,
     rdfs:label "chemical to pathway association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Pathway ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin ;
     skos:definition "An interaction between a chemical entity and a biological process or pathway." ;
@@ -3655,10 +3655,10 @@ biolink:ClinicalFinding a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "clinical finding" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ClinicalAttribute ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_attribute ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:ClinicalAttribute ;
             owl:onProperty biolink:has_attribute ],
         biolink:PhenotypicFeature ;
     skos:definition "this category is currently considered broad enough to tag clinical lab measurements and other biological attributes taken as 'clinical traits' with some statistical score, for example, a p value in genetic associations." ;
@@ -3668,13 +3668,13 @@ biolink:ClinicalMeasurement a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "clinical measurement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_attribute_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:has_attribute_type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:has_attribute_type ],
         biolink:ClinicalAttribute ;
     skos:definition "A clinical measurement is a special kind of attribute which results from a laboratory observation from a subject individual or sample. Measurements can be connected to their subject by the 'has attribute' slot." ;
@@ -3733,38 +3733,38 @@ biolink:ContributorAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "contributor association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:qualifiers ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:InformationContentEntity ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:qualifiers ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:qualifiers ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Agent ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:InformationContentEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "Any association between an entity (such as a publication) and various agents that contribute to its realisation" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3797,10 +3797,10 @@ biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin a owl:Class,
             owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -3808,23 +3808,23 @@ biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease or phenotypic feature to genetic inheritance association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneticInheritance ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin ;
     skos:definition "An association between either a disease or a phenotypic feature and its mode of (genetic) inheritance." ;
@@ -3834,13 +3834,13 @@ biolink:DiseaseOrPhenotypicFeatureToLocationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease or phenotypic feature to location association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin ;
@@ -3854,10 +3854,10 @@ biolink:DiseaseToEntityAssociationMixin a owl:Class,
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -3877,17 +3877,17 @@ biolink:DiseaseToPhenotypicFeatureAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PhenotypicFeature ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:PhenotypicFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:subject ],
@@ -3932,10 +3932,10 @@ biolink:DrugToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "drug to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -3978,28 +3978,28 @@ biolink:DruggableGeneToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "druggable gene to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DruggableGeneCategoryEnum ;
             owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:GeneToDiseaseAssociation,
@@ -4013,10 +4013,10 @@ biolink:EntityToDiseaseAssociation a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:FDA_approval_status ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:FDAApprovalStatusEnum ;
             owl:onProperty biolink:FDA_approval_status ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:FDAApprovalStatusEnum ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:FDA_approval_status ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4025,22 +4025,22 @@ biolink:EntityToFeatureOrDiseaseQualifiersMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to feature or disease qualifiers mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:severity_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:onset_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:onset_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:severity_qualifier ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Onset ;
             owl:onProperty biolink:onset_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:severity_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:onset_qualifier ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:SeverityValue ;
-            owl:onProperty biolink:severity_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:onset_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:severity_qualifier ],
         biolink:FrequencyQualifierMixin ;
     skos:definition "Qualifiers for entity to disease or phenotype associations." ;
@@ -4050,13 +4050,13 @@ biolink:EntityToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:FDAApprovalStatusEnum ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:FDA_approval_status ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:FDA_approval_status ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:FDAApprovalStatusEnum ;
             owl:onProperty biolink:FDA_approval_status ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4096,22 +4096,22 @@ biolink:ExonToTranscriptRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exon to transcript relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Transcript ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Exon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A transcript is formed from multiple exons" ;
@@ -4121,23 +4121,23 @@ biolink:ExposureEventToOutcomeAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exposure event to outcome association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:population_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:time_type ;
-            owl:onProperty biolink:temporal_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:temporal_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:temporal_context_qualifier ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:population_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:population_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:population_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:temporal_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:time_type ;
+            owl:onProperty biolink:temporal_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:temporal_context_qualifier ],
         biolink:Association,
         biolink:EntityToOutcomeAssociationMixin ;
     skos:definition "An association between an exposure event and an outcome." ;
@@ -4147,13 +4147,13 @@ biolink:ExposureEventToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exposure event to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:ExposureEvent ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ExposureEvent ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin ;
@@ -4274,13 +4274,13 @@ biolink:FrequencyQualifierMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "frequency qualifier mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:frequency_value ;
+            owl:onProperty biolink:frequency_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:frequency_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:frequency_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:frequency_value ;
             owl:onProperty biolink:frequency_qualifier ] ;
     skos:definition "Qualifier for frequency type associations" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4290,40 +4290,40 @@ biolink:FrequencyQuantifier a owl:Class,
     rdfs:label "frequency quantifier" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_percentage ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Double ;
             owl:onProperty biolink:has_percentage ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty biolink:has_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_count ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_total ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Double ;
             owl:onProperty biolink:has_quotient ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_percentage ],
+            owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_percentage ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_quotient ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Integer ;
             owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty biolink:has_count ],
         biolink:RelationshipQuantifier ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4331,10 +4331,10 @@ biolink:GeneAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
@@ -4351,22 +4351,19 @@ biolink:GeneExpressionMixin a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:expression_site ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:phenotypic_state ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:expression_site ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:phenotypic_state ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:phenotypic_state ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:expression_site ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:stage_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:LifeStage ;
@@ -4375,14 +4372,17 @@ biolink:GeneExpressionMixin a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:expression_site ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:stage_qualifier ],
+            owl:onProperty biolink:phenotypic_state ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:quantifier_qualifier ] ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:phenotypic_state ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:quantifier_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:expression_site ] ;
     skos:definition "Observed gene expression intensity, context (site, stage) and associated phenotypic status within which the expression occurs." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4390,40 +4390,40 @@ biolink:GeneHasVariantThatContributesToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene has variant that contributes to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         biolink:GeneToDiseaseAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4721,50 +4721,50 @@ biolink:GeneToExpressionSiteAssociation a owl:Class,
     rdfs:label "gene to expression site association" ;
     rdfs:seeAlso <https://github.com/monarch-initiative/ingest-artifacts/tree/master/sources/BGee> ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:stage_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:quantifier_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:quantifier_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:LifeStage ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:quantifier_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:stage_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:quantifier_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:stage_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "An association between a gene and a gene expression site, possibly qualified by stage/timing info." ;
     skos:editorialNote "TBD: introduce subclasses for distinction between wild-type and experimental conditions?" ;
@@ -4777,10 +4777,10 @@ biolink:GeneToGeneCoexpressionAssociation a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:GeneExpressionMixin,
         biolink:GeneToGeneAssociation ;
@@ -4792,31 +4792,31 @@ biolink:GeneToGeneFamilyAssociation a owl:Class,
     rdfs:label "gene to gene family association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneFamily ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneFamily ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Set membership of a gene in a family of genes related by common evolutionary ancestry usually inferred by sequence comparisons. The genes in a given family generally share common sequence motifs which generally map onto shared gene product structure-function relationships." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4826,31 +4826,31 @@ biolink:GeneToGeneHomologyAssociation a owl:Class,
     rdfs:label "gene to gene homology association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:object ],
         biolink:GeneToGeneAssociation ;
     skos:definition "A homology association between two genes. May be orthology (in which case the species of subject and object should differ) or paralogy (in which case the species may be the same)" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4859,32 +4859,32 @@ biolink:GeneToGeneProductRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene product relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneProductMixin ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneProductMixin ;
+            owl:onProperty biolink:object ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A gene is transcribed and potentially translated to a gene product" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4893,22 +4893,22 @@ biolink:GeneToGoTermAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to go term association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:object ],
         biolink:FunctionalAssociation ;
     skos:altLabel "functional association" ;
@@ -4919,13 +4919,16 @@ biolink:GeneToPathwayAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to pathway association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Pathway ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -4933,9 +4936,6 @@ biolink:GeneToPathwayAssociation a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:GeneToEntityAssociationMixin ;
     skos:definition "An interaction between a gene or gene product and a biological process or pathway." ;
@@ -4945,22 +4945,22 @@ biolink:GeneToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhenotypicFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
@@ -4999,10 +4999,10 @@ biolink:GenotypeAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Genotype ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -5016,13 +5016,13 @@ biolink:GenotypeToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -5030,26 +5030,26 @@ biolink:GenotypeToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
@@ -5064,31 +5064,31 @@ biolink:GenotypeToGenotypePartAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to genotype part association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom biolink:Genotype ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Genotype ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Any association between one genotype and a genotypic entity that is a sub-component of it" ;
@@ -5101,20 +5101,20 @@ biolink:GenotypeToPhenotypicFeatureAssociation a owl:Class,
             owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
         biolink:GenotypeToEntityAssociationMixin ;
@@ -5128,29 +5128,29 @@ biolink:GenotypeToVariantAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Any association between a genotype and a sequence variant." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5193,10 +5193,10 @@ biolink:GeographicLocationAtTime a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:time_type ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:time_type ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:timepoint ],
         biolink:GeographicLocation ;
     skos:definition "a location that can be described in lat/long coordinates, for a particular time" ;
@@ -5240,32 +5240,32 @@ biolink:InformationContentEntityToNamedThingAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "information content entity to named thing association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "association between a named thing and a information content entity where the specific context of the relationship between that named thing and the publication is unknown. For example, model organisms databases often capture the knowledge that a gene is found in a journal article, but not specifically the context in which that gene was documented in the article. In these cases, this association with the accompanying predicate 'mentions' could be used. Conversely, for more specific associations (like 'gene to disease association', the publication should be captured as an edge property)." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5289,13 +5289,13 @@ biolink:MacromolecularMachineToBiologicalProcessAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine to biological process association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:BiologicalProcess ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:FunctionalAssociation,
         biolink:MacromolecularMachineToEntityAssociationMixin ;
@@ -5306,13 +5306,13 @@ biolink:MacromolecularMachineToCellularComponentAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine to cellular component association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:CellularComponent ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:CellularComponent ;
             owl:onProperty biolink:object ],
         biolink:FunctionalAssociation,
         biolink:MacromolecularMachineToEntityAssociationMixin ;
@@ -5323,13 +5323,13 @@ biolink:MacromolecularMachineToMolecularActivityAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine to molecular activity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularActivity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:object ],
         biolink:FunctionalAssociation,
         biolink:MacromolecularMachineToEntityAssociationMixin ;
@@ -5341,7 +5341,16 @@ biolink:MaterialSampleDerivationAssociation a owl:Class,
     rdfs:label "material sample derivation association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MaterialSample ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
@@ -5350,21 +5359,12 @@ biolink:MaterialSampleDerivationAssociation a owl:Class,
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MaterialSample ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "An association between a material sample and the material entity from which it is derived." ;
@@ -5392,22 +5392,22 @@ biolink:MolecularActivityToChemicalEntityAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular activity to chemical entity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularActivity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples" ;
@@ -5418,21 +5418,21 @@ biolink:MolecularActivityToMolecularActivityAssociation a owl:Class,
     rdfs:label "molecular activity to molecular activity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularActivity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularActivity ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples" ;
@@ -5443,31 +5443,31 @@ biolink:MolecularActivityToPathwayAssociation a owl:Class,
     rdfs:label "molecular activity to pathway association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Pathway ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Association that holds the relationship between a reaction and the pathway it participates in." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5477,49 +5477,49 @@ biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation a owl:Class,
     rdfs:label "named thing associated with likelihood of named thing association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_aspect_qualifier ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -5552,10 +5552,10 @@ biolink:OrganismTaxonToEntityAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to entity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -5570,16 +5570,10 @@ biolink:OrganismTaxonToEnvironmentAssociation a owl:Class,
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -5588,11 +5582,17 @@ biolink:OrganismTaxonToEnvironmentAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:OrganismTaxonToEntityAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5601,41 +5601,41 @@ biolink:OrganismTaxonToOrganismTaxonInteraction a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to organism taxon interaction" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:associated_environmental_context ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:associated_environmental_context ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:associated_environmental_context ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:associated_environmental_context ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:subject ],
         biolink:OrganismTaxonToOrganismTaxonAssociation ;
     skos:definition "An interaction relationship between two taxa. This may be a symbiotic relationship (encompassing mutualism and parasitism), or it may be non-symbiotic. Example: plague transmitted_by flea; cattle domesticated_by Homo sapiens; plague infects Homo sapiens" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5644,32 +5644,32 @@ biolink:OrganismTaxonToOrganismTaxonSpecialization a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to organism taxon specialization" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         biolink:OrganismTaxonToOrganismTaxonAssociation ;
     skos:definition "A child-parent relationship between two taxa. For example: Homo sapiens subclass_of Homo" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5681,20 +5681,20 @@ biolink:OrganismToOrganismAssociation a owl:Class,
             owl:allValuesFrom biolink:IndividualOrganism ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:IndividualOrganism ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -5719,26 +5719,17 @@ biolink:PairwiseMolecularInteraction a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "pairwise molecular interaction" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:interacting_molecules_category ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:interacting_molecules_category ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
@@ -5746,22 +5737,31 @@ biolink:PairwiseMolecularInteraction a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:interacting_molecules_category ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:interacting_molecules_category ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:PairwiseGeneToGeneInteraction ;
     skos:definition "An interaction at the molecular level between two physical entities" ;
@@ -5870,31 +5870,31 @@ biolink:PopulationToPopulationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "population to population association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "An association between a two populations" ;
@@ -5912,194 +5912,194 @@ biolink:PredicateMapping a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "predicate mapping" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalContextQualifierEnum ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:exact_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:qualified_predicate ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_derivative_qualifier ],
+            owl:onProperty biolink:broad_match ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_derivative_qualifier ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:broad_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:broad_match ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:broad_match ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:mapped_predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:narrow_match ],
+            owl:onProperty biolink:object_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:species_context_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:exact_match ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:exact_match ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:narrow_match ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:broad_match ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalContextQualifierEnum ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:broad_match ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:exact_match ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:mapped_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:exact_match ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:mapped_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ] ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_part_qualifier ] ;
     skos:definition "A deprecated predicate mapping object contains the deprecated predicate and an example of the rewiring that should be done to use a qualified statement in its place." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -6187,13 +6187,13 @@ biolink:ReactionToCatalystAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "reaction to catalyst association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:ReactionToParticipantAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6231,20 +6231,20 @@ biolink:SequenceVariantModulatesTreatmentAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "sequence variant modulates treatment association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Treatment ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:SequenceVariant ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -6258,28 +6258,28 @@ biolink:Serial a owl:Class,
     rdfs:label "serial" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:issue ],
+            owl:onProperty biolink:iso_abbreviation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:issue ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:issue ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:iso_abbreviation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:iso_abbreviation ],
@@ -6287,19 +6287,19 @@ biolink:Serial a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:iso_abbreviation ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:issue ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:type ],
         biolink:Publication ;
     skos:altLabel "journal" ;
@@ -6321,13 +6321,13 @@ biolink:SmallMolecule a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "small molecule" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
         biolink:MolecularEntity ;
     skos:altLabel "chemical substance" ;
@@ -6364,10 +6364,10 @@ biolink:SocioeconomicExposure a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "socioeconomic exposure" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:SocioeconomicAttribute ;
             owl:onProperty biolink:has_attribute ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SocioeconomicAttribute ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:has_attribute ],
         biolink:Attribute,
         biolink:ExposureEvent ;
@@ -6419,11 +6419,14 @@ biolink:TaxonToTaxonAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "taxon to taxon association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
@@ -6432,9 +6435,6 @@ biolink:TaxonToTaxonAssociation a owl:Class,
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6458,23 +6458,23 @@ biolink:TranscriptToGeneRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "transcript to gene relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Transcript ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Transcript ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A gene is a collection of transcripts" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6483,13 +6483,13 @@ biolink:VariantAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:ModelToDiseaseAssociationMixin,
@@ -6500,10 +6500,10 @@ biolink:VariantToGeneExpressionAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to gene expression association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -6520,10 +6520,10 @@ biolink:VariantToPhenotypicFeatureAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
@@ -6534,50 +6534,50 @@ biolink:VariantToPopulationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to population association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:SequenceVariant ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_count ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:has_count ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_quotient ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_total ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:has_quotient ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:has_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:has_total ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_quotient ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_total ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_count ],
         biolink:Association,
         biolink:FrequencyQualifierMixin,
         biolink:FrequencyQuantifier,
@@ -7120,24 +7120,6 @@ biolink:BookChapter a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "book chapter" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:chapter ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:chapter ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:published_in ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
@@ -7146,6 +7128,24 @@ biolink:BookChapter a owl:Class,
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:chapter ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:chapter ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:chapter ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:published_in ],
         biolink:Publication ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -7163,13 +7163,13 @@ biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "cell line to disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:CellLineToEntityAssociationMixin,
@@ -7181,10 +7181,10 @@ biolink:ChemicalExposure a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical exposure" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:QuantityValue ;
             owl:onProperty biolink:has_quantitative_value ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:QuantityValue ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_quantitative_value ],
         biolink:Attribute,
         biolink:ExposureEvent ;
@@ -7197,23 +7197,23 @@ biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation a owl:C
         linkml:ClassDefinition ;
     rdfs:label "chemical or drug or treatment to disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:FDA_adverse_event_level ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:FDA_adverse_event_level ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:FDAIDAAdverseEventEnum ;
             owl:onProperty biolink:FDA_adverse_event_level ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin,
         biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin ;
@@ -7333,77 +7333,77 @@ biolink:GenomicSequenceLocalization a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genomic sequence localization" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:start_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:StrandEnum ;
-            owl:onProperty biolink:strand ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:phase ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:end_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:strand ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:genome_build ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:start_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:genome_build ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:phase ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:end_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:start_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:end_interbase_coordinate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:StrandEnum ;
             owl:onProperty biolink:genome_build ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NucleicAcidEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:strand ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:genome_build ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:start_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:start_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:start_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:StrandEnum ;
+            owl:onProperty biolink:strand ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:strand ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:end_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhaseEnum ;
             owl:onProperty biolink:phase ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:phase ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:end_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:phase ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NucleicAcidEntity ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:end_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:genome_build ],
         biolink:SequenceAssociation ;
     skos:broadMatch dcid:Chromosome ;
     skos:definition "A relationship between a sequence feature and a nucleic acid entity it is localized to. The reference entity may be a chromosome, chromosome region or information entity such as a contig." ;
@@ -7414,29 +7414,29 @@ biolink:GenotypeToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
@@ -7450,13 +7450,16 @@ biolink:GeographicLocation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "geographic location" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Float ;
             owl:onProperty biolink:latitude ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Float ;
             owl:onProperty biolink:longitude ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:longitude ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:latitude ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -7464,9 +7467,6 @@ biolink:GeographicLocation a owl:Class,
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:latitude ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:longitude ],
         biolink:PlanetaryEntity ;
     skos:definition "a location that can be described in lat/long coordinates" ;
     skos:exactMatch STY:T083,
@@ -7477,10 +7477,10 @@ biolink:MacromolecularMachineToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
@@ -7507,13 +7507,13 @@ biolink:PairwiseGeneToGeneInteraction a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "pairwise gene to gene interaction" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:GeneToGeneAssociation ;
     skos:definition "An interaction between two genes or two gene products. May be physical (e.g. protein binding) or genetic (between genes). May be symmetric (e.g. protein interaction) or directed (e.g. phosphorylation)" ;
@@ -7545,41 +7545,41 @@ biolink:ReactionToParticipantAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "reaction to participant association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom biolink:ReactionDirectionEnum ;
+            owl:onProperty biolink:reaction_direction ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:reaction_side ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ReactionSideEnum ;
-            owl:onProperty biolink:reaction_side ],
+            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:stoichiometry ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:reaction_direction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:reaction_side ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:reaction_direction ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty biolink:stoichiometry ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:reaction_direction ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:stoichiometry ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:ReactionSideEnum ;
             owl:onProperty biolink:reaction_side ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:stoichiometry ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:stoichiometry ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ReactionDirectionEnum ;
-            owl:onProperty biolink:reaction_direction ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:ChemicalToChemicalAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -7614,23 +7614,23 @@ biolink:Treatment a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "treatment" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_drug ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Drug ;
             owl:onProperty biolink:has_drug ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Device ;
-            owl:onProperty biolink:has_device ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_device ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_procedure ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_drug ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Procedure ;
             owl:onProperty biolink:has_procedure ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Device ;
+            owl:onProperty biolink:has_device ],
         biolink:ChemicalOrDrugOrTreatment,
         biolink:ExposureEvent,
         biolink:NamedThing ;
@@ -7646,32 +7646,32 @@ biolink:VariantToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
         biolink:VariantToEntityAssociationMixin ;
@@ -7682,22 +7682,22 @@ biolink:VariantToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Gene ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:VariantToEntityAssociationMixin ;
@@ -8297,19 +8297,19 @@ biolink:AnatomicalEntityToAnatomicalEntityAssociation a owl:Class,
     rdfs:label "anatomical entity to anatomical entity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:subject ],
@@ -8338,7 +8338,7 @@ biolink:ChemicalRole a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical role" ;
     rdfs:subClassOf biolink:Attribute ;
-    skos:definition "	A role played by the molecular entity or part thereof within a chemical context." ;
+    skos:definition "A role played by the molecular entity or part thereof within a chemical context." ;
     skos:exactMatch <http://purl.obolibrary.org/obo/CHEBI_51086> ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8346,13 +8346,13 @@ biolink:ChemicalToChemicalAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to chemical association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin ;
@@ -8414,13 +8414,13 @@ biolink:GeneToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8458,23 +8458,23 @@ biolink:OrganismTaxonToOrganismTaxonAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to organism taxon association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         biolink:Association,
         biolink:OrganismTaxonToEntityAssociation ;
     skos:definition "A relationship between two organism taxon nodes" ;
@@ -8520,13 +8520,13 @@ biolink:VariantToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8837,10 +8837,10 @@ biolink:DatasetDistribution a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:distribution_download_url ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:distribution_download_url ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:distribution_download_url ],
         biolink:InformationContentEntity ;
     skos:definition "an item that holds distribution level information about a dataset." ;
@@ -8851,19 +8851,19 @@ biolink:DatasetSummary a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "dataset summary" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:source_logo ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:source_web_page ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:source_logo ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:source_web_page ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:source_logo ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:source_web_page ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:source_web_page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:source_logo ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -8876,13 +8876,13 @@ biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to disease or phenotypic feature association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:object ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8908,23 +8908,23 @@ biolink:GeneToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Disease ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Disease ;
+            owl:onProperty biolink:object ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
         biolink:GeneToEntityAssociationMixin ;
@@ -8940,20 +8940,20 @@ biolink:GeneToGeneAssociation a owl:Class,
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:altLabel "molecular or genetic interaction" ;
     skos:definition "abstract parent class for different kinds of gene-gene or gene product to gene product relationships. Includes homology and interaction." ;
@@ -9003,17 +9003,17 @@ biolink:ModelToDiseaseAssociationMixin a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ] ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ] ;
     skos:definition "This mixin is used for any association class for which the subject (source node) plays the role of a 'model', in that it recapitulates some features of the disease in a way that is useful for studying the disease outside a patient carrying the disease" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -9053,8 +9053,14 @@ biolink:QuantityValue a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "quantity value" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_numeric_value ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_unit ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_numeric_value ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_unit ],
@@ -9062,13 +9068,7 @@ biolink:QuantityValue a owl:Class,
             owl:allValuesFrom biolink:unit ;
             owl:onProperty biolink:has_unit ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_numeric_value ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Double ;
-            owl:onProperty biolink:has_numeric_value ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_numeric_value ],
         biolink:Annotation ;
     skos:definition "A value of an attribute that is quantitative and measurable, expressed as a combination of a unit and a numeric value" ;
@@ -9078,20 +9078,20 @@ biolink:SequenceFeatureRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "sequence feature relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:NucleicAcidEntity ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NucleicAcidEntity ;
             owl:onProperty biolink:subject ],
@@ -9104,13 +9104,13 @@ biolink:ThingWithTaxon a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "thing with taxon" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:in_taxon ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:in_taxon ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:in_taxon ] ;
     skos:definition "A mixin that can be used on any entity that can be taxonomically classified. This includes individual organisms; genes, their products and other molecular entities; body parts; biological processes" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -9233,10 +9233,10 @@ biolink:ChemicalToEntityAssociationMixin a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:ChemicalEntityToEntityAssociationMixin ;
     skos:definition "An interaction between a chemical entity and another entity" ;
@@ -9254,32 +9254,32 @@ biolink:DatasetVersion a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "dataset version" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Dataset ;
+            owl:onProperty biolink:has_dataset ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:ingest_date ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_dataset ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:ingest_date ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_dataset ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_distribution ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:ingest_date ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_distribution ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:ingest_date ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DatasetDistribution ;
             owl:onProperty biolink:has_distribution ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Dataset ;
-            owl:onProperty biolink:has_dataset ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:ingest_date ],
         biolink:InformationContentEntity ;
     skos:definition "an item that holds version level information about a dataset." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -9301,20 +9301,20 @@ biolink:FunctionalAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "functional association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:MacromolecularMachineMixin ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -9326,17 +9326,17 @@ biolink:GeneProductMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene product mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:label_type ;
-            owl:onProperty biolink:synonym ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:synonym ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:xref ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:synonym ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:label_type ;
+            owl:onProperty biolink:synonym ],
         biolink:GeneOrGeneProduct ;
     skos:definition "The functional molecular product of a single gene locus. Gene products are either proteins or functional RNA molecules." ;
     skos:exactMatch <http://purl.obolibrary.org/obo/GENO_0000907>,
@@ -9348,10 +9348,10 @@ biolink:MacromolecularMachineMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:symbol_type ;
@@ -9724,25 +9724,7 @@ biolink:Entity a owl:Class,
     rdfs:label "entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:label_type ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Attribute ;
-            owl:onProperty biolink:has_attribute ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:description ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:narrative_text ;
             owl:onProperty biolink:description ],
@@ -9750,11 +9732,41 @@ biolink:Entity a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:label_type ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:category_type ;
+            owl:onProperty biolink:category ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Attribute ;
+            owl:onProperty biolink:has_attribute ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:category ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:iri_type ;
+            owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_attribute ],
@@ -9762,23 +9774,11 @@ biolink:Entity a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:iri ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:iri_type ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:category_type ;
-            owl:onProperty biolink:category ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:category ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:name ] ;
+            owl:onProperty biolink:description ] ;
     skos:definition "Root Biolink Model class for all things and informational relationships, real or imagined." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -9786,22 +9786,22 @@ biolink:EntityToPhenotypicFeatureAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to phenotypic feature association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:sex_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:sex_qualifier ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhenotypicFeature ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:BiologicalSex ;
-            owl:onProperty biolink:sex_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:sex_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:sex_qualifier ],
         biolink:EntityToFeatureOrDiseaseQualifiersMixin,
         biolink:FrequencyQuantifier ;
@@ -9928,11 +9928,11 @@ biolink:ChemicalMixture a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical mixture" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:highest_FDA_approval_status ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:highest_FDA_approval_status ],
+            owl:onProperty biolink:routes_of_delivery ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalMixture ;
+            owl:onProperty biolink:is_supplement ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:drug_regulatory_status_world_wide ],
@@ -9940,26 +9940,26 @@ biolink:ChemicalMixture a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:is_supplement ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:highest_FDA_approval_status ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:highest_FDA_approval_status ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:drug_regulatory_status_world_wide ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:routes_of_delivery ],
+            owl:onProperty biolink:is_supplement ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:highest_FDA_approval_status ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:drug_regulatory_status_world_wide ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DrugDeliveryEnum ;
             owl:onProperty biolink:routes_of_delivery ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalMixture ;
-            owl:onProperty biolink:is_supplement ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:highest_FDA_approval_status ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:is_supplement ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:drug_regulatory_status_world_wide ],
         biolink:ChemicalEntity ;
     skos:closeMatch dcid:ChemicalCompound ;
     skos:definition "A chemical mixture is a chemical entity composed of two or more molecular entities." ;
@@ -10220,13 +10220,13 @@ biolink:EntityToDiseaseAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to disease association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Disease ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:object ],
         biolink:EntityToFeatureOrDiseaseQualifiersMixin ;
     skos:definition "mixin class for any association whose object (target node) is a disease" ;
@@ -10236,13 +10236,13 @@ biolink:Genotype a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_zygosity ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Zygosity ;
             owl:onProperty biolink:has_zygosity ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_zygosity ],
         biolink:BiologicalEntity,
         biolink:GenomicEntity,
@@ -10493,32 +10493,32 @@ biolink:BiologicalProcessOrActivity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "biological process or activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_output ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Occurrent ;
             owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Occurrent ;
+            owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhysicalEntity ;
             owl:onProperty biolink:enabled_by ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Occurrent ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:enabled_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:enabled_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_output ],
         biolink:BiologicalEntity,
         biolink:Occurrent,
         biolink:OntologyClass ;
@@ -10556,37 +10556,37 @@ biolink:Agent a owl:Class,
     rdfs:label "agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:address ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:address ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
+            owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:affiliation ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:affiliation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:address ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:address ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:affiliation ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:address ],
         biolink:AdministrativeEntity ;
     skos:altLabel "group" ;
     skos:definition "person, group, organization or project that provides a piece of information (i.e. a knowledge association)" ;
@@ -10613,31 +10613,31 @@ biolink:MolecularActivity a owl:Class,
     rdfs:label "molecular activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularEntity ;
             owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:enabled_by ],
+            owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MacromolecularMachineMixin ;
             owl:onProperty biolink:enabled_by ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:onProperty biolink:has_input ],
         biolink:BiologicalProcessOrActivity,
         biolink:Occurrent,
         biolink:OntologyClass ;
@@ -10692,13 +10692,13 @@ biolink:ExposureEvent a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exposure event" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:timepoint ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:time_type ;
+            owl:onProperty biolink:timepoint ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:timepoint ],
         biolink:OntologyClass ;
     skos:altLabel "experimental condition",
@@ -10757,13 +10757,13 @@ biolink:MolecularEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:is_metabolite ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:is_metabolite ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty biolink:is_metabolite ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:is_metabolite ],
         biolink:ChemicalEntity ;
     skos:definition "A molecular entity is a chemical entity composed of individual or covalently bonded atoms." ;
@@ -10788,26 +10788,26 @@ biolink:Gene a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:label_type ;
+            owl:onProperty biolink:synonym ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:symbol ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:symbol ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:symbol ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:label_type ;
             owl:onProperty biolink:synonym ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:synonym ],
+            owl:onProperty biolink:symbol ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:symbol ],
         biolink:BiologicalEntity,
         biolink:ChemicalEntityOrGeneOrGeneProduct,
         biolink:GeneOrGeneProduct,
@@ -10830,38 +10830,38 @@ biolink:InformationContentEntity a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:rights ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:license ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:rights ],
+            owl:onProperty biolink:creation_date ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:creation_date ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:format ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:format ],
+            owl:onProperty biolink:rights ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:format ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:license ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:license ],
+            owl:onProperty biolink:format ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Date ;
             owl:onProperty biolink:creation_date ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:creation_date ],
+            owl:onProperty biolink:rights ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:rights ],
+            owl:onProperty biolink:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:license ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:license ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:format ],
         biolink:NamedThing ;
     skos:altLabel "information",
         "information artefact",
@@ -10886,41 +10886,14 @@ biolink:Publication a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "publication" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:keywords ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:summary ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:summary ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:authors ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:authors ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:summary ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
+            owl:onProperty biolink:pages ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:keywords ],
@@ -10928,29 +10901,56 @@ biolink:Publication a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:type ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:summary ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:mesh_terms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:mesh_terms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:pages ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:keywords ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:authors ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:mesh_terms ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:xref ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:summary ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:pages ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:mesh_terms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:authors ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:xref ],
         biolink:InformationContentEntity ;
     skos:definition "Any published piece of information. Can refer to a whole publication, its encompassing publication (i.e. journal or book) or to a part of a publication, if of significant knowledge scope (e.g. a figure, figure legend, or section highlighted by NLP). The scope is intended to be general and include information published on the web, as well as printed materials, either directly or in one of the Publication Biolink category subclasses." ;
     skos:exactMatch IAO:0000311 ;
@@ -10986,47 +10986,47 @@ biolink:Attribute a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "attribute" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_attribute_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_quantitative_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:iri_type ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:label_type ;
             owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:has_attribute_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:QuantityValue ;
-            owl:onProperty biolink:has_quantitative_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_qualitative_value ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_qualitative_value ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:has_qualitative_value ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_quantitative_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:has_attribute_type ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:has_attribute_type ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:iri_type ;
+            owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_qualitative_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_qualitative_value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:QuantityValue ;
+            owl:onProperty biolink:has_quantitative_value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_attribute_type ],
         biolink:NamedThing,
         biolink:OntologyClass ;
     skos:definition "A property or characteristic of an entity. For example, an apple may have properties such as color, shape, age, crispiness. An environmental sample may have attributes such as depth, lat, long, material." ;
@@ -11062,13 +11062,13 @@ biolink:GenomicEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genomic entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_biological_sequence ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:biological_sequence ;
-            owl:onProperty biolink:has_biological_sequence ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:has_biological_sequence ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> ;
     skos:narrowMatch STY:T028,
@@ -11078,20 +11078,8 @@ biolink:SequenceVariant a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "sequence variant" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:has_biological_sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_biological_sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Gene ;
-            owl:onProperty biolink:has_gene ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_gene ],
@@ -11099,7 +11087,19 @@ biolink:SequenceVariant a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_biological_sequence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Gene ;
+            owl:onProperty biolink:has_gene ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:has_biological_sequence ],
         biolink:BiologicalEntity,
         biolink:GenomicEntity,
@@ -11130,43 +11130,43 @@ biolink:ChemicalEntity a owl:Class,
     rdfs:label "chemical entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_chemical_role ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:trade_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:trade_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:available_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:max_tolerated_dose ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:max_tolerated_dose ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:is_toxic ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DrugAvailabilityEnum ;
             owl:onProperty biolink:available_from ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty biolink:is_toxic ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:trade_name ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:trade_name ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalRole ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:max_tolerated_dose ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_chemical_role ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:is_toxic ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:max_tolerated_dose ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:is_toxic ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty biolink:is_toxic ],
+            owl:allValuesFrom biolink:ChemicalRole ;
+            owl:onProperty biolink:has_chemical_role ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:available_from ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:max_tolerated_dose ],
         biolink:ChemicalEntityOrGeneOrGeneProduct,
         biolink:ChemicalEntityOrProteinOrPolypeptide,
         biolink:ChemicalOrDrugOrTreatment,
@@ -11274,6 +11274,17 @@ biolink:NamedThing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "named thing" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:onDatatype xsd:string ;
+                    owl:withRestrictions ( [ xsd:pattern "^biolink:\\d+$" ] ) ] ;
+            owl:onProperty biolink:category ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:provided_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:xref ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:provided_by ],
         [ a owl:Restriction ;
@@ -11282,17 +11293,6 @@ biolink:NamedThing a owl:Class,
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^biolink:\\d+$" ] ) ] ;
-            owl:onProperty biolink:category ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:provided_by ],
         biolink:Entity ;
     skos:definition "a databased entity or concept/class" ;
     skos:exactMatch STY:T071,
@@ -11306,83 +11306,44 @@ biolink:Association a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:original_object ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:timepoint ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty biolink:negated ],
+            owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:EvidenceType ;
             owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:knowledge_source ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:category_type ;
-            owl:onProperty biolink:category ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:original_subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:InformationResource ;
             owl:onProperty biolink:aggregator_knowledge_source ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualifiers ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:primary_knowledge_source ],
+            owl:onProperty biolink:negated ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:InformationResource ;
-            owl:onProperty biolink:knowledge_source ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:time_type ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:negated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:InformationResource ;
-            owl:onProperty biolink:primary_knowledge_source ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:original_subject ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:original_subject ],
+            owl:onProperty biolink:primary_knowledge_source ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:original_object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:original_object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:timepoint ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:primary_knowledge_source ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom biolink:category_type ;
+            owl:onProperty biolink:category ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -11390,50 +11351,89 @@ biolink:Association a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:type ],
+            owl:allValuesFrom biolink:InformationResource ;
+            owl:onProperty biolink:aggregator_knowledge_source ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:negated ],
+            owl:onProperty biolink:knowledge_source ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:original_predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:time_type ;
+            owl:onProperty biolink:timepoint ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Publication ;
             owl:onProperty biolink:publications ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:original_object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:InformationResource ;
+            owl:onProperty biolink:knowledge_source ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:original_subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:original_subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:original_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:knowledge_source ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:aggregator_knowledge_source ],
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:original_subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:original_predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty biolink:negated ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:qualifiers ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:original_object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:negated ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:original_predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_evidence ],
+            owl:onProperty biolink:primary_knowledge_source ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:category ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:original_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Publication ;
-            owl:onProperty biolink:publications ],
+            owl:allValuesFrom biolink:InformationResource ;
+            owl:onProperty biolink:primary_knowledge_source ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:qualifiers ],
+            owl:onProperty biolink:publications ],
         biolink:Entity ;
     skos:definition "A typed association between two entities, supported by evidence" ;
     skos:exactMatch OBAN:association,
@@ -11569,414 +11569,9 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     skos:definition "Entity and association taxonomy and datamodel for life-sciences data" .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PairwiseGeneToGeneInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:IndividualOrganism ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:IndividualOrganism .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NamedThing ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NamedThing .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToExpressionSiteAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToExpressionSiteAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleicAcidEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleicAcidEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExposureEventToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExposureEventToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneFamilyAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneFamilyAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Treatment ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Treatment .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExposureEventToOutcomeAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExposureEventToOutcomeAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntityAssessesNamedThingAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntityAssessesNamedThingAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Hospitalization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Hospitalization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceVariant ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceVariant .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToPopulationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToPopulationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismToOrganismAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismToOrganismAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Snv ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Snv .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Activity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Activity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ComplexMolecularMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ComplexMolecularMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Dataset ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Dataset .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Publication ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Publication .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CommonDataElement ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CommonDataElement .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyPopulation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyPopulation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PopulationOfIndividualOrganisms ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PopulationOfIndividualOrganisms .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLineAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLineAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MaterialSample ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MaterialSample .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehavioralFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehavioralFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Transcript ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Transcript .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NoncodingRNAProduct ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NoncodingRNAProduct .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Genotype ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Genotype .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Entity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Entity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenomicBackgroundExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenomicBackgroundExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalProcessOrActivity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalProcessOrActivity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyVariable ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyVariable .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BioticExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BioticExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalAffectsGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalAffectsGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Disease ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Disease .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalGeneInteractionAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalGeneInteractionAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalModifier ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalModifier .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhenotypicFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhenotypicFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Gene ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Gene .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SocioeconomicAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SocioeconomicAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Attribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Attribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProteinDomain ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProteinDomain .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhysiologicalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhysiologicalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetVersion ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetVersion .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToVariantAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToVariantAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneHasVariantThatContributesToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneHasVariantThatContributesToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Case ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Case .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReagentTargetedGene ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReagentTargetedGene .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ContributorAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ContributorAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicLocationAtTime ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicLocationAtTime .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:FunctionalAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:FunctionalAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SeverityValue ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SeverityValue .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReactionToParticipantAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReactionToParticipantAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneFamily ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneFamily .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MaterialSampleDerivationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MaterialSampleDerivationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GrossAnatomicalStructure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GrossAnatomicalStructure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToGenotypePartAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToGenotypePartAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RelativeFrequencyAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RelativeFrequencyAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalProcessExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalProcessExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Serial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Serial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneProductRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneProductRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhysicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhysicalEntity .
-
-[] a owl:Restriction ;
     rdfs:subClassOf biolink:Genome ;
     owl:onProperty biolink:category ;
     owl:someValuesFrom biolink:Genome .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetDistribution ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetDistribution .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation ;
@@ -11984,14 +11579,289 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation .
 
 [] a owl:Restriction ;
+    rdfs:subClassOf biolink:Zygosity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Zygosity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehavioralExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehavioralExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PairwiseMolecularInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PairwiseMolecularInteraction .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NucleicAcidSequenceMotif ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NucleicAcidSequenceMotif .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToGeneExpressionAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToGeneExpressionAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhysiologicalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhysiologicalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonSpecialization ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonSpecialization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhenotypicQuality ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhenotypicQuality .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SocioeconomicAttribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SocioeconomicAttribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PosttranslationalModification ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PosttranslationalModification .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToPathwayAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToPathwayAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugToGeneInteractionExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugToGeneInteractionExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ContributorAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ContributorAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalEntityAssessesNamedThingAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalEntityAssessesNamedThingAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Phenomenon ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Phenomenon .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Transcript ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Transcript .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SeverityValue ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SeverityValue .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GrossAnatomicalStructure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GrossAnatomicalStructure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToPopulationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToPopulationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Gene ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Gene .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NucleicAcidEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NucleicAcidEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Publication ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Publication .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Snv ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Snv .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:InformationResource ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:InformationResource .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProteinDomain ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProteinDomain .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Polypeptide ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Polypeptide .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismToOrganismAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismToOrganismAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:InformationContentEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:InformationContentEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CodingSequence ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CodingSequence .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ConceptCountAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ConceptCountAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalTrial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalTrial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Behavior ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Behavior .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToChemicalEntityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToChemicalEntityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonInteraction .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PairwiseGeneToGeneInteraction .
+
+[] a owl:Restriction ;
     rdfs:subClassOf biolink:EnvironmentalProcess ;
     owl:onProperty biolink:category ;
     owl:someValuesFrom biolink:EnvironmentalProcess .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:PopulationToPopulationAssociation ;
+    rdfs:subClassOf biolink:Onset ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PopulationToPopulationAssociation .
+    owl:someValuesFrom biolink:Onset .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Drug ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Drug .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLine ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLine .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalAffectsGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalAffectsGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Entity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Entity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalFinding ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalFinding .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:FoodAdditive ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:FoodAdditive .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SocioeconomicExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SocioeconomicExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalModifier ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalModifier .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalMeasurement ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalMeasurement .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EvidenceType ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EvidenceType .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation ;
@@ -12004,179 +11874,14 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:OrganismTaxon .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociation ;
+    rdfs:subClassOf biolink:Article ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EntityToPhenotypicFeatureAssociation .
+    owl:someValuesFrom biolink:Article .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:ConceptCountAnalysisResult ;
+    rdfs:subClassOf biolink:BiologicalProcess ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ConceptCountAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RNAProduct ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RNAProduct .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Agent ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Agent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularComplex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularComplex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToPathwayAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToPathwayAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellularOrganism ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellularOrganism .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ObservedExpectedFrequencyAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ObservedExpectedFrequencyAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalAnatomicalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalAnatomicalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Behavior ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Behavior .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProcessedMaterial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProcessedMaterial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetSummary ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetSummary .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:FoodAdditive ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:FoodAdditive .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehavioralExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehavioralExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToMolecularActivityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToMolecularActivityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleicAcidSequenceMotif ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleicAcidSequenceMotif .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToChemicalAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToChemicalAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RNAProductIsoform ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RNAProductIsoform .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MicroRNA ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MicroRNA .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneticInheritance ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneticInheritance .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TranscriptToGeneRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TranscriptToGeneRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProteinFamily ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProteinFamily .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularMachineToMolecularActivityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularMachineToMolecularActivityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EntityToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EntityToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceVariantModulatesTreatmentAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceVariantModulatesTreatmentAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Pathway ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Pathway .
+    owl:someValuesFrom biolink:BiologicalProcess .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:EnvironmentalFeature ;
@@ -12184,289 +11889,14 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:EnvironmentalFeature .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:Procedure ;
+    rdfs:subClassOf biolink:GeneToGeneAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Procedure .
+    owl:someValuesFrom biolink:GeneToGeneAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:Book ;
+    rdfs:subClassOf biolink:DrugToGeneAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Book .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChiSquaredAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChiSquaredAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PairwiseMolecularInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PairwiseMolecularInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Phenomenon ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Phenomenon .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AdministrativeEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AdministrativeEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BookChapter ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BookChapter .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CodingSequence ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CodingSequence .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Study ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Study .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToPathwayAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToPathwayAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGoTermAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGoTermAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalSex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalSex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenomicSequenceLocalization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenomicSequenceLocalization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Protein ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Protein .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceFeatureRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceFeatureRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Zygosity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Zygosity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypicSex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypicSex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CaseToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CaseToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalFoodContaminant ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalFoodContaminant .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalIntervention ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalIntervention .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TaxonToTaxonAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TaxonToTaxonAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Virus ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Virus .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ConfidenceLevel ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ConfidenceLevel .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SmallMolecule ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SmallMolecule .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleosomeModification ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleosomeModification .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellularComponent ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellularComponent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:LifeStage ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:LifeStage .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:InformationResource ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:InformationResource .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExonToTranscriptRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExonToTranscriptRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularMachineToCellularComponentAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularMachineToCellularComponentAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToLocationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToLocationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PlanetaryEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PlanetaryEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseToExposureEventAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseToExposureEventAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:InformationContentEntityToNamedThingAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:InformationContentEntityToNamedThingAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Cohort ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Cohort .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Drug ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Drug .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalMeasurement ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalMeasurement .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToChemicalEntityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToChemicalEntityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhenotypicQuality ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhenotypicQuality .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehaviorToBehavioralFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehaviorToBehavioralFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Article ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Article .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Onset ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Onset .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonSpecialization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonSpecialization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReactionToCatalystAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReactionToCatalystAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ComplexChemicalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ComplexChemicalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToGeneExpressionAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToGeneExpressionAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonAssociation .
+    owl:someValuesFrom biolink:DrugToGeneAssociation .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:MacromolecularMachineToBiologicalProcessAssociation ;
@@ -12474,79 +11904,64 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:MacromolecularMachineToBiologicalProcessAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalCourse ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalCourse .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Event ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Event .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalAnatomicalStructure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalAnatomicalStructure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SiRNA ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SiRNA .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TextMiningResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TextMiningResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalRole ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalRole .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalTrial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalTrial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicLocation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicLocation .
-
-[] a owl:Restriction ;
     rdfs:subClassOf biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation ;
     owl:onProperty biolink:category ;
     owl:someValuesFrom biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalFinding ;
+    rdfs:subClassOf biolink:ChemicalGeneInteractionAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalFinding .
+    owl:someValuesFrom biolink:ChemicalGeneInteractionAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation ;
+    rdfs:subClassOf biolink:StudyResult ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation .
+    owl:someValuesFrom biolink:StudyResult .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:Association ;
+    rdfs:subClassOf biolink:Cohort ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Association .
+    owl:someValuesFrom biolink:Cohort .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:SocioeconomicExposure ;
+    rdfs:subClassOf biolink:MaterialSample ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SocioeconomicExposure .
+    owl:someValuesFrom biolink:MaterialSample .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeAsAModelOfDiseaseAssociation ;
+    rdfs:subClassOf biolink:MolecularActivity ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeAsAModelOfDiseaseAssociation .
+    owl:someValuesFrom biolink:MolecularActivity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseToExposureEventAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseToExposureEventAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularMachineToCellularComponentAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularMachineToCellularComponentAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Pathway ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Pathway .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EntityToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EntityToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellularOrganism ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellularOrganism .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceFeatureRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceFeatureRelationship .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:VariantToPhenotypicFeatureAssociation ;
@@ -12554,64 +11969,39 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:VariantToPhenotypicFeatureAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToPathwayAssociation ;
+    rdfs:subClassOf biolink:ExonToTranscriptRelationship ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToPathwayAssociation .
+    owl:someValuesFrom biolink:ExonToTranscriptRelationship .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneHomologyAssociation ;
+    rdfs:subClassOf biolink:OrganismAttribute ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneHomologyAssociation .
+    owl:someValuesFrom biolink:OrganismAttribute .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugToGeneInteractionExposure ;
+    rdfs:subClassOf biolink:Book ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugToGeneInteractionExposure .
+    owl:someValuesFrom biolink:Book .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:Polypeptide ;
+    rdfs:subClassOf biolink:Virus ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Polypeptide .
+    owl:someValuesFrom biolink:Virus .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:DruggableGeneToDiseaseAssociation ;
+    rdfs:subClassOf biolink:ExposureEventToOutcomeAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DruggableGeneToDiseaseAssociation .
+    owl:someValuesFrom biolink:ExposureEventToOutcomeAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalExposure ;
+    rdfs:subClassOf biolink:SequenceVariant ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalExposure .
+    owl:someValuesFrom biolink:SequenceVariant .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismalEntityAsAModelOfDiseaseAssociation ;
+    rdfs:subClassOf biolink:EnvironmentalFoodContaminant ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismalEntityAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhenotypicSex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhenotypicSex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EvidenceType ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EvidenceType .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:InformationContentEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:InformationContentEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PosttranslationalModification ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PosttranslationalModification .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalProcess .
+    owl:someValuesFrom biolink:EnvironmentalFoodContaminant .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:Exon ;
@@ -12619,9 +12009,14 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:Exon .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToGeneAssociation ;
+    rdfs:subClassOf biolink:LifeStage ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToGeneAssociation .
+    owl:someValuesFrom biolink:LifeStage .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:ProteinIsoform ;
@@ -12629,24 +12024,54 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:ProteinIsoform .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:Cell ;
+    rdfs:subClassOf biolink:Hospitalization ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Cell .
+    owl:someValuesFrom biolink:Hospitalization .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLine ;
+    rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLine .
+    owl:someValuesFrom biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:Device ;
+    rdfs:subClassOf biolink:ChemicalExposure ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Device .
+    owl:someValuesFrom biolink:ChemicalExposure .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneCoexpressionAssociation ;
+    rdfs:subClassOf biolink:ClinicalIntervention ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneCoexpressionAssociation .
+    owl:someValuesFrom biolink:ClinicalIntervention .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:InformationContentEntityToNamedThingAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:InformationContentEntityToNamedThingAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalAnatomicalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalAnatomicalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PopulationOfIndividualOrganisms ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PopulationOfIndividualOrganisms .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneFamily ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneFamily .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RNAProduct ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RNAProduct .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:OrganismTaxonToEnvironmentAssociation ;
@@ -12654,9 +12079,14 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:OrganismTaxonToEnvironmentAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:Haplotype ;
+    rdfs:subClassOf biolink:GeneToExpressionSiteAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Haplotype .
+    owl:someValuesFrom biolink:GeneToExpressionSiteAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReagentTargetedGene ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReagentTargetedGene .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:ChemicalToChemicalDerivationAssociation ;
@@ -12664,7 +12094,577 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:ChemicalToChemicalDerivationAssociation .
 
 [] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneCoexpressionAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneCoexpressionAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BookChapter ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BookChapter .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EntityToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicLocation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicLocation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalCourse ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalCourse .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceVariantModulatesTreatmentAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceVariantModulatesTreatmentAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Haplotype ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Haplotype .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChiSquaredAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChiSquaredAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalAnatomicalStructure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalAnatomicalStructure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneProductRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneProductRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Case ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Case .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TaxonToTaxonAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TaxonToTaxonAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalMixture ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetDistribution ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetDistribution .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReactionToParticipantAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReactionToParticipantAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:FunctionalAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:FunctionalAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RelativeFrequencyAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RelativeFrequencyAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetVersion ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetVersion .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehavioralFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehavioralFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProteinFamily ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProteinFamily .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SiRNA ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SiRNA .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalSex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalSex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CaseToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CaseToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Cell ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Cell .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalAttribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalAttribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenomicSequenceLocalization ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenomicSequenceLocalization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TranscriptToGeneRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TranscriptToGeneRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLineAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLineAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EnvironmentalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EnvironmentalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Event ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Event .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToVariantAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToVariantAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhysicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhysicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicLocationAtTime ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicLocationAtTime .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ComplexChemicalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ComplexChemicalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToPathwayAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToPathwayAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToGenotypePartAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToGenotypePartAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismalEntityAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismalEntityAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularComplex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularComplex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToChemicalAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToChemicalAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneHasVariantThatContributesToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneHasVariantThatContributesToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ConfidenceLevel ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ConfidenceLevel .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneFamilyAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneFamilyAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SmallMolecule ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SmallMolecule .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ExposureEventToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ExposureEventToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneHomologyAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneHomologyAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalProcessExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalProcessExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Dataset ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Dataset .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:IndividualOrganism ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:IndividualOrganism .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Genotype ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Genotype .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Serial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Serial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellularComponent ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellularComponent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Study ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Study .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularMixture ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Device ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Device .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Treatment ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Treatment .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReactionToCatalystAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReactionToCatalystAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGoTermAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGoTermAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CommonDataElement ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CommonDataElement .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DruggableGeneToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DruggableGeneToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetSummary ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetSummary .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Activity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Activity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MicroRNA ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MicroRNA .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Association ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Association .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Protein ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Protein .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ObservedExpectedFrequencyAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ObservedExpectedFrequencyAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ComplexMolecularMixture ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ComplexMolecularMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Attribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Attribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RNAProductIsoform ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RNAProductIsoform .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToPathwayAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToPathwayAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhenotypicSex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhenotypicSex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PlanetaryEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PlanetaryEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Agent ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Agent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PopulationToPopulationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PopulationToPopulationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Procedure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Procedure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhenotypicFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhenotypicFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToLocationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToLocationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProcessedMaterial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProcessedMaterial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MaterialSampleDerivationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MaterialSampleDerivationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:StudyVariable ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:StudyVariable .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Disease ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Disease .
+
+[] a owl:Restriction ;
     rdfs:subClassOf biolink:Food ;
     owl:onProperty biolink:category ;
     owl:someValuesFrom biolink:Food .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehaviorToBehavioralFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehaviorToBehavioralFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NamedThing ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NamedThing .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:StudyPopulation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:StudyPopulation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalRole ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalRole .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneticInheritance ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneticInheritance .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AdministrativeEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AdministrativeEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NucleosomeModification ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NucleosomeModification .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NoncodingRNAProduct ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NoncodingRNAProduct .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TextMiningResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TextMiningResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularMachineToMolecularActivityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularMachineToMolecularActivityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToMolecularActivityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToMolecularActivityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BioticExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BioticExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalProcessOrActivity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalProcessOrActivity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypicSex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypicSex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenomicBackgroundExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenomicBackgroundExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceAssociation .
 

--- a/tests/test_biolink_model/output/biolink-model.owl.ttl
+++ b/tests/test_biolink_model/output/biolink-model.owl.ttl
@@ -102,10 +102,10 @@ biolink:MappingCollection a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "mapping collection" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PredicateMapping ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:predicate_mappings ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:PredicateMapping ;
             owl:onProperty biolink:predicate_mappings ] ;
     skos:definition "A collection of deprecated mappings." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -1588,13 +1588,13 @@ biolink:CaseToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "case to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Case ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:definition "An abstract association for use where the case is the subject" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -1603,13 +1603,13 @@ biolink:CellLineToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "cell line to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:CellLine ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:definition "An relationship between a cell line and another entity" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -1623,10 +1623,10 @@ biolink:DrugToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "drug to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Drug ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Drug ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -1639,13 +1639,13 @@ biolink:EntityToExposureEventAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to exposure event association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ExposureEvent ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ExposureEvent ;
             owl:onProperty biolink:object ] ;
     skos:definition "An association between some entity and an exposure event." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -1654,13 +1654,13 @@ biolink:EntityToOutcomeAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to outcome association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Outcome ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Outcome ;
             owl:onProperty biolink:object ] ;
     skos:definition "An association between some entity and an outcome" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -1669,10 +1669,10 @@ biolink:EpigenomicEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "epigenomic entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:biological_sequence ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:biological_sequence ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -1683,10 +1683,10 @@ biolink:MaterialSampleToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "material sample to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:MaterialSample ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MaterialSample ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -2833,22 +2833,22 @@ biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation a owl:Class,
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
@@ -2860,11 +2860,11 @@ biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "anatomical entity to anatomical entity part of association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -2872,20 +2872,20 @@ biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:subject ],
         biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
     skos:definition "A relationship between two anatomical entities where the relationship is mereological, i.e the two entities are related by parthood. This includes relationships between cellular components and cells, between cells and tissues, tissues and whole organisms" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -2894,41 +2894,41 @@ biolink:Article a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "article" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:published_in ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:iso_abbreviation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:issue ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:iso_abbreviation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:issue ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:iso_abbreviation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:published_in ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:volume ],
         biolink:Publication ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -2936,23 +2936,23 @@ biolink:BehaviorToBehavioralFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "behavior to behavioral feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Behavior ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom biolink:BehavioralFeature ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:BehavioralFeature ;
-            owl:onProperty biolink:object ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin ;
     skos:definition "An association between an mixture behavior and a behavioral feature manifested by the individual exhibited or has exhibited the behavior." ;
@@ -2980,9 +2980,6 @@ biolink:Book a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "book" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
@@ -2997,6 +2994,9 @@ biolink:Book a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
         biolink:Publication ;
     skos:definition "This class may rarely be instantiated except if use cases of a given knowledge graph support its utility." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3114,10 +3114,10 @@ biolink:CellLineAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "cell line as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:CellLine ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:CellLine ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -3139,167 +3139,167 @@ biolink:ChemicalAffectsGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical affects gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:subject_context_qualifier ],
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:subject_part_qualifier ],
+            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
+            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_part_qualifier ],
+            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
+            owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:object_part_qualifier ],
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
         biolink:Association ;
     skos:definition "Describes an effect that a chemical has on a gene or gene product (e.g. an impact of on its abundance, activity, localization, processing, expression, etc.)" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3308,17 +3308,14 @@ biolink:ChemicalEntityAssessesNamedThingAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical entity assesses named thing association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
@@ -3327,13 +3324,16 @@ biolink:ChemicalEntityAssessesNamedThingAssociation a owl:Class,
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -3341,8 +3341,26 @@ biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical entity or gene or gene product regulates gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -3356,26 +3374,8 @@ biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "A regulatory relationship between two genes" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3405,104 +3405,104 @@ biolink:ChemicalGeneInteractionAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical gene interaction association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
             owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_part_qualifier ],
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
             owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
             owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_part_qualifier ],
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object_context_qualifier ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin ;
     skos:definition "describes a physical interaction between a chemical entity and a gene or gene product. Any biological or chemical effect resulting from such an interaction are out of scope, and covered by the ChemicalAffectsGeneAssociation type (e.g. impact of a chemical on the abundance, activity, structure, etc, of either participant in the interaction)" ;
@@ -3516,10 +3516,10 @@ biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation,
         biolink:ChemicalToEntityAssociationMixin,
@@ -3555,38 +3555,38 @@ biolink:ChemicalToChemicalDerivationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to chemical derivation association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MacromolecularMachineMixin ;
-            owl:onProperty biolink:catalyst_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:catalyst_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MacromolecularMachineMixin ;
+            owl:onProperty biolink:catalyst_qualifier ],
         biolink:ChemicalToChemicalAssociation ;
     skos:definition """A causal relationship between two chemical entities, where the subject represents the upstream entity and the object represents the downstream. For any such association there is an implicit reaction:
   IF
@@ -3602,13 +3602,13 @@ biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin,
@@ -3621,23 +3621,23 @@ biolink:ChemicalToPathwayAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to pathway association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Pathway ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Pathway ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin ;
     skos:definition "An interaction between a chemical entity and a biological process or pathway." ;
@@ -3733,38 +3733,38 @@ biolink:ContributorAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "contributor association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:qualifiers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Agent ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:qualifiers ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:qualifiers ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:InformationContentEntity ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualifiers ],
         biolink:Association ;
     skos:definition "Any association between an entity (such as a publication) and various agents that contribute to its realisation" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3794,13 +3794,13 @@ biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease or phenotypic feature to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -3808,6 +3808,9 @@ biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease or phenotypic feature to genetic inheritance association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneticInheritance ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
@@ -3822,9 +3825,6 @@ biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation a owl:Class,
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneticInheritance ;
-            owl:onProperty biolink:object ],
         biolink:Association,
         biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin ;
     skos:definition "An association between either a disease or a phenotypic feature and its mode of (genetic) inheritance." ;
@@ -3834,13 +3834,13 @@ biolink:DiseaseOrPhenotypicFeatureToLocationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease or phenotypic feature to location association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin ;
@@ -3851,13 +3851,13 @@ biolink:DiseaseToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -3880,14 +3880,14 @@ biolink:DiseaseToPhenotypicFeatureAssociation a owl:Class,
             owl:allValuesFrom biolink:PhenotypicFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -3932,13 +3932,13 @@ biolink:DrugToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "drug to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:DrugToEntityAssociationMixin ;
@@ -3978,29 +3978,29 @@ biolink:DruggableGeneToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "druggable gene to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_evidence ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DruggableGeneCategoryEnum ;
             owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_evidence ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:GeneToDiseaseAssociation,
         biolink:GeneToEntityAssociationMixin ;
@@ -4013,10 +4013,10 @@ biolink:EntityToDiseaseAssociation a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:FDA_approval_status ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:FDAApprovalStatusEnum ;
             owl:onProperty biolink:FDA_approval_status ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:FDAApprovalStatusEnum ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:FDA_approval_status ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4025,23 +4025,23 @@ biolink:EntityToFeatureOrDiseaseQualifiersMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to feature or disease qualifiers mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Onset ;
-            owl:onProperty biolink:onset_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:onset_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:severity_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:onset_qualifier ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:SeverityValue ;
             owl:onProperty biolink:severity_qualifier ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:severity_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:onset_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:severity_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:onset_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Onset ;
+            owl:onProperty biolink:onset_qualifier ],
         biolink:FrequencyQualifierMixin ;
     skos:definition "Qualifiers for entity to disease or phenotype associations." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4050,13 +4050,13 @@ biolink:EntityToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:FDA_approval_status ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:FDAApprovalStatusEnum ;
             owl:onProperty biolink:FDA_approval_status ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:FDA_approval_status ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4096,22 +4096,22 @@ biolink:ExonToTranscriptRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exon to transcript relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Transcript ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Transcript ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Exon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A transcript is formed from multiple exons" ;
@@ -4122,21 +4122,21 @@ biolink:ExposureEventToOutcomeAssociation a owl:Class,
     rdfs:label "exposure event to outcome association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:population_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:time_type ;
             owl:onProperty biolink:temporal_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:population_context_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:population_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:temporal_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:population_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:population_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:time_type ;
             owl:onProperty biolink:temporal_context_qualifier ],
         biolink:Association,
         biolink:EntityToOutcomeAssociationMixin ;
@@ -4147,13 +4147,13 @@ biolink:ExposureEventToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exposure event to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ExposureEvent ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin ;
@@ -4277,10 +4277,10 @@ biolink:FrequencyQualifierMixin a owl:Class,
             owl:allValuesFrom biolink:frequency_value ;
             owl:onProperty biolink:frequency_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:frequency_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:frequency_qualifier ] ;
     skos:definition "Qualifier for frequency type associations" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4289,41 +4289,41 @@ biolink:FrequencyQuantifier a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "frequency quantifier" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Double ;
-            owl:onProperty biolink:has_percentage ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Double ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_quotient ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_percentage ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_percentage ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_quotient ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_total ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_percentage ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Double ;
             owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_percentage ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Double ;
+            owl:onProperty biolink:has_percentage ],
         biolink:RelationshipQuantifier ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4348,17 +4348,20 @@ biolink:GeneExpressionMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene expression mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:phenotypic_state ],
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:quantifier_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:expression_site ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:phenotypic_state ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:phenotypic_state ],
@@ -4366,23 +4369,20 @@ biolink:GeneExpressionMixin a owl:Class,
             owl:allValuesFrom biolink:LifeStage ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:quantifier_qualifier ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:expression_site ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:stage_qualifier ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:expression_site ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:quantifier_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:expression_site ] ;
+            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:onProperty biolink:phenotypic_state ] ;
     skos:definition "Observed gene expression intensity, context (site, stage) and associated phenotypic status within which the expression occurs." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4390,41 +4390,41 @@ biolink:GeneHasVariantThatContributesToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene has variant that contributes to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         biolink:GeneToDiseaseAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4721,49 +4721,49 @@ biolink:GeneToExpressionSiteAssociation a owl:Class,
     rdfs:label "gene to expression site association" ;
     rdfs:seeAlso <https://github.com/monarch-initiative/ingest-artifacts/tree/master/sources/BGee> ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:stage_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:quantifier_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:LifeStage ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:stage_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:quantifier_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:stage_qualifier ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "An association between a gene and a gene expression site, possibly qualified by stage/timing info." ;
@@ -4774,13 +4774,13 @@ biolink:GeneToGeneCoexpressionAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene coexpression association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:GeneExpressionMixin,
         biolink:GeneToGeneAssociation ;
@@ -4791,17 +4791,17 @@ biolink:GeneToGeneFamilyAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene family association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneFamily ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -4809,13 +4809,13 @@ biolink:GeneToGeneFamilyAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "Set membership of a gene in a family of genes related by common evolutionary ancestry usually inferred by sequence comparisons. The genes in a given family generally share common sequence motifs which generally map onto shared gene product structure-function relationships." ;
@@ -4825,32 +4825,32 @@ biolink:GeneToGeneHomologyAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene homology association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         biolink:GeneToGeneAssociation ;
     skos:definition "A homology association between two genes. May be orthology (in which case the species of subject and object should differ) or paralogy (in which case the species may be the same)" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4859,20 +4859,14 @@ biolink:GeneToGeneProductRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene product relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneProductMixin ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
@@ -4883,8 +4877,14 @@ biolink:GeneToGeneProductRelationship a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneProductMixin ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A gene is transcribed and potentially translated to a gene product" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4894,22 +4894,22 @@ biolink:GeneToGoTermAssociation a owl:Class,
     rdfs:label "gene to go term association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Gene ;
-            owl:onProperty biolink:subject ],
         biolink:FunctionalAssociation ;
     skos:altLabel "functional association" ;
     skos:exactMatch WBVocab:Gene-GO-Association ;
@@ -4920,22 +4920,22 @@ biolink:GeneToPathwayAssociation a owl:Class,
     rdfs:label "gene to pathway association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Pathway ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:GeneToEntityAssociationMixin ;
     skos:definition "An interaction between a gene or gene product and a biological process or pathway." ;
@@ -4948,20 +4948,20 @@ biolink:GeneToPhenotypicFeatureAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhenotypicFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
         biolink:GeneToEntityAssociationMixin ;
@@ -5016,13 +5016,13 @@ biolink:GenotypeToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -5030,8 +5030,23 @@ biolink:GenotypeToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Gene ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
@@ -5039,23 +5054,8 @@ biolink:GenotypeToGeneAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Gene ;
-            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Any association between a genotype and a gene. The genotype have have multiple variants in that gene or a single one. There is no assumption of cardinality" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5064,32 +5064,32 @@ biolink:GenotypeToGenotypePartAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to genotype part association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Genotype ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom biolink:Genotype ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Any association between one genotype and a genotypic entity that is a sub-component of it" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5098,7 +5098,7 @@ biolink:GenotypeToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -5107,14 +5107,14 @@ biolink:GenotypeToPhenotypicFeatureAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Genotype ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
         biolink:GenotypeToEntityAssociationMixin ;
@@ -5128,29 +5128,29 @@ biolink:GenotypeToVariantAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:SequenceVariant ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "Any association between a genotype and a sequence variant." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5241,16 +5241,13 @@ biolink:InformationContentEntityToNamedThingAssociation a owl:Class,
     rdfs:label "information content entity to named thing association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
@@ -5259,13 +5256,16 @@ biolink:InformationContentEntityToNamedThingAssociation a owl:Class,
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "association between a named thing and a information content entity where the specific context of the relationship between that named thing and the publication is unknown. For example, model organisms databases often capture the knowledge that a gene is found in a journal article, but not specifically the context in which that gene was documented in the article. In these cases, this association with the accompanying predicate 'mentions' could be used. Conversely, for more specific associations (like 'gene to disease association', the publication should be captured as an edge property)." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5289,13 +5289,13 @@ biolink:MacromolecularMachineToBiologicalProcessAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine to biological process association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:BiologicalProcess ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:FunctionalAssociation,
         biolink:MacromolecularMachineToEntityAssociationMixin ;
@@ -5323,13 +5323,13 @@ biolink:MacromolecularMachineToMolecularActivityAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine to molecular activity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:FunctionalAssociation,
         biolink:MacromolecularMachineToEntityAssociationMixin ;
@@ -5340,31 +5340,31 @@ biolink:MaterialSampleDerivationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "material sample derivation association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MaterialSample ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:MaterialSample ;
             owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "An association between a material sample and the material entity from which it is derived." ;
@@ -5392,12 +5392,6 @@ biolink:MolecularActivityToChemicalEntityAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular activity to chemical entity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
@@ -5408,6 +5402,12 @@ biolink:MolecularActivityToChemicalEntityAssociation a owl:Class,
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples" ;
@@ -5417,23 +5417,23 @@ biolink:MolecularActivityToMolecularActivityAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular activity to molecular activity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularActivity ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularActivity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5445,28 +5445,28 @@ biolink:MolecularActivityToPathwayAssociation a owl:Class,
             owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Pathway ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:Pathway ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "Association that holds the relationship between a reaction and the pathway it participates in." ;
@@ -5476,50 +5476,50 @@ biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "named thing associated with likelihood of named thing association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:object_context_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:object_context_qualifier ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -5552,13 +5552,13 @@ biolink:OrganismTaxonToEntityAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to entity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:definition "An association between an organism taxon and another entity" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5567,20 +5567,20 @@ biolink:OrganismTaxonToEnvironmentAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to environment association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
@@ -5591,7 +5591,7 @@ biolink:OrganismTaxonToEnvironmentAssociation a owl:Class,
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:OrganismTaxonToEntityAssociation ;
@@ -5602,40 +5602,40 @@ biolink:OrganismTaxonToOrganismTaxonInteraction a owl:Class,
     rdfs:label "organism taxon to organism taxon interaction" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:associated_environmental_context ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:associated_environmental_context ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:associated_environmental_context ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:associated_environmental_context ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:associated_environmental_context ],
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:object ],
         biolink:OrganismTaxonToOrganismTaxonAssociation ;
     skos:definition "An interaction relationship between two taxa. This may be a symbiotic relationship (encompassing mutualism and parasitism), or it may be non-symbiotic. Example: plague transmitted_by flea; cattle domesticated_by Homo sapiens; plague infects Homo sapiens" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5644,32 +5644,32 @@ biolink:OrganismTaxonToOrganismTaxonSpecialization a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to organism taxon specialization" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
         biolink:OrganismTaxonToOrganismTaxonAssociation ;
     skos:definition "A child-parent relationship between two taxa. For example: Homo sapiens subclass_of Homo" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5681,20 +5681,20 @@ biolink:OrganismToOrganismAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:IndividualOrganism ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:IndividualOrganism ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:IndividualOrganism ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -5702,10 +5702,10 @@ biolink:OrganismalEntityAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organismal entity as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismalEntity ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:OrganismalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -5719,50 +5719,50 @@ biolink:PairwiseMolecularInteraction a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "pairwise molecular interaction" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:interacting_molecules_category ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:interacting_molecules_category ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:interacting_molecules_category ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:interacting_molecules_category ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:PairwiseGeneToGeneInteraction ;
     skos:definition "An interaction at the molecular level between two physical entities" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5871,30 +5871,30 @@ biolink:PopulationToPopulationAssociation a owl:Class,
     rdfs:label "population to population association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "An association between a two populations" ;
@@ -5913,76 +5913,112 @@ biolink:PredicateMapping a owl:Class,
     rdfs:label "predicate mapping" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_direction_qualifier ],
+            owl:onProperty biolink:exact_match ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_context_qualifier ],
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:species_context_qualifier ],
+            owl:onProperty biolink:mapped_predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_direction_qualifier ],
+            owl:onProperty biolink:object_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
+            owl:onProperty biolink:exact_match ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:mapped_predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:mapped_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalContextQualifierEnum ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:broad_match ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_context_qualifier ],
@@ -5990,116 +6026,80 @@ biolink:PredicateMapping a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:broad_match ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:broad_match ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:narrow_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
+            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:exact_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:narrow_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:exact_match ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalContextQualifierEnum ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:exact_match ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:qualified_predicate ],
+            owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_part_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualified_predicate ],
+            owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:exact_match ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ] ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ] ;
     skos:definition "A deprecated predicate mapping object contains the deprecated predicate and an example of the rewiring that should be done to use a qualified statement in its place." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -6190,10 +6190,10 @@ biolink:ReactionToCatalystAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         biolink:ReactionToParticipantAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6231,8 +6231,14 @@ biolink:SequenceVariantModulatesTreatmentAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "sequence variant modulates treatment association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Treatment ;
             owl:onProperty biolink:object ],
@@ -6241,12 +6247,6 @@ biolink:SequenceVariantModulatesTreatmentAssociation a owl:Class,
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "An association between a sequence variant and a treatment or health intervention. The treatment object itself encompasses both the disease and the drug used." ;
@@ -6257,50 +6257,50 @@ biolink:Serial a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "serial" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:type ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:iso_abbreviation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:issue ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:iso_abbreviation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:volume ],
+            owl:onProperty biolink:issue ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:iso_abbreviation ],
         biolink:Publication ;
     skos:altLabel "journal" ;
     skos:definition "This class may rarely be instantiated except if use cases of a given knowledge graph support its utility." ;
@@ -6321,13 +6321,13 @@ biolink:SmallMolecule a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "small molecule" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
         biolink:MolecularEntity ;
     skos:altLabel "chemical substance" ;
@@ -6422,20 +6422,20 @@ biolink:TaxonToTaxonAssociation a owl:Class,
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -6458,23 +6458,23 @@ biolink:TranscriptToGeneRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "transcript to gene relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Transcript ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Transcript ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A gene is a collection of transcripts" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6483,13 +6483,13 @@ biolink:VariantAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:ModelToDiseaseAssociationMixin,
@@ -6500,13 +6500,13 @@ biolink:VariantToGeneExpressionAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to gene expression association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:GeneExpressionMixin,
         biolink:VariantToGeneAssociation ;
@@ -6517,13 +6517,13 @@ biolink:VariantToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
@@ -6534,49 +6534,49 @@ biolink:VariantToPopulationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to population association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_quotient ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_quotient ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_count ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:has_total ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:has_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:has_quotient ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_total ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_count ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_quotient ],
         biolink:Association,
         biolink:FrequencyQualifierMixin,
@@ -7120,32 +7120,32 @@ biolink:BookChapter a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "book chapter" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:chapter ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:volume ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:chapter ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:chapter ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:chapter ],
+            owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:chapter ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:published_in ],
+            owl:onProperty biolink:volume ],
         biolink:Publication ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -7166,10 +7166,10 @@ biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:CellLineToEntityAssociationMixin,
@@ -7181,10 +7181,10 @@ biolink:ChemicalExposure a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical exposure" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:QuantityValue ;
             owl:onProperty biolink:has_quantitative_value ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:QuantityValue ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_quantitative_value ],
         biolink:Attribute,
         biolink:ExposureEvent ;
@@ -7197,15 +7197,6 @@ biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation a owl:C
         linkml:ClassDefinition ;
     rdfs:label "chemical or drug or treatment to disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:FDA_adverse_event_level ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:FDAIDAAdverseEventEnum ;
             owl:onProperty biolink:FDA_adverse_event_level ],
         [ a owl:Restriction ;
@@ -7214,6 +7205,15 @@ biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation a owl:C
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:FDA_adverse_event_level ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:FDA_adverse_event_level ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin,
         biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin ;
@@ -7334,76 +7334,76 @@ biolink:GenomicSequenceLocalization a owl:Class,
     rdfs:label "genomic sequence localization" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:end_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:start_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:genome_build ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:phase ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:strand ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:start_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:strand ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:end_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:start_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:phase ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:StrandEnum ;
             owl:onProperty biolink:strand ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:phase ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:StrandEnum ;
-            owl:onProperty biolink:genome_build ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:start_interbase_coordinate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:end_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:end_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:genome_build ],
+            owl:onProperty biolink:end_interbase_coordinate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhaseEnum ;
             owl:onProperty biolink:phase ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:NucleicAcidEntity ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:phase ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:StrandEnum ;
+            owl:onProperty biolink:genome_build ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:genome_build ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NucleicAcidEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NucleicAcidEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:strand ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NucleicAcidEntity ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:end_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:SequenceAssociation ;
     skos:broadMatch dcid:Chromosome ;
     skos:definition "A relationship between a sequence feature and a nucleic acid entity it is localized to. The reference entity may be a chromosome, chromosome region or information entity such as a contig." ;
@@ -7414,32 +7414,32 @@ biolink:GenotypeToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
         biolink:GenotypeToEntityAssociationMixin ;
@@ -7450,23 +7450,23 @@ biolink:GeographicLocation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "geographic location" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Float ;
             owl:onProperty biolink:longitude ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:latitude ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:latitude ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Float ;
             owl:onProperty biolink:latitude ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:longitude ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:latitude ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:longitude ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty biolink:longitude ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:latitude ],
         biolink:PlanetaryEntity ;
     skos:definition "a location that can be described in lat/long coordinates" ;
     skos:exactMatch STY:T083,
@@ -7507,13 +7507,13 @@ biolink:PairwiseGeneToGeneInteraction a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "pairwise gene to gene interaction" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:GeneToGeneAssociation ;
     skos:definition "An interaction between two genes or two gene products. May be physical (e.g. protein binding) or genetic (between genes). May be symmetric (e.g. protein interaction) or directed (e.g. phosphorylation)" ;
@@ -7545,41 +7545,41 @@ biolink:ReactionToParticipantAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "reaction to participant association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:stoichiometry ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:reaction_side ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:reaction_side ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty biolink:stoichiometry ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:reaction_direction ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ReactionDirectionEnum ;
-            owl:onProperty biolink:reaction_direction ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:stoichiometry ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:reaction_direction ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ReactionSideEnum ;
             owl:onProperty biolink:reaction_side ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:reaction_direction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:stoichiometry ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:reaction_side ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:reaction_side ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ReactionDirectionEnum ;
+            owl:onProperty biolink:reaction_direction ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:reaction_direction ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:stoichiometry ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty biolink:stoichiometry ],
         biolink:ChemicalToChemicalAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -7614,15 +7614,6 @@ biolink:Treatment a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "treatment" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Procedure ;
-            owl:onProperty biolink:has_procedure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_drug ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_device ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_procedure ],
         [ a owl:Restriction ;
@@ -7631,6 +7622,15 @@ biolink:Treatment a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Device ;
             owl:onProperty biolink:has_device ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Procedure ;
+            owl:onProperty biolink:has_procedure ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_device ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_drug ],
         biolink:ChemicalOrDrugOrTreatment,
         biolink:ExposureEvent,
         biolink:NamedThing ;
@@ -7647,31 +7647,31 @@ biolink:VariantToDiseaseAssociation a owl:Class,
     rdfs:label "variant to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
         biolink:VariantToEntityAssociationMixin ;
@@ -7682,23 +7682,23 @@ biolink:VariantToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:VariantToEntityAssociationMixin ;
     skos:definition "An association between a variant and a gene, where the variant has a genetic association with the gene (i.e. is in linkage disequilibrium)" ;
@@ -8297,22 +8297,22 @@ biolink:AnatomicalEntityToAnatomicalEntityAssociation a owl:Class,
     rdfs:label "anatomical entity to anatomical entity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8338,7 +8338,7 @@ biolink:ChemicalRole a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical role" ;
     rdfs:subClassOf biolink:Attribute ;
-    skos:definition "	A role played by the molecular entity or part thereof within a chemical context." ;
+    skos:definition "A role played by the molecular entity or part thereof within a chemical context." ;
     skos:exactMatch <http://purl.obolibrary.org/obo/CHEBI_51086> ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8346,13 +8346,13 @@ biolink:ChemicalToChemicalAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to chemical association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin ;
@@ -8414,13 +8414,13 @@ biolink:GeneToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8458,22 +8458,22 @@ biolink:OrganismTaxonToOrganismTaxonAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to organism taxon association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:OrganismTaxonToEntityAssociation ;
@@ -8520,10 +8520,10 @@ biolink:VariantToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:SequenceVariant ;
@@ -8834,13 +8834,13 @@ biolink:DatasetDistribution a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "dataset distribution" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:distribution_download_url ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:distribution_download_url ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:distribution_download_url ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:distribution_download_url ],
         biolink:InformationContentEntity ;
     skos:definition "an item that holds distribution level information about a dataset." ;
@@ -8851,23 +8851,23 @@ biolink:DatasetSummary a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "dataset summary" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:source_logo ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:source_logo ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:source_web_page ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:source_web_page ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:source_logo ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:source_web_page ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:source_logo ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:source_web_page ],
         biolink:InformationContentEntity ;
     skos:definition "an item that holds summary level information about a dataset." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -8909,21 +8909,21 @@ biolink:GeneToDiseaseAssociation a owl:Class,
     rdfs:label "gene to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
@@ -8937,23 +8937,23 @@ biolink:GeneToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:altLabel "molecular or genetic interaction" ;
     skos:definition "abstract parent class for different kinds of gene-gene or gene product to gene product relationships. Includes homology and interaction." ;
@@ -9000,20 +9000,20 @@ biolink:ModelToDiseaseAssociationMixin a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:subject ] ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ] ;
     skos:definition "This mixin is used for any association class for which the subject (source node) plays the role of a 'model', in that it recapitulates some features of the disease in a way that is useful for studying the disease outside a patient carrying the disease" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -9053,20 +9053,20 @@ biolink:QuantityValue a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "quantity value" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_unit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_numeric_value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_numeric_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_unit ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Double ;
             owl:onProperty biolink:has_numeric_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_numeric_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_numeric_value ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_unit ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:unit ;
             owl:onProperty biolink:has_unit ],
@@ -9079,12 +9079,12 @@ biolink:SequenceFeatureRelationship a owl:Class,
     rdfs:label "sequence feature relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom biolink:NucleicAcidEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NucleicAcidEntity ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -9093,7 +9093,7 @@ biolink:SequenceFeatureRelationship a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "For example, a particular exon is part of a particular transcript or gene" ;
@@ -9107,10 +9107,10 @@ biolink:ThingWithTaxon a owl:Class,
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:in_taxon ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:in_taxon ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:in_taxon ] ;
     skos:definition "A mixin that can be used on any entity that can be taxonomically classified. This includes individual organisms; genes, their products and other molecular entities; body parts; biological processes" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -9230,13 +9230,13 @@ biolink:ChemicalToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:ChemicalEntityToEntityAssociationMixin ;
     skos:definition "An interaction between a chemical entity and another entity" ;
@@ -9254,32 +9254,32 @@ biolink:DatasetVersion a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "dataset version" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_dataset ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:ingest_date ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_distribution ],
+            owl:onProperty biolink:ingest_date ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Dataset ;
             owl:onProperty biolink:has_dataset ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:ingest_date ],
+            owl:onProperty biolink:has_distribution ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_distribution ],
+            owl:onProperty biolink:has_dataset ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DatasetDistribution ;
             owl:onProperty biolink:has_distribution ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:ingest_date ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_distribution ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_dataset ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_dataset ],
+            owl:onProperty biolink:ingest_date ],
         biolink:InformationContentEntity ;
     skos:definition "an item that holds version level information about a dataset." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -9301,23 +9301,23 @@ biolink:FunctionalAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "functional association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MacromolecularMachineMixin ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "An association between a macromolecular machine mixin (gene, gene product or complex of gene products) and either a molecular activity, a biological process or a cellular location in which a function is executed." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -9326,13 +9326,13 @@ biolink:GeneProductMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene product mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:label_type ;
             owl:onProperty biolink:synonym ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -9348,13 +9348,13 @@ biolink:MacromolecularMachineMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:symbol_type ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:name ] ;
     skos:definition "A union of gene locus, gene product, and macromolecular complex. These are the basic units of function in a cell. They either carry out individual biological activities, or they encode molecules which do this." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -9723,62 +9723,62 @@ biolink:Entity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:description ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:id ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:label_type ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_attribute ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:category ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:iri_type ;
             owl:onProperty biolink:iri ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:narrative_text ;
+            owl:onProperty biolink:description ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_attribute ],
+            owl:onProperty biolink:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:category_type ;
-            owl:onProperty biolink:category ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:category ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:narrative_text ;
-            owl:onProperty biolink:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Attribute ;
             owl:onProperty biolink:has_attribute ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:category_type ;
+            owl:onProperty biolink:category ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:label_type ;
-            owl:onProperty biolink:name ] ;
+            owl:onProperty biolink:iri ] ;
     skos:definition "Root Biolink Model class for all things and informational relationships, real or imagined." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -9789,19 +9789,19 @@ biolink:EntityToPhenotypicFeatureAssociationMixin a owl:Class,
             owl:allValuesFrom biolink:PhenotypicFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:BiologicalSex ;
             owl:onProperty biolink:sex_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:sex_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:BiologicalSex ;
             owl:onProperty biolink:sex_qualifier ],
         biolink:EntityToFeatureOrDiseaseQualifiersMixin,
         biolink:FrequencyQuantifier ;
@@ -9928,25 +9928,31 @@ biolink:ChemicalMixture a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical mixture" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:highest_FDA_approval_status ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:drug_regulatory_status_world_wide ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:is_supplement ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:drug_regulatory_status_world_wide ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:drug_regulatory_status_world_wide ],
+            owl:onProperty biolink:highest_FDA_approval_status ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:drug_regulatory_status_world_wide ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalMixture ;
             owl:onProperty biolink:is_supplement ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:highest_FDA_approval_status ],
+            owl:onProperty biolink:routes_of_delivery ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:drug_regulatory_status_world_wide ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalMixture ;
             owl:onProperty biolink:is_supplement ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DrugDeliveryEnum ;
@@ -9954,12 +9960,6 @@ biolink:ChemicalMixture a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:highest_FDA_approval_status ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:routes_of_delivery ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:is_supplement ],
         biolink:ChemicalEntity ;
     skos:closeMatch dcid:ChemicalCompound ;
     skos:definition "A chemical mixture is a chemical entity composed of two or more molecular entities." ;
@@ -10220,13 +10220,13 @@ biolink:EntityToDiseaseAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to disease association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Disease ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:object ],
         biolink:EntityToFeatureOrDiseaseQualifiersMixin ;
     skos:definition "mixin class for any association whose object (target node) is a disease" ;
@@ -10236,13 +10236,13 @@ biolink:Genotype a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_zygosity ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_zygosity ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Zygosity ;
-            owl:onProperty biolink:has_zygosity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_zygosity ],
         biolink:BiologicalEntity,
         biolink:GenomicEntity,
@@ -10469,10 +10469,10 @@ biolink:OrganismalEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organismal entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_attribute ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:has_attribute ],
         biolink:BiologicalEntity,
         biolink:SubjectOfInvestigation ;
@@ -10493,24 +10493,6 @@ biolink:BiologicalProcessOrActivity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "biological process or activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Occurrent ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:enabled_by ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhysicalEntity ;
             owl:onProperty biolink:enabled_by ],
         [ a owl:Restriction ;
@@ -10519,6 +10501,24 @@ biolink:BiologicalProcessOrActivity a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Occurrent ;
             owl:onProperty biolink:has_output ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_output ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_output ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Occurrent ;
+            owl:onProperty biolink:has_input ],
         biolink:BiologicalEntity,
         biolink:Occurrent,
         biolink:OntologyClass ;
@@ -10555,38 +10555,38 @@ biolink:Agent a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:address ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:affiliation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:address ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:affiliation ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:address ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:name ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:address ],
         biolink:AdministrativeEntity ;
     skos:altLabel "group" ;
     skos:definition "person, group, organization or project that provides a piece of information (i.e. a knowledge association)" ;
@@ -10612,32 +10612,32 @@ biolink:MolecularActivity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_output ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_input ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_input ],
+            owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MacromolecularMachineMixin ;
             owl:onProperty biolink:enabled_by ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:MolecularEntity ;
             owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:enabled_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularEntity ;
             owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_input ],
         biolink:BiologicalProcessOrActivity,
         biolink:Occurrent,
         biolink:OntologyClass ;
@@ -10692,13 +10692,13 @@ biolink:ExposureEvent a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exposure event" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:time_type ;
+            owl:onProperty biolink:timepoint ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:timepoint ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:time_type ;
             owl:onProperty biolink:timepoint ],
         biolink:OntologyClass ;
     skos:altLabel "experimental condition",
@@ -10722,13 +10722,13 @@ biolink:OrganismTaxon a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_taxonomic_rank ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_taxonomic_rank ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:TaxonomicRank ;
-            owl:onProperty biolink:has_taxonomic_rank ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_taxonomic_rank ],
         biolink:NamedThing ;
     skos:altLabel "taxon",
@@ -10757,13 +10757,13 @@ biolink:MolecularEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:is_metabolite ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty biolink:is_metabolite ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:is_metabolite ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:is_metabolite ],
         biolink:ChemicalEntity ;
     skos:definition "A molecular entity is a chemical entity composed of individual or covalently bonded atoms." ;
@@ -10797,16 +10797,16 @@ biolink:Gene a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:symbol ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:synonym ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:symbol ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:symbol ],
         biolink:BiologicalEntity,
         biolink:ChemicalEntityOrGeneOrGeneProduct,
@@ -10827,17 +10827,32 @@ biolink:InformationContentEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "information content entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:license ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:license ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:rights ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:license ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:format ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:license ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:rights ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:format ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:creation_date ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:rights ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Date ;
             owl:onProperty biolink:creation_date ],
@@ -10845,22 +10860,7 @@ biolink:InformationContentEntity a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:format ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:rights ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:format ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:format ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:creation_date ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:rights ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:creation_date ],
         biolink:NamedThing ;
     skos:altLabel "information",
@@ -10886,71 +10886,71 @@ biolink:Publication a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "publication" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:mesh_terms ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:summary ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:keywords ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:summary ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:pages ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:authors ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:mesh_terms ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:summary ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:xref ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:mesh_terms ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:keywords ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
+            owl:onProperty biolink:summary ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:summary ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:pages ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:pages ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:keywords ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:summary ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:authors ],
+            owl:onProperty biolink:mesh_terms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:keywords ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
+            owl:onProperty biolink:pages ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:xref ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:authors ],
         biolink:InformationContentEntity ;
     skos:definition "Any published piece of information. Can refer to a whole publication, its encompassing publication (i.e. journal or book) or to a part of a publication, if of significant knowledge scope (e.g. a figure, figure legend, or section highlighted by NLP). The scope is intended to be general and include information published on the web, as well as printed materials, either directly or in one of the Publication Biolink category subclasses." ;
     skos:exactMatch IAO:0000311 ;
@@ -10986,47 +10986,47 @@ biolink:Attribute a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "attribute" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:label_type ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:iri_type ;
+            owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:has_qualitative_value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_qualitative_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:has_attribute_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_qualitative_value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:QuantityValue ;
+            owl:onProperty biolink:has_quantitative_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_quantitative_value ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_attribute_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:has_attribute_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:label_type ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:has_qualitative_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_quantitative_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_qualitative_value ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_qualitative_value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:iri_type ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:QuantityValue ;
-            owl:onProperty biolink:has_quantitative_value ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:has_attribute_type ],
         biolink:NamedThing,
         biolink:OntologyClass ;
     skos:definition "A property or characteristic of an entity. For example, an apple may have properties such as color, shape, age, crispiness. An environmental sample may have attributes such as depth, lat, long, material." ;
@@ -11062,13 +11062,13 @@ biolink:GenomicEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genomic entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:biological_sequence ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:biological_sequence ;
             owl:onProperty biolink:has_biological_sequence ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> ;
     skos:narrowMatch STY:T028,
@@ -11078,17 +11078,11 @@ biolink:SequenceVariant a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "sequence variant" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_biological_sequence ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_gene ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:has_gene ],
@@ -11097,10 +11091,16 @@ biolink:SequenceVariant a owl:Class,
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:has_gene ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_biological_sequence ],
         biolink:BiologicalEntity,
         biolink:GenomicEntity,
         biolink:OntologyClass,
@@ -11129,14 +11129,35 @@ biolink:ChemicalEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:trade_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:trade_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:max_tolerated_dose ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:is_toxic ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:available_from ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:max_tolerated_dose ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:is_toxic ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:trade_name ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:max_tolerated_dose ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:trade_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalRole ;
+            owl:onProperty biolink:has_chemical_role ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DrugAvailabilityEnum ;
             owl:onProperty biolink:available_from ],
@@ -11144,28 +11165,7 @@ biolink:ChemicalEntity a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_chemical_role ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:available_from ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:trade_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:max_tolerated_dose ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty biolink:is_toxic ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalRole ;
-            owl:onProperty biolink:has_chemical_role ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:max_tolerated_dose ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:max_tolerated_dose ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:is_toxic ],
         biolink:ChemicalEntityOrGeneOrGeneProduct,
         biolink:ChemicalEntityOrProteinOrPolypeptide,
@@ -11241,10 +11241,10 @@ biolink:OntologyClass a owl:Class,
     rdfs:label "ontology class" ;
     rdfs:seeAlso <https://github.com/biolink/biolink-model/issues/486> ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -11274,13 +11274,13 @@ biolink:NamedThing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "named thing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:provided_by ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:category ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:provided_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
@@ -11288,11 +11288,11 @@ biolink:NamedThing a owl:Class,
                     owl:withRestrictions ( [ xsd:pattern "^biolink:\\d+$" ] ) ] ;
             owl:onProperty biolink:category ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:provided_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:xref ],
         biolink:Entity ;
     skos:definition "a databased entity or concept/class" ;
     skos:exactMatch STY:T071,
@@ -11306,62 +11306,65 @@ biolink:Association a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:category ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty biolink:negated ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:publications ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:original_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:aggregator_knowledge_source ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:qualifiers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:original_subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:original_subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:timepoint ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:negated ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:InformationResource ;
-            owl:onProperty biolink:knowledge_source ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:aggregator_knowledge_source ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:primary_knowledge_source ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:original_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:original_subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:publications ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:time_type ;
-            owl:onProperty biolink:timepoint ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:InformationResource ;
-            owl:onProperty biolink:primary_knowledge_source ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:original_subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:knowledge_source ],
+            owl:onProperty biolink:negated ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:category_type ;
             owl:onProperty biolink:category ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:category ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:timepoint ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty biolink:negated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Publication ;
+            owl:onProperty biolink:publications ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:knowledge_source ],
@@ -11369,38 +11372,47 @@ biolink:Association a owl:Class,
             owl:allValuesFrom biolink:InformationResource ;
             owl:onProperty biolink:aggregator_knowledge_source ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:timepoint ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:original_object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:original_subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:original_object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:primary_knowledge_source ],
+            owl:onProperty biolink:original_object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:time_type ;
+            owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:type ],
+            owl:onProperty biolink:primary_knowledge_source ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:InformationResource ;
+            owl:onProperty biolink:knowledge_source ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:original_object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:original_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualifiers ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:primary_knowledge_source ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:EvidenceType ;
             owl:onProperty biolink:has_evidence ],
@@ -11408,32 +11420,20 @@ biolink:Association a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:original_predicate ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:original_subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Publication ;
-            owl:onProperty biolink:publications ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:negated ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:original_predicate ],
+            owl:allValuesFrom biolink:InformationResource ;
+            owl:onProperty biolink:primary_knowledge_source ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:qualifiers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:original_object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:qualifiers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:negated ],
+            owl:onProperty biolink:knowledge_source ],
         biolink:Entity ;
     skos:definition "A typed association between two entities, supported by evidence" ;
     skos:exactMatch OBAN:association,
@@ -11569,894 +11569,9 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     skos:definition "Entity and association taxonomy and datamodel for life-sciences data" .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:PlanetaryEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PlanetaryEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Activity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Activity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneCoexpressionAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneCoexpressionAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Event ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Event .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugToGeneInteractionExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugToGeneInteractionExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Treatment ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Treatment .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SocioeconomicAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SocioeconomicAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToPathwayAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToPathwayAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetDistribution ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetDistribution .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceVariant ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceVariant .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Virus ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Virus .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToGenotypePartAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToGenotypePartAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalFoodContaminant ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalFoodContaminant .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:FoodAdditive ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:FoodAdditive .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Cohort ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Cohort .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Book ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Book .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularMachineToBiologicalProcessAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularMachineToBiologicalProcessAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalAnatomicalStructure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalAnatomicalStructure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalRole ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalRole .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Onset ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Onset .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalIntervention ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalIntervention .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalCourse ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalCourse .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToGeneExpressionAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToGeneExpressionAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TranscriptToGeneRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TranscriptToGeneRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalProcessOrActivity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalProcessOrActivity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TaxonToTaxonAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TaxonToTaxonAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Serial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Serial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyVariable ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyVariable .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Association ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Association .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalAnatomicalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalAnatomicalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Zygosity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Zygosity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGoTermAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGoTermAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AdministrativeEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AdministrativeEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:IndividualOrganism ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:IndividualOrganism .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalMeasurement ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalMeasurement .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToChemicalEntityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToChemicalEntityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneFamilyAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneFamilyAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Case ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Case .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToPathwayAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToPathwayAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BioticExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BioticExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BookChapter ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BookChapter .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismalEntityAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismalEntityAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToChemicalDerivationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToChemicalDerivationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleicAcidEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleicAcidEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Study ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Study .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularMachineToMolecularActivityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularMachineToMolecularActivityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReactionToCatalystAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReactionToCatalystAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Transcript ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Transcript .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NamedThing ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NamedThing .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReactionToParticipantAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReactionToParticipantAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToPathwayAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToPathwayAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhenotypicFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhenotypicFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonSpecialization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonSpecialization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Snv ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Snv .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleicAcidSequenceMotif ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleicAcidSequenceMotif .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ContributorAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ContributorAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehavioralExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehavioralExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SocioeconomicExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SocioeconomicExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PairwiseGeneToGeneInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:InformationContentEntityToNamedThingAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:InformationContentEntityToNamedThingAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MaterialSample ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MaterialSample .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneHasVariantThatContributesToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneHasVariantThatContributesToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxon ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxon .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalTrial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalTrial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Haplotype ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Haplotype .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Agent ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Agent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MaterialSampleDerivationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MaterialSampleDerivationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToChemicalAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToChemicalAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Behavior ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Behavior .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneProductRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneProductRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntityAssessesNamedThingAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntityAssessesNamedThingAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProteinDomain ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProteinDomain .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Polypeptide ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Polypeptide .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenomicBackgroundExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenomicBackgroundExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Gene ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Gene .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PopulationOfIndividualOrganisms ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PopulationOfIndividualOrganisms .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Publication ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Publication .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalAffectsGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalAffectsGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProteinIsoform ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProteinIsoform .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EntityToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismToOrganismAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismToOrganismAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Attribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Attribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:InformationResource ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:InformationResource .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLine ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLine .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:LifeStage ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:LifeStage .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EntityToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EntityToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseToExposureEventAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseToExposureEventAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProteinFamily ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProteinFamily .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypicSex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypicSex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MicroRNA ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MicroRNA .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalModifier ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalModifier .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToExpressionSiteAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToExpressionSiteAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToLocationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToLocationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetVersion ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetVersion .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Protein ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Protein .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SiRNA ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SiRNA .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceVariantModulatesTreatmentAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceVariantModulatesTreatmentAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Phenomenon ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Phenomenon .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalProcessExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalProcessExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NoncodingRNAProduct ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NoncodingRNAProduct .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Genome ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Genome .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Exon ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Exon .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalGeneInteractionAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalGeneInteractionAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Cell ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Cell .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SeverityValue ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SeverityValue .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToEnvironmentAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToEnvironmentAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExposureEventToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExposureEventToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChiSquaredAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChiSquaredAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellularOrganism ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellularOrganism .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellularComponent ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellularComponent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Procedure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Procedure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Genotype ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Genotype .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleosomeModification ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleosomeModification .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GrossAnatomicalStructure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GrossAnatomicalStructure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalFinding ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalFinding .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToVariantAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToVariantAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToPopulationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToPopulationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularMachineToCellularComponentAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularMachineToCellularComponentAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneFamily ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneFamily .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ConceptCountAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ConceptCountAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneticInheritance ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneticInheritance .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehavioralFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehavioralFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ConfidenceLevel ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ConfidenceLevel .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Pathway ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Pathway .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProcessedMaterial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProcessedMaterial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Drug ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Drug .
-
-[] a owl:Restriction ;
     rdfs:subClassOf biolink:PhenotypicQuality ;
     owl:onProperty biolink:category ;
     owl:someValuesFrom biolink:PhenotypicQuality .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Disease ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Disease .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DruggableGeneToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DruggableGeneToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ObservedExpectedFrequencyAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ObservedExpectedFrequencyAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Entity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Entity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SmallMolecule ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SmallMolecule .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PopulationToPopulationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PopulationToPopulationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExposureEventToOutcomeAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExposureEventToOutcomeAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLineAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLineAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:InformationContentEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:InformationContentEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PairwiseMolecularInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PairwiseMolecularInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:DiseaseToPhenotypicFeatureAssociation ;
@@ -12464,104 +11579,14 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:DiseaseToPhenotypicFeatureAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExonToTranscriptRelationship ;
+    rdfs:subClassOf biolink:Event ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExonToTranscriptRelationship .
+    owl:someValuesFrom biolink:Event .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhysicalEntity ;
+    rdfs:subClassOf biolink:GeneToPathwayAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhysicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReagentTargetedGene ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReagentTargetedGene .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenomicSequenceLocalization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenomicSequenceLocalization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RNAProduct ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RNAProduct .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CommonDataElement ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CommonDataElement .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicLocationAtTime ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicLocationAtTime .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularComplex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularComplex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehaviorToBehavioralFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehaviorToBehavioralFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CodingSequence ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CodingSequence .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicLocation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicLocation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ComplexMolecularMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ComplexMolecularMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetSummary ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetSummary .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Hospitalization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Hospitalization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PosttranslationalModification ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PosttranslationalModification .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Device ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Device .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CaseToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CaseToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:FunctionalAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:FunctionalAssociation .
+    owl:someValuesFrom biolink:GeneToPathwayAssociation .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:AnatomicalEntity ;
@@ -12569,54 +11594,44 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:AnatomicalEntity .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:TextMiningResult ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureExposure ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TextMiningResult .
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureExposure .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:ComplexChemicalExposure ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ComplexChemicalExposure .
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:RNAProductIsoform ;
+    rdfs:subClassOf biolink:PathologicalAnatomicalStructure ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RNAProductIsoform .
+    owl:someValuesFrom biolink:PathologicalAnatomicalStructure .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:EvidenceType ;
+    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EvidenceType .
+    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:Article ;
+    rdfs:subClassOf biolink:Attribute ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Article .
+    owl:someValuesFrom biolink:Attribute .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceFeatureRelationship ;
+    rdfs:subClassOf biolink:Procedure ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceFeatureRelationship .
+    owl:someValuesFrom biolink:Procedure .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation ;
+    rdfs:subClassOf biolink:NucleosomeModification ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation .
+    owl:someValuesFrom biolink:NucleosomeModification .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:RelativeFrequencyAnalysisResult ;
+    rdfs:subClassOf biolink:Device ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RelativeFrequencyAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyPopulation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyPopulation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Food ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Food .
+    owl:someValuesFrom biolink:Device .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:Dataset ;
@@ -12624,19 +11639,94 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:Dataset .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToMolecularActivityAssociation ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToMolecularActivityAssociation .
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToDiseaseAssociation ;
+    rdfs:subClassOf biolink:EnvironmentalFeature ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToDiseaseAssociation .
+    owl:someValuesFrom biolink:EnvironmentalFeature .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugToGeneAssociation ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonSpecialization ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugToGeneAssociation .
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonSpecialization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularMachineToMolecularActivityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularMachineToMolecularActivityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToChemicalEntityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToChemicalEntityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Transcript ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Transcript .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TaxonToTaxonAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TaxonToTaxonAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToChemicalDerivationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToChemicalDerivationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Serial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Serial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SiRNA ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SiRNA .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Pathway ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Pathway .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalMeasurement ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalMeasurement .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BookChapter ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BookChapter .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehavioralFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehavioralFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReagentTargetedGene ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReagentTargetedGene .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:PhenotypicSex ;
@@ -12644,14 +11734,24 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:PhenotypicSex .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToDiseaseAssociation ;
+    rdfs:subClassOf biolink:PosttranslationalModification ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToDiseaseAssociation .
+    owl:someValuesFrom biolink:PosttranslationalModification .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneHomologyAssociation ;
+    rdfs:subClassOf biolink:Genotype ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneHomologyAssociation .
+    owl:someValuesFrom biolink:Genotype .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EnvironmentalFoodContaminant ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EnvironmentalFoodContaminant .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PlanetaryEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PlanetaryEntity .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:ChemicalExposure ;
@@ -12659,12 +11759,912 @@ In an RDF database, nodes will typically have an rdf:type triples. This can be t
     owl:someValuesFrom biolink:ChemicalExposure .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalSex ;
+    rdfs:subClassOf biolink:ComplexMolecularMixture ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalSex .
+    owl:someValuesFrom biolink:ComplexMolecularMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:StudyResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:StudyResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CaseToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CaseToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SocioeconomicAttribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SocioeconomicAttribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Entity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Entity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Virus ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Virus .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseToExposureEventAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseToExposureEventAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalGeneInteractionAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalGeneInteractionAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:StudyVariable ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:StudyVariable .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Gene ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Gene .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:PhysiologicalProcess ;
     owl:onProperty biolink:category ;
     owl:someValuesFrom biolink:PhysiologicalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TranscriptToGeneRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TranscriptToGeneRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Book ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Book .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalProcessExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalProcessExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Protein ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Protein .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalAffectsGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalAffectsGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicLocation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicLocation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReactionToCatalystAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReactionToCatalystAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToLocationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToLocationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehaviorToBehavioralFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehaviorToBehavioralFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProteinFamily ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProteinFamily .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PairwiseGeneToGeneInteraction .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Polypeptide ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Polypeptide .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToMolecularActivityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToMolecularActivityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetSummary ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetSummary .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalTrial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalTrial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToGeneExpressionAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToGeneExpressionAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneHasVariantThatContributesToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneHasVariantThatContributesToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceFeatureRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceFeatureRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToGenotypePartAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToGenotypePartAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RelativeFrequencyAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RelativeFrequencyAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalCourse ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalCourse .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ContributorAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ContributorAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularMachineToCellularComponentAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularMachineToCellularComponentAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SocioeconomicExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SocioeconomicExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PairwiseMolecularInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PairwiseMolecularInteraction .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Case ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Case .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CodingSequence ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CodingSequence .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ConceptCountAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ConceptCountAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Study ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Study .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:IndividualOrganism ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:IndividualOrganism .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EntityToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EntityToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Article ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Article .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalSex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalSex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxon ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxon .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalAttribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalAttribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismAttribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismAttribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CommonDataElement ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CommonDataElement .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:FoodAdditive ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:FoodAdditive .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypicSex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypicSex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularMachineToBiologicalProcessAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularMachineToBiologicalProcessAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneticInheritance ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneticInheritance .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MaterialSampleDerivationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MaterialSampleDerivationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalModifier ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalModifier .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismToOrganismAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismToOrganismAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NucleicAcidSequenceMotif ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NucleicAcidSequenceMotif .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:StudyPopulation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:StudyPopulation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EnvironmentalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EnvironmentalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceVariant ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceVariant .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EvidenceType ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EvidenceType .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PopulationOfIndividualOrganisms ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PopulationOfIndividualOrganisms .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToPopulationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToPopulationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToChemicalAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToChemicalAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneFamily ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneFamily .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLineAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLineAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Activity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Activity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProteinDomain ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProteinDomain .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChiSquaredAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChiSquaredAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToExpressionSiteAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToExpressionSiteAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NucleicAcidEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NucleicAcidEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ComplexChemicalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ComplexChemicalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Snv ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Snv .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Phenomenon ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Phenomenon .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:InformationResource ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:InformationResource .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugToGeneInteractionExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugToGeneInteractionExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MicroRNA ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MicroRNA .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TextMiningResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TextMiningResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Drug ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Drug .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalAnatomicalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalAnatomicalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:InformationContentEntityToNamedThingAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:InformationContentEntityToNamedThingAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularComplex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularComplex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhysicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhysicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProteinIsoform ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProteinIsoform .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToEnvironmentAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToEnvironmentAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellularOrganism ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellularOrganism .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ConfidenceLevel ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ConfidenceLevel .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Disease ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Disease .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneFamilyAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneFamilyAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularMixture ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AdministrativeEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AdministrativeEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellularComponent ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellularComponent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DruggableGeneToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DruggableGeneToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ObservedExpectedFrequencyAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ObservedExpectedFrequencyAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalEntityAssessesNamedThingAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalEntityAssessesNamedThingAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicLocationAtTime ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicLocationAtTime .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalMixture ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalIntervention ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalIntervention .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Cohort ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Cohort .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLine ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLine .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Publication ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Publication .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReactionToParticipantAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReactionToParticipantAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Zygosity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Zygosity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PopulationToPopulationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PopulationToPopulationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Haplotype ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Haplotype .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ExposureEventToOutcomeAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ExposureEventToOutcomeAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ExposureEventToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ExposureEventToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:InformationContentEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:InformationContentEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Behavior ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Behavior .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalProcessOrActivity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalProcessOrActivity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RNAProduct ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RNAProduct .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalRole ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalRole .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToPathwayAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToPathwayAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:LifeStage ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:LifeStage .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Hospitalization ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Hospitalization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenomicBackgroundExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenomicBackgroundExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Genome ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Genome .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BioticExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BioticExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NamedThing ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NamedThing .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GrossAnatomicalStructure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GrossAnatomicalStructure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneProductRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneProductRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:FunctionalAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:FunctionalAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneHomologyAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneHomologyAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneCoexpressionAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneCoexpressionAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonInteraction .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhenotypicFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhenotypicFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Cell ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Cell .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenomicSequenceLocalization ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenomicSequenceLocalization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Agent ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Agent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGoTermAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGoTermAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Food ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Food .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceVariantModulatesTreatmentAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceVariantModulatesTreatmentAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProcessedMaterial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProcessedMaterial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MaterialSample ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MaterialSample .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Onset ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Onset .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Exon ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Exon .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EnvironmentalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EnvironmentalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NoncodingRNAProduct ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NoncodingRNAProduct .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismalEntityAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismalEntityAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Treatment ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Treatment .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalFinding ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalFinding .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetVersion ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetVersion .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToVariantAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToVariantAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EntityToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SeverityValue ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SeverityValue .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SmallMolecule ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SmallMolecule .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Association ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Association .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToPathwayAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToPathwayAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehavioralExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehavioralExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ExonToTranscriptRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ExonToTranscriptRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetDistribution ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetDistribution .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RNAProductIsoform ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RNAProductIsoform .
 

--- a/tests/test_biolink_model/output/biolink-model.proto
+++ b/tests/test_biolink_model/output/biolink-model.proto
@@ -732,7 +732,7 @@ message ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation
   fDAIDAAdverseEventEnum fDAAdverseEventLevel = 0
   predicateType predicate = 0
  }
-// 	A role played by the molecular entity or part thereof within a chemical context.
+// A role played by the molecular entity or part thereof within a chemical context.
 message ChemicalRole
  {
   string id = 0

--- a/tests/test_generators/input/shaclgen_custom_class_range.yaml
+++ b/tests/test_generators/input/shaclgen_custom_class_range.yaml
@@ -1,0 +1,19 @@
+id: https://w3id.org/linkml/examples/personinfo
+name: personinfo
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://w3id.org/linkml/examples/personinfo/
+imports:
+  - linkml:types
+default_range: string
+default_prefix: ex
+
+classes:
+  Person:
+  Container:
+    tree_root: true
+    attributes:
+      persons:
+        multivalued: true
+        inlined_as_list: true
+        range: Person

--- a/tests/test_generators/test_shaclgen.py
+++ b/tests/test_generators/test_shaclgen.py
@@ -253,3 +253,16 @@ def test_ifabsent(input_path):
         datatype=ShaclDataType.URI.uri_ref,
     )
     check_slot_default_value(URIRef("https://w3id.org/linkml/tests/kitchen_sink/ifabsent_not_literal"), "heartfelt")
+
+
+def test_custom_class_range_is_blank_node_or_iri(input_path):
+    shacl = ShaclGenerator(input_path("shaclgen_custom_class_range.yaml"), mergeimports=True).serialize()
+
+    g = rdflib.Graph()
+    g.parse(data=shacl)
+
+    container_properties = g.objects(URIRef("https://w3id.org/linkml/examples/personinfo/Container"), SH.property)
+    persons_node = next(container_properties, None)
+    assert persons_node
+
+    assert (persons_node, SH.nodeKind, SH.BlankNodeOrIRI) in g

--- a/tests/test_issues/test_issue_494.py
+++ b/tests/test_issues/test_issue_494.py
@@ -14,7 +14,7 @@ def test_jsonschema_validation(input_path):
     with pytest.raises(
         RuntimeError,
         match="Multiple potential target "
-        r"classes found: \['Container', 'annotation'\]. "
+        r"classes found: \[('Container'|'annotation'), ('Container'|'annotation')\]. "
         "Please specify a target using --target-class "
         "or by adding tree_root: true to the relevant class in the schema",
     ):


### PR DESCRIPTION
## Introduction

As mentioned in #1596, when using the Shacl generator on an ontology that contains attributes/slots referencing a custom class without an identifier, the resulting node kind is `sh:BlankNode`.

## Use Cases

If we base ourselves on the ontology described in #1596 to which we add a `name` attribute to the `Person` class, we have the following use cases.

### Compliant Case

```json
{
  "@context": {
    "ex": "https://w3id.org/linkml/examples/personinfo/"
  },
  "@graph": [
    {
      "@id": "http://example.org/ns#container",
      "@type": [
        "ex:Container"
      ],
      "ex:persons": [
        {
          "@type": "ex:Person",
          "ex:name": "bob"
        },
        {
          "@type": "ex:Person",
          "ex:name": "alice"
        }
      ]
    }
  ]
}
```

This works because the persons don't have an `@id` attribute.

### Non-Compliant Cases

```json
{
  "@context": {
    "ex": "https://w3id.org/linkml/examples/personinfo/"
  },
  "@graph": [
    {
      "@id": "http://example.org/ns#container",
      "@type": [
        "ex:Container"
      ],
      "ex:persons": [
        {
          "@id": "http://example.org/bob"
        },
        {
          "@id": "http://example.org/alice"
        }
      ]
    },
    {
      "@id": "http://example.org/bob",
      "@type": "ex:Person",
      "ex:name": "bob"
    },
    {
      "@id": "http://example.org/alice",
      "@type": "ex:Person",
      "ex:name": "alice"
    }
  ]
}
```

Will fail with the following output:

```turtle
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Violation ;
	sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
	sh:sourceShape _:n3119 ;
	sh:focusNode <http://example.org/ns#container> ;
	sh:value <http://example.org/alice> ;
	sh:resultPath ex:persons ;
	sh:resultMessage "Value does not have node kind sh:BlankNode" ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Violation ;
	sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
	sh:sourceShape _:n3119 ;
	sh:focusNode <http://example.org/ns#container> ;
	sh:value <http://example.org/bob> ;
	sh:resultPath ex:persons ;
	sh:resultMessage "Value does not have node kind sh:BlankNode" ;
] .
```

This will also give the same output as `@id` attributes are specified.

```json
{
  "@context": {
    "ex": "https://w3id.org/linkml/examples/personinfo/"
  },
  "@graph": [
    {
      "@id": "http://example.org/ns#container",
      "@type": [
        "ex:Container"
      ],
      "ex:persons": [
        {
          "@id": "http://example.org/bob",
          "@type": "ex:Person",
          "ex:name": "bob"
        },
        {
          "@id": "http://example.org/alice",
          "@type": "ex:Person",
          "ex:name": "alice"
        }
      ]
    }
  ]
}
```

## Solution

To fix this, the easiest solution is to change the node kind from `sh:BlankNode` to `sh:BlankNodeOrIRI` which allows the node to either : be defined without an `@id`, be defined with an `@id` or to be referenced through its `@id` when defined elsewhere.

This is what I suggested in this answer https://github.com/linkml/linkml/issues/1596#issuecomment-1980324749.

Closes #1596