### PR TITLE
Add `--without-cache` option to tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,9 +180,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--with-output", action="store_true", help="dump output in compliance test for richer debugging information"
     )
-    parser.addoption(
-        "--without-cache", action="store_true", help="Don't use a sqlite cache for network requests"
-    )
+    parser.addoption("--without-cache", action="store_true", help="Don't use a sqlite cache for network requests")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--with-output", action="store_true", help="dump output in compliance test for richer debugging information"
     )
+    parser.addoption(
+        "--without-cache", action="store_true", help="Don't use a sqlite cache for network requests"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -207,6 +210,9 @@ def patch_requests_cache(pytestconfig):
     Cache network requests - for each unique network request, store it in
     an sqlite cache. only do unique requests once per session.
     """
+    if pytestconfig.getoption("--without-cache"):
+        yield
+        return
     cache_file = Path(__file__).parent / "output" / "requests-cache.sqlite"
     requests_cache.install_cache(
         str(cache_file),


### PR DESCRIPTION
Fix: https://github.com/linkml/linkml/issues/1305
Fix: https://github.com/linkml/linkml/issues/1297

The tests can be run in parallel, except for tests which make network requests because the requests cache isn't designed for it. we should have an option to disable it anyway.

The odd `yield; return;` pattern is because if there is any yield statement in the function, pytest expects it to yield something, so we yield nothing and then have no cleanup stage when `--without-cache` is passed

tests can then be run in parallel like:

```shell
pip install pytest-xdist
pytest -n auto --without-cache
```

