### PR TITLE
Documentation: Recommend the official docker image in docs and improve structure of installation intro

### DIFF
--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -24,13 +24,18 @@ pip install linkml
 
 ## Alternative protocol: Use Docker
 
-You can also use the Docker image, courtesy of the Monarch Initiative:
+You can also use the [official Docker/OCI image for LinkML](docker.io/linkml/linkml):
 
+To start a shell from the image:
 ```bash
-docker run -v $(PWD):/work -w /work/ --rm -ti monarchinitiative/linkml
+docker run -v ./:/work -w /work/ --rm -ti docker.io/linkml/linkml
 ```
 
-This comes with LinkML already installed
+Then try some commands:
+```bash
+linkml-ws --help
+gen-project --help
+```
 
 ## Installation for contributors
 

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -1,6 +1,12 @@
 # Quick Install Guide
 
-## Install Python
+There are multiple ways to installing LinkML.
+
+## Local installation: Use the Python package
+
+If you are developing locally you can install LinkML as a python package in your local environment.
+
+### Install Python
 
 Get the latest version of Python at https://www.python.org/downloads/ or with your operating system’s package manager.
 
@@ -13,8 +19,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>>
 ```
 
-
-## Install LinkML
+### Install LinkML
 
 The latest version can always be installed with:
 
@@ -22,7 +27,7 @@ The latest version can always be installed with:
 pip install linkml
 ```
 
-## Alternative protocol: Use Docker
+## Alternative: Use the official Docker/OCI iamge
 
 You can also use the [official Docker/OCI image for LinkML](docker.io/linkml/linkml):
 

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -27,7 +27,7 @@ The latest version can always be installed with:
 pip install linkml
 ```
 
-## Alternative: Use the official Docker/OCI iamge
+## Alternative: Use the official Docker/OCI image
 
 You can also use the [official Docker/OCI image for LinkML](https://hub.docker.com/r/linkml/linkml):
 

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -29,7 +29,7 @@ pip install linkml
 
 ## Alternative: Use the official Docker/OCI iamge
 
-You can also use the [official Docker/OCI image for LinkML](docker.io/linkml/linkml):
+You can also use the [official Docker/OCI image for LinkML](https://hub.docker.com/r/linkml/linkml):
 
 To start a shell from the image:
 ```bash


### PR DESCRIPTION
The docker.io/monarchinitiative/linkml OCI image has last been updated 3 years ago and there is an official docker image. This should be mentioned in the docs.

Also i took the opportunity to improve the structure of the installation guide a bit.