### PR TITLE
[pydanticgen] implement `string_serialization`

### DIFF
--- a/linkml/generators/pydanticgen/black.py
+++ b/linkml/generators/pydanticgen/black.py
@@ -18,6 +18,7 @@ except ImportError:
 def _default_mode() -> "Mode":
     return Mode(
         target_versions={TargetVersion.PY311},
+        line_length=120
     )
 
 

--- a/linkml/generators/pydanticgen/black.py
+++ b/linkml/generators/pydanticgen/black.py
@@ -16,10 +16,7 @@ except ImportError:
 
 
 def _default_mode() -> "Mode":
-    return Mode(
-        target_versions={TargetVersion.PY311},
-        line_length=120
-    )
+    return Mode(target_versions={TargetVersion.PY311}, line_length=120)
 
 
 def format_black(code: str, mode: Optional["Mode"] = None) -> str:

--- a/linkml/generators/pydanticgen/includes.py
+++ b/linkml/generators/pydanticgen/includes.py
@@ -1,0 +1,46 @@
+"""
+Classes to inject in generated pydantic models
+"""
+from typing import Dict, Any
+from pydantic import BaseModel
+from pydantic.version import VERSION
+PYDANTIC_VERSION = int(VERSION[0])
+
+
+LinkMLMeta_v1 = """
+class LinkMLMeta(BaseModel):
+    __root__: Dict[str, Any] = {}
+    
+    def __getattr__(self, key:str):
+        return getattr(self.__root__, key)
+        
+    def __getitem__(self, key:str):
+        return self.__root__[key]
+    
+    def __setitem__(self, key:str, value):
+        self.__root__[key] = value
+   
+    class Config:
+        allow_mutation = False
+"""
+
+LinkMLMeta_v2 = """
+class LinkMLMeta(RootModel):
+    root: Dict[str, Any] = {}
+    model_config = ConfigDict(frozen=True)
+    
+    def __getattr__(self, key:str):
+        return getattr(self.root, key)
+        
+    def __getitem__(self, key:str):
+        return self.root[key]
+    
+    def __setitem__(self, key:str, value):
+        self.root[key] = value
+    
+"""
+
+# if PYDANTIC_VERSION >= 2:
+#     LinkMLMeta = eval(LinkMLMeta_v2)
+# else:
+#     LinkMLMeta = eval(LinkMLMeta_v1)

--- a/linkml/generators/pydanticgen/includes.py
+++ b/linkml/generators/pydanticgen/includes.py
@@ -1,9 +1,9 @@
 """
 Classes to inject in generated pydantic models
 """
-from typing import Dict, Any
-from pydantic import BaseModel
+
 from pydantic.version import VERSION
+
 PYDANTIC_VERSION = int(VERSION[0])
 
 

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -639,9 +639,7 @@ class PydanticGenerator(OOCodeGenerator):
             for attribute in list(class_def.attributes.keys()):
                 del class_def.attributes[attribute]
             for sn in sv.class_slots(class_name):
-                # TODO: fix runtime, copy should not be necessary
-                s = deepcopy(sv.induced_slot(sn, class_name))
-                # logging.error(f'Induced slot {class_name}.{sn} == {s.name} {s.range}')
+                s = sv.induced_slot(sn, class_name)
                 s.name = underscore(s.name)
                 if s.description:
                     s.description = s.description.replace('"', '\\"')
@@ -738,7 +736,11 @@ class PydanticGenerator(OOCodeGenerator):
                 attrs[attr_name] = self.include_metadata(attrs[attr_name], src_attr)
 
             new_class = PydanticClass(
-                name=k, attributes=attrs, description=c.description, pydantic_ver=self.pydantic_version
+                name=k,
+                attributes=attrs,
+                description=c.description,
+                pydantic_ver=self.pydantic_version,
+                string_serialization=c.string_serialization,
             )
             new_class = self.include_metadata(new_class, c)
             if k in bases:

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -5,7 +5,7 @@ import textwrap
 from collections import defaultdict
 from copy import copy, deepcopy
 from dataclasses import dataclass, field
-from enum import Enum, auto
+from enum import Enum
 from pathlib import Path
 from types import ModuleType
 from typing import Dict, List, Literal, Optional, Set, Type, TypeVar, Union, overload
@@ -103,18 +103,18 @@ DEFAULT_IMPORTS = (
 DEFAULT_INJECTS = {1: [includes.LinkMLMeta_v1], 2: [includes.LinkMLMeta_v2]}
 
 
-class MetadataMode(Enum):
-    FULL = auto()
+class MetadataMode(str, Enum):
+    FULL = "full"
     """
     all metadata from the source schema will be included, even if it is represented by the template classes, 
     and even if it is represented by some child class (eg. "classes" will be included with schema metadata
     """
-    EXCEPT_CHILDREN = auto()
+    EXCEPT_CHILDREN = "except_children"
     """
     all metadata from the source schema will be included, even if it is represented by the template classes,
     except if it is represented by some child template class (eg. "classes" will be excluded from schema metadata)
     """
-    AUTO = auto()
+    AUTO = "auto"
     """
     Only the metadata that isn't represented by the template classes or excluded with ``meta_exclude`` will be included 
     """
@@ -591,7 +591,10 @@ class PydanticGenerator(OOCodeGenerator):
         elif self.metadata_mode in (MetadataMode.FULL, MetadataMode.FULL.value):
             meta = remove_empty_items(source)
         else:
-            raise ValueError("Unknown metadata mode, needs to be one of MetadataMode")
+            raise ValueError(
+                f"Unknown metadata mode '{self.metadata_mode}', needs to be one of "
+                f"{[mode.value for mode in MetadataMode]}"
+            )
 
         model.meta = meta
         return model

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -230,7 +230,7 @@ class PydanticGenerator(OOCodeGenerator):
             from typing_extensions import Literal
         
     """
-    metadata_mode: MetadataMode = MetadataMode.AUTO
+    metadata_mode: Union[MetadataMode, str, None] = MetadataMode.AUTO
     """
     How to include schema metadata in generated pydantic models.
     

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -573,11 +573,17 @@ class PydanticGenerator(OOCodeGenerator):
         elif self.metadata_mode in (MetadataMode.AUTO, MetadataMode.AUTO.value):
             meta = {k: v for k, v in remove_empty_items(source).items() if k not in model.exclude_from_meta()}
         elif self.metadata_mode in (MetadataMode.EXCEPT_CHILDREN, MetadataMode.EXCEPT_CHILDREN.value):
-            meta = {
-                k: v
-                for k, v in remove_empty_items(source).items()
-                if not isinstance(getattr(model, k, None), TemplateModel)
-            }
+            meta = {}
+            for k,v in remove_empty_items(source).items():
+                if not hasattr(model, k):
+                    meta[k] = v
+                elif isinstance(getattr(model, k), list) and not any([isinstance(item, TemplateModel) for item in getattr(model, k)]):
+                    meta[k] = v
+                elif isinstance(getattr(model, k), dict) and not any([isinstance(item, TemplateModel) for item in getattr(model, k).values()]):
+                    meta[k] = v
+                elif not isinstance(getattr(model, k), TemplateModel):
+                    meta[k] = v
+
         elif self.metadata_mode in (MetadataMode.FULL, MetadataMode.FULL.value):
             meta = remove_empty_items(source)
         else:

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -744,6 +744,12 @@ Available templates to override:
     default="forbid",
     help="How to handle extra fields in BaseModel.",
 )
+@click.option(
+    "--black",
+    is_flag=True,
+    default=False,
+    help="Format generated models with black (must be present in the environment)"
+)
 @click.version_option(__version__, "-V", "--version")
 @click.command()
 def cli(
@@ -757,6 +763,7 @@ def cli(
     array_representations=list("list"),
     pydantic_version=1,
     extra_fields: Literal["allow", "forbid", "ignore"] = "forbid",
+    black:bool=False,
     **args,
 ):
     """Generate pydantic classes to represent a LinkML model"""
@@ -782,6 +789,7 @@ def cli(
         gen_classvars=classvars,
         gen_slots=slots,
         template_dir=template_dir,
+        black=black,
         **args,
     )
     print(gen.serialize())

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -27,9 +27,8 @@ from linkml_runtime.linkml_model.meta import (
     TypeDefinition,
 )
 from linkml_runtime.utils.compile_python import compile_python
-from linkml_runtime.utils.formatutils import camelcase, underscore
+from linkml_runtime.utils.formatutils import camelcase, underscore, remove_empty_items
 from linkml_runtime.utils.schemaview import SchemaView
-from linkml_runtime.utils.yamlutils import remove_empty_items
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 from linkml._version import __version__

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -564,7 +564,7 @@ class PydanticGenerator(OOCodeGenerator):
 
         Metadata inclusion mode is dependent on :attr:`.metadata_mode` - see:
 
-        - :enum:`.MetadataMode`
+        - :class:`.MetadataMode`
         - :meth:`.TemplateModel.exclude_from_meta`
 
         """
@@ -574,12 +574,16 @@ class PydanticGenerator(OOCodeGenerator):
             meta = {k: v for k, v in remove_empty_items(source).items() if k not in model.exclude_from_meta()}
         elif self.metadata_mode in (MetadataMode.EXCEPT_CHILDREN, MetadataMode.EXCEPT_CHILDREN.value):
             meta = {}
-            for k,v in remove_empty_items(source).items():
+            for k, v in remove_empty_items(source).items():
                 if not hasattr(model, k):
                     meta[k] = v
-                elif isinstance(getattr(model, k), list) and not any([isinstance(item, TemplateModel) for item in getattr(model, k)]):
+                elif isinstance(getattr(model, k), list) and not any(
+                    [isinstance(item, TemplateModel) for item in getattr(model, k)]
+                ):
                     meta[k] = v
-                elif isinstance(getattr(model, k), dict) and not any([isinstance(item, TemplateModel) for item in getattr(model, k).values()]):
+                elif isinstance(getattr(model, k), dict) and not any(
+                    [isinstance(item, TemplateModel) for item in getattr(model, k).values()]
+                ):
                     meta[k] = v
                 elif not isinstance(getattr(model, k), TemplateModel):
                     meta[k] = v

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -28,8 +28,8 @@ from linkml_runtime.linkml_model.meta import (
 )
 from linkml_runtime.utils.compile_python import compile_python
 from linkml_runtime.utils.formatutils import camelcase, underscore
-from linkml_runtime.utils.yamlutils import remove_empty_items
 from linkml_runtime.utils.schemaview import SchemaView
+from linkml_runtime.utils.yamlutils import remove_empty_items
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 from linkml._version import __version__
@@ -38,6 +38,7 @@ from linkml.generators.common.type_designators import (
     get_type_designator_value,
 )
 from linkml.generators.oocodegen import OOCodeGenerator
+from linkml.generators.pydanticgen import includes
 from linkml.generators.pydanticgen.array import ArrayRangeGenerator, ArrayRepresentation
 from linkml.generators.pydanticgen.build import SlotResult
 from linkml.generators.pydanticgen.template import (
@@ -51,7 +52,6 @@ from linkml.generators.pydanticgen.template import (
     PydanticModule,
     TemplateModel,
 )
-from linkml.generators.pydanticgen import includes
 from linkml.utils.generator import shared_arguments
 from linkml.utils.ifabsent_functions import ifabsent_value_declaration
 
@@ -108,10 +108,7 @@ DEFAULT_IMPORTS = (
     )
 )
 
-DEFAULT_INJECTS = {
-    1: [includes.LinkMLMeta_v1],
-    2: [includes.LinkMLMeta_v2]
-}
+DEFAULT_INJECTS = {1: [includes.LinkMLMeta_v1], 2: [includes.LinkMLMeta_v2]}
 
 
 @dataclass
@@ -663,11 +660,15 @@ class PydanticGenerator(OOCodeGenerator):
                     predef_slot = str(predef_slot)
                 new_fields["predefined"] = predef_slot
                 new_fields["name"] = attr_name
-                attr_meta = {k:v for k,v in remove_empty_items(src_attr).items() if k not in PydanticAttribute.exclude_from_meta() }
+                attr_meta = {
+                    k: v
+                    for k, v in remove_empty_items(src_attr).items()
+                    if k not in PydanticAttribute.exclude_from_meta()
+                }
 
                 attrs[attr_name] = PydanticAttribute(**new_fields, pydantic_ver=self.pydantic_version, meta=attr_meta)
 
-            class_meta = {k:v for k,v in remove_empty_items(c).items() if k not in PydanticClass.exclude_from_meta() }
+            class_meta = {k: v for k, v in remove_empty_items(c).items() if k not in PydanticClass.exclude_from_meta()}
 
             new_class = PydanticClass(
                 name=k, attributes=attrs, description=c.description, pydantic_ver=self.pydantic_version, meta=class_meta
@@ -676,7 +677,9 @@ class PydanticGenerator(OOCodeGenerator):
                 new_class.bases = bases[k]
             classes[k] = new_class
 
-        schema_meta = {k:v for k,v in remove_empty_items(schema).items() if k not in PydanticModule.exclude_from_meta() }
+        schema_meta = {
+            k: v for k, v in remove_empty_items(schema).items() if k not in PydanticModule.exclude_from_meta()
+        }
 
         module = PydanticModule(
             pydantic_ver=self.pydantic_version,
@@ -687,7 +690,7 @@ class PydanticGenerator(OOCodeGenerator):
             injected_classes=injected_classes,
             enums=enums,
             classes=classes,
-            meta=schema_meta
+            meta=schema_meta,
         )
         return module
 
@@ -748,7 +751,7 @@ Available templates to override:
     "--black",
     is_flag=True,
     default=False,
-    help="Format generated models with black (must be present in the environment)"
+    help="Format generated models with black (must be present in the environment)",
 )
 @click.version_option(__version__, "-V", "--version")
 @click.command()
@@ -763,7 +766,7 @@ def cli(
     array_representations=list("list"),
     pydantic_version=1,
     extra_fields: Literal["allow", "forbid", "ignore"] = "forbid",
-    black:bool=False,
+    black: bool = False,
     **args,
 ):
     """Generate pydantic classes to represent a LinkML model"""

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -303,6 +303,7 @@ class PydanticClass(TemplateModel):
     bases: Union[List[str], str] = PydanticBaseModel.default_name
     description: Optional[str] = None
     attributes: Optional[Dict[str, PydanticAttribute]] = None
+    string_serialization: Optional[str] = None
     meta: Optional[Dict[str, Any]] = None
     """
     Metadata for the class to be included in a linkml_meta class attribute

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -1,9 +1,11 @@
+import pdb
 from importlib.util import find_spec
-from typing import Any, ClassVar, Dict, Generator, List, Literal, Optional, Union, overload
+from typing import Any, ClassVar, Dict, Generator, List, Literal, Optional, Tuple, Union, overload
 
 from jinja2 import Environment, PackageLoader
 from pydantic import BaseModel, Field
 from pydantic.version import VERSION as PYDANTIC_VERSION
+
 
 try:
     if find_spec("black") is not None:
@@ -55,6 +57,7 @@ class TemplateModel(BaseModel):
 
     template: ClassVar[str]
     pydantic_ver: int = int(PYDANTIC_VERSION[0])
+    meta_exclude: ClassVar[List[str]] = None
 
     def render(self, environment: Optional[Environment] = None, black: bool = False) -> str:
         """
@@ -129,6 +132,17 @@ class TemplateModel(BaseModel):
             if mode == "json":
                 return self.json(**kwargs)
             return self.dict(**kwargs)
+
+    @classmethod
+    def exclude_from_meta(cls: 'TemplateModel') -> List[str]:
+        """
+        Attributes in the source definition to exclude from linkml_meta
+        """
+        #pdb.set_trace()
+        ret = [*cls.model_fields.keys()]
+        if cls.meta_exclude is not None:
+            ret = ret + cls.meta_exclude
+        return ret
 
 
 def _render(
@@ -211,6 +225,7 @@ class PydanticAttribute(TemplateModel):
     """
 
     template: ClassVar[str] = "attribute.py.jinja"
+    meta_exclude: ClassVar[List[str]] = ['from_schema', 'owner', 'range', 'multivalued', 'inlined', 'inlined_as_list']
 
     name: str
     required: bool = False
@@ -235,6 +250,10 @@ class PydanticAttribute(TemplateModel):
     minimum_value: Optional[Union[int, float]] = None
     maximum_value: Optional[Union[int, float]] = None
     pattern: Optional[str] = None
+    meta: Optional[Dict[str, Any]] = None
+    """
+    Metadata for the slot to be included in a Field annotation
+    """
 
     if int(PYDANTIC_VERSION[0]) >= 2:
 
@@ -281,11 +300,18 @@ class PydanticClass(TemplateModel):
     """
 
     template: ClassVar[str] = "class.py.jinja"
+    meta_exclude: ClassVar[List[str]] = ['slots', 'is_a']
 
     name: str
     bases: Union[List[str], str] = PydanticBaseModel.default_name
     description: Optional[str] = None
     attributes: Optional[Dict[str, PydanticAttribute]] = None
+    meta: Optional[Dict[str, Any]] = None
+    """
+    Metadata for the class to be included in a linkml_meta class attribute
+    """
+
+
 
     def _validators(self) -> Optional[Dict[str, PydanticValidator]]:
         if self.attributes is None:
@@ -546,6 +572,7 @@ class PydanticModule(TemplateModel):
     """
 
     template: ClassVar[str] = "module.py.jinja"
+    meta_exclude: ClassVar[str] = ['slots']
 
     metamodel_version: Optional[str] = None
     version: Optional[str] = None
@@ -554,6 +581,11 @@ class PydanticModule(TemplateModel):
     imports: List[Union[Import, ConditionalImport]] = Field(default_factory=list)
     enums: Dict[str, PydanticEnum] = Field(default_factory=dict)
     classes: Dict[str, PydanticClass] = Field(default_factory=dict)
+    meta: Optional[Dict[str, Any]] = None
+    """
+    Metadata for the schema to be included in a linkml_meta module-level instance of LinkMLMeta
+    """
+
 
     if int(PYDANTIC_VERSION[0]) >= 2:
 

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -1,11 +1,9 @@
-import pdb
 from importlib.util import find_spec
-from typing import Any, ClassVar, Dict, Generator, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, ClassVar, Dict, Generator, List, Literal, Optional, Union, overload
 
 from jinja2 import Environment, PackageLoader
 from pydantic import BaseModel, Field
 from pydantic.version import VERSION as PYDANTIC_VERSION
-
 
 try:
     if find_spec("black") is not None:
@@ -134,11 +132,10 @@ class TemplateModel(BaseModel):
             return self.dict(**kwargs)
 
     @classmethod
-    def exclude_from_meta(cls: 'TemplateModel') -> List[str]:
+    def exclude_from_meta(cls: "TemplateModel") -> List[str]:
         """
         Attributes in the source definition to exclude from linkml_meta
         """
-        #pdb.set_trace()
         ret = [*cls.model_fields.keys()]
         if cls.meta_exclude is not None:
             ret = ret + cls.meta_exclude
@@ -225,7 +222,7 @@ class PydanticAttribute(TemplateModel):
     """
 
     template: ClassVar[str] = "attribute.py.jinja"
-    meta_exclude: ClassVar[List[str]] = ['from_schema', 'owner', 'range', 'multivalued', 'inlined', 'inlined_as_list']
+    meta_exclude: ClassVar[List[str]] = ["from_schema", "owner", "range", "multivalued", "inlined", "inlined_as_list"]
 
     name: str
     required: bool = False
@@ -300,7 +297,7 @@ class PydanticClass(TemplateModel):
     """
 
     template: ClassVar[str] = "class.py.jinja"
-    meta_exclude: ClassVar[List[str]] = ['slots', 'is_a']
+    meta_exclude: ClassVar[List[str]] = ["slots", "is_a"]
 
     name: str
     bases: Union[List[str], str] = PydanticBaseModel.default_name
@@ -310,8 +307,6 @@ class PydanticClass(TemplateModel):
     """
     Metadata for the class to be included in a linkml_meta class attribute
     """
-
-
 
     def _validators(self) -> Optional[Dict[str, PydanticValidator]]:
         if self.attributes is None:
@@ -572,7 +567,7 @@ class PydanticModule(TemplateModel):
     """
 
     template: ClassVar[str] = "module.py.jinja"
-    meta_exclude: ClassVar[str] = ['slots']
+    meta_exclude: ClassVar[str] = ["slots"]
 
     metamodel_version: Optional[str] = None
     version: Optional[str] = None
@@ -585,7 +580,6 @@ class PydanticModule(TemplateModel):
     """
     Metadata for the schema to be included in a linkml_meta module-level instance of LinkMLMeta
     """
-
 
     if int(PYDANTIC_VERSION[0]) >= 2:
 

--- a/linkml/generators/pydanticgen/templates/__str__.py.jinja
+++ b/linkml/generators/pydanticgen/templates/__str__.py.jinja
@@ -1,0 +1,8 @@
+    def __str__(self) -> str:
+        if self.linkml_meta is not None:
+            kwargs = self.linkml_meta
+        else:
+            kwargs = {}
+
+        kwargs.update(self.model_dump())
+        return '''{{ string_serialization | replace("'''", "") }}'''.format(**kwargs)

--- a/linkml/generators/pydanticgen/templates/attribute.py.jinja
+++ b/linkml/generators/pydanticgen/templates/attribute.py.jinja
@@ -7,4 +7,10 @@
     {%- if minimum_value != None %}, ge={{minimum_value}}{% endif -%}
     {%- if maximum_value != None %}, le={{maximum_value}}{% endif -%}
 {%- endif -%}
-)
+{%- if meta != None -%}
+    {%- if pydantic_ver == 1 -%}
+    , linkml_meta = {{ meta | pprint | indent(width=8) }}
+    {% else -%}
+    , json_schema_extra = { "linkml_meta": {{ meta | pprint | indent(width=8) }} }
+    {%- endif -%}
+{%- endif -%})

--- a/linkml/generators/pydanticgen/templates/class.py.jinja
+++ b/linkml/generators/pydanticgen/templates/class.py.jinja
@@ -20,6 +20,9 @@ class {{ name }}({% if bases is string %}{{ bases }}{% else %}{{ bases | join(',
     {{ validator }}
             {% endfor -%}
         {% endif %}
+        {% if string_serialization %}
+    {% include '__str__.py.jinja' %}
+        {% endif %}
     {% else %}
     pass
     {% endif %}

--- a/linkml/generators/pydanticgen/templates/class.py.jinja
+++ b/linkml/generators/pydanticgen/templates/class.py.jinja
@@ -5,7 +5,7 @@ class {{ name }}({% if bases is string %}{{ bases }}{% else %}{{ bases | join(',
     """
     {% endif -%}
     {% if meta != None %}
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({{ meta | pprint | indent(width=8) }})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({% if pydantic_ver == 1 %}__root__={% endif %}{{ meta | pprint | indent(width=8) }})
 
     {% endif %}
     {%  if attributes or validators %}

--- a/linkml/generators/pydanticgen/templates/class.py.jinja
+++ b/linkml/generators/pydanticgen/templates/class.py.jinja
@@ -21,6 +21,7 @@ class {{ name }}({% if bases is string %}{{ bases }}{% else %}{{ bases | join(',
             {% endfor -%}
         {% endif %}
         {% if string_serialization %}
+
     {% include '__str__.py.jinja' %}
         {% endif %}
     {% else %}

--- a/linkml/generators/pydanticgen/templates/class.py.jinja
+++ b/linkml/generators/pydanticgen/templates/class.py.jinja
@@ -4,6 +4,10 @@ class {{ name }}({% if bases is string %}{{ bases }}{% else %}{{ bases | join(',
     {{ description | indent(width=4) }}
     """
     {% endif -%}
+    {% if meta != None %}
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({{ meta | pprint | indent(width=8) }})
+
+    {% endif %}
     {%  if attributes or validators %}
         {% if attributes %}
             {% for attr in attributes.values() %}

--- a/linkml/generators/pydanticgen/templates/module.py.jinja
+++ b/linkml/generators/pydanticgen/templates/module.py.jinja
@@ -15,7 +15,7 @@ version = "{{version if version else None}}"
     {% endfor %}
 {% endif %}
 {% if meta != None %}
-linkml_meta = LinkMLMeta({{ meta | pprint | indent(width=4) }} )
+linkml_meta = LinkMLMeta({% if pydantic_ver == 1 %}__root__={% endif %}{{ meta | pprint | indent(width=4) }} )
 {% else %}
 linkml_meta = None
 {% endif %}

--- a/linkml/generators/pydanticgen/templates/module.py.jinja
+++ b/linkml/generators/pydanticgen/templates/module.py.jinja
@@ -7,18 +7,25 @@ version = "{{version if version else None}}"
 
 
 {{ base_model }}
-{% if enums %}
-    {% for e in enums.values() %}
 
-{{ e }}
-    {% endfor %}
-{% endif %}
 {% if injected_classes %}
     {% for c in injected_classes%}
 
 {{ c }}
     {% endfor %}
 {% endif %}
+{% if meta != None %}
+linkml_meta = LinkMLMeta({{ meta | pprint | indent(width=4) }} )
+{% else %}
+linkml_meta = None
+{% endif %}
+{% if enums %}
+    {% for e in enums.values() %}
+
+{{ e }}
+    {% endfor %}
+{% endif %}
+
 {% for c in classes.values() %}
 
 {{ c }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import shutil
 import sys
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from importlib.abc import MetaPathFinder
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, ClassVar, Dict, Optional, Set
 
 import pytest
 import requests_cache
@@ -11,6 +12,7 @@ from _pytest.assertion.util import _diff_text
 from linkml_runtime.linkml_model.meta import SchemaDefinition
 
 import tests
+from linkml.utils.generator import Generator
 from tests.utils.compare_rdf import compare_rdf
 from tests.utils.dirutils import are_dir_trees_equal
 
@@ -250,3 +252,19 @@ def mock_black_import():
 
     sys.modules.update(removed)
     sys.meta_path.remove(meta_finder)
+
+
+@dataclass
+class Compliance:
+    _implements: ClassVar[Dict[str, Set[Generator]]] = {}
+
+    @classmethod
+    def implements(cls, term: str, generator: Generator):
+        if term not in cls._implements:
+            cls._implements[term] = set()
+        cls._implements[term].add(generator)
+
+
+@pytest.fixture(scope="function")
+def compliance():
+    return Compliance

--- a/tests/test_compliance/test_array_compliance.py
+++ b/tests/test_compliance/test_array_compliance.py
@@ -111,7 +111,7 @@ def test_array(framework, description, ndim, object, is_valid):
                         "exact_number_dimensions": ndim,
                     },
                     "_mappings": {
-                        PYDANTIC: f"s1: Optional[{expected_range[ndim]}] = Field(None)",
+                        PYDANTIC: f"s1: Optional[{expected_range[ndim]}] = Field(None",
                     },
                 },
             },

--- a/tests/test_compliance/test_boolean_slot_compliance.py
+++ b/tests/test_compliance/test_boolean_slot_compliance.py
@@ -1440,7 +1440,7 @@ def test_min_max(framework, min_val, max_val, equals_number: Optional[int], valu
                     "equals_number": equals_number,
                     "_mappings": {
                         PYDANTIC: (
-                            f"{SLOT_S1}: int = Field(..., ge={min_val}, le={max_val})" if not equals_number else ""
+                            f"{SLOT_S1}: int = Field(..., ge={min_val}, le={max_val}" if not equals_number else ""
                         )
                     },
                 },

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -89,7 +89,7 @@ def test_attributes(framework, description, object, is_valid):
             "attributes": {
                 SLOT_S1: {
                     "_mappings": {
-                        PYDANTIC: "s1: Optional[str] = Field(None)",
+                        PYDANTIC: "s1: Optional[str] = Field(None",
                         PYTHON_DATACLASSES: "s1: Optional[str] = None",
                     }
                 },
@@ -456,10 +456,10 @@ def test_cardinality(framework, multivalued, required, data_name, value):
     :return:
     """
     choices = {
-        (PYDANTIC, False, False): "Optional[str] = Field(None)",
-        (PYDANTIC, False, True): "str = Field(...)",
-        (PYDANTIC, True, False): "Optional[List[str]] = Field(default_factory=list)",
-        (PYDANTIC, True, True): "List[str] = Field(default_factory=list)",
+        (PYDANTIC, False, False): "Optional[str] = Field(None",
+        (PYDANTIC, False, True): "str = Field(...",
+        (PYDANTIC, True, False): "Optional[List[str]] = Field(default_factory=list",
+        (PYDANTIC, True, True): "List[str] = Field(default_factory=list",
         # TODO: values
         (PYTHON_DATACLASSES, False, False): "",
         (PYTHON_DATACLASSES, False, True): "",

--- a/tests/test_compliance/test_designates_type_compliance.py
+++ b/tests/test_compliance/test_designates_type_compliance.py
@@ -83,9 +83,7 @@ def test_designates_type(framework, description, type_range, object, is_valid, o
                     "range": type_range,
                     "_mappings": {
                         PYDANTIC: (
-                            f'{SLOT_TYPE}: Literal["{CLASS_C1}"] = Field("{CLASS_C1}")'
-                            if type_range == "string"
-                            else ""
+                            f'{SLOT_TYPE}: Literal["{CLASS_C1}"] = Field("{CLASS_C1}"' if type_range == "string" else ""
                         ),
                     },
                 },

--- a/tests/test_compliance/test_inheritance_compliance.py
+++ b/tests/test_compliance/test_inheritance_compliance.py
@@ -126,7 +126,7 @@ def test_basic_class_inheritance(framework, description, cls: str, object, is_va
             "attributes": {
                 SLOT_S1: {
                     "_mappings": {
-                        PYDANTIC: "s1: Optional[str] = Field(None)",
+                        PYDANTIC: "s1: Optional[str] = Field(None",
                         PYTHON_DATACLASSES: "s1: Optional[str] = None",
                     }
                 },
@@ -260,7 +260,7 @@ def test_mixins(framework, description, cls, object, is_valid):
             "attributes": {
                 SLOT_S1: {
                     "_mappings": {
-                        PYDANTIC: "s1: Optional[str] = Field(None)",
+                        PYDANTIC: "s1: Optional[str] = Field(None",
                         PYTHON_DATACLASSES: "s1: Optional[str] = None",
                     }
                 },

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -1,6 +1,5 @@
 import importlib
 import inspect
-import pdb
 import sys
 import typing
 from contextlib import nullcontext as does_not_raise
@@ -1776,4 +1775,3 @@ attr: {attr}
         annotations={"meta": {"value": meta_str_value}}, aliases=alias_values, attr=attr_str_value
     )
     compliance.implements("string_serialization", PydanticGenerator)
-    pdb.set_trace()

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -1,5 +1,7 @@
 import importlib
 import inspect
+import pdb
+import sys
 import typing
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
@@ -7,7 +9,12 @@ from importlib.metadata import version
 from importlib.util import find_spec
 from pathlib import Path
 from types import GeneratorType, ModuleType
-from typing import Callable, ClassVar, Dict, List, Literal, Optional, ParamSpec, Union, get_args, get_origin
+from typing import Callable, ClassVar, Dict, List, Literal, Optional, Union, get_args, get_origin
+
+if sys.version_info.minor >= 10:
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 import numpy as np
 import pytest
@@ -1769,3 +1776,4 @@ attr: {attr}
         annotations={"meta": {"value": meta_str_value}}, aliases=alias_values, attr=attr_str_value
     )
     compliance.implements("string_serialization", PydanticGenerator)
+    pdb.set_trace()

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -187,11 +187,9 @@ slots:
         """
     gen = PydanticGenerator(schema_str, package=PACKAGE)
     code = gen.serialize()
-    lines = code.splitlines()
-    ix = lines.index("class C(ConfiguredBaseModel):")
-    assert lines[ix + 2] == "    inlined_things: Optional[Dict[str, Union[A, B]]] = Field(default_factory=dict)"
-    assert lines[ix + 3] == "    inlined_as_list_things: Optional[List[Union[A, B]]] = Field(default_factory=list)"
-    assert lines[ix + 4] == "    not_inlined_things: Optional[List[str]] = Field(default_factory=list)"
+    assert "inlined_things: Optional[Dict[str, Union[A, B]]] = Field(default_factory=dict" in code
+    assert "inlined_as_list_things: Optional[List[Union[A, B]]] = Field(default_factory=list" in code
+    assert "not_inlined_things: Optional[List[str]] = Field(default_factory=list" in code
 
 
 @pytest.mark.parametrize(
@@ -271,10 +269,10 @@ slots:
 def test_pydantic_inlining(range, multivalued, inlined, inlined_as_list, B_has_identifier, expected, notes):
     # Case = namedtuple("multivalued", "inlined", "inlined_as_list", "B_has_identities")
     expected_default_factories = {
-        "Optional[List[str]]": "Field(default_factory=list)",
-        "Optional[List[B]]": "Field(default_factory=list)",
-        "Optional[Dict[str, B]]": "Field(default_factory=dict)",
-        "Optional[Dict[str, str]]": "Field(default_factory=dict)",
+        "Optional[List[str]]": "Field(default_factory=list",
+        "Optional[List[B]]": "Field(default_factory=list",
+        "Optional[Dict[str, B]]": "Field(default_factory=dict",
+        "Optional[Dict[str, str]]": "Field(default_factory=dict",
     }
 
     sb = SchemaBuilder("test")
@@ -294,16 +292,12 @@ def test_pydantic_inlining(range, multivalued, inlined, inlined_as_list, B_has_i
     schema_str = yaml_dumper.dumps(schema)
     gen = PydanticGenerator(schema_str, package=PACKAGE)
     code = gen.serialize()
-    lines = code.splitlines()
-    ix = lines.index("class A(ConfiguredBaseModel):")
-    assert ix > 0
-    # assume a single blank line separating
-    slot_line = lines[ix + 1]
-    assert f"a2b: {expected}" in slot_line, f"did not find expected {expected} in {slot_line}"
+
+    assert f"a2b: {expected}" in code, f"did not find expected {expected} in {code}"
     if expected not in expected_default_factories:
         raise ValueError(f"unexpected default factory for {expected}")
     assert (
-        expected_default_factories[expected] in slot_line
+        expected_default_factories[expected] in code
     ), f"did not find expected default factory {expected_default_factories[expected]}"
 
 
@@ -346,20 +340,12 @@ classes:
 
     gen = PydanticGenerator(schema_str)
     code = gen.serialize()
-    lines = code.splitlines()
-    ix = lines.index("class Test(ConfiguredBaseModel):")
-    integer_slot_line = lines[ix + 4].strip()
-    assert integer_slot_line == "attr1: Optional[int] = Field(10)"
-    string_slot_line = lines[ix + 5].strip()
-    assert string_slot_line == 'attr2: Optional[str] = Field("hello world")'
-    boolean_slot_line = lines[ix + 6].strip()
-    assert boolean_slot_line == "attr3: Optional[bool] = Field(True)"
-    float_slot_line = lines[ix + 7].strip()
-    assert float_slot_line == "attr4: Optional[float] = Field(1.0)"
-    date_slot_line = lines[ix + 8].strip()
-    assert date_slot_line == "attr5: Optional[date] = Field(date(2020, 1, 1))"
-    datetime_slot_line = lines[ix + 9].strip()
-    assert datetime_slot_line == "attr6: Optional[datetime ] = Field(datetime(2020, 1, 1, 0, 0, 0))"
+    assert "attr1: Optional[int] = Field(10" in code
+    assert 'attr2: Optional[str] = Field("hello world"' in code
+    assert "attr3: Optional[bool] = Field(True" in code
+    assert "attr4: Optional[float] = Field(1.0" in code
+    assert "attr5: Optional[date] = Field(date(2020, 1, 1)" in code
+    assert "attr6: Optional[datetime ] = Field(datetime(2020, 1, 1, 0, 0, 0)" in code
 
 
 def test_multiline_module(input_path):
@@ -1568,7 +1554,7 @@ def test_generate_array_bounded_implicit_exact(representation, array_bounded):
     if ArrayRepresentation.NPARRAY in representation or representation == ArrayRepresentation.NPARRAY:
         return
 
-    generated = PydanticGenerator(array_bounded, array_representations=representation).render()
+    generated = PydanticGenerator(array_bounded, array_representations=representation, metadata_mode=None).render()
     explicit = generated.classes["ExactDimensions"].attributes["array"]
     implicit = generated.classes["ImplicitExact"].attributes["array"]
     assert explicit.render() == implicit.render()
@@ -1583,7 +1569,7 @@ def test_generate_array_complex_implicit_exact(representation, array_complex):
     if ArrayRepresentation.NPARRAY in representation or representation == ArrayRepresentation.NPARRAY:
         return
 
-    generated = PydanticGenerator(array_complex, array_representations=representation).render()
+    generated = PydanticGenerator(array_complex, array_representations=representation, metadata_mode=None).render()
     explicit = generated.classes["ComplexExactShapeArray"].attributes["array"]
     implicit = generated.classes["ComplexImplicitExactShapeArray"].attributes["array"]
     assert explicit.render() == implicit.render()
@@ -1598,8 +1584,12 @@ def test_generate_array_complex_noop_exact(representation, array_complex, array_
     if ArrayRepresentation.NPARRAY in representation or representation == ArrayRepresentation.NPARRAY:
         return
 
-    generated_complex = PydanticGenerator(array_complex, array_representations=representation).render()
-    generated_parameterized = PydanticGenerator(array_parameterized, array_representations=representation).render()
+    generated_complex = PydanticGenerator(
+        array_complex, array_representations=representation, metadata_mode=None
+    ).render()
+    generated_parameterized = PydanticGenerator(
+        array_parameterized, array_representations=representation, metadata_mode=None
+    ).render()
     complex = generated_complex.classes["ComplexNoOpExactShapeArray"].attributes["array"]
     parameterized = generated_parameterized.classes["ParameterizedArray"].attributes["array"]
     assert complex.render() == parameterized.render()
@@ -1646,7 +1636,9 @@ def test_template_black(array_complex):
     """
     When black is installed, we should format template models with black :)
     """
-    generated = PydanticGenerator(array_complex, array_representations=[ArrayRepresentation.LIST]).render()
+    generated = PydanticGenerator(
+        array_complex, array_representations=[ArrayRepresentation.LIST], metadata_mode=None
+    ).render()
     array_repr = generated.classes["ComplexRangeShapeArray"].attributes["array"].render(black=True)
     if PYDANTIC_VERSION >= 2:
         assert (
@@ -1660,9 +1652,7 @@ def test_template_black(array_complex):
                 min_length=2,
                 max_length=5,
                 item_type=conlist(
-                    min_length=6,
-                    max_length=6,
-                    item_type=Union[List[int], List[List[int]], List[List[List[int]]]],
+                    min_length=6, max_length=6, item_type=Union[List[int], List[List[int]], List[List[List[int]]]]
                 ),
             ),
         ),
@@ -1682,9 +1672,7 @@ def test_template_black(array_complex):
                 min_items=2,
                 max_items=5,
                 item_type=conlist(
-                    min_items=6,
-                    max_items=6,
-                    item_type=Union[List[int], List[List[int]], List[List[List[int]]]],
+                    min_items=6, max_items=6, item_type=Union[List[int], List[List[int]], List[List[List[int]]]],
                 ),
             ),
         ),
@@ -1716,7 +1704,9 @@ def test_template_noblack(array_complex, mock_black_import):
     from linkml.generators.pydanticgen import PydanticGenerator
     from linkml.generators.pydanticgen.array import ArrayRepresentation
 
-    generated = PydanticGenerator(array_complex, array_representations=[ArrayRepresentation.LIST]).render()
+    generated = PydanticGenerator(
+        array_complex, array_representations=[ArrayRepresentation.LIST], metadata_mode=None
+    ).render()
     array_repr = generated.classes["ComplexRangeShapeArray"].attributes["array"].render(black=False)
     if PYDANTIC_VERSION >= 2:
         assert (

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -1672,7 +1672,7 @@ def test_template_black(array_complex):
                 min_items=2,
                 max_items=5,
                 item_type=conlist(
-                    min_items=6, max_items=6, item_type=Union[List[int], List[List[int]], List[List[List[int]]]],
+                    min_items=6, max_items=6, item_type=Union[List[int], List[List[int]], List[List[List[int]]]]
                 ),
             ),
         ),

--- a/tests/test_issues/test_linkml_issue_1094.py
+++ b/tests/test_issues/test_linkml_issue_1094.py
@@ -45,4 +45,4 @@ def test_pydanticgen_inline_dict():
 
     output_subset = [line for line in output.splitlines() if "has_bikes: " in line]
     assert len(output_subset) == 1
-    assert "has_bikes: Dict[str, str] = Field(default_factory=dict)" in output_subset[0]
+    assert "has_bikes: Dict[str, str] = Field(default_factory=dict" in output_subset[0]


### PR DESCRIPTION
depends on:
- [ ] merging https://github.com/linkml/linkml/pull/2036
  
  this PR builds on #2036, see the [diff between branches](https://github.com/sneakers-the-rat/linkml/compare/pydanticgen-metadata..pydanticgen-string-template) for what is unique to this PR

---

> *i have implemented*
> *the `string_serialization`*
> *that was in*
> *the metamodel*
> 
> *and which*
> *you were probably*
> *hoping*
> *i wouldnt*
> 
> *Forgive me*
> *the metaprogramming potential*
> *so fucked up*
> *and so good*

couldn't sleep, saw this earlier while doing https://github.com/linkml/linkml/pull/2052 and had a whacky idea

so like

```yaml
classes:
  MyClass:
    attributes:
      attr:
    annotations:
      meta:
        value: my special metadata annotation
    aliases:
    - alias1
    - alias2
    string_serialization: |
      ---
      annotations: {annotations[meta][value]}
      aliases: {aliases}
      attr: {attr}
``` 

becomes

```python
class MyModel(ConfiguredBaseModel):
    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['alias1', 'alias2'],
         'annotations': {'meta': {'tag': 'meta',
                                  'value': 'a string value set as a linkml '
                                           'classdefinition metadata value'}},
         'from_schema': 'pydantic'})

    attr: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'attr', 'domain_of': ['StringSerialization']} })
    
    def __str__(self) -> str:
        if self.linkml_meta is not None:
            kwargs = self.linkml_meta
        else:
            kwargs = {}

        kwargs.update(self.model_dump())
        return '''
---
annotations: {annotations[meta][value]}
aliases: {aliases}
attr: {attr}
'''.format(**kwargs)

```

which of course works like

```python
>>> instance = MyModel(attr=attr_str_value)
>>> print(str(instance))

---
annotations: a string value set as a linkml classdefinition metadata value
aliases: ['alias1', 'alias2']
attr: a string value set as a class attribute
```

so one could imagine the metaprogramming possibilities that could be had if one were to eval (after, perhaps, safely escaping) a string that looked like another model or format and so on. 

also this is just a demonstration of 𝓉𝒽𝑒 𝒻𝓊𝓃𝓏𝒾𝑒𝓈 𝓉𝑜 𝒷𝑒 𝒽𝒶𝒹 with the pydanticgen templating system :)

@cmungall i also added a little sketch of a pytest-fixture based complement to the compliance framework - the teeniest, tiniest hookable version. obvs it doesn't implement all the semantics of the existing compliance framework, but i'm thinking about how it would be nice to be able to surface some of what happens in the `helper` module, and allow for both 'proper' compliance tests alongside the ability to allow tests that might not fit well there to declare that a certain test implements a part of the metamodel. just a quick idea :)
