### PR TITLE
[ci] only checkout with tags for non-tag runs

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -2,11 +2,10 @@ name: Build Docker Image
 
 on:
   push:
-#    branches:
-#      - "main"
+    branches:
+      - "main"
     tags:
-     # - "v*"
-      - "*"
+      - "v*"
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-tags: true
           fetch-depth: 100
 
       - name: Docker metadata

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 100
+          fetch-tags: ${{ github.event_name == 'push' && !contains(github.ref, 'refs/tags/') }}
 
       - name: Docker metadata
         uses: docker/metadata-action@v4

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -2,10 +2,11 @@ name: Build Docker Image
 
 on:
   push:
-    branches:
-      - "main"
+#    branches:
+#      - "main"
     tags:
-      - "v*"
+     # - "v*"
+      - "*"
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 100
-          fetch-tags: ${{ github.event_name == 'push' && !contains(github.ref, 'refs/tags/') }}
+          fetch-tags: ${{ github.event_name == 'push' && ! contains(github.ref, 'refs/tags/') }}
 
       - name: Docker metadata
         uses: docker/metadata-action@v4


### PR DESCRIPTION
Fix: https://github.com/linkml/linkml/issues/2007

@pkalita-lbl basically did all the work for this - 
- The cloned version of the repository needs to have at least one tag in the current branch's history in order for dynamic versioning to work
- https://github.com/linkml/linkml/pull/1980 made the docker build action do a depth=100 fetch instead of a depth=1 fetch to catch the most recent tagged version (hopefully, it's sort of a hack since there's no builtin method of "fetch up to the most recent tag in this branch").
- I wasn't sure if tags got fetched without the tags option ( since that's what it was introduced for here: https://github.com/actions/checkout/pull/579 ), and looking now it seems like they [don't](https://github.com/linkml/linkml/actions/runs/8319237799/job/22762230217?pr=1980#step:2:51)
- The combination of a tag-triggered build and with-tags specifically breaks the checkout action, eg for the same commit:
  - this fails: https://github.com/linkml/linkml/actions/runs/8368783078
  - this doesn't: https://github.com/linkml/linkml/actions/runs/8367682830
- That's because of a [malformed git fetch command](https://github.com/linkml/linkml/actions/runs/8368783078/job/22986576495#step:2:123): 
```
/usr/bin/git -c protocol.version=2 fetch --prune --progress --no-recurse-submodules --depth=100 origin +4977f426cf4f3971cd66ea0dbae8fc0d039c7799:refs/tags/v1.7.6

  Error: fatal: Cannot fetch both 4977f426cf4f3971cd66ea0dbae8fc0d039c7799 and refs/tags/v1.7.6 to refs/tags/v1.7.6
```

[compared to](https://github.com/linkml/linkml/actions/runs/8367682830/job/22910511296#step:2:51)

```
/usr/bin/git -c protocol.version=2 fetch --prune --progress --no-recurse-submodules --depth=100 origin +4977f426cf4f3971cd66ea0dbae8fc0d039c7799:refs/remotes/origin/main
```

I've never actually used `refspec` syntax like that before, but the docs are here: 
- https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt-ltrefspecgt
- https://git-scm.com/book/en/v2/Git-Internals-The-Refspec

so basically the second one works because it will fetch that commit and create a ref under the usual `refs/remotes/origin/main` and since the `--no-tags` flag isn't given, it will also grab the remote ref for the tag into `/refs/tags/v1.7.6` - two refs to two refs. the second one fails because it is fetching the commit and the tag into the same ref `/refs/tags/v1.7.6`. That's because a tag push is a separate event from a commit push (the linked examples are from the commit vs tag push for a given commit) and thus has the tag ref as the current `{{github.ref}}`.

since the purpose for the change in the first place was to make sure we have tags, and the tag-triggered actions by definition fetch the tag, introducing a switch that only fetches tags when the action is triggered by a commit. doing it this way vs. adding an additional `run` command bc of the extremely mild overhead of adding an extra step.

opening this PR not as a draft while still working on it so that CI runs bc it's a CI-based PR, sry for the notifs.

theoretically this should apply to all CI actions but docker is the only action that runs on a new tag. unsure why that is, just fixing it.
