### PR TITLE
[pydanticgen] Add CLI options for `linkml_meta` mode, tests and bugfixes for `linkml_meta`

### DIFF
--- a/linkml/generators/pydanticgen/__init__.py
+++ b/linkml/generators/pydanticgen/__init__.py
@@ -1,4 +1,4 @@
-from linkml.generators.pydanticgen.pydanticgen import DEFAULT_IMPORTS, PydanticGenerator, cli
+from linkml.generators.pydanticgen.pydanticgen import DEFAULT_IMPORTS, MetadataMode, PydanticGenerator, cli
 from linkml.generators.pydanticgen.template import (
     ConditionalImport,
     Import,
@@ -18,6 +18,7 @@ __all__ = [
     "DEFAULT_IMPORTS",
     "Import",
     "Imports",
+    "MetadataMode",
     "PydanticAttribute",
     "PydanticBaseModel",
     "PydanticClass",

--- a/linkml/generators/pydanticgen/includes.py
+++ b/linkml/generators/pydanticgen/includes.py
@@ -19,6 +19,9 @@ class LinkMLMeta(BaseModel):
     
     def __setitem__(self, key:str, value):
         self.__root__[key] = value
+        
+    def __contains__(self, key:str) -> bool:
+        return key in self.__root__
    
     class Config:
         allow_mutation = False
@@ -37,6 +40,9 @@ class LinkMLMeta(RootModel):
     
     def __setitem__(self, key:str, value):
         self.root[key] = value
+        
+    def __contains__(self, key:str) -> bool:
+        return key in self.root
     
 """
 

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -758,10 +758,6 @@ class PydanticGenerator(OOCodeGenerator):
                 new_class.bases = bases[k]
             classes[k] = new_class
 
-        # schema_meta = {
-        #     k: v for k, v in remove_empty_items(schema).items() if k not in PydanticModule.exclude_from_meta()
-        # }
-
         module = PydanticModule(
             pydantic_ver=self.pydantic_version,
             metamodel_version=self.schema.metamodel_version,

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -600,7 +600,7 @@ class PydanticGenerator(OOCodeGenerator):
         else:
             raise ValueError(
                 f"Unknown metadata mode '{self.metadata_mode}', needs to be one of "
-                f"{[mode.value for mode in MetadataMode]}"
+                f"{[mode for mode in MetadataMode]}"
             )
 
         model.meta = meta
@@ -753,9 +753,9 @@ class PydanticGenerator(OOCodeGenerator):
                 new_class.bases = bases[k]
             classes[k] = new_class
 
-        schema_meta = {
-            k: v for k, v in remove_empty_items(schema).items() if k not in PydanticModule.exclude_from_meta()
-        }
+        # schema_meta = {
+        #     k: v for k, v in remove_empty_items(schema).items() if k not in PydanticModule.exclude_from_meta()
+        # }
 
         module = PydanticModule(
             pydantic_ver=self.pydantic_version,
@@ -766,7 +766,6 @@ class PydanticGenerator(OOCodeGenerator):
             injected_classes=injected_classes,
             enums=enums,
             classes=classes,
-            meta=schema_meta,
         )
         module = self.include_metadata(module, pyschema)
         return module
@@ -830,6 +829,14 @@ Available templates to override:
     default=False,
     help="Format generated models with black (must be present in the environment)",
 )
+@click.option(
+    "--meta",
+    type=click.Choice([k for k in MetadataMode]),
+    default="auto",
+    help="How to include linkml schema metadata in generated pydantic classes. "
+         "See docs for MetadataMode for full description of choices. "
+         "Default (auto) is to include all metadata that can't be otherwise represented"
+)
 @click.version_option(__version__, "-V", "--version")
 @click.command()
 def cli(
@@ -844,6 +851,7 @@ def cli(
     pydantic_version=int(PYDANTIC_VERSION[0]),
     extra_fields: Literal["allow", "forbid", "ignore"] = "forbid",
     black: bool = False,
+    meta: MetadataMode = "auto",
     **args,
 ):
     """Generate pydantic classes to represent a LinkML model"""
@@ -870,6 +878,7 @@ def cli(
         gen_slots=slots,
         template_dir=template_dir,
         black=black,
+        metadata_mode=meta,
         **args,
     )
     print(gen.serialize())

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -322,6 +322,11 @@ class PydanticClass(TemplateModel):
         def validators(self) -> Optional[Dict[str, PydanticValidator]]:
             return self._validators()
 
+        @computed_field
+        def slots(self) -> Optional[Dict[str, PydanticAttribute]]:
+            """alias of attributes"""
+            return self.attributes
+
     else:
         validators: Optional[Dict[str, PydanticValidator]]
 
@@ -575,7 +580,7 @@ class PydanticModule(TemplateModel):
     version: Optional[str] = None
     base_model: PydanticBaseModel = PydanticBaseModel()
     injected_classes: Optional[List[str]] = None
-    imports: List[Union[Import, ConditionalImport]] = Field(default_factory=list)
+    python_imports: List[Union[Import, ConditionalImport]] = Field(default_factory=list)
     enums: Dict[str, PydanticEnum] = Field(default_factory=dict)
     classes: Dict[str, PydanticClass] = Field(default_factory=dict)
     meta: Optional[Dict[str, Any]] = None

--- a/linkml/generators/pydanticgen/templates/module.py.jinja
+++ b/linkml/generators/pydanticgen/templates/module.py.jinja
@@ -1,4 +1,4 @@
-{% for import in imports %}
+{% for import in python_imports %}
 {{ import }}
 {%- endfor -%}
 

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -7,7 +7,7 @@ from importlib.metadata import version
 from importlib.util import find_spec
 from pathlib import Path
 from types import GeneratorType, ModuleType
-from typing import ClassVar, Dict, List, Literal, Optional, Union, get_args, get_origin
+from typing import ClassVar, Dict, List, Literal, Optional, Type, Union, get_args, get_origin
 
 import numpy as np
 import pytest
@@ -15,14 +15,15 @@ import yaml
 from jinja2 import DictLoader, Environment, Template
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
-from linkml_runtime.linkml_model import SchemaDefinition, SlotDefinition
+from linkml_runtime.linkml_model import Definition, SchemaDefinition, SlotDefinition
 from linkml_runtime.utils.compile_python import compile_python
+from linkml_runtime.utils.formatutils import camelcase, remove_empty_items, underscore
 from linkml_runtime.utils.schemaview import load_schema_wrap
 from pydantic import BaseModel, ValidationError
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 from linkml.generators import pydanticgen as pydanticgen_root
-from linkml.generators.pydanticgen import PydanticGenerator, array, build, pydanticgen, template
+from linkml.generators.pydanticgen import MetadataMode, PydanticGenerator, array, build, pydanticgen, template
 from linkml.generators.pydanticgen.array import AnyShapeArray, ArrayRepresentation
 from linkml.generators.pydanticgen.template import (
     ConditionalImport,
@@ -31,6 +32,7 @@ from linkml.generators.pydanticgen.template import (
     ObjectImport,
     PydanticAttribute,
     PydanticClass,
+    PydanticModule,
     PydanticValidator,
     TemplateModel,
 )
@@ -1722,3 +1724,63 @@ def test_template_noblack(array_complex, mock_black_import):
     # trying to render with black when we don't have it should raise a ValueError
     with pytest.raises(ValueError):
         _ = generated.classes["ComplexRangeShapeArray"].attributes["array"].render(black=True)
+
+
+# --------------------------------------------------
+# Metadata inclusion
+# --------------------------------------------------
+
+
+def _test_meta(linkml_meta, definition: Definition, model: Type[TemplateModel], mode: str):
+    def_clean = remove_empty_items(definition)
+    for k, v in def_clean.items():
+        if mode == "auto":
+            if k in model.exclude_from_meta():
+                assert k not in linkml_meta
+            else:
+                assert k in linkml_meta
+        elif mode == "full":
+            assert k in linkml_meta
+        elif mode == "except_children":
+            # basically nothing that has a template model
+            if k in ("slots", "classes", "enums", "attributes"):
+                assert k not in linkml_meta
+            else:
+                assert k in linkml_meta
+        elif mode == "None":
+            assert linkml_meta is None or k not in linkml_meta
+        else:
+            raise ValueError(f"Don't know how to test this metadata mode: {mode}")
+
+
+@pytest.mark.skipif(PYDANTIC_VERSION < 2, reason="Pydantic v1 is deprecated")
+@pytest.mark.parametrize("mode", MetadataMode)
+def test_linkml_meta(kitchen_sink_path, tmp_path, input_path, mode):
+    """
+    Pydanticgen can inject missing linkml metadata from schema definitions
+    with several different modes :)
+    """
+    schema = SchemaView(kitchen_sink_path)
+
+    gen = PydanticGenerator(kitchen_sink_path, package=PACKAGE, metadata_mode=mode)
+    code = gen.serialize()
+    module = compile_python(code, PACKAGE)
+    _test_meta(module.linkml_meta, schema.schema, PydanticModule, mode)
+
+    for cls_name, cls_def in schema.all_classes().items():
+        if cls_def["class_uri"] == "linkml:Any":
+            continue
+        cls = getattr(module, camelcase(cls_name))  # type: Type[BaseModel]
+        if mode == MetadataMode.NONE:
+            assert not hasattr(cls, "linkml_meta")
+        else:
+            _test_meta(cls.linkml_meta, cls_def, PydanticClass, mode)
+
+        # pydantic
+
+        for slot_def in schema.class_induced_slots(cls_name):
+            extra = cls.model_fields[underscore(slot_def.name)].json_schema_extra
+            if mode == MetadataMode.NONE:
+                assert extra is None or "linkml_meta" not in extra
+            else:
+                _test_meta(extra["linkml_meta"], slot_def, PydanticAttribute, mode)

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -1776,8 +1776,6 @@ def test_linkml_meta(kitchen_sink_path, tmp_path, input_path, mode):
         else:
             _test_meta(cls.linkml_meta, cls_def, PydanticClass, mode)
 
-        # pydantic
-
         for slot_def in schema.class_induced_slots(cls_name):
             extra = cls.model_fields[underscore(slot_def.name)].json_schema_extra
             if mode == MetadataMode.NONE:

--- a/tests/test_scripts/test_gen_pydantic.py
+++ b/tests/test_scripts/test_gen_pydantic.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+from linkml_runtime.utils.compile_python import compile_python
+
 from linkml.generators.pydanticgen import cli
 
 
@@ -20,3 +22,28 @@ attr: attr_2
 range: Optional[List[float]]"""
         in result.stdout
     )
+
+
+def test_pydantic_metadata_mode(input_path):
+    """
+    Should be possible to change metadata modes from the CLI
+
+    Note that this does not test the functionality of including metadata, just
+    the ability to specify from the CLI
+    """
+    pydantic_dir = input_path("pydantic")
+    args = [str(Path(pydantic_dir) / "simple.yaml"), '--meta', 'None']
+
+    runner = CliRunner()
+    result = runner.invoke(cli, args)
+    mod = compile_python(result.stdout)
+    assert mod.linkml_meta is None
+
+    args = [str(Path(pydantic_dir) / "simple.yaml"), '--meta', 'auto']
+
+    runner = CliRunner()
+    result = runner.invoke(cli, args)
+    mod = compile_python(result.stdout)
+    assert mod.linkml_meta['id'] == 'simple'
+
+

--- a/tests/test_scripts/test_gen_pydantic.py
+++ b/tests/test_scripts/test_gen_pydantic.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from click.testing import CliRunner
-
 from linkml_runtime.utils.compile_python import compile_python
 
 from linkml.generators.pydanticgen import cli
@@ -32,18 +31,16 @@ def test_pydantic_metadata_mode(input_path):
     the ability to specify from the CLI
     """
     pydantic_dir = input_path("pydantic")
-    args = [str(Path(pydantic_dir) / "simple.yaml"), '--meta', 'None']
+    args = [str(Path(pydantic_dir) / "simple.yaml"), "--meta", "None"]
 
     runner = CliRunner()
     result = runner.invoke(cli, args)
     mod = compile_python(result.stdout)
     assert mod.linkml_meta is None
 
-    args = [str(Path(pydantic_dir) / "simple.yaml"), '--meta', 'auto']
+    args = [str(Path(pydantic_dir) / "simple.yaml"), "--meta", "auto"]
 
     runner = CliRunner()
     result = runner.invoke(cli, args)
     mod = compile_python(result.stdout)
-    assert mod.linkml_meta['id'] == 'simple'
-
-
+    assert mod.linkml_meta["id"] == "simple"


### PR DESCRIPTION
Continues: https://github.com/linkml/linkml/pull/2036

#2036 was merged before i could get it quite finished, so returning to do that now.

This pr...

Adds:
- CLI option `--meta` to PydanticGen to be able to switch the metadata inclusion mode. Default behavior remains unchanged
- `__contains__` method to `LinkMLMeta` object
- `slots` alias to `attributes` in `PydanticClass` because they are equivalent at the point of generating pydantic fields.
- TESTS for the metadata inclusion methods lol which revealed several of these bugs.

Changes:
- rename `imports` to `python_imports` in PydanticModule to avoid accidentally excluding `imports` in metadata

Fixes:
- uses `include_metadata` method for `PydanticModule` instead of the weird special cased version which ignored the metadata mode setting
- fix buggy logic for `except_children` mode where everything would fall through the `if ... elif` chain eventually, making it == the `full` mode.
