### PR TITLE
Improve Dockerfile: Update Baseimages, make build work with Buildah/Podman and install python packages globally in runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye as builder
+FROM python:3.12-bookworm as builder
 
 # https://stackoverflow.com/questions/53835198/integrating-python-poetry-with-docker
 ENV PYTHONFAULTHANDLER=1 \
@@ -20,7 +20,7 @@ ADD --keep-git-dir=true . .
 RUN poetry build
 
 #######################################
-FROM python:3.9-slim-bullseye as runner
+FROM python:3.12-slim-bookworm as runner
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
 RUN apt update && apt install -y gcc musl-dev python3-dev && rm -rf /var/lib/apt/lists/*
 
+COPY --from=builder /code/dist/*.whl /tmp/linkml-whl/
+RUN pip install /tmp/linkml-whl/*.whl
+
 RUN useradd --create-home linkmluser
 WORKDIR /home/linkmluser
 USER linkmluser
-ENV PATH="${PATH}:/home/linkmluser/.local/bin"
-
-COPY --from=builder /code/dist/*.whl /tmp
-RUN pip install --user /tmp/*.whl
 
 # command to run on container start
 CMD [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN poetry self add "poetry-dynamic-versioning[plugin]"
 WORKDIR /code
 
 # Build project. The .git directory is needed for poetry-dynamic-versioning
-ADD --keep-git-dir=true . .
+COPY . .
 RUN poetry build
 
 #######################################


### PR DESCRIPTION
I made some changes to the Dockerfile that i think are helpful:
- Update Baseimages to use the Python 3.12 images based on Debian bookworm (current stable)
- Make the build work with Buildah/Podman by using COPY instead of ADD
- Install python packages globally in the runner image, so a downstream user has more flexibility in what can be done with the image
