### PR TITLE
Automatically PR to update poetry lockfile

### DIFF
--- a/.github/workflows/poetry-update.yaml
+++ b/.github/workflows/poetry-update.yaml
@@ -1,0 +1,44 @@
+name: Poetry update
+# with code borrowed from https://github.com/fuzzylabs/gha-poetry-update/blob/main/action.yml
+
+on:
+  schedule:
+    # once a week, monday at midnight GMT
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Set up python
+      if: env.RUN_UPDATE != 'false'
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+    - name: Update lockfile
+      id: lockfile-update
+      run: |
+        UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g')
+        echo "UPDATE_MESSAGE=$UPDATE_MESSAGE" >> "$GITHUB_OUTPUT"
+    - name: Create pull request
+      if: steps.lockfile-update.outputs.UPDATE_MESSAGE != ""
+      uses: peter-evans/create-pull-request@v6
+      with:
+        branch: update-lockfile
+        title: "[poetry] Update Lockfile"
+        commit-message: "Update poetry lockfile"
+        labels: poetry
+        add-paths: poetry.lock
+        body: |
+          Update poetry dependencies: 
+          
+          ${{ steps.lockfile-update.outputs.UPDATE_MESSAGE }}
+          
+        
+
+

--- a/.github/workflows/poetry-update.yaml
+++ b/.github/workflows/poetry-update.yaml
@@ -14,7 +14,6 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Set up python
-      if: env.RUN_UPDATE != 'false'
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
@@ -26,7 +25,6 @@ jobs:
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g')
         echo "UPDATE_MESSAGE=$UPDATE_MESSAGE" >> "$GITHUB_OUTPUT"
     - name: Create pull request
-      if: steps.lockfile-update.outputs.UPDATE_MESSAGE != ""
       uses: peter-evans/create-pull-request@v6
       with:
         branch: update-lockfile


### PR DESCRIPTION
Following: https://github.com/linkml/linkml/pull/2002

See https://github.com/linkml/linkml/pull/2002#issuecomment-2011699884 which links to some of the conversation and prior issues (that i'll also link at the bottom for the sake of recordkeeping)

This action runs an action once a week (or on demand) to create a pull request updating the lockfile. 

The body of the PR will look something like this (eg. for the current state of the repo):

```
Update poetry dependencies:

  •  rpds-py (0.17.1 -> 0.18.0)
  •  typing-extensions (4.9.0 -> 4.10.0)
  •  packaging (23.2 -> 24.0)
  •  pyparsing (3.1.1 -> 3.1.2)
  •  referencing (0.33.0 -> 0.34.0)
  •  urllib3 (2.2.0 -> 2.2.1)
  •  pydantic (1.10.14 -> 2.6.4)
  •  traitlets (5.14.1 -> 5.14.2)
  •  curies (0.7.7 -> 0.7.8)
  •  jupyter-core (5.7.1 -> 5.7.2)
  •  python-dateutil (2.8.2 -> 2.9.0.post0)
  •  types-python-dateutil (2.8.19.20240106 -> 2.9.0.20240316)
  •  filelock (3.13.1 -> 3.13.3)
  •  jupyter-client (8.6.0 -> 8.6.1)
  •  nbformat (5.9.2 -> 5.10.3)
  •  prefixmaps (0.1.7 -> 0.2.2)
  •  cachetools (5.3.2 -> 5.3.3)
  •  comm (0.2.1 -> 0.2.2)
  •  debugpy (1.8.0 -> 1.8.1)
  •  linkml-runtime (1.7.0 -> 1.7.4)
  •  nbclient (0.9.0 -> 0.10.0)
  •  virtualenv (20.25.0 -> 20.25.1)
  •  graphviz (0.20.1 -> 0.20.3)
  •  ipykernel (6.29.2 -> 6.29.3)
  •  nbconvert (7.16.0 -> 7.16.3)
  •  sqlalchemy (2.0.25 -> 2.0.29)
  •  tox (4.12.1 -> 4.14.2)
```

this forces our development environment to be within a week of what ppl would experience if they were to install linkml with pip (which will install the most recent version of all packages matching the version spec in `pyproject.toml`). Note how it is updating `pydantic` here which we have kept locked at `1.10.14` by sheer force of not updating the lockfile (see [1925](https://github.com/linkml/linkml/issues/1925) and [1957](https://github.com/linkml/linkml/pull/1957)).

The `create-pull-request` action will keep updating the same pull request if it is not merged by the time the next run happens, so we won't stack up a bunch of lockfile PRs. We can set these up to automatically merge if all tests pass if we try this out for awhile and decide that would be a good idea - that could be something we set up as an additional step after the `main` tests, since it looks like the github branch protections-based automerge needs to be explicitly enabled for each PR, which makes sense. I figured we might as well get the manual version going first before we try and automate that since inevitably there will be some kinks to work out.

I'm also not sure if i need to do more to configure the token, but i suppose we will see on first run

also sorry if i keep making new labels and that's not wanted - i set the PR to use the `poetry` label so that we can quickly see all the PRs made by this action, distinct from the more general `devops` label which includes all devops stuff. i can change that and delete the label if we don't like that.

Prior related issues:
- https://github.com/linkml/linkml/issues/1641
- https://github.com/linkml/linkml/issues/1749
- https://github.com/linkml/linkml/issues/1567 (and i think this might partially close that)