### PR TITLE
Use app installation token in poetry update workflow

### DIFF
--- a/.github/workflows/poetry-update.yaml
+++ b/.github/workflows/poetry-update.yaml
@@ -47,22 +47,23 @@ jobs:
           echo "$UPDATE_MSG"
           echo EOF
         } >> "$GITHUB_ENV"
-
+    - uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ vars.PR_BOT_APP_ID }}
+        private-key: ${{ secrets.PR_BOT_APP_PRIVATE_KEY }}
     - name: Create pull request
       uses: peter-evans/create-pull-request@v6
       with:
+        token: ${{ steps.app-token.outputs.token }}
         branch: update-lockfile
         title: "[poetry] Update Lockfile"
         commit-message: "Update poetry lockfile"
         labels: poetry
         add-paths: poetry.lock
         body: |
-          Update poetry dependencies: 
-          
+          Update poetry dependencies:
+
           | Current | Updated |
           | ------- | ------- |
           ${{ env.UPDATE_MSG }}
-          
-        
-
-

--- a/.github/workflows/poetry-update.yaml
+++ b/.github/workflows/poetry-update.yaml
@@ -61,6 +61,7 @@ jobs:
         commit-message: "Update poetry lockfile"
         labels: poetry
         add-paths: poetry.lock
+        reviewers: pkalita-lbl,cmungall,sierra-moxon
         body: |
           Update poetry dependencies:
 


### PR DESCRIPTION
Following [these instructions](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens), I created a new private GitHub App in the `linkml` org. I installed it in this repo and added the app's private key as a secret to this repo. 

With these changes the app's private key and ID will be used to get a short-lived access token in the workflow. That token is then passed to the `peter-evans/create-pull-request` action. I believe the result of this will be that:

* The PR will be open by the LinkML PR Bot app (as opposed to a specific user or the default [github-actions](https://github.com/apps/github-actions) account)
* The tests will run automatically when the PR is opened

I also added a few core developers to the reviewers list on the PR so that we get notified. 