### PR TITLE
`genshacl`: fix the propagation of `types` to SHACL `sh:datatype` and `sh:nodeKind`

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -130,7 +130,7 @@ class ShaclGenerator(Generator):
 
                             self._add_class(cl_node_pv, r)
                             range_list.append(class_node)
-                        elif r in sv.all_types().values():
+                        elif r in sv.all_types():
                             t_node = BNode()
 
                             def t_node_pv(p, v):
@@ -168,7 +168,7 @@ class ShaclGenerator(Generator):
                             prop_pv(SH.nodeKind, SH.IRI)
                         else:
                             prop_pv(SH.nodeKind, SH.BlankNodeOrIRI)
-                    elif r in sv.all_types().values():
+                    elif r in sv.all_types():
                         self._add_type(prop_pv, r)
                     elif r in sv.all_enums():
                         self._add_enum(g, prop_pv, r)
@@ -201,10 +201,11 @@ class ShaclGenerator(Generator):
         func(SH["in"], pv_node)
 
     def _add_type(self, func: Callable, r: ElementName) -> None:
+        func(SH.nodeKind, SH.Literal)
         sv = self.schemaview
         rt = sv.get_type(r)
         if rt.uri:
-            func(SH.datatype, rt.uri)
+            func(SH.datatype, URIRef(sv.get_uri(rt, expand=True)))
         else:
             logging.error(f"No URI for type {rt.name}")
 

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -486,6 +486,7 @@ def test_cardinality(framework, multivalued, required, data_name, value):
         "sh:property [ sh:datatype xsd:string ;"
         f"    {'sh:maxCount 1 ;' if not multivalued else ''}"
         f"    {'sh:minCount 1 ;' if required else ''}"
+        "    sh:nodeKind sh:Literal ;"
         "    sh:order 0 ;"
         "    sh:path ex:s1 ] ;"
         "sh:targetClass ex:C ."


### PR DESCRIPTION
In the previous state, the edited code was never reached. With this change, a linkml or custom type as slot range will propagate to the property's `sh:datatype` in SHACL. In addition, a `sh:nodekind` of `sh:Literal` is added for such properties (based on my interpretation of [this comment](https://github.com/linkml/linkml/pull/1300#issuecomment-1439412104))

This PR is intended to close https://github.com/linkml/linkml/issues/1299. It does pretty much the same as https://github.com/linkml/linkml/pull/1300, but that PR has been stagnant for over a year and is based on old state of `main`. So I though a fresh PR might be useful to get the fix merged. Happy to close again if the preference would be to rather update the existing PR.

TODO:
- test updates