### PR TITLE
validator: support including validator context when reporting errors

### DIFF
--- a/linkml/validator/cli.py
+++ b/linkml/validator/cli.py
@@ -108,6 +108,9 @@ DEPRECATED = "[DEPRECATED: only used in legacy mode]"
     help=f"{DEPRECATED} When handling range constraints, include all descendants of the range "
     "class instead of just the range class",
 )
+@click.option(
+    "--verbose", "-v", is_flag=True, default=False, help="Provide more verbose reporting of validation errors."
+)
 @click.argument("data_sources", nargs=-1, type=click.Path(exists=True))
 @click.version_option(__version__, "-V", "--version")
 @click.pass_context
@@ -123,6 +126,7 @@ def cli(
     input_format: Optional[str],
     index_slot: Optional[str],
     include_range_class_descendants: bool,
+    verbose: bool,
 ):
     if legacy_mode:
         from linkml.validators import jsonschemavalidator
@@ -183,6 +187,9 @@ def cli(
         for result in validator.iter_results_from_source(loader, config.target_class):
             severity_counter[result.severity] += 1
             click.echo(f"[{result.severity.value}] [{loader.source}/{result.instance_index}] {result.message}")
+            if verbose:
+                for ctx in result.context:
+                    click.echo(f"[CONTEXT] {ctx}")
 
     if sum(severity_counter.values()) == 0:
         click.echo("No issues found")

--- a/linkml/validator/cli.py
+++ b/linkml/validator/cli.py
@@ -109,7 +109,11 @@ DEPRECATED = "[DEPRECATED: only used in legacy mode]"
     "class instead of just the range class",
 )
 @click.option(
-    "--include-context/--no-include-context", "-D", default=False, help="Include additional context when reporting of validation errors."
+    "--include-context/--no-include-context",
+    "-D",
+    default=False,
+    show_default=True,
+    help="Include additional context when reporting of validation errors.",
 )
 @click.argument("data_sources", nargs=-1, type=click.Path(exists=True))
 @click.version_option(__version__, "-V", "--version")

--- a/linkml/validator/cli.py
+++ b/linkml/validator/cli.py
@@ -109,7 +109,7 @@ DEPRECATED = "[DEPRECATED: only used in legacy mode]"
     "class instead of just the range class",
 )
 @click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Provide more verbose reporting of validation errors."
+    "--include-context/--no-include-context", "-D", default=False, help="Include additional context when reporting of validation errors."
 )
 @click.argument("data_sources", nargs=-1, type=click.Path(exists=True))
 @click.version_option(__version__, "-V", "--version")
@@ -126,7 +126,7 @@ def cli(
     input_format: Optional[str],
     index_slot: Optional[str],
     include_range_class_descendants: bool,
-    verbose: bool,
+    include_context: bool,
 ):
     if legacy_mode:
         from linkml.validators import jsonschemavalidator
@@ -187,7 +187,7 @@ def cli(
         for result in validator.iter_results_from_source(loader, config.target_class):
             severity_counter[result.severity] += 1
             click.echo(f"[{result.severity.value}] [{loader.source}/{result.instance_index}] {result.message}")
-            if verbose:
+            if include_context:
                 for ctx in result.context:
                     click.echo(f"[CONTEXT] {ctx}")
 

--- a/linkml/validator/plugins/jsonschema_validation_plugin.py
+++ b/linkml/validator/plugins/jsonschema_validation_plugin.py
@@ -46,6 +46,7 @@ class JsonschemaValidationPlugin(ValidationPlugin):
             path_override=self.json_schema_path,
         )
         for error in validator.iter_errors(instance):
+            error_context = [ctx.message for ctx in error.context]
             best_error = best_match([error])
             yield ValidationResult(
                 type="jsonschema validation",
@@ -53,4 +54,5 @@ class JsonschemaValidationPlugin(ValidationPlugin):
                 instance=instance,
                 instantiates=context.target_class,
                 message=f"{best_error.message} in /{'/'.join(str(p) for p in best_error.absolute_path)}",
+                context=error_context,
             )

--- a/linkml/validator/report.py
+++ b/linkml/validator/report.py
@@ -28,6 +28,7 @@ class ValidationResult(BaseModel):
     instance: Optional[Any] = None
     instance_index: Optional[int] = None
     instantiates: Optional[str] = None
+    context: List[str] = []
 
 
 class ValidationReport(BaseModel):


### PR DESCRIPTION
Motivation:

When validating JSON, the `linkml-validate` command builds a JSON Schema against which the JSON input is checked.  If there are validation problems, the command prints a single line for each such problem.

In some cases, the failing node is a composition (`allOf`, `anyOf`, `oneOf`) and the resulting error message is currently rather vague.

Modification:

Update the `ValidationResult` class to include a List of strings.  These are the validation errors that led to the composition failing.

Note, these contextual failures could (themselves) have further contextual failures, forming a tree.  In the interests of keeping the patch small, this change records only the next level; however, a future patch may address this issue.

The error output is updated to support providing the validation error's context as lines starting `[CONTEXT]`.

The command-line arguments are updated to support the `-v`/`--verbose` flag.  Specifying this flag results in the validator printing any validation error context.

Note, the flag is included to support backwards compatibility, but it may be acceptable to print the validation error's context always.

Result:

`linkml-validate` now supports the `-v`/`--verbose` option.  Specifying this option will result in certain validation error reports containing more information.

Closes: #2088