### PR TITLE
Ensure consistency of cardinality displayed on edges of Mermaid class diagram

### DIFF
--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -1,3 +1,10 @@
+{% macro relationship(element, slot) %}
+    {% set range_element = gen.name(schemaview.get_element(slot.range)) %}
+    {% set relation_label = gen.name(slot) %}
+    {{ gen.name(element) }} --> "{{ gen.cardinality(slot) }}" {{ range_element }} : {{ relation_label }}
+    click {{ range_element }} href "../{{ range_element }}"
+{% endmacro %}
+
 {% if schemaview.class_parents(element.name) and schemaview.class_children(element.name) %}
 ```{{ gen.mermaid_directive() }}
  classDiagram
@@ -16,12 +23,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-        {% if s.multivalued -%}
-          {{ gen.name(element) }} --> "*" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
-        {% else -%}
-          {{ gen.name(element) }} --> "1" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
-        {% endif %}
-          click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
+          {{ relationship(element, s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -37,12 +39,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-        {% if s.multivalued -%}
-          {{ gen.name(element) }} --> "*" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
-        {% else -%}
-          {{ gen.name(element) }} --> "1" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
-        {% endif %}
-          click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
+          {{ relationship(element, s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -58,12 +55,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-        {% if s.multivalued -%}
-          {{ gen.name(element) }} --> "*" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
-        {% else -%}
-          {{ gen.name(element) }} --> "1" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
-        {% endif %}
-          click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
+          {{ relationship(element, s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -75,12 +67,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-        {% if s.multivalued -%}
-          {{ gen.name(element) }} --> "*" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
-        {% else -%}
-          {{ gen.name(element) }} --> "1" {{ gen.name(schemaview.get_element(s.range)) }} : {{ gen.name(s) }}
-        {% endif %}
-          click {{ gen.name(schemaview.get_element(s.range)) }} href "../{{gen.name(schemaview.get_element(s.range))}}"
+          {{ relationship(element, s) }}
         {% endif %}
       {% endfor %}
 ```

--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -1,4 +1,4 @@
-{% macro relationship(element, slot) %}
+{% macro slot_relationship(element, slot) %}
     {% set range_element = gen.name(schemaview.get_element(slot.range)) %}
     {% set relation_label = gen.name(slot) %}
     {{ gen.name(element) }} --> "{{ gen.cardinality(slot) }}" {{ range_element }} : {{ relation_label }}
@@ -23,7 +23,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ relationship(element, s) }}
+          {{ slot_relationship(element, s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -39,7 +39,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ relationship(element, s) }}
+          {{ slot_relationship(element, s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -55,7 +55,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ relationship(element, s) }}
+          {{ slot_relationship(element, s) }}
         {% endif %}
       {% endfor %}
 ```
@@ -67,7 +67,7 @@
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
         {% if s.range not in gen.all_type_object_names() %}
-          {{ relationship(element, s) }}
+          {{ slot_relationship(element, s) }}
         {% endif %}
       {% endfor %}
 ```

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -265,18 +265,18 @@ def test_docgen(kitchen_sink_path, input_path, tmp_path):
     )
     assert_mdfile_contains(
         tmp_path / "FamilialRelationship.md",
-        ("| [related_to](related_to.md) | 1..1 <br/> [Person](Person.md) |  | " "[Relationship](Relationship.md) |"),
+        ("| [related_to](related_to.md) | 1 <br/> [Person](Person.md) |  | [Relationship](Relationship.md) |"),
         after="## Slots",
     )
     # test inheritance column
     assert_mdfile_contains(
         tmp_path / "Person.md",
-        "| [id](id.md) | 1..1 <br/> [String](String.md) |  | direct |",
+        "| [id](id.md) | 1 <br/> [String](String.md) |  | direct |",
         after="## Slots",
     )
     assert_mdfile_contains(
         tmp_path / "Person.md",
-        ("| [aliases](aliases.md) | 0..* <br/> [String](String.md) |  | [HasAliases](HasAliases.md) |"),
+        ("| [aliases](aliases.md) | * <br/> [String](String.md) |  | [HasAliases](HasAliases.md) |"),
         after="## Slots",
     )
     # Examples


### PR DESCRIPTION
The way it is right now, we are only displaying cardinality based on the multiplicity (single/multi-valuedness) of a slot, not considering the required-ness of the slot.

This PR seeks to update class_diagram.md.jinja2 so we show the cardinality in such a way that it is consistent with our definition of cardinality: https://linkml.io/linkml/schemas/slots.html#slot-cardinality which is a slight deviation from the recommendations by the Mermaid library development group: https://mermaid.js.org/syntax/classDiagram.html#cardinality-multiplicity-on-relations