### PR TITLE
Fix testing infrasucture for Pydantic 2 default

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,16 +20,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        pydantic-version: ["1", "2"]
         exclude:
+          # Test on Windows with only the oldest and newest Python versions
           - os: windows-latest
-            python-version: "3.8"
+            python-version: "3.9"
           - os: windows-latest
-            pydantic-version: "2"
-          - python-version: "3.8"
-            pydantic-version: "2"
-          - python-version: "3.9"
-            pydantic-version: "2"
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.11"
 
     # See https://github.com/snok/install-poetry#running-on-windows
     defaults:
@@ -75,13 +73,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root -E tests
-
-      #----------------------------------------------
-      # install pydantic
-      #----------------------------------------------
-      - name: Install Pydantic
-        run: poetry add pydantic@^${{ matrix.pydantic-version }}
+        run: poetry install --no-interaction --no-root --all-extras
 
       #----------------------------------------------
       #         setup and install graphviz

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
+        id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -66,7 +67,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
       # install dependencies if cache does not exist

--- a/.github/workflows/test-pydantic1.yaml
+++ b/.github/workflows/test-pydantic1.yaml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v3
+        id: setup-python
         with:
           python-version: "3.12"
 
@@ -43,7 +44,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
       # install dependencies if cache does not exist

--- a/.github/workflows/test-pydantic1.yaml
+++ b/.github/workflows/test-pydantic1.yaml
@@ -1,0 +1,71 @@
+name: Build and test with Pydantic 1
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+
+      #----------------------------------------------
+      #          install & configure poetry
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.2
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root --all-extras
+
+      #----------------------------------------------
+      # install pydantic
+      #----------------------------------------------
+      - name: Install Pydantic
+        run: poetry add pydantic@^1
+
+      #----------------------------------------------
+      #         setup and install graphviz
+      #----------------------------------------------
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v1
+
+      #----------------------------------------------
+      #              run tests
+      #----------------------------------------------
+      - name: Run tests
+        run: poetry run pytest --with-slow

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -11,7 +11,7 @@ Then clone the repository and install the development dependencies:
 ```shell
 git clone https://github.com/linkml/linkml
 cd linkml
-poetry install
+poetry install --all-extras
 ```
 
 ## LinkML Testing Framework
@@ -63,8 +63,8 @@ issues are with reference to the old [biolinkml](https://github.com/biolink/biol
 
 Use marks to run or exclude groups of tests:
 
-- `network` - (currently unused in CI) - tests marked as requiring network access/making network requests in order to succeed. 
-- `slow` - tests that are necessary to test technical correctness but are sufficiently long that it's worth excluding them during routine development/when running tests locally. 
+- `network` - (currently unused in CI) - tests marked as requiring network access/making network requests in order to succeed.
+- `slow` - tests that are necessary to test technical correctness but are sufficiently long that it's worth excluding them during routine development/when running tests locally.
   By default, tests marked `slow` are not run, and require the `--with-slow` flag to run. Slow tests are included in the CI testing action. Typical use is to do most development
   work without running `slow` tests, and then running the full test suite `--with-slow` before submitting or merging a pull request.
 - `skip`, `xfail` - see [skip and xfail docs](https://docs.pytest.org/en/latest/how-to/skipping.html)
@@ -146,19 +146,19 @@ New tests in any directory should be written using pytest.
 
 LinkML both generates and depends on Pydantic. [Pydantic V2](https://docs.pydantic.dev/2.4/migration/) brought a number of breaking changes, but we intend to support both V1 and V2. By default, the `PydanticGenerator` class will generate code compatible with the version of Pydantic that is installed in your environment. This can be overridden by explicitly setting the `pydantic_version` field.
 
-As of October 2023, our default development environment still specifies Pydantic 1 (as determined by the `poetry.lock` file). But since we also support Pydantic 2 (as specified in `pyproject.toml`), it is important to test with Pydantic 2 in your environment. To facilitate that there is a `tox` environment called `pydantic2`. To run all tests with Pydantic 2 installed:
+As of March 2024, our default development environment specifies Pydantic 2 (as determined by the `poetry.lock` file). But since we also support Pydantic 1 (as specified in `pyproject.toml`), it is important to test with Pydantic 1 in your environment. To facilitate that there is a `tox` environment called `pydantic1`. To run all tests with Pydantic 1 installed:
 
 ```shell
-poetry run tox -e pydantic2
+poetry run tox -e pydantic1
 ```
 
 Additional arguments will be passed to `pytest`. For example, to run a specific test:
 
 ```shell
-poetry run tox -e pydantic2 -- tests/test_compliance/test_core_compliance.py
+poetry run tox -e pydantic1 -- -- tests/test_compliance/test_core_compliance.py
 ```
 
-Our main GitHub Actions testing workflow will also automatically perform one test run with Pydantic 2 in the environment.
+Our main GitHub Actions testing workflow will also automatically perform at least one test run with Pydantic 1 in the environment.
 
 ## Code formatting and linting
 

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -76,6 +76,7 @@ DEFAULT_IMPORTS = (
     + Import(module="decimal", objects=[ObjectImport(name="Decimal")])
     + Import(module="enum", objects=[ObjectImport(name="Enum")])
     + Import(module="re")
+    + Import(module="sys")
     + Import(
         module="typing",
         objects=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ sqlalchemy = ">=1.4.31"
 watchdog = ">=0.9.0"
 pyshacl = { version = "^0.25.0", optional = true }
 black = { version=">=24.0.0", optional = true }
+typing-extensions = { version=">=4.4.0", python="<3.9" }
 
 [tool.poetry.group.dev.dependencies]
 chardet = "*"

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -1,5 +1,6 @@
 """Compliance tests for core constructs."""
 
+import sys
 import unicodedata
 
 import pytest
@@ -188,7 +189,11 @@ def test_type_range(framework, linkml_type, example_value):
             pass
     # Pydantic coerces by default; see https://docs.pydantic.dev/latest/usage/types/strict_types/
     if coerced:
-        if linkml_type == "boolean" and not isinstance(v, int) and v != "1":
+        if sys.version_info < (3, 10) and framework == PYDANTIC and linkml_type == "boolean" and isinstance(v, float):
+            # On Python 3.9 and earlier, Pydantic will coerce floats to bools. This goes against
+            # what their docs say should happen or why it only affects older Python version.
+            expected_behavior = ValidationBehavior.COERCES
+        elif linkml_type == "boolean" and not isinstance(v, int) and v != "1":
             pass
         else:
             if framework in [PYDANTIC, PYTHON_DATACLASSES]:

--- a/tests/test_compliance/test_custom_type_compliance.py
+++ b/tests/test_compliance/test_custom_type_compliance.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from linkml_runtime.utils.formatutils import camelcase
 
@@ -81,7 +83,11 @@ def test_typeof(framework, linkml_type, example_value):
             pass
     # Pydantic coerces by default; see https://docs.pydantic.dev/latest/usage/types/strict_types/
     if coerced:
-        if linkml_type == "boolean" and not isinstance(v, int) and v != "1":
+        if sys.version_info < (3, 10) and framework == PYDANTIC and linkml_type == "boolean" and isinstance(v, float):
+            # On Python 3.9 and earlier, Pydantic will coerce floats to bools. This goes against
+            # what their docs say should happen or why it only affects older Python version.
+            expected_behavior = ValidationBehavior.COERCES
+        elif linkml_type == "boolean" and not isinstance(v, int) and v != "1":
             pass
         else:
             if framework in [PYDANTIC, PYTHON_DATACLASSES]:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
 envlist =
     lint
     py{38,39,310,311}
-    pydantic2
+    pydantic1
 
 [testenv]
 # Running tests via poetry within the tox environment is not the ideal
@@ -18,18 +18,18 @@ allowlist_externals = poetry
 deps =
     pytest
 commands =
-    poetry install --no-root --sync
+    poetry install --no-root --sync --all-extras
     poetry run pytest {posargs}
 
-[testenv:pydantic2]
+[testenv:pydantic1]
 allowlist_externals = poetry
 commands_pre =
-    poetry install --no-root --sync
+    poetry install --no-root --sync --all-extras
     # This `pip` call looks weird but we want to avoid doing a `poetry add` or
     # `poetry update` here because that will mess with the the pyproject.toml
     # and poetry.lock. But we want this change to only to be ephemeral in the
     # tox testenv.
-    poetry run pip install 'pydantic>=2,<3'
+    poetry run pip install 'pydantic>=1,<2'
 commands =
     poetry run pytest {posargs}
 


### PR DESCRIPTION
Fixes #2040 

### Summary

* With Pydandic 2.x.x specified in our `poetry.lock` file, running tests directly via `pytest` or the `tox` `py3x` testenvs will use Pydantic v2. These changes replace the existing "special case" `pydantic2` testenv with a `pydantic1` testenv. The new testenv operates the same as the old one, except swapping Pydantic v1 for v2.
* Previously the `main.yaml` testing workflow had a `pydantic-version` variable in the configuration matrix. With the addition of Python 3.11 and 3.12 to the testing matrix (https://github.com/linkml/linkml/pull/1704), the matrix permutations were starting to get a little unruly. Here I'm splitting off Pydantic 1 testing into a separate workflow (`.github/workflows/test-pydantic1.yaml`). I then updated the `exclude` combinations in `main.yaml` so that what we end up running is:
  * All supported Python version with Pydantic 2 on Ubuntu (`main.yaml`)
  * The oldest and newest supported Python versions with Pydantic 2 on Windows (`main.yaml`)
  * The latest supported Python version with Pydantic 1 on Ubuntu (`test-pydantic1.yaml`)
* The updated testing workflows caught a few issues we had missed with our previous configuration matrix. @sneakers-the-rat fixed a few issues in the Pydantic generator that crop up when using older Python versions. I updated a few compliance tests to accurately reflect the actual behavior of Pydantic on older Python versions.