### PR TITLE
gen-pydantic not properly handling multivalued, required fields. 

### DIFF
--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -409,7 +409,7 @@ class PydanticGenerator(OOCodeGenerator):
                     # Multivalued slots that are either not inlined (just an identifier) or are
                     # inlined as lists should get default_factory list, if they're inlined but
                     # not as a list, that means a dictionary
-                    elif slot.multivalued:
+                    elif slot.multivalued and not slot.required:
                         has_identifier_slot = self.range_class_has_identifier_slot(slot)
 
                         if slot.inlined and not slot.inlined_as_list and has_identifier_slot:

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -517,7 +517,7 @@ def test_cardinality(framework, multivalued, required, data_name, value):
         (PYDANTIC, False, False): "Optional[str] = Field(None",
         (PYDANTIC, False, True): "str = Field(...",
         (PYDANTIC, True, False): "Optional[List[str]] = Field(default_factory=list",
-        (PYDANTIC, True, True): "List[str] = Field(default_factory=list",
+        (PYDANTIC, True, True): "List[str] = Field(...",
         # TODO: values
         (PYTHON_DATACLASSES, False, False): "",
         (PYTHON_DATACLASSES, False, True): "",

--- a/tests/test_issues/test_linkml_issue_1094.py
+++ b/tests/test_issues/test_linkml_issue_1094.py
@@ -66,4 +66,4 @@ def test_pydanticgen_inline_dict():
     output = gen.serialize()
     output_subset = [line for line in output.splitlines() if "has_bikes: " in line]
     assert len(output_subset) == 1
-    assert "has_bikes: Dict[str, str] = Field(..." in output_subset[0]
+    assert "has_bikes: Dict[str, Union[str, Bike]] = Field(...," in output_subset[0]

--- a/tests/test_issues/test_linkml_issue_1094.py
+++ b/tests/test_issues/test_linkml_issue_1094.py
@@ -63,7 +63,5 @@ def test_pydanticgen_inline_dict():
     assert dict_field.default_factory is None
     assert list_field.default_factory is None
 
-    output = gen.serialize()
-    output_subset = [line for line in output.splitlines() if "has_bikes: " in line]
-    assert len(output_subset) == 1
-    assert "has_bikes: Dict[str, Union[str, Bike]] = Field(...," in output_subset[0]
+    assert str(dict_field.default) == "PydanticUndefined"
+    assert str(list_field.default) == "PydanticUndefined"

--- a/tests/test_issues/test_linkml_issue_1094.py
+++ b/tests/test_issues/test_linkml_issue_1094.py
@@ -62,3 +62,8 @@ def test_pydanticgen_inline_dict():
 
     assert dict_field.default_factory is None
     assert list_field.default_factory is None
+
+    output = gen.serialize()
+    output_subset = [line for line in output.splitlines() if "has_bikes: " in line]
+    assert len(output_subset) == 1
+    assert "has_bikes: Dict[str, str] = Field(..." in output_subset[0]


### PR DESCRIPTION
When generating a multivalued attribute with the Pydantic model, a `default_factory` is provided currently. However, validation will not work as expected with this `default_factory`. 

A Pydantic field is described as required as follows (https://github.com/pydantic/pydantic/blob/d654a0766c2f3c6fe0a12718f32aa3bf4d3ecc86/pydantic/fields.py#L577-L583): 

```python
def is_required(self) -> bool:
        """Check if the field is required (i.e., does not have a default value or factory).

        Returns:
            `True` if the field is required, `False` otherwise.
        """
        return self.default is PydanticUndefined and self.default_factory is None
```

However, in the `pydanticgen.py` file:

```python
def get_predefined_slot_values(self) -> Dict[str, Dict[str, str]]:
...
      elif slot.multivalued:
          has_identifier_slot = self.range_class_has_identifier_slot(slot)

          if slot.inlined and not slot.inlined_as_list and has_identifier_slot:
              slot_values[camelcase(class_def.name)][slot.name] = "default_factory=dict"
          else:
              slot_values[camelcase(class_def.name)][slot.name] = "default_factory=list"
```

It does not consider that if the slot is required, it should not be providing a `default_factory`.  

I've suggested a simple change in this PR. Thank you!

An example of the unintended behavior below:
<details>
<summary>schema.yaml</summary>

```
name: dataset_config
id: placeholder

imports:
  - linkml:types
  
classes:
  Container:
    tree_root: true
    attributes:
      names:
        range: string
        multivalued: true
        required: true
```
</details>

Command: `gen-pydantic schema.yaml --pydantic-version 2 > schema.py`

<details>
<summary>Generated pydantic model (schema.py)</summary>

```python
from __future__ import annotations 
from datetime import (
    datetime,
    date
)
from decimal import Decimal 
from enum import Enum 
import re
import sys
from typing import (
    Any,
    ClassVar,
    List,
    Literal,
    Dict,
    Optional,
    Union
)
from pydantic.version import VERSION  as PYDANTIC_VERSION 
if int(PYDANTIC_VERSION[0])>=2:
    from pydantic import (
        BaseModel,
        ConfigDict,
        Field,
        RootModel,
        field_validator
    )
else:
    from pydantic import (
        BaseModel,
        Field,
        validator
    )

metamodel_version = "None"
version = "None"


class ConfiguredBaseModel(BaseModel):
    model_config = ConfigDict(
        validate_assignment = True,
        validate_default = True,
        extra = "forbid",
        arbitrary_types_allowed = True,
        use_enum_values = True,
        strict = False,
    )
    pass




class LinkMLMeta(RootModel):
    root: Dict[str, Any] = {}
    model_config = ConfigDict(frozen=True)

    def __getattr__(self, key:str):
        return getattr(self.root, key)

    def __getitem__(self, key:str):
        return self.root[key]

    def __setitem__(self, key:str, value):
        self.root[key] = value


linkml_meta = LinkMLMeta({'default_prefix': 'placeholder/',
     'id': 'placeholder',
     'name': 'dataset_config'} )


class Container(ConfiguredBaseModel):
    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'placeholder', 'tree_root': True})

    names: List[str] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'alias': 'names', 'domain_of': ['Container']} })
    # Should not have default_factory value, because then when creating a Container object, no ValidationError will be thrown if there is no provided names value

# Model rebuild
# see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
Container.model_rebuild()
```
</details>

With the fix provided:

<details>
<summary>Generated pydantic model (fixed)</summary>

```python
ffrom __future__ import annotations 
from datetime import (
    datetime,
    date
)
from decimal import Decimal 
from enum import Enum 
import re
import sys
from typing import (
    Any,
    ClassVar,
    List,
    Literal,
    Dict,
    Optional,
    Union
)
from pydantic.version import VERSION  as PYDANTIC_VERSION 
if int(PYDANTIC_VERSION[0])>=2:
    from pydantic import (
        BaseModel,
        ConfigDict,
        Field,
        RootModel,
        field_validator
    )
else:
    from pydantic import (
        BaseModel,
        Field,
        validator
    )

metamodel_version = "None"
version = "None"


class ConfiguredBaseModel(BaseModel):
    model_config = ConfigDict(
        validate_assignment = True,
        validate_default = True,
        extra = "forbid",
        arbitrary_types_allowed = True,
        use_enum_values = True,
        strict = False,
    )
    pass




class LinkMLMeta(RootModel):
    root: Dict[str, Any] = {}
    model_config = ConfigDict(frozen=True)

    def __getattr__(self, key:str):
        return getattr(self.root, key)

    def __getitem__(self, key:str):
        return self.root[key]

    def __setitem__(self, key:str, value):
        self.root[key] = value


linkml_meta = LinkMLMeta({'default_prefix': 'placeholder/',
     'id': 'placeholder',
     'name': 'dataset_config'} )


class Container(ConfiguredBaseModel):
    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'placeholder', 'tree_root': True})

    names: List[str] = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'names', 'domain_of': ['Container']} })


# Model rebuild
# see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
Container.model_rebuild()
```
</details>