### PR TITLE
Display single/multi-valuedness (cardinality) on slot edges

### DIFF
--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -16,7 +16,11 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --> {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% if s.multivalued -%}
+          {{ gen.name(element) }} --> "*" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% else -%}
+          {{ gen.name(element) }} --> "1" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% endif %}
           click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
         {% endif %}
       {% endfor %}
@@ -33,7 +37,11 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --> {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% if s.multivalued -%}
+          {{ gen.name(element) }} --> "*" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% else -%}
+          {{ gen.name(element) }} --> "1" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% endif %}
           click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
         {% endif %}
       {% endfor %}
@@ -50,7 +58,11 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --> {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% if s.multivalued -%}
+          {{ gen.name(element) }} --> "*" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% else -%}
+          {{ gen.name(element) }} --> "1" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% endif %}
           click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
         {% endif %}
       {% endfor %}
@@ -63,7 +75,11 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ gen.name(element) }} --> {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% if s.multivalued -%}
+          {{ gen.name(element) }} --> "*" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% else -%}
+          {{ gen.name(element) }} --> "1" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
+        {% endif %}
           click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
Show single / multi-valuedness cardinality (`1` /  `*`) on slot edges.

Part of #931 