### PR TITLE
`shaclgen`: Add `--include-annotations` option to let annotations be part of shacl shapes

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -222,6 +222,7 @@ class ShaclGenerator(Generator):
             logging.error(f"No URI for type {rt.name}")
 
     def _add_annotations(self, func: Callable, item) -> None:
+        # TODO: migrate some of this logic to SchemaView
         sv = self.schemaview
         annotations = item.annotations
         # item could be a class, slot or type

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -4,12 +4,18 @@ from dataclasses import dataclass
 from typing import Callable
 
 import click
+from jsonasobj2 import as_dict, JsonObj
 from linkml_runtime.linkml_model.meta import ElementName
 from linkml_runtime.utils.formatutils import underscore
+from linkml_runtime.utils.yamlutils import (   
+    extended_float,
+    extended_int,
+    extended_str,
+)
 from linkml_runtime.utils.schemaview import SchemaView
 from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.collection import Collection
-from rdflib.namespace import RDF, SH
+from rdflib.namespace import RDF, SH, XSD
 
 from linkml._version import __version__
 from linkml.generators.shacl.ifabsent_processor import IfAbsentProcessor
@@ -24,6 +30,8 @@ class ShaclGenerator(Generator):
     """True means add 'sh:closed=true' to all shapes, except of mixin shapes and shapes, that have parents"""
     suffix: str = None
     """parameterized suffix to be appended. No suffix per default."""
+    include_annotations: bool = False
+    """True means include all class / slot / type annotations in generated Node or Property shapes"""
     generatorname = os.path.basename(__file__)
     generatorversion = "0.0.1"
     valid_formats = ["ttl"]
@@ -83,6 +91,8 @@ class ShaclGenerator(Generator):
             list_node = BNode()
             Collection(g, list_node, [RDF.type])
             shape_pv(SH.ignoredProperties, list_node)
+            if c.annotations and self.include_annotations:
+                self._add_annotations(shape_pv, c)
             order = 0
             for s in sv.class_induced_slots(c.name):
                 # fixed in linkml-runtime 1.1.3
@@ -176,6 +186,8 @@ class ShaclGenerator(Generator):
                         add_simple_data_type(prop_pv, r)
                     if s.pattern:
                         prop_pv(SH.pattern, Literal(s.pattern))
+                    if s.annotations and self.include_annotations:
+                        self._add_annotations(prop_pv, s)
 
                 ifabsent_processor.process_slot(prop_pv, s, class_uri)
 
@@ -206,8 +218,48 @@ class ShaclGenerator(Generator):
         rt = sv.get_type(r)
         if rt.uri:
             func(SH.datatype, URIRef(sv.get_uri(rt, expand=True)))
+            if rt.pattern:
+                func(SH.pattern, Literal(rt.pattern))
+            if rt.annotations and self.include_annotations:
+                self._add_annotations(func, rt)
         else:
             logging.error(f"No URI for type {rt.name}")
+    
+    def _add_annotations(self, func: Callable, item) -> None:
+        sv = self.schemaview
+        annotations = item.annotations
+        # item could be a class, slot or type
+        # annotation type could be dict (on types) or JsonObj (on slots)
+        if type(annotations) == JsonObj:
+            annotations = as_dict(annotations)
+        for a in annotations.values():
+            # If ':' is in the tag, treat it as a CURIE, otherwise string Literal
+            if ":" in a['tag']:
+                N_predicate = URIRef(sv.expand_curie(a['tag']))
+            else:
+                N_predicate = Literal(a['tag'], datatype=XSD.string)
+            # If the value is a string and ':' is in the value, treat it as a CURIE,
+            # otherwise treat as Literal with derived XSD datatype
+            if type(a['value']) == extended_str and ":" in a['value']:
+                N_object = URIRef(sv.expand_curie(a['value']))
+            else:
+                N_object = Literal(a['value'], datatype=self._getXSDtype(a['value']))
+            
+            func(N_predicate, N_object)
+
+    def _getXSDtype(self, value):
+        value_type = type(value)
+        if value_type == bool:
+            return XSD.boolean
+        elif value_type == extended_str:
+            return XSD.string
+        elif value_type == extended_int:
+            return XSD.integer
+        elif value_type == extended_float:
+            # TODO: distinguish between xsd:decimal and xsd:double?
+            return XSD.decimal
+        else:
+            return None
 
 
 def add_simple_data_type(func: Callable, r: ElementName) -> None:
@@ -230,6 +282,12 @@ def add_simple_data_type(func: Callable, r: ElementName) -> None:
     default=None,
     show_default=True,
     help="Use --suffix to append given string to SHACL class name (e. g. --suffix Shape: Person becomes PersonShape).",
+)
+@click.option(
+    "--include-annotations/--exclude-annotations",
+    default=False,
+    show_default=True,
+    help="Use --include-annotations to include annotations of slots, types, and classes in the generated SHACL shapes.",
 )
 @click.version_option(__version__, "-V", "--version")
 def cli(yamlfile, **args):

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -4,15 +4,11 @@ from dataclasses import dataclass
 from typing import Callable
 
 import click
-from jsonasobj2 import as_dict, JsonObj
+from jsonasobj2 import JsonObj, as_dict
 from linkml_runtime.linkml_model.meta import ElementName
 from linkml_runtime.utils.formatutils import underscore
-from linkml_runtime.utils.yamlutils import (   
-    extended_float,
-    extended_int,
-    extended_str,
-)
 from linkml_runtime.utils.schemaview import SchemaView
+from linkml_runtime.utils.yamlutils import extended_float, extended_int, extended_str
 from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.collection import Collection
 from rdflib.namespace import RDF, SH, XSD
@@ -224,7 +220,7 @@ class ShaclGenerator(Generator):
                 self._add_annotations(func, rt)
         else:
             logging.error(f"No URI for type {rt.name}")
-    
+
     def _add_annotations(self, func: Callable, item) -> None:
         sv = self.schemaview
         annotations = item.annotations
@@ -234,17 +230,17 @@ class ShaclGenerator(Generator):
             annotations = as_dict(annotations)
         for a in annotations.values():
             # If ':' is in the tag, treat it as a CURIE, otherwise string Literal
-            if ":" in a['tag']:
-                N_predicate = URIRef(sv.expand_curie(a['tag']))
+            if ":" in a["tag"]:
+                N_predicate = URIRef(sv.expand_curie(a["tag"]))
             else:
-                N_predicate = Literal(a['tag'], datatype=XSD.string)
+                N_predicate = Literal(a["tag"], datatype=XSD.string)
             # If the value is a string and ':' is in the value, treat it as a CURIE,
             # otherwise treat as Literal with derived XSD datatype
-            if type(a['value']) == extended_str and ":" in a['value']:
-                N_object = URIRef(sv.expand_curie(a['value']))
+            if type(a["value"]) == extended_str and ":" in a["value"]:
+                N_object = URIRef(sv.expand_curie(a["value"]))
             else:
-                N_object = Literal(a['value'], datatype=self._getXSDtype(a['value']))
-            
+                N_object = Literal(a["value"], datatype=self._getXSDtype(a["value"]))
+
             func(N_predicate, N_object)
 
     def _getXSDtype(self, value):

--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -138,6 +138,11 @@ classes:
     see_also:
       - https://en.wikipedia.org/wiki/Person
       - schema:Person
+    annotations:
+      ks:viewer: ks:PersonViewer
+      resting: supine
+      opinions: 1000
+      fallible: true
 
   Organization:
     rank: 3

--- a/tests/test_generators/test_shaclgen.py
+++ b/tests/test_generators/test_shaclgen.py
@@ -145,6 +145,29 @@ EXPECTED_any_of_with_suffix = [
     ),
 ]
 
+EXPECTED_with_annotations = [
+    (
+        rdflib.term.URIRef("https://w3id.org/linkml/tests/kitchen_sink/Person"),
+        rdflib.term.URIRef("https://w3id.org/linkml/tests/kitchen_sink/viewer"),
+        rdflib.term.URIRef("https://w3id.org/linkml/tests/kitchen_sink/PersonViewer"),
+    ),
+    (
+        rdflib.term.URIRef("https://w3id.org/linkml/tests/kitchen_sink/Person"),
+        rdflib.term.Literal("resting", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
+        rdflib.term.Literal("supine", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
+    ),
+    (
+        rdflib.term.URIRef("https://w3id.org/linkml/tests/kitchen_sink/Person"),
+        rdflib.term.Literal("opinions", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
+        rdflib.term.Literal("1000", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#integer")),
+    ),
+    (
+        rdflib.term.URIRef("https://w3id.org/linkml/tests/kitchen_sink/Person"),
+        rdflib.term.Literal("fallible", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
+        rdflib.term.Literal("true", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#boolean")),
+    ),
+]
+
 
 def test_shacl(kitchen_sink_path):
     """tests shacl generation"""
@@ -162,6 +185,12 @@ def test_shacl_suffix(kitchen_sink_path):
     """tests shacl generation with suffix option"""
     shaclstr = ShaclGenerator(kitchen_sink_path, mergeimports=True, closed=True, suffix="Shape").serialize()
     do_test(shaclstr, EXPECTED_suffix, EXPECTED_any_of_with_suffix)
+
+
+def test_shacl_annotations(kitchen_sink_path):
+    """tests shacl generation with annotation option"""
+    shaclstr = ShaclGenerator(kitchen_sink_path, mergeimports=True, include_annotations=True).serialize()
+    do_test(shaclstr, EXPECTED_with_annotations, EXPECTED_any_of)
 
 
 def do_test(shaclstr, expected, expected_any_of):

--- a/tests/test_scripts/__snapshots__/genjsonld/meta.json
+++ b/tests/test_scripts/__snapshots__/genjsonld/meta.json
@@ -1526,6 +1526,24 @@
         "P"
       ],
       "definition_uri": "https://w3id.org/linkml/tests/kitchen_sink/Person",
+      "annotations": [
+        {
+          "tag": "ks:viewer",
+          "value": "ks:PersonViewer"
+        },
+        {
+          "tag": "resting",
+          "value": "supine"
+        },
+        {
+          "tag": "opinions",
+          "value": 1000
+        },
+        {
+          "tag": "fallible",
+          "value": true
+        }
+      ],
       "description": "A person, living or dead",
       "in_subset": [
         "subset_A"

--- a/tests/test_scripts/__snapshots__/genjsonld/meta.jsonld
+++ b/tests/test_scripts/__snapshots__/genjsonld/meta.jsonld
@@ -1643,6 +1643,28 @@
         "P"
       ],
       "definition_uri": "https://w3id.org/linkml/tests/kitchen_sink/Person",
+      "annotations": [
+        {
+          "tag": "ks:viewer",
+          "value": "ks:PersonViewer",
+          "@type": "Annotation"
+        },
+        {
+          "tag": "resting",
+          "value": "supine",
+          "@type": "Annotation"
+        },
+        {
+          "tag": "opinions",
+          "value": 1000,
+          "@type": "Annotation"
+        },
+        {
+          "tag": "fallible",
+          "value": true,
+          "@type": "Annotation"
+        }
+      ],
       "description": "A person, living or dead",
       "in_subset": [
         "subset_A"

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl.n3
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl.n3
@@ -1120,7 +1120,11 @@ ks:Person a owl:Class ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
-    sh:order 2 .
+    sh:order 2 ;
+    ks:fallible true ;
+    ks:opinions 1000 ;
+    ks:resting "supine" ;
+    ks:viewer "ks:PersonViewer" .
 
 <https://w3id.org/linkml/tests/core/ended_at_time> a owl:DatatypeProperty ;
     rdfs:label "ended at time" ;

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl.ttl
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl.ttl
@@ -1120,7 +1120,11 @@ ks:Person a owl:Class ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
-    sh:order 2 .
+    sh:order 2 ;
+    ks:fallible true ;
+    ks:opinions 1000 ;
+    ks:resting "supine" ;
+    ks:viewer "ks:PersonViewer" .
 
 <https://w3id.org/linkml/tests/core/ended_at_time> a owl:DatatypeProperty ;
     rdfs:label "ended at time" ;

--- a/tests/test_scripts/__snapshots__/genyaml/meta.yaml
+++ b/tests/test_scripts/__snapshots__/genyaml/meta.yaml
@@ -1240,6 +1240,19 @@ classes:
     id_prefixes:
     - P
     definition_uri: https://w3id.org/linkml/tests/kitchen_sink/Person
+    annotations:
+      ks:viewer:
+        tag: ks:viewer
+        value: ks:PersonViewer
+      resting:
+        tag: resting
+        value: supine
+      opinions:
+        tag: opinions
+        value: 1000
+      fallible:
+        tag: fallible
+        value: true
     description: A person, living or dead
     in_subset:
     - subset A


### PR DESCRIPTION
This is for the SHACL generator in response to https://github.com/linkml/linkml/issues/1618.

Code is added to `shaclgen.py` to:
- allow users to specify the --include-annotations tag if they want annotations (on classes, slots, and types) to be included in the exported SHACL shapes
- determine the datatype of both annotation tag and value:
   - a CURIE is identified by searching for the ':' character in the tag or value
   - if not a CURIE, the annotation tag is assumed to be a literal with type string
   - if not a CURIE, the annotation value is a literal with datatype determined using python `type` and `extended_float`, `extended_int`, `extended_str`, etc
   - add the correct triples to the shacl output (to a nodeshape for classes, and to a property shape for slots and slots with types as ranges)

In addition, the `test_shaclgen` test is updated to test for annotations on classes, and the kitchen sink schema is updated to include annotations on the person class. Several snapshot data files needed to be updated as well because of the change to that schema, so that existing tests would still succeed.

Uncertainties:
- I was unsure how to test for annotations on types and slots, because the related rdf terms in the graph generated from the kitchen sink schema would be blank nodes with transient IDs, so these can't be captured in the "EXPECTED" triples.
- Are there other elements that can also have annotations that aren't included and should ideally form part of this PR?
- I am not sure if my approach to get the element type, and hence the XSD datatype, is sensible; happy to update this approach if there are LinkML-preferred ways of doing the same
- I currently have a workaround in the code for a `jsonasobj2` issue, mentioned here: https://github.com/linkml/linkml/issues/1665#issuecomment-2112481434
- UPDATE: conflicts can arise when a slot has annotations, and if that same slot has a type as a range, where the type also has annotations. If some of these annotations have the same `tag`, the current way that the code is implemented means that the values will be appended, not replaced. It seems to me that the desired behaviour will differ based on the use case. So the question is whether more user-defined controls should be implemented to direct such behaviour?
