### PR TITLE
Ensure unique key constraints on foreign keys are mapped in SQL transform.

### DIFF
--- a/linkml/generators/sqlalchemygen.py
+++ b/linkml/generators/sqlalchemygen.py
@@ -121,6 +121,7 @@ class SQLAlchemyGenerator(Generator):
             is_join_table=lambda c: any(tag for tag in c.annotations.keys() if tag == "linkml:derived_from"),
             classes=rel_schema_classes_ordered,
         )
+        logging.debug(f"# Generated code:\n{code}")
         return code
 
     def serialize(self, **kwargs) -> str:

--- a/linkml/utils/sqlutils.py
+++ b/linkml/utils/sqlutils.py
@@ -223,7 +223,6 @@ class SQLStore:
             for n, nu_typ in inspect.getmembers(self.module):
                 # TODO: make more efficient
                 if n == typ.__name__:
-                    # print(f'Creating {nu_typ} from: {inst_args}')
                     nu_obj = nu_typ(**inst_args)
                     return nu_obj
             raise ValueError(f"Cannot find {typ.__name__} in {self.module}")
@@ -262,9 +261,7 @@ class SQLStore:
             for n, nu_typ in inspect.getmembers(self.native_module):
                 # TODO: make more efficient
                 if n == typ.__name__:
-                    # print(f'CREATING {nu_typ} FROM {inst_args}')
                     nu_obj = nu_typ(**inst_args)
-                    # print(f'CREATED {nu_obj}')
                     return nu_obj
             raise ValueError(f"Cannot find {typ.__name__} in {self.native_module}")
         else:

--- a/linkml/validator/plugins/shacl_validation_plugin.py
+++ b/linkml/validator/plugins/shacl_validation_plugin.py
@@ -45,10 +45,10 @@ class ShaclValidationPlugin(ValidationPlugin):
         return g
 
     def process(self, instance: Any, context: ValidationContext) -> Iterator[ValidationResult]:
-        """Perform JSON Schema validation on the provided instance
+        """Perform SHACL Schema validation on the provided instance
 
         :param instance: The instance to validate
-        :param context: The validation context which provides a JSON Schema artifact
+        :param context: The validation context which provides a SHACL artifact
         :return: Iterator over validation results
         :rtype: Iterator[ValidationResult]
         """

--- a/tests/test_compliance/test_inlined_compliance.py
+++ b/tests/test_compliance/test_inlined_compliance.py
@@ -221,10 +221,6 @@ def test_inlined(framework, inlined, inlined_as_list, multivalued, foreign_key, 
             }
         }
         is_valid = entailed_inlined and not multivalued
-        if framework == JSON_SCHEMA:
-            if inlined and not inlined_as_list and multivalued and foreign_key:
-                # TODO: json-schema generation appears incorrect here
-                implementation_status = ValidationBehavior.INCOMPLETE
     elif data == "flat_list":
         inst = {
             SLOT_S1: [id_val, id_val2],
@@ -232,6 +228,8 @@ def test_inlined(framework, inlined, inlined_as_list, multivalued, foreign_key, 
         is_valid = not entailed_inlined and multivalued
         if framework == SQL_DDL_SQLITE and multivalued and foreign_key:
             # TODO: bug in SQLA for this case
+            # AttributeError: 'DId' object has no attribute '_sa_instance_state'
+            # https://github.com/linkml/linkml/issues/1160
             implementation_status = ValidationBehavior.INCOMPLETE
     elif data == "inlined_list":
         inst = {

--- a/tests/test_compliance/test_uniqueness_compliance.py
+++ b/tests/test_compliance/test_uniqueness_compliance.py
@@ -11,6 +11,7 @@ from tests.test_compliance.helper import (
 from tests.test_compliance.test_compliance import (
     CLASS_C,
     CLASS_CONTAINER,
+    CLASS_D,
     CORE_FRAMEWORKS,
     SLOT_ID,
     SLOT_S1,
@@ -148,43 +149,45 @@ def test_unique_keys(framework, description, objects, is_valid, is_valid_if_null
     Tests unique keys
 
     """
-    classes = {
-        CLASS_CONTAINER: {
-            "attributes": {
-                "entities": {
-                    "range": CLASS_C,
-                    "multivalued": True,
-                    "inlined": True,
-                    "inlined_as_list": True,
+    classes = (
+        {
+            CLASS_CONTAINER: {
+                "attributes": {
+                    "entities": {
+                        "range": CLASS_C,
+                        "multivalued": True,
+                        "inlined": True,
+                        "inlined_as_list": True,
+                    },
+                },
+            },
+            CLASS_C: {
+                "attributes": {
+                    SLOT_S1: {},
+                    SLOT_S2: {},
+                    SLOT_S3: {},
+                },
+                "unique_keys": {
+                    "main": {
+                        "unique_key_slots": [SLOT_S1, SLOT_S2],
+                        "consider_nulls_inequal": consider_nulls_inequal,
+                    },
+                    "secondary": {
+                        "unique_key_slots": [SLOT_S1, SLOT_S3],
+                        "consider_nulls_inequal": consider_nulls_inequal,
+                    },
+                },
+                "_mappings": {
+                    SQL_DDL_SQLITE: f"UNIQUE ({SLOT_S1}, {SLOT_S2})",
+                    OWL: (
+                        "@prefix ex: <http://example.org/> ."
+                        "@prefix owl: <http://www.w3.org/2002/07/owl#> ."
+                        "ex:C owl:hasKey (ex:s1 ex:s2) , (ex:s1 ex:s3) ."
+                    ),
                 },
             },
         },
-        CLASS_C: {
-            "attributes": {
-                SLOT_S1: {},
-                SLOT_S2: {},
-                SLOT_S3: {},
-            },
-            "unique_keys": {
-                "main": {
-                    "unique_key_slots": [SLOT_S1, SLOT_S2],
-                    "consider_nulls_inequal": consider_nulls_inequal,
-                },
-                "secondary": {
-                    "unique_key_slots": [SLOT_S1, SLOT_S3],
-                    "consider_nulls_inequal": consider_nulls_inequal,
-                },
-            },
-            "_mappings": {
-                SQL_DDL_SQLITE: f"UNIQUE ({SLOT_S1}, {SLOT_S2})",
-                OWL: (
-                    "@prefix ex: <http://example.org/> ."
-                    "@prefix owl: <http://www.w3.org/2002/07/owl#> ."
-                    "ex:C owl:hasKey (ex:s1 ex:s2) , (ex:s1 ex:s3) ."
-                ),
-            },
-        },
-    }
+    )
     schema = validated_schema(
         test_unique_keys,
         f"NIE{consider_nulls_inequal}",
@@ -219,3 +222,189 @@ def test_unique_keys(framework, description, objects, is_valid, is_valid_if_null
         expected_behavior=expected_behavior,
         description=description,
     )
+
+
+D_INST_1 = {SLOT_ID: "ex:d1", SLOT_S3: "t"}
+D_INST_2 = {SLOT_ID: "ex:d2", SLOT_S3: "t"}
+
+
+@pytest.mark.parametrize(
+    "schema_name,d_has_id,s1def,s2def,ddl,valid_objs,invalid_objs",
+    [
+        (
+            "s1_ref",
+            True,
+            {"range": CLASS_D},
+            {"range": "integer"},
+            "UNIQUE (s1, s2)",
+            [
+                ("ex:d1", 5),
+                ("ex:d1", 4),
+            ],
+            [
+                ("ex:d1", 5),
+                ("ex:d1", 5),
+            ],
+        ),
+        (
+            "s1_inlined",
+            True,
+            {"range": CLASS_D, "inlined": True},
+            {"range": "integer"},
+            "UNIQUE (s1_id, s2)",
+            [
+                (D_INST_1, 5),
+                (D_INST_2, 5),
+            ],
+            [
+                (D_INST_1, 5),
+                (D_INST_1, 5),
+            ],
+        ),
+        (
+            "s1_multivalued",
+            True,
+            {"range": "integer", "multivalued": True},
+            {"range": "integer"},
+            "",
+            [
+                ([1, 2], 5),
+                ([1, 3], 5),
+            ],
+            [
+                ([1, 2], 5),
+                ([1, 2], 5),
+            ],
+        ),
+        (
+            "s1_multivalued_ref",
+            True,
+            {"range": CLASS_D, "multivalued": True},
+            {"range": "integer"},
+            "",
+            [
+                (["ex:d1", "ex:d2"], 5),
+                (["ex:d1"], 5),
+            ],
+            [
+                (["ex:d1"], 5),
+                (["ex:d1"], 5),
+            ],
+        ),
+        (
+            "s1_multivalued_inlined",
+            False,
+            {"range": CLASS_D, "multivalued": True, "inlined_as_list": True},
+            {"range": "integer"},
+            "",
+            [
+                ([D_INST_1, D_INST_2], 5),
+                ([D_INST_1], 5),
+            ],
+            [
+                ([D_INST_1], 5),
+                ([D_INST_1], 5),
+            ],
+        ),
+    ],
+)
+@pytest.mark.parametrize("framework", CORE_FRAMEWORKS)
+def test_inlined_unique_keys(framework, schema_name, d_has_id, s1def, s2def, ddl, valid_objs, invalid_objs):
+    """
+    Tests unique keys where some slots may be inlined
+
+    """
+    consider_nulls_inequal = True
+    is_inlined = s1def.get("inlined_as_list", False) or s1def.get("inlined", False)
+    d_is_top_level = s1def["range"] == CLASS_D and not is_inlined
+    classes = {
+        CLASS_CONTAINER: {
+            "attributes": {
+                "entities": {
+                    "range": CLASS_C,
+                    "multivalued": True,
+                    "inlined": True,
+                    "inlined_as_list": True,
+                },
+            },
+        },
+        CLASS_C: {
+            "attributes": {
+                SLOT_S1: s1def,
+                SLOT_S2: s2def,
+            },
+            "unique_keys": {
+                "main": {
+                    "unique_key_slots": [SLOT_S1, SLOT_S2],
+                    "consider_nulls_inequal": consider_nulls_inequal,
+                },
+            },
+            "_mappings": {
+                SQL_DDL_SQLITE: ddl,
+                # OWL: (
+                #    "@prefix ex: <http://example.org/> ."
+                #    "@prefix owl: <http://www.w3.org/2002/07/owl#> ."
+                #    "ex:C owl:hasKey (ex:s1 ex:s2) , (ex:s1 ex:s3) ."
+                # ),
+            },
+        },
+        CLASS_D: {
+            "attributes": {
+                SLOT_ID: {
+                    "identifier": d_has_id,
+                },
+                SLOT_S3: {},
+            },
+        },
+    }
+    if d_is_top_level:
+        classes[CLASS_CONTAINER]["attributes"]["d_entities"] = {
+            "range": CLASS_D,
+            "multivalued": True,
+            "inlined": True,
+            "inlined_as_list": True,
+        }
+    schema = validated_schema(
+        test_inlined_unique_keys,
+        schema_name,
+        framework,
+        classes=classes,
+        core_elements=["unique_keys", "inlined"],
+    )
+    for is_valid, objects in [(True, valid_objs), (False, invalid_objs)]:
+        if objects is None:
+            continue
+        obj = {"entities": [{SLOT_S1: s1, SLOT_S2: s2} for s1, s2 in objects]}
+        if d_is_top_level:
+            obj["d_entities"] = [D_INST_1, D_INST_2]
+        expected_behavior = ValidationBehavior.IMPLEMENTS
+        if not is_valid:
+            if framework == SQL_DDL_SQLITE:
+                # SQLite and most RDBMSs treats nulls as inequal
+                if not consider_nulls_inequal:
+                    expected_behavior = ValidationBehavior.IMPLEMENTS
+                else:
+                    expected_behavior = ValidationBehavior.INCOMPLETE
+            elif framework == OWL:
+                # TODO: by its open world nature, OWL will not consider clashes to be a violation
+                # unless Unique Name Assumptions are explicitly asserted. This is currently outside
+                # of the scope of the limited OWL support in this test suite.
+                expected_behavior = ValidationBehavior.INCOMPLETE
+            else:
+                # only supported in SQL backends
+                expected_behavior = ValidationBehavior.INCOMPLETE
+        if framework == SQL_DDL_SQLITE and schema_name == "s1_multivalued_ref":
+            # TODO: bug in SQLA for this case
+            # AttributeError: 'DId' object has no attribute '_sa_instance_state'
+            # https://github.com/linkml/linkml/issues/1160
+            expected_behavior = ValidationBehavior.INCOMPLETE
+        check_data(
+            schema,
+            f"V{is_valid}",
+            framework,
+            obj,
+            is_valid,
+            target_class=CLASS_CONTAINER,
+            expected_behavior=expected_behavior,
+            description=f"Expected validity={is_valid}",
+        )

--- a/tests/test_compliance/test_uniqueness_compliance.py
+++ b/tests/test_compliance/test_uniqueness_compliance.py
@@ -149,45 +149,43 @@ def test_unique_keys(framework, description, objects, is_valid, is_valid_if_null
     Tests unique keys
 
     """
-    classes = (
-        {
-            CLASS_CONTAINER: {
-                "attributes": {
-                    "entities": {
-                        "range": CLASS_C,
-                        "multivalued": True,
-                        "inlined": True,
-                        "inlined_as_list": True,
-                    },
-                },
-            },
-            CLASS_C: {
-                "attributes": {
-                    SLOT_S1: {},
-                    SLOT_S2: {},
-                    SLOT_S3: {},
-                },
-                "unique_keys": {
-                    "main": {
-                        "unique_key_slots": [SLOT_S1, SLOT_S2],
-                        "consider_nulls_inequal": consider_nulls_inequal,
-                    },
-                    "secondary": {
-                        "unique_key_slots": [SLOT_S1, SLOT_S3],
-                        "consider_nulls_inequal": consider_nulls_inequal,
-                    },
-                },
-                "_mappings": {
-                    SQL_DDL_SQLITE: f"UNIQUE ({SLOT_S1}, {SLOT_S2})",
-                    OWL: (
-                        "@prefix ex: <http://example.org/> ."
-                        "@prefix owl: <http://www.w3.org/2002/07/owl#> ."
-                        "ex:C owl:hasKey (ex:s1 ex:s2) , (ex:s1 ex:s3) ."
-                    ),
+    classes = {
+        CLASS_CONTAINER: {
+            "attributes": {
+                "entities": {
+                    "range": CLASS_C,
+                    "multivalued": True,
+                    "inlined": True,
+                    "inlined_as_list": True,
                 },
             },
         },
-    )
+        CLASS_C: {
+            "attributes": {
+                SLOT_S1: {},
+                SLOT_S2: {},
+                SLOT_S3: {},
+            },
+            "unique_keys": {
+                "main": {
+                    "unique_key_slots": [SLOT_S1, SLOT_S2],
+                    "consider_nulls_inequal": consider_nulls_inequal,
+                },
+                "secondary": {
+                    "unique_key_slots": [SLOT_S1, SLOT_S3],
+                    "consider_nulls_inequal": consider_nulls_inequal,
+                },
+            },
+            "_mappings": {
+                SQL_DDL_SQLITE: f"UNIQUE ({SLOT_S1}, {SLOT_S2})",
+                OWL: (
+                    "@prefix ex: <http://example.org/> ."
+                    "@prefix owl: <http://www.w3.org/2002/07/owl#> ."
+                    "ex:C owl:hasKey (ex:s1 ex:s2) , (ex:s1 ex:s3) ."
+                ),
+            },
+        },
+    }
     schema = validated_schema(
         test_unique_keys,
         f"NIE{consider_nulls_inequal}",

--- a/tests/test_issues/test_linkml_issue_2006.py
+++ b/tests/test_issues/test_linkml_issue_2006.py
@@ -1,4 +1,3 @@
-
 from linkml.generators import SQLTableGenerator
 
 schema_yaml = """

--- a/tests/test_issues/test_linkml_issue_2006.py
+++ b/tests/test_issues/test_linkml_issue_2006.py
@@ -1,0 +1,37 @@
+
+from linkml.generators import SQLTableGenerator
+
+schema_yaml = """
+id: https://examples.org/my-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+  myschema: https://examples.org/my-schema
+imports:
+  - linkml:types
+default_prefix: myschema
+default_range: string
+
+classes:
+  MyClass:
+    slots:
+      - my_slot
+    unique_keys:
+      identifier:
+        unique_key_slots:
+          - my_slot
+
+slots:
+  my_slot:
+    multivalued: true
+    range: string
+"""
+
+
+def test_uniqueness_constraint_on_multivalued():
+    """See https://github.com/linkml/linkml/issues/2006"""
+    gen = SQLTableGenerator(schema_yaml)
+    output = gen.serialize()
+    assert "MyClass_my_slot" in output, "expected backref for multivalued"
+    # the uniqueness constraint is necessarily dropped since it can't
+    # be directly represented in SQL after relmodel transformation
+    assert "unique" not in output.lower(), "expected MV uniqueness constraint to be dropped"


### PR DESCRIPTION
the SQLTableGenerator first pre-processes using RelationalModelTransformer,
including

 - mapping multivalueds to backrefs
 - translating ranges of classes to foreign keys, using (x_id) conventions

Previously the slots referred to in unique_keys were not mapped
forward, see #2006. This PR fixes this

- unique slots are mapped forward where possible
- where not possible (multivalueds) the constraint is dropped

Fixes #2006
