### PR TITLE
owlgen - skip nested annotations

### DIFF
--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -274,6 +274,8 @@ class OwlSchemaGenerator(Generator):
                 self.graph.add((uri, metaslot_uri, obj))
 
         for k, v in e.annotations.items():
+            if isinstance(v, dict) or isinstance(v, list):
+                continue
             if ":" not in k:
                 default_prefix = this_sv.schema.default_prefix
                 if default_prefix in this_sv.schema.prefixes:

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -303,6 +303,8 @@ def _generate_framework_output(schema: Dict, framework: str, mappings: List = No
         for context, impdict in mappings:
             if framework in impdict:
                 expected = impdict[framework]
+                if expected is None:
+                    continue
                 if isinstance(expected, (list, str)) and framework in [SHACL, OWL]:
                     assert compare_rdf(expected, output, subsumes=framework in [OWL]) == set()
                 elif isinstance(expected, str):

--- a/tests/test_compliance/test_annotation_compliance.py
+++ b/tests/test_compliance/test_annotation_compliance.py
@@ -12,9 +12,9 @@ import rdflib
 
 from tests.test_compliance.helper import (
     OWL,
-    validated_schema,
     ValidationBehavior,
     check_data,
+    validated_schema,
 )
 from tests.test_compliance.test_compliance import CLASS_C, CORE_FRAMEWORKS, SLOT_S1
 

--- a/tests/test_compliance/test_annotation_compliance.py
+++ b/tests/test_compliance/test_annotation_compliance.py
@@ -131,5 +131,5 @@ def test_annotation(
         True,
         target_class=CLASS_C,
         expected_behavior=ValidationBehavior.IMPLEMENTS,
-        description=f"trivial data test, mainly serves to check there is no edge case issues",
+        description="trivial data test, mainly serves to check there is no edge case issues",
     )

--- a/tests/test_compliance/test_annotation_compliance.py
+++ b/tests/test_compliance/test_annotation_compliance.py
@@ -12,7 +12,9 @@ import rdflib
 
 from tests.test_compliance.helper import (
     OWL,
-    validated_schema, ValidationBehavior, check_data,
+    validated_schema,
+    ValidationBehavior,
+    check_data,
 )
 from tests.test_compliance.test_compliance import CLASS_C, CORE_FRAMEWORKS, SLOT_S1
 


### PR DESCRIPTION
Nested annotations will require blank nodes and are likely to be owl-full