### PR TITLE
Run code quality checks only once in testing workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  quality-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check pyproject.toml and poetry.lock
+        run: poetry check
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Run codespell
+        run: tox -e codespell
+      - name: Run code quality checks
+        run: tox -e lint
+
   test:
+    needs:
+      - quality-checks
     strategy:
       fail-fast: false
       matrix:
@@ -41,39 +61,22 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Install poetry
+        run: pipx install poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
 
       #----------------------------------------------
-      #          install & configure poetry
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.3.2
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: venv-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
-      #----------------------------------------------
-      # install dependencies if cache does not exist
+      # install dependencies
       #----------------------------------------------
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root --all-extras
 
       #----------------------------------------------
@@ -81,14 +84,6 @@ jobs:
       #----------------------------------------------
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1
-
-      #----------------------------------------------
-      #    Linting & code quality
-      #----------------------------------------------
-      - name: Check common spelling errors
-        run: poetry run tox -e codespell
-      - name: Check with flake8
-        run: poetry run tox -e lint
 
       #----------------------------------------------
       #              coverage report
@@ -99,12 +94,13 @@ jobs:
           poetry run coverage xml
           poetry run coverage report -m
         shell: bash
+
       #----------------------------------------------
       #           upload coverage results
       #----------------------------------------------
       - name: Upload coverage report
         if: github.repository == 'linkml/linkml'
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v4
         with:
           name: codecov-results-${{ matrix.os }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixes #2054 

### Summary

* Moved code quality checks to a new job in `main.yaml`. This job only runs once and if it successfully completes the `test` job (with the same permutations as before) will run. 
* Added a call to `poetry check` to the code quality job. This will fail if our `pyproject.toml` file has formatting issues or is out of sync with `poetry.lock` (https://python-poetry.org/docs/cli/#check). This was inspired by the recent attempts to get automatic, periodic updates to the lock file working.
* Updated Poetry installation and virtual environment caching to be inline with the current best practices suggested by the `setup-python` action https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages

### Comments

* With the way the workflow is currently configured, the tests will not run if the code quality checks fail. This is consistent with the current behavior (except that the quality checks only happen once). But by having them as separate jobs, we now have control over that. If we removed the `needs` block in the `test` job, the code quality checks and tests could run in parallel. Something to consider.
* I really like that the `setup-python` action now has built-in support for Poetry virtual environment caching. It's nice to let someone else get that right for us! If it seems to work well here we should roll that out to workflows in our other repos.