### PR TITLE
[perf] Finish putting file I/O behind `--with-output` flag in compliance tests (and other free perf)

### DIFF
--- a/linkml/generators/jsonldgen.py
+++ b/linkml/generators/jsonldgen.py
@@ -60,8 +60,8 @@ class JSONLDGenerator(Generator):
     """Path to a JSONLD context file"""
 
     def __post_init__(self) -> None:
-        super().__post_init__()
         self.original_schema = deepcopy(self.schema)
+        super().__post_init__()
 
     def _add_type(self, node: YAMLRoot) -> dict:
         if self.format == "jsonld":

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -499,7 +499,7 @@ class PydanticGenerator(OOCodeGenerator):
         return None
 
     def _template_environment(self) -> Environment:
-        env = TemplateModel.environment()
+        env = TemplateModel.environment
         if self.template_dir is not None:
             loader = ChoiceLoader([FileSystemLoader(self.template_dir), env.loader])
             env.loader = loader
@@ -644,10 +644,11 @@ class PydanticGenerator(OOCodeGenerator):
         for k, c in pyschema.classes.items():
             attrs = {}
             for attr_name, src_attr in c.attributes.items():
+                src_attr = src_attr._as_dict
                 new_fields = {
-                    k: src_attr._as_dict.get(k, None)
+                    k: src_attr.get(k, None)
                     for k in PydanticAttribute.model_fields.keys()
-                    if src_attr._as_dict.get(k, None) is not None
+                    if src_attr.get(k, None) is not None
                 }
                 predef_slot = predefined.get(k, {}).get(attr_name, None)
                 if predef_slot is not None:

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -499,7 +499,7 @@ class PydanticGenerator(OOCodeGenerator):
         return None
 
     def _template_environment(self) -> Environment:
-        env = TemplateModel.environment
+        env = TemplateModel.environment()
         if self.template_dir is not None:
             loader = ChoiceLoader([FileSystemLoader(self.template_dir), env.loader])
             env.loader = loader

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -54,6 +54,16 @@ class TemplateModel(BaseModel):
     """
 
     template: ClassVar[str]
+    environment: ClassVar[Environment] = Environment(
+        loader=PackageLoader("linkml.generators.pydanticgen", "templates"), trim_blocks=True, lstrip_blocks=True
+    )
+    """
+    Default environment for Template models.
+
+    uses a :class:`jinja2.PackageLoader` for the templates directory within this module
+    with the ``trim_blocks`` and ``lstrip_blocks`` parameters set to ``True`` so that the
+    default templates could be written in a more readable way.
+    """
     pydantic_ver: int = int(PYDANTIC_VERSION[0])
 
     def render(self, environment: Optional[Environment] = None, black: bool = False) -> str:
@@ -70,7 +80,7 @@ class TemplateModel(BaseModel):
             black (bool): if ``True`` , format template with black. (default False)
         """
         if environment is None:
-            environment = TemplateModel.environment()
+            environment = TemplateModel.environment
 
         if int(PYDANTIC_VERSION[0]) >= 2:
             fields = {**self.model_fields, **self.model_computed_fields}
@@ -90,19 +100,6 @@ class TemplateModel(BaseModel):
             raise ValueError("black formatting was requested, but black is not installed in this environment")
         else:
             return rendered
-
-    @classmethod
-    def environment(cls) -> Environment:
-        """
-        Default environment for Template models.
-
-        uses a :class:`jinja2.PackageLoader` for the templates directory within this module
-        with the ``trim_blocks`` and ``lstrip_blocks`` parameters set to ``True`` so that the
-        default templates could be written in a more readable way.
-        """
-        return Environment(
-            loader=PackageLoader("linkml.generators.pydanticgen", "templates"), trim_blocks=True, lstrip_blocks=True
-        )
 
     if int(PYDANTIC_VERSION[0]) < 2:
         # simulate pydantic 2's model_fields behavior

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -1,3 +1,4 @@
+from copy import copy
 from importlib.util import find_spec
 from typing import Any, ClassVar, Dict, Generator, List, Literal, Optional, Union, overload
 
@@ -54,16 +55,10 @@ class TemplateModel(BaseModel):
     """
 
     template: ClassVar[str]
-    environment: ClassVar[Environment] = Environment(
+    _environment: ClassVar[Environment] = Environment(
         loader=PackageLoader("linkml.generators.pydanticgen", "templates"), trim_blocks=True, lstrip_blocks=True
     )
-    """
-    Default environment for Template models.
 
-    uses a :class:`jinja2.PackageLoader` for the templates directory within this module
-    with the ``trim_blocks`` and ``lstrip_blocks`` parameters set to ``True`` so that the
-    default templates could be written in a more readable way.
-    """
     pydantic_ver: int = int(PYDANTIC_VERSION[0])
 
     def render(self, environment: Optional[Environment] = None, black: bool = False) -> str:
@@ -80,7 +75,7 @@ class TemplateModel(BaseModel):
             black (bool): if ``True`` , format template with black. (default False)
         """
         if environment is None:
-            environment = TemplateModel.environment
+            environment = TemplateModel.environment()
 
         if int(PYDANTIC_VERSION[0]) >= 2:
             fields = {**self.model_fields, **self.model_computed_fields}
@@ -100,6 +95,16 @@ class TemplateModel(BaseModel):
             raise ValueError("black formatting was requested, but black is not installed in this environment")
         else:
             return rendered
+
+    @classmethod
+    def environment(cls) -> Environment:
+        """
+        Default environment for Template models.
+        uses a :class:`jinja2.PackageLoader` for the templates directory within this module
+        with the ``trim_blocks`` and ``lstrip_blocks`` parameters set to ``True`` so that the
+        default templates could be written in a more readable way.
+        """
+        return copy(cls._environment)
 
     if int(PYDANTIC_VERSION[0]) < 2:
         # simulate pydantic 2's model_fields behavior

--- a/linkml/generators/rdfgen.py
+++ b/linkml/generators/rdfgen.py
@@ -7,15 +7,15 @@ Generate a JSON LD representation of the model
 
 import os
 import urllib.parse as urlparse
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import List, Optional
-from copy import deepcopy
 
 import click
+from linkml_runtime.linkml_model import SchemaDefinition
 from rdflib import Graph
 from rdflib.plugin import Parser as rdflib_Parser
 from rdflib.plugin import plugins as rdflib_plugins
-from linkml_runtime.linkml_model import SchemaDefinition
 
 from linkml import METAMODEL_CONTEXT_URI
 from linkml._version import __version__

--- a/linkml/generators/rdfgen.py
+++ b/linkml/generators/rdfgen.py
@@ -9,11 +9,13 @@ import os
 import urllib.parse as urlparse
 from dataclasses import dataclass
 from typing import List, Optional
+from copy import deepcopy
 
 import click
 from rdflib import Graph
 from rdflib.plugin import Parser as rdflib_Parser
 from rdflib.plugin import plugins as rdflib_plugins
+from linkml_runtime.linkml_model import SchemaDefinition
 
 from linkml import METAMODEL_CONTEXT_URI
 from linkml._version import __version__
@@ -35,13 +37,19 @@ class RDFGenerator(Generator):
     # ObjectVars
     emit_metadata: bool = False
     context: List[str] = None
+    original_schema: SchemaDefinition = None
+    """See https://github.com/linkml/linkml/issues/871"""
+
+    def __post_init__(self):
+        self.original_schema = deepcopy(self.schema)
+        super().__post_init__()
 
     def _data(self, g: Graph) -> str:
         return g.serialize(format="turtle" if self.format == "ttl" else self.format)
 
     def end_schema(self, output: Optional[str] = None, context: str = None, **_) -> None:
         gen = JSONLDGenerator(
-            self,
+            self.original_schema,
             format=JSONLDGenerator.valid_formats[0],
             metadata=self.emit_metadata,
             importmap=self.importmap,

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -225,8 +225,7 @@ class Generator(metaclass=abc.ABCMeta):
                 # schemaloader based methods require schemas to have been created via SchemaLoader,
                 # which prepopulates some fields (e.g. definition_url). If the schema has not been processed through the
                 # loader, then roundtrip
-                if any(c for c in schema.classes.values() if not c.definition_uri):
-                    schema = yaml_dumper.dumps(schema)
+                schema = schema._as_dict
             loader = SchemaLoader(
                 schema,
                 self.base_dir,

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -30,7 +30,6 @@ from typing import Callable, ClassVar, Dict, List, Mapping, Optional, Set, TextI
 import click
 from click import Argument, Command, Option
 from linkml_runtime import SchemaView
-from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
     ClassDefinitionName,

--- a/tests/test_compliance/conftest.py
+++ b/tests/test_compliance/conftest.py
@@ -1,9 +1,10 @@
 import logging
 
+from tests import WITH_OUTPUT
 from tests.test_compliance.helper import report
 
 
 def pytest_sessionfinish(session, exitstatus) -> None:
     logging.info(f"finishing session: {session} {exitstatus}")
-    if exitstatus == 0:
+    if exitstatus == 0 and WITH_OUTPUT:
         report()

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -29,6 +29,12 @@ from linkml_runtime.utils.introspection import package_schemaview
 from linkml_runtime.utils.yamlutils import YAMLRoot
 from pydantic import BaseModel
 
+try:
+    from yaml import CSafeDumper as SafeDumper
+except ImportError:
+    from yaml import SafeDumper
+
+
 import tests
 from linkml import generators as generators
 from linkml.generators import (
@@ -616,7 +622,7 @@ def _extract_mappings(schema: Dict) -> Iterator[Tuple[Dict, List]]:
 
 def _as_compact_yaml(obj: Union[YAMLRoot, BaseModel, Dict]) -> str:
     if isinstance(obj, dict):
-        ys = yaml.dump(_clean_dict(obj), sort_keys=False)
+        ys = yaml.dump(_clean_dict(obj), sort_keys=False, Dumper=SafeDumper)
         ys = ys.replace("{}", "")
         return ys
     return yaml_dumper.dumps(obj)
@@ -772,7 +778,6 @@ def check_data(
                             py_inst = py_cls(**object_to_validate)
                             logging.info(f"Unexpectedly instantiated {py_inst}")
             if py_inst is not None:
-                yaml.safe_load(yaml_dumper.dumps(py_inst))
                 # assert roundtripped.items() == object_to_validate.items()
                 if valid and not exclude_rdf:
                     if isinstance(gen, PythonGenerator):

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -5,7 +5,6 @@ import enum
 import json
 import logging
 import os
-import pdb
 import shutil
 import subprocess
 import tempfile
@@ -792,7 +791,7 @@ def check_data(
             context_dir = _schema_out_path(schema) / "generated" / "jsonld_context.context.jsonld"
             if not context_dir.exists() and tests.WITH_OUTPUT:
                 raise AssertionError(f"Could not find {context_dir}")
-            context = json.loads(cached_generator_output[(schema['name'], 'jsonld_context')][1])['@context']
+            context = json.loads(cached_generator_output[(schema["name"], "jsonld_context")][1])["@context"]
             json_object = copy(object_to_validate)
             json_object["@context"] = context
             jsonld_path = out_dir / f"{data_name}.jsonld"

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -159,7 +159,7 @@ class FeatureSet(BaseModel):
     features: List[Feature]
 
 
-cached_generator_output: Dict[Tuple[SCHEMA_NAME, FRAMEWORK], Tuple[Generator, str]] = {}
+cached_generator_output: Dict[Tuple[SCHEMA_NAME, FRAMEWORK], Tuple[Generator, str, Optional[Path]]] = {}
 """Cache generators and their outputs to avoid repeated computation."""
 
 all_test_results: List[DataCheck] = []
@@ -255,7 +255,9 @@ def _get_metamodel_elements(obj: Any) -> Iterator[str]:
         pass
 
 
-def _generate_framework_output(schema: Dict, framework: str, mappings: List = None) -> Tuple[Generator, str, str]:
+def _generate_framework_output(
+    schema: Dict, framework: str, mappings: List = None
+) -> Tuple[Generator, str, Optional[Path]]:
     """
     Compile a schema using a framework (e.g. jsonschema generation).
 
@@ -294,11 +296,16 @@ def _generate_framework_output(schema: Dict, framework: str, mappings: List = No
                         output += stream.read()
         else:
             output = gen.serialize()
-        out_dir = _schema_out_path(schema) / "generated"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        out_path = out_dir / f"{framework}.{gen.file_extension}"
-        with open(out_path, "w", encoding="utf-8") as stream:
-            stream.write(output)
+
+        if tests.WITH_OUTPUT:
+            out_dir = _schema_out_path(schema) / "generated"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = out_dir / f"{framework}.{gen.file_extension}"
+            with open(out_path, "w", encoding="utf-8") as stream:
+                stream.write(output)
+        else:
+            out_path = None
+
         cached_generator_output[pair] = (gen, output, out_path)
         for context, impdict in mappings:
             if framework in impdict:
@@ -490,20 +497,20 @@ def _make_schema(
     parent_out_dir = _schema_out_path(schema, parent=True)
     schema["source_file"] = str(out_dir / "schema.yaml")
 
-    # Write top-level README (TODO: avoid doing this for each combination)
-    with open(parent_out_dir / "README.md", "w", encoding="utf-8") as stream:
-        dlines = [x.strip() for x in schema["description"].split("\n")]
-        dlines = [x for x in dlines if not x.startswith(":")]
-        desc = "\n".join(dlines)
-        stream.write(f"# {test.__name__}\n\n")
-        stream.write(f"{desc}\n\n")
-        stream.write("## Elements Tested\n\n")
-        if not core_elements:
-            raise AssertionError(f"No core elements defined for for {schema_name}")
-        for el in core_elements:
-            stream.write(f"* [{el}](https://w3id.org/linkml/{el})\n")
-
     if tests.WITH_OUTPUT:
+        # Write top-level README (TODO: avoid doing this for each combination)
+        with open(parent_out_dir / "README.md", "w", encoding="utf-8") as stream:
+            dlines = [x.strip() for x in schema["description"].split("\n")]
+            dlines = [x for x in dlines if not x.startswith(":")]
+            desc = "\n".join(dlines)
+            stream.write(f"# {test.__name__}\n\n")
+            stream.write(f"{desc}\n\n")
+            stream.write("## Elements Tested\n\n")
+            if not core_elements:
+                raise AssertionError(f"No core elements defined for for {schema_name}")
+            for el in core_elements:
+                stream.write(f"* [{el}](https://w3id.org/linkml/{el})\n")
+
         # Write README for this schema combo
         with open(out_dir / "README.md", "w", encoding="utf-8") as stream:
             dlines = [x.strip() for x in schema["description"].split("\n")]
@@ -526,15 +533,19 @@ def _make_schema(
             stream.write("```yaml\n")
             yaml.safe_dump(schema_minimal, stream, sort_keys=False)
             stream.write("```\n\n")
+
         with open(out_dir / "mappings.txt", "w", encoding="utf-8") as stream:
             stream.write(str(mappings))
-    with open(out_dir / "schema.yaml", "w", encoding="utf-8") as stream:
-        yaml.safe_dump(schema, stream, sort_keys=False)
+
+        with open(out_dir / "schema.yaml", "w", encoding="utf-8") as stream:
+            yaml.safe_dump(schema, stream, sort_keys=False)
+
     if imported_schemas:
         for imp in imported_schemas:
             imp_path = f'{out_dir / imp["name"]}.yaml'
             with open(imp_path, "w", encoding="utf-8") as imp_stream:
                 yaml.safe_dump(imp, imp_stream, sort_keys=False)
+
     if not schema["name"]:
         raise ValueError(f"Schema name not set: {schema}")
     return schema, mappings
@@ -779,10 +790,11 @@ def check_data(
             json_object = copy(object_to_validate)
             json_object["@context"] = context
             jsonld_path = out_dir / f"{data_name}.jsonld"
-            with open(jsonld_path, "w", encoding="utf-8") as stream:
-                json.dump(json_object, stream, indent=2, sort_keys=True, ensure_ascii=False)
+            if tests.WITH_OUTPUT:
+                with open(jsonld_path, "w", encoding="utf-8") as stream:
+                    json.dump(json_object, stream, indent=2, sort_keys=True, ensure_ascii=False)
             g = rdflib.Graph()
-            g.parse(jsonld_path, format="json-ld")
+            g.parse(data=json.dumps(json_object, indent=2, sort_keys=True, ensure_ascii=False), format="json-ld")
             if not valid and expected_behavior == ValidationBehavior.IMPLEMENTS:
                 logging.info(f"Skipping validation for {jsonld_path}")
         elif isinstance(gen, OwlSchemaGenerator):
@@ -879,7 +891,7 @@ def _convert_data_to_rdf(schema: dict, instance: dict, target_class: str, ttl_pa
     except Exception as e:
         logging.info(f"Could not instantiate {py_cls} from {instance}; exception: {e}")
         return None
-    schemaview = SchemaView(yaml.dump(schema))
+    schemaview = SchemaView(SchemaDefinition(**schema))
     g = rdflib_dumper.as_rdf_graph(
         py_inst,
         schemaview=schemaview,
@@ -889,11 +901,12 @@ def _convert_data_to_rdf(schema: dict, instance: dict, target_class: str, ttl_pa
             "P": "http://example.org/P/",
         },
     )
-    g.serialize(ttl_path, format="turtle")
+    ttl_output = g.serialize(format="turtle")
     g = rdflib.Graph()
-    g.parse(ttl_path, format="turtle")
-    roundtripped = rdflib_loader.load(ttl_path, target_class=py_cls, schemaview=schemaview)
-    yaml_dumper.dump(roundtripped, to_file=ttl_path + ".yaml")
+    g.parse(data=ttl_output, format="turtle")
+    roundtripped = rdflib_loader.load(ttl_output, target_class=py_cls, schemaview=schemaview)
+    if tests.WITH_OUTPUT:
+        yaml_dumper.dump(roundtripped, to_file=ttl_path + ".yaml")
     return g
 
 

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -5,6 +5,7 @@ import enum
 import json
 import logging
 import os
+import pdb
 import shutil
 import subprocess
 import tempfile
@@ -789,9 +790,9 @@ def check_data(
             plugins = [JsonschemaValidationPlugin(closed=True, include_range_class_descendants=False)]
         elif isinstance(gen, ContextGenerator):
             context_dir = _schema_out_path(schema) / "generated" / "jsonld_context.context.jsonld"
-            if not context_dir.exists():
+            if not context_dir.exists() and tests.WITH_OUTPUT:
                 raise AssertionError(f"Could not find {context_dir}")
-            context = json.load(context_dir.open())["@context"]
+            context = json.loads(cached_generator_output[(schema['name'], 'jsonld_context')][1])['@context']
             json_object = copy(object_to_validate)
             json_object["@context"] = context
             jsonld_path = out_dir / f"{data_name}.jsonld"

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -939,7 +939,7 @@ def test_template_models_templates():
     for model in TemplateModel.__subclasses__():
         assert hasattr(model, "template")
         assert isinstance(model.template, str)
-        env = model.environment
+        env = model.environment()
         template = env.get_template(model.template)
         assert isinstance(template, Template)
 
@@ -948,7 +948,7 @@ def test_default_environment():
     """
     Check that the default environment has the configuration for our templates
     """
-    env = TemplateModel.environment
+    env = TemplateModel.environment()
     assert env.trim_blocks
     assert env.lstrip_blocks
 

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -939,7 +939,7 @@ def test_template_models_templates():
     for model in TemplateModel.__subclasses__():
         assert hasattr(model, "template")
         assert isinstance(model.template, str)
-        env = model.environment()
+        env = model.environment
         template = env.get_template(model.template)
         assert isinstance(template, Template)
 
@@ -948,7 +948,7 @@ def test_default_environment():
     """
     Check that the default environment has the configuration for our templates
     """
-    env = TemplateModel.environment()
+    env = TemplateModel.environment
     assert env.trim_blocks
     assert env.lstrip_blocks
 

--- a/tests/test_validator/conftest.py
+++ b/tests/test_validator/conftest.py
@@ -1,4 +1,8 @@
 import pytest
+from linkml_runtime.linkml_model import SchemaDefinition
+from linkml_runtime.loaders import yaml_loader
+
+from linkml.validator.validation_context import ValidationContext
 
 
 @pytest.fixture
@@ -10,3 +14,9 @@ def tmp_file_factory(tmp_path):
         return str(file_path)
 
     return factory
+
+
+@pytest.fixture(scope="module")
+def validation_context(input_path) -> ValidationContext:
+    schema = yaml_loader.load(input_path("personinfo.yaml"), SchemaDefinition)
+    return ValidationContext(schema, "Person")

--- a/tests/test_validator/test_jsonschema_validation_plugin.py
+++ b/tests/test_validator/test_jsonschema_validation_plugin.py
@@ -2,16 +2,9 @@ import json
 
 import pytest
 from linkml_runtime.linkml_model import ClassDefinition, SchemaDefinition, SlotDefinition
-from linkml_runtime.loaders import yaml_loader
 
 from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.validation_context import ValidationContext
-
-
-@pytest.fixture
-def validation_context(input_path) -> ValidationContext:
-    schema = yaml_loader.load(input_path("personinfo.yaml"), SchemaDefinition)
-    return ValidationContext(schema, "Person")
 
 
 def test_valid_instance(validation_context):

--- a/tests/test_validator/test_pydantic_validation_plugin.py
+++ b/tests/test_validator/test_pydantic_validation_plugin.py
@@ -1,18 +1,9 @@
 import pytest
-from linkml_runtime.linkml_model import SchemaDefinition
-from linkml_runtime.loaders import yaml_loader
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 from linkml.validator.plugins.pydantic_validation_plugin import PydanticValidationPlugin
-from linkml.validator.validation_context import ValidationContext
 
 IS_PYDANTIC_V1 = PYDANTIC_VERSION[0] == "1"
-
-
-@pytest.fixture
-def validation_context(input_path):
-    schema = yaml_loader.load(input_path("personinfo.yaml"), SchemaDefinition)
-    return ValidationContext(schema, "Person")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
hey it's me again, profiling and fixing perf while i wait for my PR tests to finish running lol.

Previously in https://github.com/linkml/linkml/pull/1941 we had found out that making I/O optional behind a `--with-output` flag brought down testing time by 25%, and now i'm here to finish the job!

Profiling, we see that when running the whole `test_compliance` directory that `safe_dump` takes up 243s of 527 cumulative testing time.

<img width="988" alt="Screenshot 2024-04-01 at 5 35 56 PM" src="https://github.com/linkml/linkml/assets/12961499/e1d8f50a-d0f3-44de-88b4-443751fd5b6f">

There are a number of places in the compliance testing helpers that read and write schemas and output, but each of them also allows the in-memory schema or generated content to be used instead. The only exception to being moved behind `--with-output` are the import tests, which do require that the schema files be written to disk. Otherwise I tried to preserve existing behavior as much as possible.

While I was doing that I also noticed a few other low-hanging fruit perf optimizations:
- Make pydanticgen template environment a class attribute rather than a method since it actually ends up taking awhile to load the env every time - it's the same every time so don't keep loading it!
- Make the shacl validation plugin only load each graph for each schema once by caching it in a private dict by the hash of the stringified schema.
- in `Generator._initialize_using_schemaloader` Rather than roundtripping all the way to yaml and back when initializing from schemaloader, just dump to a dict, which seems to do the same thing according to the tests. 
- Make the pydantic and json schema validation context a single fixture function with a module-level scope also so we don't need to load the same schema anew for every file :)
- Use the CSafeDumper when possible.
- Remove one no-op dump and load ( i assume the ability to dump and load python generated models should be tested elsewhere )

Altogether for a run of the whole compliance test directory with cprofile enables, this makes for a perf boost:
- Current time: 527s
- This PR: 157s
- Change: -370s (70%)
