### PR TITLE
Mappings section should show on individual element pages and not just classes

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -99,20 +99,6 @@ URI: {{ gen.uri_link(element) }}
 
 {% include "common_metadata.md.jinja2" %}
 
-
-{% if schemaview.get_mappings(element.name).items() -%}
-## Mappings
-
-| Mapping Type | Mapped Value |
-| ---  | ---  |
-{% for m, mt in schemaview.get_mappings(element.name).items() -%}
-{% if mt|length > 0 -%}
-| {{ m }} | {{ mt|join(', ') }} |
-{% endif -%}
-{% endfor %}
-
-{% endif -%}
-
 {% if gen.example_object_blobs(element.name) -%}
 ## Examples
 {% for name, blob in gen.example_object_blobs(element.name) -%}

--- a/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/linkml/generators/docgen/common_metadata.md.jinja2
@@ -76,3 +76,16 @@ Instances of this class *should* have identifiers with one of the following pref
 * imported from: {{ element.imported_from }}
 {% endif %}
 {% endif %}
+
+{% if schemaview.get_mappings(element.name).items() -%}
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+{% for m, mt in schemaview.get_mappings(element.name).items() -%}
+{% if mt|length > 0 -%}
+| {{ m }} | {{ mt|join(', ') }} |
+{% endif -%}
+{% endfor %}
+
+{% endif -%}


### PR DESCRIPTION
Prior to this PR it used to be the case that the `Mappings` section got rendered only on class documentation pages. This came in as a request from @wdduncan where he pointed that we should ideally be able to see `Mappings` on all element pages (class, slot, etc.) if present.