### PR TITLE
convert enhancements to pytest

### DIFF
--- a/linkml/generators/pythongen.py
+++ b/linkml/generators/pythongen.py
@@ -4,6 +4,7 @@ import os
 import re
 from copy import copy
 from dataclasses import dataclass
+from pathlib import Path
 from types import ModuleType
 from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple, Union
 
@@ -62,6 +63,8 @@ class PythonGenerator(Generator):
     emit_metadata: bool = True
 
     def __post_init__(self) -> None:
+        if isinstance(self.schema, Path):
+            self.schema = str(self.schema)
         self.sourcefile = self.schema
         self.schemaview = SchemaView(self.schema, base_dir=self.base_dir)
         super().__post_init__()

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -129,7 +129,7 @@ class Generator(metaclass=abc.ABCMeta):
     useuris: Optional[bool] = None
     """True means declared class slot uri's are used.  False means use model uris"""
 
-    log_level: int = DEFAULT_LOG_LEVEL_INT
+    log_level: Optional[int] = DEFAULT_LOG_LEVEL_INT
     """Logging level, 0 is minimum"""
 
     mergeimports: Optional[bool] = True
@@ -179,6 +179,7 @@ class Generator(metaclass=abc.ABCMeta):
     def __post_init__(self) -> None:
         if not self.logger:
             self.logger = logging.getLogger()
+        if self.log_level is not None:
             self.logger.setLevel(self.log_level)
         if self.format is None:
             self.format = self.valid_formats[0]

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -82,7 +82,7 @@ class Generator(metaclass=abc.ABCMeta):
     For usage `Generator Docs <https://linkml.io/linkml/generators/>`_
     """
 
-    schema: Union[str, TextIO, SchemaDefinition, "Generator"]
+    schema: Union[str, TextIO, SchemaDefinition, "Generator", Path]
     """metamodel compliant schema.  Can be URI, file name, actual schema, another generator, an
         open file or a pre-parsed schema"""
 
@@ -179,6 +179,7 @@ class Generator(metaclass=abc.ABCMeta):
     def __post_init__(self) -> None:
         if not self.logger:
             self.logger = logging.getLogger()
+            self.logger.setLevel(self.log_level)
         if self.format is None:
             self.format = self.valid_formats[0]
         if self.format not in self.valid_formats:
@@ -190,7 +191,11 @@ class Generator(metaclass=abc.ABCMeta):
             self.source_file_size = None
         if self.requires_metamodel:
             self.metamodel = _resolved_metamodel(self.mergeimports)
+
         schema = self.schema
+        if isinstance(schema, Path):
+            schema = str(schema)
+
         # TODO: remove aliasing
         self.emit_metadata = self.metadata
         if self.uses_schemaloader:

--- a/linkml/utils/rawloader.py
+++ b/linkml/utils/rawloader.py
@@ -1,5 +1,6 @@
 import copy
 from datetime import datetime
+from pathlib import Path
 from typing import Optional, TextIO, Union
 from urllib.parse import urlparse
 
@@ -29,7 +30,7 @@ SchemaDefinition.MissingRequiredField = mrf
 
 
 def load_raw_schema(
-    data: Union[str, dict, TextIO],
+    data: Union[str, dict, TextIO, Path],
     source_file: Optional[str] = None,
     source_file_date: Optional[str] = None,
     source_file_size: Optional[int] = None,
@@ -57,6 +58,9 @@ def load_raw_schema(
         assert source_file is None, "source_file parameter not allowed if data is a file or URL"
         assert source_file_date is None, "source_file_date parameter not allowed if data is a file or URL"
         assert source_file_size is None, "source_file_size parameter not allowed if data is a file or URL"
+
+    if isinstance(data, Path):
+        data = str(data)
 
     # Convert the input into a valid SchemaDefinition
     if isinstance(data, (str, dict, TextIO)):

--- a/linkml/utils/schemaloader.py
+++ b/linkml/utils/schemaloader.py
@@ -2,6 +2,7 @@ import logging
 import os
 from collections import OrderedDict
 from copy import deepcopy
+from pathlib import Path
 from typing import Dict, Iterator, List, Mapping, Optional, Set, TextIO, Tuple, Union, cast
 from urllib.parse import urlparse
 
@@ -32,7 +33,7 @@ from linkml.utils.schemasynopsis import SchemaSynopsis
 class SchemaLoader:
     def __init__(
         self,
-        data: Union[str, TextIO, SchemaDefinition, dict],
+        data: Union[str, TextIO, SchemaDefinition, dict, Path],
         base_dir: Optional[str] = None,
         namespaces: Optional[Namespaces] = None,
         useuris: Optional[bool] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,9 @@ filterwarnings = [
 ]
 markers = [
   "network: mark tests that make external network requests",
-  "slow: mark test as slow to run"
+  "slow: mark test as slow to run",
+  "no_asserts: tests that don't have meaningful asserts, but are only snapshot comparisons, or historically had print statements, or other non-erroring behavior",
+  "strcmp: tests that compare stringified values rather than the values themselves"
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import sys
 from abc import ABC, abstractmethod
 from importlib.abc import MetaPathFinder
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import pytest
 import requests_cache
@@ -116,15 +116,15 @@ class SnapshotDirectory(Snapshot):
 
 
 @pytest.fixture
-def snapshot_path(request) -> Callable[[str], Path]:
-    def get_path(relative_path):
+def snapshot_path(request) -> Callable[[Union[str, Path]], Path]:
+    def get_path(relative_path: Union[str, Path]):
         return request.path.parent / "__snapshots__" / relative_path
 
     return get_path
 
 
 @pytest.fixture
-def snapshot(snapshot_path, pytestconfig, monkeypatch) -> Callable[[str], Snapshot]:
+def snapshot(snapshot_path, pytestconfig, monkeypatch) -> Callable[[Union[str, Path]], Snapshot]:
     # Patching SchemaDefinition's setter here prevents metadata that can be variable
     # between systems from entering the snapshot files. This could be part of its own
     # fixture but it's not clear if it would be useful outside of tests that
@@ -142,7 +142,7 @@ def snapshot(snapshot_path, pytestconfig, monkeypatch) -> Callable[[str], Snapsh
 
     monkeypatch.setattr(SchemaDefinition, "__setattr__", patched)
 
-    def get_snapshot(relative_path, **kwargs):
+    def get_snapshot(relative_path: Union[str, Path], **kwargs):
         path = snapshot_path(relative_path)
         if not path.suffix:
             return SnapshotDirectory(path, pytestconfig)

--- a/tests/test_enhancements/__snapshots__/enumeration/alternatives.py
+++ b/tests/test_enhancements/__snapshots__/enumeration/alternatives.py
@@ -1,5 +1,5 @@
 # Auto generated from alternatives.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:37
+# Generation date: 2000-01-01T00:00:00
 # Schema: alternatives
 #
 # id: http://example.org/test/alternatives

--- a/tests/test_enhancements/__snapshots__/enumeration/alternatives.yaml
+++ b/tests/test_enhancements/__snapshots__/enumeration/alternatives.yaml
@@ -539,6 +539,6 @@ classes:
     class_uri: evidence:AllEnums
 metamodel_version: 1.7.0
 source_file: alternatives.yaml
-source_file_date: '2023-07-14T13:43:06'
-source_file_size: 2692
-generation_date: '2024-04-03T09:29:37'
+source_file_date: '2000-01-01T00:00:00'
+source_file_size: 1
+generation_date: '2000-01-01T00:00:00'

--- a/tests/test_enhancements/__snapshots__/enumeration/evidence.py
+++ b/tests/test_enhancements/__snapshots__/enumeration/evidence.py
@@ -1,5 +1,5 @@
 # Auto generated from evidence.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Generation date: 2000-01-01T00:00:00
 # Schema: evidence
 #
 # id: http://example.org/test/evidence

--- a/tests/test_enhancements/__snapshots__/enumeration/notebook_model_1.py
+++ b/tests/test_enhancements/__snapshots__/enumeration/notebook_model_1.py
@@ -1,9 +1,9 @@
-# Auto generated from notebook_model_2.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Auto generated from notebook_model_1.yaml by pythongen.py version: 0.0.1
+# Generation date: 2000-01-01T00:00:00
 # Schema: simple
 #
 # id: http://example.org/test/simple
-# description: Enumeration with some non-std values
+# description: Very simple enumeration
 # license: https://creativecommons.org/publicdomain/zero/1.0/
 
 import dataclasses
@@ -39,61 +39,48 @@ DEFAULT_ = PLAY
 # Types
 
 # Class references
-class SampleId(extended_str):
+class PositionalRecordId(extended_str):
     pass
 
 
 @dataclass
-class Sample(YAMLRoot):
-    id: Union[str, SampleId] = None
-    position: Union[Union[str, "UnusualEnumPatterns"], List[Union[str, "UnusualEnumPatterns"]]] = None
+class PositionalRecord(YAMLRoot):
+    id: Union[str, PositionalRecordId] = None
+    position: Union[str, "OpenEnum"] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
             self.MissingRequiredField("id")
-        if not isinstance(self.id, SampleId):
-            self.id = SampleId(self.id)
+        if not isinstance(self.id, PositionalRecordId):
+            self.id = PositionalRecordId(self.id)
 
         if self._is_empty(self.position):
             self.MissingRequiredField("position")
-        if not isinstance(self.position, list):
-            self.position = [self.position] if self.position is not None else []
-        self.position = [v if isinstance(v, UnusualEnumPatterns) else UnusualEnumPatterns(v) for v in self.position]
+        if not isinstance(self.position, OpenEnum):
+            self.position = OpenEnum(self.position)
 
         super().__post_init__(**kwargs)
 
 
 # Enumerations
-class UnusualEnumPatterns(EnumDefinitionImpl):
+class OpenEnum(EnumDefinitionImpl):
     """
-    Very odd enumeration
+    Baseline enumeration -- simple code/value pairs, where the value (description) is optional
     """
-    M = PermissibleValue(
-        text="M",
-        description="Normal selection")
+    a = PermissibleValue(
+        text="a",
+        description="top")
+    b = PermissibleValue(
+        text="b",
+        description="middle")
+    c = PermissibleValue(
+        text="c",
+        description="bottom")
+    d = PermissibleValue(text="d")
 
     _defn = EnumDefinition(
-        name="UnusualEnumPatterns",
-        description="Very odd enumeration",
+        name="OpenEnum",
+        description="Baseline enumeration -- simple code/value pairs, where the value (description) is optional",
     )
-
-    @classmethod
-    def _addvals(cls):
-        setattr(cls, "1",
-            PermissibleValue(
-                text="1",
-                description="Numeric selection"))
-        setattr(cls, "def",
-            PermissibleValue(
-                text="def",
-                description="Python reserved word"))
-        setattr(cls, "embedded space",
-            PermissibleValue(
-                text="embedded space",
-                description="Embedded space"))
-        setattr(cls, "% ! -- whoo",
-            PermissibleValue(
-                text="% ! -- whoo",
-                description="Really weird stuff"))
 
 # Slots

--- a/tests/test_enhancements/__snapshots__/enumeration/notebook_model_2.py
+++ b/tests/test_enhancements/__snapshots__/enumeration/notebook_model_2.py
@@ -1,9 +1,9 @@
-# Auto generated from notebook_model_3.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Auto generated from notebook_model_2.yaml by pythongen.py version: 0.0.1
+# Generation date: 2000-01-01T00:00:00
 # Schema: simple
 #
 # id: http://example.org/test/simple
-# description: Very simple enumeration
+# description: Enumeration with some non-std values
 # license: https://creativecommons.org/publicdomain/zero/1.0/
 
 import dataclasses
@@ -31,7 +31,6 @@ version = None
 dataclasses._init_fn = dataclasses_init_fn_with_kwargs
 
 # Namespaces
-SCT = CurieNamespace('SCT', 'http://snomed.info/id/')
 LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
 PLAY = CurieNamespace('play', 'http://example.org/test/play/')
 DEFAULT_ = PLAY
@@ -40,37 +39,42 @@ DEFAULT_ = PLAY
 # Types
 
 # Class references
-class FavoriteColorId(extended_str):
+class SampleId(extended_str):
     pass
 
 
 @dataclass
-class FavoriteColor(YAMLRoot):
-    id: Union[str, FavoriteColorId] = None
-    position: Union[str, "Colors"] = None
+class Sample(YAMLRoot):
+    id: Union[str, SampleId] = None
+    position: Union[Union[str, "UnusualEnumPatterns"], List[Union[str, "UnusualEnumPatterns"]]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
             self.MissingRequiredField("id")
-        if not isinstance(self.id, FavoriteColorId):
-            self.id = FavoriteColorId(self.id)
+        if not isinstance(self.id, SampleId):
+            self.id = SampleId(self.id)
 
         if self._is_empty(self.position):
             self.MissingRequiredField("position")
-        if not isinstance(self.position, Colors):
-            self.position = Colors(self.position)
+        if not isinstance(self.position, list):
+            self.position = [self.position] if self.position is not None else []
+        self.position = [v if isinstance(v, UnusualEnumPatterns) else UnusualEnumPatterns(v) for v in self.position]
 
         super().__post_init__(**kwargs)
 
 
 # Enumerations
-class Colors(EnumDefinitionImpl):
+class UnusualEnumPatterns(EnumDefinitionImpl):
     """
-    Color values, mapped to SNOMED CT
+    Very odd enumeration
     """
+    M = PermissibleValue(
+        text="M",
+        description="Normal selection")
+
     _defn = EnumDefinition(
-        name="Colors",
-        description="Color values, mapped to SNOMED CT",
+        name="UnusualEnumPatterns",
+        description="Very odd enumeration",
     )
 
     @classmethod
@@ -78,25 +82,18 @@ class Colors(EnumDefinitionImpl):
         setattr(cls, "1",
             PermissibleValue(
                 text="1",
-                description="Red",
-                meaning=SCT["371240000"]))
-        setattr(cls, "2",
+                description="Numeric selection"))
+        setattr(cls, "def",
             PermissibleValue(
-                text="2",
-                description="Yellow",
-                meaning=SCT["371244009"]))
-        setattr(cls, "3",
+                text="def",
+                description="Python reserved word"))
+        setattr(cls, "embedded space",
             PermissibleValue(
-                text="3",
-                meaning=SCT["405738005"]))
-        setattr(cls, "4",
+                text="embedded space",
+                description="Embedded space"))
+        setattr(cls, "% ! -- whoo",
             PermissibleValue(
-                text="4",
-                description="Muted",
-                meaning=SCT["abcde"]))
-        setattr(cls, "9",
-            PermissibleValue(
-                text="9",
-                description="Muddy"))
+                text="% ! -- whoo",
+                description="Really weird stuff"))
 
 # Slots

--- a/tests/test_enhancements/__snapshots__/enumeration/notebook_model_3.py
+++ b/tests/test_enhancements/__snapshots__/enumeration/notebook_model_3.py
@@ -1,5 +1,5 @@
-# Auto generated from notebook_model_1.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Auto generated from notebook_model_3.yaml by pythongen.py version: 0.0.1
+# Generation date: 2000-01-01T00:00:00
 # Schema: simple
 #
 # id: http://example.org/test/simple
@@ -31,6 +31,7 @@ version = None
 dataclasses._init_fn = dataclasses_init_fn_with_kwargs
 
 # Namespaces
+SCT = CurieNamespace('SCT', 'http://snomed.info/id/')
 LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
 PLAY = CurieNamespace('play', 'http://example.org/test/play/')
 DEFAULT_ = PLAY
@@ -39,48 +40,63 @@ DEFAULT_ = PLAY
 # Types
 
 # Class references
-class PositionalRecordId(extended_str):
+class FavoriteColorId(extended_str):
     pass
 
 
 @dataclass
-class PositionalRecord(YAMLRoot):
-    id: Union[str, PositionalRecordId] = None
-    position: Union[str, "OpenEnum"] = None
+class FavoriteColor(YAMLRoot):
+    id: Union[str, FavoriteColorId] = None
+    position: Union[str, "Colors"] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
             self.MissingRequiredField("id")
-        if not isinstance(self.id, PositionalRecordId):
-            self.id = PositionalRecordId(self.id)
+        if not isinstance(self.id, FavoriteColorId):
+            self.id = FavoriteColorId(self.id)
 
         if self._is_empty(self.position):
             self.MissingRequiredField("position")
-        if not isinstance(self.position, OpenEnum):
-            self.position = OpenEnum(self.position)
+        if not isinstance(self.position, Colors):
+            self.position = Colors(self.position)
 
         super().__post_init__(**kwargs)
 
 
 # Enumerations
-class OpenEnum(EnumDefinitionImpl):
+class Colors(EnumDefinitionImpl):
     """
-    Baseline enumeration -- simple code/value pairs, where the value (description) is optional
+    Color values, mapped to SNOMED CT
     """
-    a = PermissibleValue(
-        text="a",
-        description="top")
-    b = PermissibleValue(
-        text="b",
-        description="middle")
-    c = PermissibleValue(
-        text="c",
-        description="bottom")
-    d = PermissibleValue(text="d")
-
     _defn = EnumDefinition(
-        name="OpenEnum",
-        description="Baseline enumeration -- simple code/value pairs, where the value (description) is optional",
+        name="Colors",
+        description="Color values, mapped to SNOMED CT",
     )
+
+    @classmethod
+    def _addvals(cls):
+        setattr(cls, "1",
+            PermissibleValue(
+                text="1",
+                description="Red",
+                meaning=SCT["371240000"]))
+        setattr(cls, "2",
+            PermissibleValue(
+                text="2",
+                description="Yellow",
+                meaning=SCT["371244009"]))
+        setattr(cls, "3",
+            PermissibleValue(
+                text="3",
+                meaning=SCT["405738005"]))
+        setattr(cls, "4",
+            PermissibleValue(
+                text="4",
+                description="Muted",
+                meaning=SCT["abcde"]))
+        setattr(cls, "9",
+            PermissibleValue(
+                text="9",
+                description="Muddy"))
 
 # Slots

--- a/tests/test_enhancements/__snapshots__/enumeration/notebook_model_4.py
+++ b/tests/test_enhancements/__snapshots__/enumeration/notebook_model_4.py
@@ -1,5 +1,5 @@
 # Auto generated from notebook_model_4.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Generation date: 2000-01-01T00:00:00
 # Schema: simple
 #
 # id: http://example.org/test/simple

--- a/tests/test_enhancements/__snapshots__/issue_pattern/pattern_1.py
+++ b/tests/test_enhancements/__snapshots__/issue_pattern/pattern_1.py
@@ -1,5 +1,5 @@
 # Auto generated from pattern_1.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Generation date: 2000-01-01T00:00:00
 # Schema: pattern_1
 #
 # id: http://example.org/test/pattern_1

--- a/tests/test_enhancements/__snapshots__/python_generation/python_complex_ranges.py
+++ b/tests/test_enhancements/__snapshots__/python_generation/python_complex_ranges.py
@@ -1,5 +1,5 @@
 # Auto generated from python_complex_ranges.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Generation date: 2000-01-01T00:00:00
 # Schema: complex_ranges
 #
 # id: http://examples.org/linkml/test/complex_ranges

--- a/tests/test_enhancements/__snapshots__/python_generation/python_lists_and_keys.py
+++ b/tests/test_enhancements/__snapshots__/python_generation/python_lists_and_keys.py
@@ -1,5 +1,5 @@
 # Auto generated from python_lists_and_keys.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Generation date: 2000-01-01T00:00:00
 # Schema: lists_and_keys
 #
 # id: http://examples.org/linkml/test/lists_and_keys

--- a/tests/test_enhancements/__snapshots__/python_generation/python_types.py
+++ b/tests/test_enhancements/__snapshots__/python_generation/python_types.py
@@ -1,5 +1,5 @@
 # Auto generated from python_types.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Generation date: 2000-01-01T00:00:00
 # Schema: ptypes
 #
 # id: http://examples.org/linkml/test/ptypes

--- a/tests/test_enhancements/__snapshots__/string_serialization/simple_example.py
+++ b/tests/test_enhancements/__snapshots__/string_serialization/simple_example.py
@@ -1,5 +1,5 @@
 # Auto generated from simple_example.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-04-03T09:29:38
+# Generation date: 2000-01-01T00:00:00
 # Schema: example.org
 #
 # id: http://example.org

--- a/tests/test_enhancements/__snapshots__/string_template/templated_classes.py
+++ b/tests/test_enhancements/__snapshots__/string_template/templated_classes.py
@@ -1,0 +1,86 @@
+# Auto generated from templated_classes.yaml by pythongen.py version: 0.0.1
+# Generation date: 2000-01-01T00:00:00
+# Schema: string_templates
+#
+# id: http://examples.org/linkml/test/string_templates
+# description: Test cases for the string_template model
+# license: https://creativecommons.org/publicdomain/zero/1.0/
+
+import dataclasses
+import re
+from jsonasobj2 import JsonObj, as_dict
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from datetime import date, datetime
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
+
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
+from linkml_runtime.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+from linkml_runtime.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from rdflib import Namespace, URIRef
+from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.linkml_model.types import Integer, String
+
+metamodel_version = "1.7.0"
+version = None
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+DEFAULT_ = LINKML
+
+
+# Types
+
+# Class references
+
+
+
+@dataclass
+class FirstClass(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LINKML["FirstClass"]
+    class_class_curie: ClassVar[str] = "linkml:FirstClass"
+    class_name: ClassVar[str] = "first class"
+    class_model_uri: ClassVar[URIRef] = LINKML.FirstClass
+
+    name: str = None
+    age: Optional[int] = None
+    gender: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.name):
+            self.MissingRequiredField("name")
+        if not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.age is not None and not isinstance(self.age, int):
+            self.age = int(self.age)
+
+        if self.gender is not None and not isinstance(self.gender, str):
+            self.gender = str(self.gender)
+
+        super().__post_init__(**kwargs)
+
+
+# Enumerations
+
+
+# Slots
+class slots:
+    pass
+
+slots.firstClass__name = Slot(uri=LINKML.name, name="firstClass__name", curie=LINKML.curie('name'),
+                   model_uri=LINKML.firstClass__name, domain=None, range=str)
+
+slots.firstClass__age = Slot(uri=LINKML.age, name="firstClass__age", curie=LINKML.curie('age'),
+                   model_uri=LINKML.firstClass__age, domain=None, range=Optional[int])
+
+slots.firstClass__gender = Slot(uri=LINKML.gender, name="firstClass__gender", curie=LINKML.curie('gender'),
+                   model_uri=LINKML.firstClass__gender, domain=None, range=Optional[str])

--- a/tests/test_enhancements/environment.py
+++ b/tests/test_enhancements/environment.py
@@ -1,4 +1,0 @@
-from tests.utils.test_environment import TestEnvironment
-
-# This set of tests actually works with the test root directories
-env = TestEnvironment(__file__)

--- a/tests/test_enhancements/test_enumeration.py
+++ b/tests/test_enhancements/test_enumeration.py
@@ -1,243 +1,158 @@
 import logging
-import unittest
-from typing import List, Union
+from pathlib import Path
 
+import pytest
 from linkml_runtime.utils.compile_python import compile_python
 
 from linkml.generators.pythongen import PythonGenerator
 from linkml.generators.yamlgen import YAMLGenerator
-from tests.test_enhancements.environment import env
-from tests.utils.filters import yaml_filter
-from tests.utils.python_comparator import compare_python
-from tests.utils.test_environment import TestEnvironmentTestCase
 
 
-class EnumerationTestCase(TestEnvironmentTestCase):
-    env = env
-    testdir = "enumeration"
+@pytest.mark.no_asserts
+def test_evidence(input_path, snapshot):
+    """Test evidence enumeration"""
+    generated = PythonGenerator(
+        Path(input_path("enumeration")) / "evidence.yaml",
+        mergeimports=False,
+    ).serialize()
+    assert generated == snapshot(Path("enumeration") / "evidence.py")
 
-    def _check_error(self, file: str, error: str) -> None:
-        with self.assertRaises(ValueError, msg=error) as e:
-            YAMLGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                mergeimports=False,
-                log_level=logging.INFO,
-            ).serialize(validateonly=True)
-        # print(str(e.exception))
-        self.assertIn(error, str(e.exception), error)
 
-    def _check_warns(self, file: str, msgs: Union[str, List[str]]) -> None:
-        with self.redirect_logstream() as logger:
-            YAMLGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                mergeimports=False,
-                log_level=logging.INFO,
-                logger=logger,
-            ).serialize(validateonly=True)
-        for msg in msgs if isinstance(msgs, list) else [msgs]:
-            self.assertIn(msg, logger.result, msg)
+@pytest.mark.parametrize(
+    "file,error",
+    [
+        ("enum_name_error", '":" not allowed in identifier'),
+        ("enum_class_name_error", "Overlapping enum and class names: test1, test2"),
+        ("enum_type_name_error", "Overlapping type and enum names: test2"),
+        ("enum_error_1", 'Enum: "error1" needs a code set to have a version'),
+        ("enum_error_2", 'Enum: "error2" cannot have both version and tag'),
+        ("enum_error_3", 'Enum: "error3" needs a code set to have a tag'),
+        ("enum_error_4", 'Enum: "error4" needs a code set to have a formula'),
+        ("enum_error_5", 'Enum: "error5" can have a formula or permissible values but not both'),
+        ("enum_error_6a", 'Slot: "classError1__slot_1" enumerations cannot be inlined'),
+        ("enum_error_6b", 'Slot: "classError1__slot_1" enumerations cannot be inlined'),
+        ("enum_error_7", "Unknown PvFormulaOptions enumeration code: FOO"),
+    ],
+)
+def test_enum_errors(file, error, input_path):
+    with pytest.raises(ValueError, match=error):
+        YAMLGenerator(
+            (Path(input_path("enumeration")) / file).with_suffix(".yaml"),
+            mergeimports=False,
+            log_level=logging.INFO,
+        ).serialize(validateonly=True)
 
-    def test_evidence(self):
-        """Test evidence enumeration"""
-        file = "evidence"
-        env.generate_single_file(
-            f"{self.testdir}/{file}.py",
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(f"{self.testdir}/{file}.py")),
-            value_is_returned=True,
-        )
 
-    def test_enum_constraints(self):
-        """Test the various enum constraints"""
-        self._check_error("enum_name_error", '":" not allowed in identifier')
-
-        self._check_error("enum_class_name_error", "Overlapping enum and class names: test1, test2")
-
-        self._check_error("enum_type_name_error", "Overlapping type and enum names: test2")
-
-        self._check_warns(
+@pytest.mark.parametrize(
+    "file,warnings",
+    [
+        (
             "enum_name_overlaps",
             [
                 "Overlapping subset and slot names: a random name",
                 "Overlapping enum and slot names: a random name, a slot",
                 "Overlapping subset and enum names: a random name, a subset",
             ],
-        )
+        ),
+    ],
+)
+def test_enum_warns(file, warnings, input_path, caplog):
 
-    def test_enum_errors(self):
-        """Test the other invariants"""
-        self._check_error("enum_error_1", 'Enum: "error1" needs a code set to have a version')
-
-        self._check_error("enum_error_2", 'Enum: "error2" cannot have both version and tag')
-
-        self._check_error("enum_error_3", 'Enum: "error3" needs a code set to have a tag')
-
-        self._check_error("enum_error_4", 'Enum: "error4" needs a code set to have a formula')
-
-        self._check_error(
-            "enum_error_5",
-            'Enum: "error5" can have a formula or permissible values but not both',
-        )
-
-        self._check_error(
-            "enum_error_6a",
-            'Slot: "classError1__slot_1" enumerations cannot be inlined',
-        )
-
-        self._check_error(
-            "enum_error_6b",
-            'Slot: "classError1__slot_1" enumerations cannot be inlined',
-        )
-
-        self._check_error("enum_error_7", "Unknown PvFormulaOptions enumeration code: FOO")
-
-    @unittest.skipIf(
-        True,
-        "Enable this when we get the emitter updated to include the location of the error",
+    generator = YAMLGenerator(
+        (Path(input_path("enumeration")) / file).with_suffix(".yaml"),
+        mergeimports=False,
+        log_level=logging.INFO,
     )
-    def test_enum_valueerror(self):
-        """Make sure that the link to the error is included in the output"""
-        self._check_error("enum_error_7", 'alternatives.yaml", line ')
+    generator.serialize(validateonly=True)
+    for msg in warnings if isinstance(warnings, list) else [warnings]:
+        assert any([msg in logmsg.message for logmsg in caplog.records])
 
-    def test_enum_alternatives(self):
-        """test various variants on enum constraints"""
-        file = "alternatives"
-        env.generate_single_file(
-            env.expected_path(self.testdir, f"{file}.yaml"),
-            lambda: YAMLGenerator(env.input_path(self.testdir, f"{file}.yaml")).serialize(),
-            filtr=yaml_filter,
-            value_is_returned=True,
-        )
 
-        python_name = f"{self.testdir}/{file}.py"
+@pytest.mark.xfail
+def test_enum_valueerror(input_path):
+    """Make sure that the link to the error is included in the output"""
+    with pytest.raises(ValueError, 'alternatives.yaml", line '):
         YAMLGenerator(
-            env.input_path(self.testdir, f"{file}.yaml"),
+            (Path(input_path("enumeration")) / "enum_error_7").with_suffix(".yaml"),
             mergeimports=False,
             log_level=logging.INFO,
-        ).serialize()
-        env.generate_single_file(
-            python_name,
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(python_name)),
-            value_is_returned=True,
-        )
-
-        compile_python(env.expected_path(python_name))
-
-    def test_notebook_model_1(self):
-        file = "notebook_model_1"
-        python_name = f"{self.testdir}/{file}.py"
-        env.generate_single_file(
-            python_name,
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-                gen_classvars=False,
-                gen_slots=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(python_name)),
-            value_is_returned=True,
-        )
-
-        module = compile_python(env.expected_path(python_name))
-        c1 = module.PositionalRecord("my location", "a")
-        self.assertEqual(
-            "PositionalRecord(id='my location', position=(text='a', description='top'))",
-            str(c1),
-        )
-        self.assertEqual("a", str(c1.position))
-        self.assertEqual("(text='a', description='top')", repr(c1.position))
-        try:
-            module.PositionalRecord("your location", "z")
-        except ValueError as e:
-            self.assertEqual("Unknown OpenEnum enumeration code: z", str(e))
-        x = module.PositionalRecord("117493", "c")
-        self.assertEqual("c", str(x.position))
-        self.assertEqual(
-            "PositionalRecord(id='117493', position=(text='c', description='bottom'))",
-            repr(x),
-        )
-        self.assertEqual("(text='c', description='bottom')", repr(x.position))
-
-    def test_notebook_model_2(self):
-        file = "notebook_model_2"
-        python_name = f"{self.testdir}/{file}.py"
-        env.generate_single_file(
-            python_name,
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-                gen_classvars=False,
-                gen_slots=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(python_name)),
-            value_is_returned=True,
-        )
-
-        module = compile_python(env.expected_path(python_name))
-        module.Sample(
-            "Something",
-            [module.UnusualEnumPatterns.M, module.UnusualEnumPatterns["% ! -- whoo"]],
-        )
-
-    def test_notebook_model_3(self):
-        file = "notebook_model_3"
-        python_name = f"{self.testdir}/{file}.py"
-        env.generate_single_file(
-            python_name,
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-                gen_classvars=False,
-                gen_slots=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(python_name)),
-            value_is_returned=True,
-        )
-
-        module = compile_python(env.expected_path(python_name))
-        colorrec = module.FavoriteColor("Harold", module.Colors["2"])
-        print(colorrec)
-        print(str(colorrec.position))
-        print(colorrec.position.meaning)
-        cr2 = module.FavoriteColor("Donald", module.Colors["4"])
-        print(cr2.position.meaning)
-
-    def test_notebook_model_4(self):
-        file = "notebook_model_4"
-        python_name = f"{self.testdir}/{file}.py"
-        env.generate_single_file(
-            python_name,
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-                gen_classvars=False,
-                gen_slots=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(python_name)),
-            value_is_returned=True,
-        )
-
-        module = compile_python(env.expected_path(python_name))
-        colorrec = module.FavoriteColor("Harold", module.Colors["2"])
-        print(colorrec)
-        print(str(colorrec.position))
-        print(colorrec.position.meaning)
-        cr2 = module.FavoriteColor("Donald", module.Colors["4"])
-        print(cr2.position.meaning)
+        ).serialize(validateonly=True)
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.no_asserts
+def test_enum_alternatives(input_path, snapshot):
+    """test various variants on enum constraints"""
+    schema_file = Path(input_path("enumeration")) / "alternatives.yaml"
+
+    generated_yaml = YAMLGenerator(schema_file).serialize()
+    generated_python = (PythonGenerator(schema_file, mergeimports=False).serialize(),)
+
+    assert generated_yaml == snapshot(Path("enumeration") / "alternatives.yaml")
+    assert generated_python[0] == snapshot(Path("enumeration") / "alternatives.py")
+
+
+def test_notebook_model_1(input_path, snapshot):
+    schema_path = Path(input_path("enumeration")) / "notebook_model_1.yaml"
+    python_path = Path("enumeration") / "notebook_model_1.py"
+
+    generated = PythonGenerator(schema_path, mergeimports=False, gen_classvars=False, gen_slots=False).serialize()
+
+    assert generated == snapshot(python_path)
+
+    module = compile_python(generated)
+    c1 = module.PositionalRecord("my location", "a")
+    assert c1.id == "my location"
+    assert c1.position.code.text == "a"
+    assert c1.position.code.description == "top"
+
+    with pytest.raises(ValueError, match="Unknown OpenEnum enumeration code: z"):
+        module.PositionalRecord("your location", "z")
+
+    x = module.PositionalRecord("117493", "c")
+    assert x.id == "117493"
+    assert x.position.code.text == "c"
+    assert x.position.code.description == "bottom"
+
+
+@pytest.mark.no_asserts
+def test_notebook_model_2(input_path, snapshot):
+    schema_path = Path(input_path("enumeration")) / "notebook_model_2.yaml"
+    python_path = Path("enumeration") / "notebook_model_2.py"
+
+    generated = PythonGenerator(schema_path, mergeimports=False, gen_classvars=False, gen_slots=False).serialize()
+
+    assert generated == snapshot(python_path)
+
+    module = compile_python(generated)
+    module.Sample(
+        "Something",
+        [module.UnusualEnumPatterns.M, module.UnusualEnumPatterns["% ! -- whoo"]],
+    )
+
+
+@pytest.mark.no_asserts
+def test_notebook_model_3(input_path, snapshot):
+    schema_path = Path(input_path("enumeration")) / "notebook_model_3.yaml"
+    python_path = Path("enumeration") / "notebook_model_3.py"
+
+    generated = PythonGenerator(schema_path, mergeimports=False, gen_classvars=False, gen_slots=False).serialize()
+
+    assert generated == snapshot(python_path)
+
+    module = compile_python(generated)
+    module.FavoriteColor("Harold", module.Colors["2"])
+    module.FavoriteColor("Donald", module.Colors["4"])
+
+
+@pytest.mark.no_asserts
+def test_notebook_model_4(input_path, snapshot):
+    schema_path = Path(input_path("enumeration")) / "notebook_model_4.yaml"
+    python_path = Path("enumeration") / "notebook_model_4.py"
+
+    generated = PythonGenerator(schema_path, mergeimports=False, gen_classvars=False, gen_slots=False).serialize()
+
+    assert generated == snapshot(python_path)
+
+    module = compile_python(generated)
+    module.FavoriteColor("Harold", module.Colors["2"])
+    module.FavoriteColor("Donald", module.Colors["4"])

--- a/tests/test_enhancements/test_pattern.py
+++ b/tests/test_enhancements/test_pattern.py
@@ -1,46 +1,46 @@
-import unittest
 from io import StringIO
+from pathlib import Path
 
+import pytest
 import yaml
 from linkml_runtime.utils.compile_python import compile_python
 
 from linkml.generators.pythongen import PythonGenerator
-from tests.test_enhancements.environment import env
-from tests.utils.python_comparator import compare_python
-from tests.utils.test_environment import TestEnvironmentTestCase
-
-d1_test = """
-device: /dev/tty.Bluetooth-Incoming-Port
-label: AbCd0123-1111-FF10-AAF1-A1B2C3D4A1B2C3D4A1B2C3D4
-"""
 
 
-class PatternTestCase(TestEnvironmentTestCase):
-    env = env
-    testdir = "issue_pattern"
+def test_pattern_1(input_path, snapshot):
+    """Test the pattern enhancement"""
+    device = "/dev/tty.Bluetooth-Incoming-Port"
+    label = "AbCd0123-1111-FF10-AAF1-A1B2C3D4A1B2C3D4A1B2C3D4"
+    generated = PythonGenerator(
+        Path(input_path("issue_pattern")) / "pattern_1.yaml",
+        mergeimports=False,
+    ).serialize()
 
-    def test_pattern_1(self):
-        """Test the pattern enhancement"""
-        file = "pattern_1"
-        env.generate_single_file(
-            f"{self.testdir}/{file}.py",
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(f"{self.testdir}/{file}.py")),
-            value_is_returned=True,
-        )
-        module = compile_python(env.expected_path(self.testdir, f"{file}.py"))
-        d1 = yaml.load(StringIO(d1_test), yaml.loader.SafeLoader)
-        dev1 = module.DiskDevice(**d1)
-        self.assertEqual(
-            "DiskDevice(label='AbCd0123-1111-FF10-AAF1-A1B2C3D4A1B2C3D4A1B2C3D4', "
-            "device='/dev/tty.Bluetooth-Incoming-Port')",
-            str(dev1),
-        )
+    assert generated == snapshot(Path("issue_pattern") / "pattern_1.py")
+
+    d1_test = f"""
+    device: {device}
+    label: {label}
+    """
+
+    module = compile_python(generated)
+    d1 = yaml.load(StringIO(d1_test), yaml.loader.SafeLoader)
+    dev1 = module.DiskDevice(**d1)
+    assert dev1.label == label
+    assert dev1.device == device
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.xfail
+def test_pattern_exception(input_path):
+    """
+    Python models should validate patterns, but currently they don't
+    """
+    generated = PythonGenerator(
+        Path(input_path("issue_pattern")) / "pattern_1.yaml",
+        mergeimports=False,
+    ).serialize()
+    module = compile_python(generated)
+
+    with pytest.raises(Exception):
+        module.DiskDevice(device="hey", label="invalid")

--- a/tests/test_enhancements/test_python_output.py
+++ b/tests/test_enhancements/test_python_output.py
@@ -1,12 +1,11 @@
-import unittest
-from typing import Type
+import re
+from pathlib import Path
+from types import ModuleType
 
+import pytest
 from linkml_runtime.utils.compile_python import compile_python
 
 from linkml.generators.pythongen import PythonGenerator
-from tests.test_enhancements.environment import env
-from tests.utils.python_comparator import compare_python
-from tests.utils.test_environment import TestEnvironmentTestCase
 
 
 class NonStr:
@@ -17,15 +16,35 @@ class NonStr:
         return self.v
 
 
-python_types_entries = {
-    "Strings": [
+@pytest.fixture(scope="module")
+def python_types(input_path) -> ModuleType:
+    generated = PythonGenerator(
+        Path(input_path("python_generation")) / "python_types.yaml", mergeimports=False
+    ).serialize()
+    mod = compile_python(generated)
+    return mod
+
+
+def test_python_types_snapshot(input_path, snapshot):
+    generated = PythonGenerator(
+        Path(input_path("python_generation")) / "python_types.yaml", mergeimports=False
+    ).serialize()
+    assert generated == snapshot(Path("python_generation") / "python_types.py")
+
+
+@pytest.mark.strcmp
+@pytest.mark.parametrize(
+    "cls_name,args,argv,expected,err",
+    [
         [
+            "Strings",
             ("s1", "s2", "s3", "s4"),
             {},
             "Strings(mand_string='s1', mand_multi_string=['s2'], opt_string='s3', opt_multi_string=['s4'])",
             None,
         ],
         [
+            "Strings",
             ("s1", ["s21", "s22"], "s3", ["s41", "s42"]),
             {},
             (
@@ -35,18 +54,21 @@ python_types_entries = {
             None,
         ],
         [
+            "Strings",
             ("s1", ["s21", "s22"], None, None),
             {},
             "Strings(mand_string='s1', mand_multi_string=['s21', 's22'], opt_string=None, opt_multi_string=[])",
             None,
         ],
         [
+            "Strings",
             (NonStr("s1"), NonStr("s2"), NonStr("s3"), NonStr("s4")),
             {},
             "Strings(mand_string='s1', mand_multi_string=['s2'], opt_string='s3', opt_multi_string=['s4'])",
             None,
         ],
         [
+            "Strings",
             (
                 NonStr("s1"),
                 [NonStr("s21"), NonStr("s22")],
@@ -60,12 +82,11 @@ python_types_entries = {
             ),
             None,
         ],
-        [(), {}, "mand_string must be supplied", ValueError],
-        [("s1",), {}, "mand_multi_string must be supplied", ValueError],
-        [("s1", []), {}, "mand_multi_string must be supplied", ValueError],
-    ],
-    "Booleans": [
+        ["Strings", (), {}, "mand_string must be supplied", ValueError],
+        ["Strings", ("s1",), {}, "mand_multi_string must be supplied", ValueError],
+        ["Strings", ("s1", []), {}, "mand_multi_string must be supplied", ValueError],
         [
+            "Booleans",
             ("True", "false", 1, [1, 0, True, False]),
             {},
             (
@@ -73,96 +94,48 @@ python_types_entries = {
                 "opt_multi_boolean=[True, False, True, False])"
             ),
             None,
-        ]
-    ],
-    "Integers": [
+        ],
         [
+            "Integers",
             ("17", -2, 12 + 3, [42, "17"]),
             {},
             "Integers(mand_integer=17, mand_multi_integer=[-2], opt_integer=15, opt_multi_integer=[42, 17])",
             None,
         ],
         [
+            "Integers",
             ("17e", 1, 2, 3),
             {},
             "invalid literal for int() with base 10: '17e'",
             ValueError,
         ],
     ],
-}
+)
+def test_python_types(cls_name, args, argv, expected, err, python_types):
+    cls = getattr(python_types, cls_name)
+    if err:
+        with pytest.raises(err, match=re.escape(expected)):
+            cls(*args, **argv)
+    else:
+        inst = cls(*args, **argv)
+        assert str(inst) == expected
 
 
-class PythonOutputTestCase(TestEnvironmentTestCase):
-    env = env
+@pytest.mark.no_asserts
+def test_python_complex_ranges(input_path, snapshot):
+    """description"""
 
-    def check_expecteds(self, constructor: Type, check_entries: str) -> None:
-        checks = python_types_entries[check_entries]
-        for args, argv, expected, err in checks:
-            if not err:
-                inst = constructor(*args, **argv)
-                self.assertEqual(expected, str(inst))
-            else:
-                with self.assertRaises(err) as e:
-                    constructor(*args, **argv)
-                self.assertEqual(expected, str(e.exception))
-
-    def test_python_types(self):
-        """description"""
-        test_dir = "python_generation"
-        test_name = "python_types"
-        python_name = f"{test_dir}/{test_name}.py"
-
-        env.generate_single_file(
-            python_name,
-            lambda: PythonGenerator(
-                env.input_path(test_dir, f"{test_name}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-            ).serialize(),
-            comparator=lambda expected, actual: compare_python(expected, actual, env.expected_path(python_name)),
-            value_is_returned=True,
-        )
-
-        module = compile_python(env.expected_path(python_name))
-
-        self.check_expecteds(module.Strings, "Strings")
-        self.check_expecteds(module.Booleans, "Booleans")
-        self.check_expecteds(module.Integers, "Integers")
-
-    def test_python_complex_ranges(self):
-        """description"""
-        test_dir = "python_generation"
-        test_name = "python_complex_ranges"
-
-        env.generate_single_file(
-            f"{test_dir}/{test_name}.py",
-            lambda: PythonGenerator(
-                env.input_path(test_dir, f"{test_name}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(f"{test_dir}/{test_name}.py")),
-            value_is_returned=True,
-        )
-
-    @staticmethod
-    def test_python_lists_and_keys():
-        """description"""
-        test_dir = "python_generation"
-        test_name = "python_lists_and_keys"
-        test_path = f"{test_dir}/{test_name}.py"
-
-        env.generate_single_file(
-            test_path,
-            lambda: PythonGenerator(
-                env.input_path(test_dir, f"{test_name}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-            ).serialize(),
-            comparator=lambda expected, actual: compare_python(expected, actual, env.expected_path(test_path)),
-            value_is_returned=True,
-        )
+    generated = PythonGenerator(
+        Path(input_path("python_generation")) / "python_complex_ranges.yaml", mergeimports=False
+    ).serialize()
+    assert generated == snapshot(Path("python_generation") / "python_complex_ranges.py")
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.no_asserts
+def test_python_lists_and_keys(input_path, snapshot):
+    """description"""
+
+    generated = PythonGenerator(
+        Path(input_path("python_generation")) / "python_lists_and_keys.yaml", mergeimports=False
+    ).serialize()
+    assert generated == snapshot(Path("python_generation") / "python_lists_and_keys.py")

--- a/tests/test_enhancements/test_string_serialization.py
+++ b/tests/test_enhancements/test_string_serialization.py
@@ -1,29 +1,13 @@
-import unittest
+from pathlib import Path
+
+import pytest
 
 from linkml.generators.pythongen import PythonGenerator
-from tests.test_enhancements.environment import env
-from tests.utils.python_comparator import compare_python
-from tests.utils.test_environment import TestEnvironmentTestCase
 
 
-class StringSerializationTestCase(TestEnvironmentTestCase):
-    env = env
-    testdir = "string_serialization"
-
-    def test_simple_example(self):
-        """Test evidence enumeration"""
-        file = "simple_example"
-        env.generate_single_file(
-            f"{self.testdir}/{file}.py",
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(f"{self.testdir}/{file}.py")),
-            value_is_returned=True,
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.no_asserts
+def test_simple_example(input_path, snapshot):
+    generated = PythonGenerator(
+        Path(input_path("string_serialization")) / "simple_example.yaml", mergeimports=False
+    ).serialize()
+    assert generated == snapshot(Path("string_serialization") / "simple_example.py")

--- a/tests/test_enhancements/test_string_template.py
+++ b/tests/test_enhancements/test_string_template.py
@@ -1,42 +1,26 @@
-import unittest
+from pathlib import Path
 
+import pytest
 from linkml_runtime.utils.compile_python import compile_python
 from linkml_runtime.utils.yamlutils import from_yaml
 
 from linkml.generators.pythongen import PythonGenerator
-from tests.test_enhancements.environment import env
-from tests.utils.python_comparator import compare_python
-from tests.utils.test_environment import TestEnvironmentTestCase
 
 
-class TemplateTestCase(TestEnvironmentTestCase):
-    env = env
-    testdir = "string_template"
+@pytest.mark.xfail
+def test_template_basics(input_path, snapshot):
+    """Test the basics of a string template"""
+    generated = PythonGenerator(
+        Path(input_path("string_template")) / "templated_classes.yaml", mergeimports=False
+    ).serialize()
+    assert generated == snapshot(Path("string_template") / "templated_classes.py")
 
-    @unittest.skip("Need update to linkml-model and supporting software first")
-    def test_template_basics(self):
-        """Test the basics of a string template"""
-        file = "templated_classes"
-        env.generate_single_file(
-            f"{self.testdir}/{file}.py",
-            lambda: PythonGenerator(
-                env.input_path(self.testdir, f"{file}.yaml"),
-                importmap=env.import_map,
-                mergeimports=False,
-            ).serialize(),
-            comparator=lambda exp, act: compare_python(exp, act, self.env.expected_path(f"{self.testdir}/{file}.py")),
-            value_is_returned=True,
-        )
-        module = compile_python(env.expected_path(self.testdir, f"{file}.py"))
-        inst = module.FirstClass("Sam Sneed", 42, "Male")
-        self.assertEqual("Sam Sneed - a 42 year old Male", str(inst))
-        inst2 = module.FirstClass.parse("Jillian Johnson - a 93 year old female")
-        self.assertEqual("FirstClass(name='Jillian Johnson', age=93, gender='female')", repr(inst2))
-        self.assertEqual("Jillian Johnson - a 93 year old female", str(inst2))
-        with open(env.input_path(self.testdir, "jones.yaml")) as yf:
-            inst3 = from_yaml(yf, module.FirstClass)
-        self.assertEqual("Freddy Buster Jones - a 11 year old Undetermined", str(inst3))
-
-
-if __name__ == "__main__":
-    unittest.main()
+    module = compile_python(generated)
+    inst = module.FirstClass("Sam Sneed", 42, "Male")
+    assert "Sam Sneed - a 42 year old Male" == str(inst)
+    inst2 = module.FirstClass.parse("Jillian Johnson - a 93 year old female")
+    assert "FirstClass(name='Jillian Johnson', age=93, gender='female')" == repr(inst2)
+    assert "Jillian Johnson - a 93 year old female" == str(inst2)
+    with open(Path(input_path("string_template")) / "jones.yaml") as yf:
+        inst3 = from_yaml(yf, module.FirstClass)
+    assert "Freddy Buster Jones - a 11 year old Undetermined" == str(inst3)


### PR DESCRIPTION
Fix: https://github.com/linkml/linkml/issues/1718

Other stuff:
- Make pythongen, generator, rawloader, schemaloader accept `Path`s, at least nominally so type checkers stop complaining.
- same with `snapshot`
- add marks:
  - `no_asserts`: for keeping track of the tests that are just print statements, just snapshot comparisons, or otherwise don't make meaningful assertions - we'll want to consolidate these and make sure we have unit tests for all the behavior they test perhaps indirectly
  - `strcmp`: tests that primarily compare stringified values rather than programmatic values - these are fragile and indirect, break when the string representation of anything changes, and can't use `__eq__` of the native object types. we'll also want to progressively clean these up.
- started making tests xfail rather than skip so we know when we actually fix them/remind ourselves that we intended to turn them back on eventually
- add xfailing tests for pythongen pattern validation
- `Generator` had a `log_level` param but didn't use it, so i made it use it.

one step closer to not having to dodge outputs!