### PR TITLE
Make class blocks in mermaid class diagrams clickable/hyperlinked

### DIFF
--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -2,18 +2,22 @@
 ```{{ gen.mermaid_directive() }}
  classDiagram
     class {{ gen.name(element) }}
+    click {{ gen.name(element) }} href "../{{gen.name(element)}}"
       {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
         {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
+        click {{ gen.name(schemaview.get_element(s)) }} href "../{{gen.name(schemaview.get_element(s))}}"
       {% endfor %}
 
       {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
+        click {{ gen.name(schemaview.get_element(s)) }} href "../{{gen.name(schemaview.get_element(s))}}"
       {% endfor %}
       
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
           {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
+          click {{ s.range }} href "../{{s.range}}"
         {% endif %}
       {% endfor %}
 ```
@@ -21,13 +25,16 @@
 ```{{ gen.mermaid_directive() }}
  classDiagram
     class {{ gen.name(element) }}
+    click {{ gen.name(element) }} href "../{{gen.name(element)}}"
       {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
         {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
+        click {{ gen.name(schemaview.get_element(s)) }} href "../{{gen.name(schemaview.get_element(s))}}"
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
           {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
+          click {{ s.range }} href "../{{s.range}}"
         {% endif %}
       {% endfor %}
 ```
@@ -35,13 +42,16 @@
 ```{{ gen.mermaid_directive() }}
  classDiagram
     class {{ gen.name(element) }}
+    click {{ gen.name(element) }} href "../{{gen.name(element)}}"
       {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
+        click {{ gen.name(schemaview.get_element(s)) }} href "../{{gen.name(schemaview.get_element(s))}}"
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
           {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
+          click {{ s.range }} href "../{{s.range}}"
         {% endif %}
       {% endfor %}
 ```
@@ -49,10 +59,12 @@
 ```{{ gen.mermaid_directive() }}
  classDiagram
     class {{ gen.name(element) }}
+    click {{ gen.name(element) }} href "../{{gen.name(element)}}"
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
           {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
+          click {{ s.range }} href "../{{s.range}}"
         {% endif %}
       {% endfor %}
 ```

--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -16,8 +16,8 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
-          click {{ s.range }} href "../{{s.range}}"
+          {{ gen.name(element) }} --> {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+          click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
         {% endif %}
       {% endfor %}
 ```
@@ -33,8 +33,8 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
-          click {{ s.range }} href "../{{s.range}}"
+          {{ gen.name(element) }} --> {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+          click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
         {% endif %}
       {% endfor %}
 ```
@@ -50,8 +50,8 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
-          click {{ s.range }} href "../{{s.range}}"
+          {{ gen.name(element) }} --> {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+          click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
         {% endif %}
       {% endfor %}
 ```
@@ -63,8 +63,8 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --> {{ s.range }} : {{ gen.name(s) }}
-          click {{ s.range }} href "../{{s.range}}"
+          {{ gen.name(element) }} --> {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+          click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
         {% endif %}
       {% endfor %}
 ```


### PR DESCRIPTION
The functionality that this PR seeks to add is to make the Mermaid diagrams generated on class documentation pages "clickable". Meaning we should be able to click on the _block_ representing a class in the diagram, and be able to get to the webpage for that class.

Addresses a part of #931 