### PR TITLE
[pydanticgen] Split generation :)

### DIFF
--- a/docs/generators/pydantic.rst
+++ b/docs/generators/pydantic.rst
@@ -104,8 +104,6 @@ a single module, except for importing classes from other modules rather than
 including them directly. This is wrapped by :meth:`.PydanticGenerator.generate_split` which
 can be used to generate the module files directly
 
-.. autofunction:: generate_split
-
 
 Templates
 ---------

--- a/docs/generators/pydantic.rst
+++ b/docs/generators/pydantic.rst
@@ -1,4 +1,4 @@
-:tocdepth:  3
+:tocdepth: 3
 
 .. _pydanticgen:
 

--- a/docs/generators/pydantic.rst
+++ b/docs/generators/pydantic.rst
@@ -1,4 +1,4 @@
-:tocdepth: 3
+:tocdepth:  3
 
 .. _pydanticgen:
 

--- a/docs/generators/pydantic.rst
+++ b/docs/generators/pydantic.rst
@@ -97,10 +97,11 @@ See:
 * :attr:`.PydanticGenerator.split`
 * :attr:`.PydanticGenerator.split_pattern`
 * :attr:`.PydanticGenerator.split_context`
+* :meth:`.PydanticGenerator.generate_split`
 
 The implementation of ``split`` mode in the Generator itself still generates
 a single module, except for importing classes from other modules rather than
-including them directly. This is wrapped by :func:`.generate_split` which
+including them directly. This is wrapped by :meth:`.PydanticGenerator.generate_split` which
 can be used to generate the module files directly
 
 .. autofunction:: generate_split

--- a/docs/generators/pydantic.rst
+++ b/docs/generators/pydantic.rst
@@ -104,7 +104,6 @@ including them directly. This is wrapped by :func:`.generate_split` which
 can be used to generate the module files directly
 
 .. autofunction:: generate_split
-    :members:
 
 
 Templates

--- a/docs/generators/pydantic.rst
+++ b/docs/generators/pydantic.rst
@@ -85,6 +85,28 @@ Generator
 .. autoclass:: PydanticGenerator
     :members:
 
+Split Generation
+----------------
+
+Pydantic models can also be generated in a "split" mode where rather than
+rolling down all classes into a single file, schemas are kept as their own
+pydantic modules that import from one another.
+
+See:
+
+* :attr:`.PydanticGenerator.split`
+* :attr:`.PydanticGenerator.split_pattern`
+* :attr:`.PydanticGenerator.split_context`
+
+The implementation of ``split`` mode in the Generator itself still generates
+a single module, except for importing classes from other modules rather than
+including them directly. This is wrapped by :func:`.generate_split` which
+can be used to generate the module files directly
+
+.. autofunction:: generate_split
+    :members:
+
+
 Templates
 ---------
 

--- a/linkml/generators/oocodegen.py
+++ b/linkml/generators/oocodegen.py
@@ -76,6 +76,7 @@ class OOCodeGenerator(Generator):
     visit_all_class_slots = False
     uses_schemaloader = False
     requires_metamodel = False
+    schemaview: SchemaView = None
 
     template_file: str = None
     """Path to template"""
@@ -84,7 +85,7 @@ class OOCodeGenerator(Generator):
 
     def __post_init__(self):
         # TODO: consider moving up a level
-        self.schemaview = SchemaView(self.schema)
+        self.schemaview: SchemaView = SchemaView(self.schema)
         super().__post_init__()
 
     @abc.abstractmethod

--- a/linkml/generators/pydanticgen/__init__.py
+++ b/linkml/generators/pydanticgen/__init__.py
@@ -21,7 +21,6 @@ __all__ = [
     "cli",
     "ConditionalImport",
     "DEFAULT_IMPORTS",
-    "generate_split",
     "Import",
     "Imports",
     "MetadataMode",

--- a/linkml/generators/pydanticgen/__init__.py
+++ b/linkml/generators/pydanticgen/__init__.py
@@ -1,4 +1,10 @@
-from linkml.generators.pydanticgen.pydanticgen import DEFAULT_IMPORTS, MetadataMode, PydanticGenerator, cli
+from linkml.generators.pydanticgen.pydanticgen import (
+    DEFAULT_IMPORTS,
+    MetadataMode,
+    PydanticGenerator,
+    cli,
+    generate_split,
+)
 from linkml.generators.pydanticgen.template import (
     ConditionalImport,
     Import,

--- a/linkml/generators/pydanticgen/__init__.py
+++ b/linkml/generators/pydanticgen/__init__.py
@@ -3,7 +3,6 @@ from linkml.generators.pydanticgen.pydanticgen import (
     MetadataMode,
     PydanticGenerator,
     cli,
-    generate_split,
 )
 from linkml.generators.pydanticgen.template import (
     ConditionalImport,

--- a/linkml/generators/pydanticgen/__init__.py
+++ b/linkml/generators/pydanticgen/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "cli",
     "ConditionalImport",
     "DEFAULT_IMPORTS",
+    "generate_split",
     "Import",
     "Imports",
     "MetadataMode",

--- a/linkml/generators/pydanticgen/array.py
+++ b/linkml/generators/pydanticgen/array.py
@@ -12,7 +12,7 @@ from linkml.utils.deprecation import deprecation_warning
 if int(PYDANTIC_VERSION[0]) >= 2:
     from pydantic_core import core_schema
 else:
-    #  Support for having pydantic 1 installed in the same environment will be dropped in 1.9.0
+    # Support for having pydantic 1 installed in the same environment will be dropped in 1.9.0
     deprecation_warning("pydantic-v1")
 
 if TYPE_CHECKING:

--- a/linkml/generators/pydanticgen/array.py
+++ b/linkml/generators/pydanticgen/array.py
@@ -12,7 +12,7 @@ from linkml.utils.deprecation import deprecation_warning
 if int(PYDANTIC_VERSION[0]) >= 2:
     from pydantic_core import core_schema
 else:
-    # Support for having pydantic 1 installed in the same environment will be dropped in 1.9.0
+    #  Support for having pydantic 1 installed in the same environment will be dropped in 1.9.0
     deprecation_warning("pydantic-v1")
 
 if TYPE_CHECKING:

--- a/linkml/generators/pydanticgen/build.py
+++ b/linkml/generators/pydanticgen/build.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from typing import List, Optional, Type, TypeVar, Union
 
-from pydantic import BaseModel
+from linkml_runtime.linkml_model import SchemaDefinition
+from pydantic import BaseModel, ConfigDict
 
 from linkml.generators.pydanticgen.template import Import, Imports, PydanticAttribute, PydanticClass
 
@@ -99,3 +101,15 @@ class SlotResult(BuildResult):
 class ClassResult(BuildResult):
     cls: PydanticClass
     """Constructed Template Model for class, including attributes/slots"""
+
+
+class SplitResult(BaseModel):
+    """Build result when generating with :func:`.generate_split`"""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    main: bool = False
+    source_schema: SchemaDefinition
+    path: Path
+    serialized_module: str
+    module_import: Optional[str] = None

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -22,7 +22,6 @@ from linkml_runtime.linkml_model.meta import (
 from linkml_runtime.utils.compile_python import compile_python
 from linkml_runtime.utils.formatutils import camelcase, remove_empty_items, underscore
 from linkml_runtime.utils.schemaview import SchemaView
-from pydantic import BaseModel, ConfigDict
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 from linkml._version import __version__
@@ -30,7 +29,7 @@ from linkml.generators.common.type_designators import get_accepted_type_designat
 from linkml.generators.oocodegen import OOCodeGenerator
 from linkml.generators.pydanticgen import includes
 from linkml.generators.pydanticgen.array import ArrayRangeGenerator, ArrayRepresentation
-from linkml.generators.pydanticgen.build import ClassResult, SlotResult
+from linkml.generators.pydanticgen.build import ClassResult, SlotResult, SplitResult
 from linkml.generators.pydanticgen.template import (
     Import,
     Imports,
@@ -944,18 +943,6 @@ def _subclasses(cls: Type):
 
 
 _TEMPLATE_NAMES = sorted(list(set([c.template for c in _subclasses(TemplateModel)])))
-
-
-class SplitResult(BaseModel):
-    """Build result when generating with :func:`.generate_split`"""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    main: bool = False
-    source_schema: SchemaDefinition
-    path: Path
-    serialized_module: str
-    module_import: Optional[str] = None
 
 
 def generate_split(

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -1,12 +1,12 @@
 import inspect
 import logging
 import os
+import re
 import textwrap
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-import re
 from types import ModuleType
 from typing import ClassVar, Dict, List, Literal, Optional, Set, Tuple, Type, TypeVar, Union, overload
 
@@ -948,6 +948,7 @@ _TEMPLATE_NAMES = sorted(list(set([c.template for c in _subclasses(TemplateModel
 
 class SplitResult(BaseModel):
     """Build result when generating with :func:`.generate_split`"""
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     main: bool = False

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -902,7 +902,7 @@ class PydanticGenerator(OOCodeGenerator):
         schema_name = self.schemaview.element_by_schema_map()[class_name]
         schema = [s for s in self.schemaview.schema_map.values() if s.name == schema_name][0]
         module = self.generate_module_import(schema, self.split_context)
-        return Import(module=module, objects=[ObjectImport(name=camelcase(class_name))], generated=True)
+        return Import(module=module, objects=[ObjectImport(name=camelcase(class_name))], schema=True)
 
     def render(self) -> PydanticModule:
         sv: SchemaView
@@ -1055,9 +1055,8 @@ def generate_split(
     # --------------------------------------------------
     # Imported schemas
     # --------------------------------------------------
-    # make the rendered module strings to match to the generated imports
     imported_schema = {generator.generate_module_import(sch): sch for sch in generator.schemaview.schema_map.values()}
-    for generated_import in [i for i in rendered.python_imports if i.generated]:
+    for generated_import in [i for i in rendered.python_imports if i.schema]:
 
         import_generator = PydanticGenerator(imported_schema[generated_import.module], **gen_kwargs)
         serialized = import_generator.serialize()

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -807,11 +807,12 @@ class PydanticGenerator(OOCodeGenerator):
         else:
             raise ValueError(f"Unsupported type of element to get imports from: f{type(element)}")
 
-        skips = ('AnyType',)  # classes that are not generated for structural reasons placeholder.
-        class_imports = [self._get_element_import(cls) for cls in needed_classes if cls not in local_classes and cls not in skips]
-        imports = Imports()
-        for an_import in class_imports:
-            imports += an_import
+        # SPECIAL CASE: classes that are not generated for structural reasons.
+        # TODO: Do we want to have a general means of skipping class generation?
+        skips = ('AnyType',)
+
+        class_imports = [self._get_element_import(cls) for cls in needed_classes if (cls not in local_classes and cls not in skips)]
+        imports = Imports(imports=class_imports)
 
         return imports
 

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -277,7 +277,7 @@ class PydanticGenerator(OOCodeGenerator):
     Additional variables to pass into ``split_pattern`` when
     generating imported module names. 
     
-    Passed in as **kwargs, so e.g. if ``split_context = {'myval': 1}``
+    Passed in as ``**kwargs`` , so e.g. if ``split_context = {'myval': 1}``
     then one would use it in a template string like ``{{ myval }}``
     """
 

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -268,12 +268,15 @@ class PydanticGenerator(OOCodeGenerator):
     
     The pattern is a jinja template string that is given the ``SchemaDefinition``
     of the imported schema in the environment. Additional variables can be passed
-    into the jinja environment with the ``split_environment`` argument.
+    into the jinja environment with the :attr:`.split_context` argument.
      
     Further modification is possible by using jinja filters.
     
     After templating, the string is passed through a :attr:`SNAKE_CASE` pattern
     to replace whitespace and other characters that can't be used in module names.
+    
+    See also :meth:`.generate_module_import`, which is used to generate the
+    module portion of the import statement (and can be overridden in subclasses).
      
     Examples:
     
@@ -286,6 +289,7 @@ class PydanticGenerator(OOCodeGenerator):
         ``"...{{ schema.name }}.v{{ schema.version | replace('.', '_') }}"`` becomes
         
         ``from ...example_schema.v1_2_3 import ClassA, ...``
+    
     """
     split_context: Optional[dict] = None
     """

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -321,12 +321,11 @@ class Import(TemplateModel):
     module: str
     alias: Optional[str] = None
     objects: Optional[List[ObjectImport]] = None
-    generated: bool = False
+    schema: bool = False
     """
-    Whether or not this ``Import`` is a byproduct of model generation -- 
-    ie. that it is not expected to be provided by the environment, but might require additional
-    work on the part of the generator to provide. See :func:`.pydanticgen.generate_split` 
-    for example usage.
+    Whether or not this ``Import`` is importing another schema imported by the main schema -- 
+    ie. that it is not expected to be provided by the environment, but imported locally from within the package. 
+    Used primarily in split schema generation, see :func:`.pydanticgen.generate_split` for example usage.
     """
 
     def merge(self, other: "Import") -> List["Import"]:
@@ -376,7 +375,7 @@ class Import(TemplateModel):
                     module=self.module,
                     alias=alias,
                     objects=list(self_objs.values()),
-                    generated=self.generated or other.generated,
+                    schema=self.schema or other.schema,
                 )
             ]
         else:

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -545,7 +545,7 @@ class Imports(TemplateModel):
                 raise KeyError(f"No import with module {item} was found.\nWe have: {self.imports}")
             return an_import[0]
         else:
-            raise TypeError("Can only index with an int or a string as the name of the module," "\nGot: {type(item)}")
+            raise TypeError(f"Can only index with an int or a string as the name of the module,\nGot: {type(item)}")
 
     def __contains__(self, item: Union[Import, "Imports", List[Import]]) -> bool:
         """

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -371,7 +371,14 @@ class Import(TemplateModel):
             }
             self_objs.update(other_objs)
 
-            return [Import(module=self.module, alias=alias, objects=list(self_objs.values()))]
+            return [
+                Import(
+                    module=self.module,
+                    alias=alias,
+                    objects=list(self_objs.values()),
+                    generated=self.generated or other.generated,
+                )
+            ]
         else:
             # one is a module, the other imports objects, keep both
             return [self, other]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "linkml"
-version = "1.7.5.post241.dev0+8fd9c529"
+version = "0.0.0"
 description = "Linked Open Data Modeling Language"
 authors = [
     "Chris Mungall <cjmungall@lbl.gov>",
@@ -44,7 +44,7 @@ packages = [
 ]
 
 [tool.poetry-dynamic-versioning]
-enable = false
+enable = true
 vcs = "git"
 style = "pep440"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,8 @@ markers = [
   "network: mark tests that make external network requests",
   "slow: mark test as slow to run",
   "no_asserts: tests that don't have meaningful asserts, but are only snapshot comparisons, or historically had print statements, or other non-erroring behavior",
-  "strcmp: tests that compare stringified values rather than the values themselves"
+  "strcmp: tests that compare stringified values rather than the values themselves",
+  "pydanticgen_split: Split module generation in pydanticgen",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "linkml"
-version = "0.0.0"
+version = "1.7.5.post241.dev0+8fd9c529"
 description = "Linked Open Data Modeling Language"
 authors = [
     "Chris Mungall <cjmungall@lbl.gov>",
@@ -44,7 +44,7 @@ packages = [
 ]
 
 [tool.poetry-dynamic-versioning]
-enable = true
+enable = false
 vcs = "git"
 style = "pep440"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,11 +202,13 @@ def pytest_collection_modifyitems(config, items: List[pytest.Item]):
 
     # the fixture that mocks black import failures should always come all the way last
     # see: https://github.com/linkml/linkml/pull/2209#issuecomment-2231548078
-    # this causes really hard to diagnose errors, so we should fail testing if
-    # eg. this test changes names and we no longer put it at the end.
+    # this causes really hard to diagnose errors, but we can't fail a test run if
+    # it's not found because then we can't run a subset of the tests.
+    # so special care should be taken not to change this test in particular :)
     test_black = [i for i in items if i.name == "test_template_noblack"]
-    items.remove(test_black[0])
-    items.append(test_black[0])
+    if len(test_black) == 1:
+        items.remove(test_black[0])
+        items.append(test_black[0])
 
 
 def pytest_sessionstart(session: pytest.Session):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,15 +196,15 @@ def pytest_collection_modifyitems(config, items: List[pytest.Item]):
 
     # make sure deprecation test happens at the end
     test_deps = [i for i in items if i.name == "test_removed_are_removed"]
-    test_black = [i for i in items if i.name == "test_template_noblack"]
     if len(test_deps) == 1:
         items.remove(test_deps[0])
         items.append(test_deps[0])
 
-    # the fixture that mocks black imports should always come all the way last
+    # the fixture that mocks black import failures should always come all the way last
     # see: https://github.com/linkml/linkml/pull/2209#issuecomment-2231548078
     # this causes really hard to diagnose errors, so we should fail testing if
     # eg. this test changes names and we no longer put it at the end.
+    test_black = [i for i in items if i.name == "test_template_noblack"]
     items.remove(test_black[0])
     items.append(test_black[0])
 

--- a/tests/test_generators/input/split/README.md
+++ b/tests/test_generators/input/split/README.md
@@ -1,0 +1,9 @@
+# Split generation test case
+
+Test that pydantic generator can correctly generate split schemas - 
+rather than rolling all classes/slots into a single module, generate them
+in modules for each imported schema.
+
+- Detect all imported classes
+- Create correct relative imports
+- Don't include all classes, only those that are actually used 

--- a/tests/test_generators/input/split/main.yaml
+++ b/tests/test_generators/input/split/main.yaml
@@ -21,6 +21,10 @@ classes:
   S1_Inheritance:
     is_a: S1
 
+  S1_Has_Mixin:
+    mixins:
+      - S1Mixin
+
   AnyOfClass:
     slots:
       - any_of_slot

--- a/tests/test_generators/input/split/main.yaml
+++ b/tests/test_generators/input/split/main.yaml
@@ -1,0 +1,38 @@
+id: main
+name: main
+title: main
+imports:
+  - linkml:types
+  - s1
+  - s2
+  - s3
+version: v1.2.3
+annotations:
+  custom: 'ADDITIONAL_METADATA'
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+    slots:
+      - s2_slot
+
+  S1_Inheritance:
+    is_a: S1
+
+  AnyOfClass:
+    slots:
+      - any_of_slot
+
+slots:
+  s2_slot:
+    description: "Slot that uses S1 as a range"
+    range: S2
+
+  any_of_slot:
+    description: Detect classes imported in any_of
+    any_of:
+      - range: S1Any
+      - range: S2Any
+

--- a/tests/test_generators/input/split/s1.yaml
+++ b/tests/test_generators/input/split/s1.yaml
@@ -1,0 +1,24 @@
+id: schema_1
+name: Schema_1
+title: Schema 1
+imports:
+  - linkml:types
+version: v0.1.2
+annotations:
+  custom: 'ADDITIONAL_METADATA'
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+  S1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+  S1Any:
+    description: "One part of the any_of in main"
+    attributes:
+      value:
+        range: string

--- a/tests/test_generators/input/split/s1.yaml
+++ b/tests/test_generators/input/split/s1.yaml
@@ -22,3 +22,13 @@ classes:
     attributes:
       value:
         range: string
+  S1Mixin:
+    description: "Mixin from schema 1"
+    attributes:
+      second_value:
+        range: string
+  S1Unused:
+    description: "Unused class in schema 1"
+    attributes:
+      value:
+        range: string

--- a/tests/test_generators/input/split/s2.yaml
+++ b/tests/test_generators/input/split/s2.yaml
@@ -1,0 +1,24 @@
+id: schema_2
+name: Schema_2
+title: Schema 2
+imports:
+  - linkml:types
+version: v2.3.4
+annotations:
+  custom: 'ADDITIONAL_METADATA'
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+  S2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+  S2Any:
+    description: "One part of the any_of in main"
+    attributes:
+      value:
+        range: string

--- a/tests/test_generators/input/split/s2.yaml
+++ b/tests/test_generators/input/split/s2.yaml
@@ -5,7 +5,7 @@ imports:
   - linkml:types
 version: v2.3.4
 annotations:
-  custom: 'ADDITIONAL_METADATA'
+  custom: 'DIFFERENT_METADATA'
 classes:
   Main:
     description: "The class we use to test overrides on imports!"
@@ -19,6 +19,11 @@ classes:
         range: string
   S2Any:
     description: "One part of the any_of in main"
+    attributes:
+      value:
+        range: string
+  S2Unused:
+    description: "Unused class in schema 1"
     attributes:
       value:
         range: string

--- a/tests/test_generators/input/split/s3.yaml
+++ b/tests/test_generators/input/split/s3.yaml
@@ -1,0 +1,16 @@
+id: schema_3
+name: Schema_3
+title: Schema 3
+annotations:
+  custom: 'ADDITIONAL_METADATA'
+description: |
+  Module that should NOT be generated during split imports even though it is
+  imported by main.yaml because main.yaml doesn't use any classes from it
+imports:
+  - linkml:types
+classes:
+  S3:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -28,7 +28,6 @@ from linkml.generators.pydanticgen import (
     PydanticGenerator,
     array,
     build,
-    generate_split,
     pydanticgen,
     template,
 )
@@ -1967,7 +1966,7 @@ def test_generate_split_directory(input_path, tmp_path):
     schema = input_path("split/main.yaml")
     pattern = "..{{ schema.version | replace('.', '_') }}.{{ schema.name }}"
     output_file = tmp_path / "test_module" / "v1_2_3" / "main.py"
-    result = generate_split(schema, output_file, split_pattern=pattern)
+    result = PydanticGenerator.generate_split(schema, output_file, split_pattern=pattern)
 
     # should be possible to import the main module
     # (this checks that relative imports resolve correctly!)

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -892,8 +892,12 @@ def test_imports_future():
     future_2 = Import(module="__future__", objects=[ObjectImport(name="unicode_literals")])
     future_3 = Import(module="__future__", objects=[ObjectImport(name="generator_stop")])
     imports_2 = Imports(imports=[future_2, future_3])
-    # we haven't merged yet
-    assert imports_2.imports == [future_2, future_3]
+    # Declaring as a list should merge
+    assert imports_2.imports == [
+        Import(
+            module="__future__", objects=[ObjectImport(name="unicode_literals"), ObjectImport(name="generator_stop")]
+        )
+    ]
 
     imports += imports_2
     # now we should have merged and collapsed the future imports to a single expression at the top


### PR DESCRIPTION
Depends on: https://github.com/linkml/linkml/pull/2019

Pulling some more of my changes from https://github.com/p2p-ld/nwb-linkml/ upstream :)

## Problems
- pydantic 2 is super fast when declaring classes compared to pydantic 1. it's still pretty slow when you have a module with a zillion classes in it from a gigantic schema. 
- many people author schemas in multiple files for organization and modularity, but the generated pydantic classes all get dumped in a single file, wrecking that organization
- complex multipart schemas with multiple versions for each dependent schema are currently very difficult to use with pydantic, as there is no formal version specification in imports. It would be great to be able to create many different versions of a given schema and import between them, rather than making an independent module class for each. 

All of these problems are pretty strong barriers to practical implementation by existing formats like NWB, both in terms of ergonomics and expressiveness.

## Solution

this PR allows us to generate pydantic models split by schema!

### Generator

The generator now takes a trio of params:

- `split`: boolean flag indicating split mode
- `split_pattern`: A jinja template string that takes the `SchemaDefinition` and..
- `split_context`: additional variables passed to the generation context.

The PydanticGenerator still only generates a single module, `split` mode just replaces the generated classes imported from other schemas with import statements:

eg. with a `split_pattern` of `"..{{ schema.version | replace('.', '_') }}.{{ schema.name }}"`

we get import statements like

```python
from ..v0_1_2.schema_1 import (
    S1,
    S1Any
)
from ..v2_3_4.schema_2 import (
    S2,
    S2Any
)
```

### `generate_split`

A wrapper function `generate_split` handles generating a whole collection of python modules. So for the set of test schemas in `tests/test_generators/input/split` and the above `split_pattern`, we get a directory structure like this:

```
.
└── test_module
    ├── __init__.py
    ├── v0_1_2
    │   ├── __init__.py
    │   └── schema_1.py
    ├── v1_2_3
    │   ├── __init__.py
    │   └── main.py
    └── v2_3_4
        ├── __init__.py
        └── schema_2.py

5 directories, 7 files
```

the `generate_split` function and its helpers makes sure that we have `__init__.py` files, and also handles converting the relative imports from the generator into paths (so your `split_pattern` can imply any kind of directory structure you want to, relative to the specified output path).

questions? lmk :). Tried to document and test what seemed like it needed to be tested but lmk if i need to add any more that are missing.

## PS

Sorry this PR is non-modular and builds off https://github.com/linkml/linkml/pull/2019 , consider this a gentle nudge to merge that one (this PR will be easier to read then), and also a demonstration of how that structure + the system of passing build results back up is powerful and clear <3


