### PR TITLE
Use fetch-depth: 0 in docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -16,10 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-tags: true
-          fetch-depth: 100
+          fetch-depth: 0
 
       - name: Docker metadata
         uses: docker/metadata-action@v4


### PR DESCRIPTION
Fixes #2007 

Replaces #2017 

[The docs](https://github.com/actions/checkout?tab=readme-ov-file#usage) for `fetch-depth` say that

> 0 indicates all history for all branches and tags.

This change may increase resource usage when doing a checkout, but in practice I don't think we'll notice a difference. On the other hand it will allow Poetry dynamic versioning to divine the correct version number when run off a tag _or_ a branch.