### PR TITLE
Fix plantUML syntax bugs to do spacing and add suppor for SVG tooltips

### DIFF
--- a/linkml/generators/plantumlgen.py
+++ b/linkml/generators/plantumlgen.py
@@ -154,12 +154,12 @@ class PlantumlGenerator(Generator):
         if self.format == "svg" and len(tooltip_contents) > 200:
             tooltip_contents = tooltip_contents[0:197] + " ... "
 
-        tooltip = '" [[{' + tooltip_contents + "}]]"
+        tooltip = ' [[{' + tooltip_contents + '}]] '
         if cls.abstract:
             class_type = "abstract"
         else:
             class_type = "class"
-        return class_type + ' "' + cn + tooltip + ("{\n" + "\n".join(slot_defs) + "\n}")
+        return class_type + ' "' + cn + '"' + tooltip + ("{\n" + "\n".join(slot_defs) + "\n}")
 
     def class_associations(self, cn: ClassDefinitionName, must_render: bool = False) -> str:
         """Emit all associations for a focus class.  If none are specified, all classes are generated

--- a/linkml/generators/plantumlgen.py
+++ b/linkml/generators/plantumlgen.py
@@ -154,7 +154,7 @@ class PlantumlGenerator(Generator):
         if self.format == "svg" and len(tooltip_contents) > 200:
             tooltip_contents = tooltip_contents[0:197] + " ... "
 
-        tooltip = ' [[{' + tooltip_contents + '}]] '
+        tooltip = " [[{" + tooltip_contents + "}]] "
         if cls.abstract:
             class_type = "abstract"
         else:

--- a/linkml/generators/plantumlgen.py
+++ b/linkml/generators/plantumlgen.py
@@ -134,13 +134,12 @@ class PlantumlGenerator(Generator):
                 if True or cn in slot.domain_of:
                     mod = self.prop_modifier(cls, slot)
                     slot_defs.append(
-                        '    {field} "'
+                        '    {field} '
                         + underscore(self.aliased_slot_name(slot))
-                        + '"'
                         + mod
-                        + ' : "'
+                        + ' : '
                         + underscore(slot.range)
-                        + '"'
+                        + ' '
                         + self.cardinality(slot)
                     )
             self.class_generated.add(cn)
@@ -283,7 +282,7 @@ class PlantumlGenerator(Generator):
             if slot.multivalued:
                 return " [1..*]" if slot.required else " [0..*]"
             else:
-                return " [req]" if slot.required else " [opt]"
+                return " "
         else:
             if slot.multivalued:
                 return '"1..*" ' if slot.required else '"0..*" '

--- a/linkml/generators/plantumlgen.py
+++ b/linkml/generators/plantumlgen.py
@@ -134,12 +134,12 @@ class PlantumlGenerator(Generator):
                 if True or cn in slot.domain_of:
                     mod = self.prop_modifier(cls, slot)
                     slot_defs.append(
-                        '    {field} '
+                        "    {field} "
                         + underscore(self.aliased_slot_name(slot))
                         + mod
-                        + ' : '
+                        + " : "
                         + underscore(slot.range)
-                        + ' '
+                        + " "
                         + self.cardinality(slot)
                     )
             self.class_generated.add(cn)

--- a/linkml/generators/plantumlgen.py
+++ b/linkml/generators/plantumlgen.py
@@ -12,7 +12,11 @@ from typing import Callable, List, Optional, Set, cast
 
 import click
 import requests
-from linkml_runtime.linkml_model.meta import ClassDefinition, ClassDefinitionName, SlotDefinition
+from linkml_runtime.linkml_model.meta import (
+    ClassDefinition,
+    ClassDefinitionName,
+    SlotDefinition,
+)
 from linkml_runtime.utils.formatutils import camelcase, underscore
 
 from linkml import REQUESTS_TIMEOUT
@@ -46,6 +50,7 @@ class PlantumlGenerator(Generator):
     directory: Optional[str] = None
     kroki_server: Optional[str] = "https://kroki.io"
     load_image: bool = True
+    tooltips_flag: bool = False
 
     def visit_schema(
         self,
@@ -129,21 +134,32 @@ class PlantumlGenerator(Generator):
                 if True or cn in slot.domain_of:
                     mod = self.prop_modifier(cls, slot)
                     slot_defs.append(
-                        "    {field} "
+                        '    {field} "'
                         + underscore(self.aliased_slot_name(slot))
+                        + '"'
                         + mod
-                        + ": "
+                        + ' : "'
                         + underscore(slot.range)
+                        + '"'
                         + self.cardinality(slot)
                     )
             self.class_generated.add(cn)
         self.referenced.add(cn)
         cls = self.schema.classes[cn]
+
+        tooltip_contents = str(cls.description)
+        first_newline_index = tooltip_contents.find("\n")
+        tooltip_contents = tooltip_contents if first_newline_index < 0 else tooltip_contents[0:first_newline_index]
+
+        if self.format == "svg" and len(tooltip_contents) > 200:
+            tooltip_contents = tooltip_contents[0:197] + " ... "
+
+        tooltip = '" [[{' + tooltip_contents + "}]]"
         if cls.abstract:
             class_type = "abstract"
         else:
             class_type = "class"
-        return class_type + ' "' + cn + ('" {\n' + "\n".join(slot_defs) + "\n}" if slot_defs else '"')
+        return class_type + ' "' + cn + tooltip + ("{\n" + "\n".join(slot_defs) + "\n}")
 
     def class_associations(self, cn: ClassDefinitionName, must_render: bool = False) -> str:
         """Emit all associations for a focus class.  If none are specified, all classes are generated
@@ -217,7 +233,7 @@ class PlantumlGenerator(Generator):
                     classes.append(self.add_class(cn))
                 if mixin not in self.class_generated:
                     classes.append(self.add_class(mixin))
-                assocs.append(cn + plantuml_uses[0] + mixin + plantuml_uses[1])
+                assocs.append('"' + cn + '" ' + plantuml_uses[0] + ' "' + mixin + '" ' + plantuml_uses[1])
 
             # Classes that use the class as a mixin
             if cls.name in self.synopsis.mixinrefs:
@@ -226,7 +242,9 @@ class PlantumlGenerator(Generator):
                         classes.append(self.add_class(ClassDefinitionName(mixin)))
                     if cn not in self.class_generated:
                         classes.append(self.add_class(cn))
-                    assocs.append(ClassDefinitionName(mixin) + plantuml_uses[0] + cn + plantuml_uses[1])
+                    assocs.append(
+                        '"' + ClassDefinitionName(mixin) + '" ' + plantuml_uses[0] + ' "' + cn + '" ' + plantuml_uses[1]
+                    )
 
             # Classes that inject information
             if cn in self.synopsis.applytos.classrefs:

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -738,5 +738,5 @@ def test_uml_diagram_classr(kitchen_sink_path, tmp_path):
     assert_mdfile_contains(
         tmp_path / "Person.md",
         "# Class: Person",
-        followed_by=["```puml", "@startuml", 'class "Person" {', "@enduml"],
+        followed_by=["```puml", "@startuml", 'class "Person" [[{A person, living or dead}]] {', "@enduml"],
     )

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -16,14 +16,14 @@ MARKDOWN_FOOTER = """
 """
 
 PERSON = """
-class "Person" {
-    {field} id: string [req]
-    {field} name: string [opt]
-    {field} age_in_years: integer [opt]
-    {field} species_name: string [opt]
-    {field} stomach_count: integer [opt]
-    {field} is_living: LifeStatusEnum [opt]
-    {field} aliases: string [0..*]
+class "Person" [[{A person, living or dead}]]{
+    {field} "id" : "string" [req]
+    {field} "name" : "string" [opt]
+    {field} "age_in_years" : "integer" [opt]
+    {field} "species_name" : "string" [opt]
+    {field} "stomach_count" : "integer" [opt]
+    {field} "is_living" : "LifeStatusEnum" [opt]
+    {field} "aliases" : "string" [0..*]
 }
 """
 

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -16,7 +16,7 @@ MARKDOWN_FOOTER = """
 """
 
 PERSON = """
-class "Person" [[{A person, living or dead}]]{
+class "Person" [[{A person, living or dead}]] {
     {field} "id" : "string" [req]
     {field} "name" : "string" [opt]
     {field} "age_in_years" : "integer" [opt]

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -17,13 +17,13 @@ MARKDOWN_FOOTER = """
 
 PERSON = """
 class "Person" [[{A person, living or dead}]] {
-    {field} "id" : "string" [req]
-    {field} "name" : "string" [opt]
-    {field} "age_in_years" : "integer" [opt]
-    {field} "species_name" : "string" [opt]
-    {field} "stomach_count" : "integer" [opt]
-    {field} "is_living" : "LifeStatusEnum" [opt]
-    {field} "aliases" : "string" [0..*]
+    {field} id : string  
+    {field} name : string  
+    {field} age_in_years : integer  
+    {field} species_name : string  
+    {field} stomach_count : integer  
+    {field} is_living : LifeStatusEnum  
+    {field} aliases : string  [0..*]
 }
 """
 


### PR DESCRIPTION
The Plantuml Generator doesn't support proper spacing and quotations that lead to broken diagram generation and SVG generation.
This also adds support for SVG tooltips via PlantUML tooltip syntax.