### PR TITLE
chore: improve json schema for uris and curies

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -39,6 +39,9 @@ json_schema_types: Dict[str, Tuple[str, Optional[str]]] = {
     "xsddate": ("string", "date"),
     "xsddatetime": ("string", "date-time"),
     "xsdtime": ("string", "time"),
+    "uri": ("string", "uri"),
+    "uriorcurie": ("string", "uri"),
+    "curie": ("string", "uri"),
 }
 
 

--- a/tests/test_biolink_model/__snapshots__/biolink.schema.json
+++ b/tests/test_biolink_model/__snapshots__/biolink.schema.json
@@ -10,6 +10,7 @@
                         "biolink:Activity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -32,6 +33,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -51,6 +53,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -74,6 +77,7 @@
                 "affiliation": {
                     "description": "a professional relationship between one provider (often a person) within another provider (often an organization). Target provider identity should be specified by a CURIE. Providers may have multiple affiliations.",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -84,6 +88,7 @@
                         "biolink:Agent"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -106,6 +111,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -125,6 +131,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -152,6 +159,7 @@
                         "biolink:AnatomicalEntity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -181,6 +189,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -200,6 +209,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -229,6 +239,7 @@
                         "biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -257,6 +268,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -281,6 +293,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -289,6 +302,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -349,6 +363,7 @@
                         "biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -377,6 +392,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -401,6 +417,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -409,6 +426,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -469,6 +487,7 @@
                         "biolink:Article"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -499,6 +518,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "iso_abbreviation": {
@@ -522,6 +542,7 @@
                 "mesh_terms": {
                     "description": "mesh terms tagging a publication",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -546,6 +567,7 @@
                 },
                 "published_in": {
                     "description": "The enclosing parent serial containing the article should have industry-standard identifier from ISSN.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "rights": {
@@ -566,6 +588,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -597,6 +620,7 @@
                         "biolink:Association"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -625,6 +649,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -649,6 +674,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -657,6 +683,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -710,6 +737,7 @@
                         "biolink:Attribute"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -747,6 +775,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -766,6 +795,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -789,6 +819,7 @@
                         "biolink:Behavior"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -839,6 +870,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -858,6 +890,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -887,6 +920,7 @@
                         "biolink:BehaviorToBehavioralFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -934,6 +968,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -962,6 +997,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -970,6 +1006,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -1031,6 +1068,7 @@
                         "biolink:BehavioralExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1068,6 +1106,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -1092,6 +1131,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1115,6 +1155,7 @@
                         "biolink:BehavioralFeature"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1144,6 +1185,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -1163,6 +1205,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1191,6 +1234,7 @@
                         "biolink:BiologicalProcess"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1241,6 +1285,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -1260,6 +1305,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1282,6 +1328,7 @@
                         "biolink:BiologicalProcessOrActivity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1332,6 +1379,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -1351,6 +1399,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1373,6 +1422,7 @@
                         "biolink:BiologicalSex"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1410,6 +1460,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -1429,6 +1480,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1452,6 +1504,7 @@
                         "biolink:BioticExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1489,6 +1542,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -1513,6 +1567,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1543,6 +1598,7 @@
                         "biolink:Book"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1573,6 +1629,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "keywords": {
@@ -1588,6 +1645,7 @@
                 "mesh_terms": {
                     "description": "mesh terms tagging a publication",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1624,6 +1682,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1654,6 +1713,7 @@
                         "biolink:BookChapter"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1688,6 +1748,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "keywords": {
@@ -1703,6 +1764,7 @@
                 "mesh_terms": {
                     "description": "mesh terms tagging a publication",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1727,6 +1789,7 @@
                 },
                 "published_in": {
                     "description": "The enclosing parent book containing the chapter should have industry-standard identifier from ISBN.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "rights": {
@@ -1747,6 +1810,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1771,6 +1835,7 @@
                         "biolink:Case"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -1800,6 +1865,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -1819,6 +1885,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1848,6 +1915,7 @@
                         "biolink:CaseToPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -1895,6 +1963,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -1923,6 +1992,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -1931,6 +2001,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -2017,6 +2088,7 @@
                         "biolink:Cell"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -2046,6 +2118,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -2065,6 +2138,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2087,6 +2161,7 @@
                         "biolink:CellLine"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -2116,6 +2191,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -2135,6 +2211,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2164,6 +2241,7 @@
                         "biolink:CellLineAsAModelOfDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2196,6 +2274,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -2224,6 +2303,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -2232,6 +2312,7 @@
                 },
                 "predicate": {
                     "description": "The relationship to the disease",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -2296,6 +2377,7 @@
                         "biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2324,6 +2406,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -2348,6 +2431,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -2356,6 +2440,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -2409,6 +2494,7 @@
                         "biolink:CellularComponent"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -2438,6 +2524,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -2457,6 +2544,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2479,6 +2567,7 @@
                         "biolink:CellularOrganism"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -2508,6 +2597,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -2527,6 +2617,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2560,6 +2651,7 @@
                         "biolink:ChemicalAffectsGeneAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2592,6 +2684,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -2628,6 +2721,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -2636,6 +2730,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -2718,6 +2813,7 @@
                         "biolink:ChemicalEntity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -2747,6 +2843,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_toxic": {
@@ -2778,6 +2875,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2807,6 +2905,7 @@
                         "biolink:ChemicalEntityAssessesNamedThingAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2835,6 +2934,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -2859,6 +2959,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -2867,6 +2968,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -2935,6 +3037,7 @@
                         "biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -2963,6 +3066,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -2990,6 +3094,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -2998,6 +3103,7 @@
                 },
                 "predicate": {
                     "description": "the direction is always from regulator to regulated",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -3051,6 +3157,7 @@
                         "biolink:ChemicalExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -3088,6 +3195,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -3112,6 +3220,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -3146,6 +3255,7 @@
                         "biolink:ChemicalGeneInteractionAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -3174,6 +3284,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -3207,6 +3318,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -3215,6 +3327,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -3287,6 +3400,7 @@
                         "biolink:ChemicalMixture"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -3324,6 +3438,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_supplement": {
@@ -3366,6 +3481,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -3399,6 +3515,7 @@
                         "biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -3427,6 +3544,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -3451,6 +3569,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -3459,6 +3578,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -3523,6 +3643,7 @@
                         "biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -3551,6 +3672,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -3575,6 +3697,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -3583,6 +3706,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -3650,6 +3774,7 @@
                         "biolink:ChemicalRole"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -3687,6 +3812,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -3706,6 +3832,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -3736,6 +3863,7 @@
                         "biolink:ChemicalToChemicalAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -3764,6 +3892,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -3788,6 +3917,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -3796,6 +3926,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -3863,6 +3994,7 @@
                         "biolink:ChemicalToChemicalDerivationAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -3891,6 +4023,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -3915,6 +4048,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -3923,6 +4057,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -3983,6 +4118,7 @@
                         "biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4011,6 +4147,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -4035,6 +4172,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -4043,6 +4181,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -4103,6 +4242,7 @@
                         "biolink:ChemicalToPathwayAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4131,6 +4271,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -4155,6 +4296,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -4163,6 +4305,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -4216,6 +4359,7 @@
                         "biolink:ChiSquaredAnalysisResult"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4246,6 +4390,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -4271,6 +4416,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4293,6 +4439,7 @@
                         "biolink:ClinicalAttribute"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4330,6 +4477,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -4349,6 +4497,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4372,6 +4521,7 @@
                         "biolink:ClinicalCourse"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4409,6 +4559,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -4428,6 +4579,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4451,6 +4603,7 @@
                         "biolink:ClinicalEntity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4473,6 +4626,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -4492,6 +4646,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4514,6 +4669,7 @@
                         "biolink:ClinicalFinding"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4543,6 +4699,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -4562,6 +4719,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4584,6 +4742,7 @@
                         "biolink:ClinicalIntervention"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4606,6 +4765,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -4625,6 +4785,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4647,6 +4808,7 @@
                         "biolink:ClinicalMeasurement"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4684,6 +4846,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -4703,6 +4866,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4726,6 +4890,7 @@
                         "biolink:ClinicalModifier"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4763,6 +4928,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -4782,6 +4948,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4805,6 +4972,7 @@
                         "biolink:ClinicalTrial"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4827,6 +4995,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -4846,6 +5015,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4875,6 +5045,7 @@
                         "biolink:CodingSequence"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -4915,6 +5086,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -4950,6 +5122,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -4972,6 +5145,7 @@
                         "biolink:Cohort"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5001,6 +5175,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -5020,6 +5195,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5042,6 +5218,7 @@
                         "biolink:CommonDataElement"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5072,6 +5249,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -5097,6 +5275,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5119,6 +5298,7 @@
                         "biolink:ComplexChemicalExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5156,6 +5336,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -5175,6 +5356,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5205,6 +5387,7 @@
                         "biolink:ComplexMolecularMixture"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5242,6 +5425,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_supplement": {
@@ -5284,6 +5468,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5306,6 +5491,7 @@
                         "biolink:ConceptCountAnalysisResult"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5336,6 +5522,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -5361,6 +5548,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5383,6 +5571,7 @@
                         "biolink:ConfidenceLevel"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5413,6 +5602,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -5438,6 +5628,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5467,6 +5658,7 @@
                         "biolink:ContributorAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5495,6 +5687,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -5519,6 +5712,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -5527,6 +5721,7 @@
                 },
                 "predicate": {
                     "description": "generally one of the predicate values 'provider', 'publisher', 'editor' or 'author'",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -5580,6 +5775,7 @@
                         "biolink:Dataset"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5610,6 +5806,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -5635,6 +5832,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5657,6 +5855,7 @@
                         "biolink:DatasetDistribution"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5690,6 +5889,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -5715,6 +5915,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5737,6 +5938,7 @@
                         "biolink:DatasetSummary"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5767,6 +5969,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -5798,6 +6001,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5820,6 +6024,7 @@
                         "biolink:DatasetVersion"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5859,6 +6064,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -5884,6 +6090,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5906,6 +6113,7 @@
                         "biolink:Device"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -5928,6 +6136,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -5947,6 +6156,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -5980,6 +6190,7 @@
                         "biolink:Disease"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -6009,6 +6220,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -6028,6 +6240,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6050,6 +6263,7 @@
                         "biolink:DiseaseOrPhenotypicFeature"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -6079,6 +6293,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -6098,6 +6313,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6120,6 +6336,7 @@
                         "biolink:DiseaseOrPhenotypicFeatureExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -6157,6 +6374,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -6181,6 +6399,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6217,6 +6436,7 @@
                         "biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6245,6 +6465,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -6269,6 +6490,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -6277,6 +6499,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -6337,6 +6560,7 @@
                         "biolink:DiseaseOrPhenotypicFeatureToLocationAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6365,6 +6589,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -6389,6 +6614,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -6397,6 +6623,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -6457,6 +6684,7 @@
                         "biolink:DiseaseToExposureEventAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6485,6 +6713,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -6509,6 +6738,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -6517,6 +6747,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -6577,6 +6808,7 @@
                         "biolink:DiseaseToPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6624,6 +6856,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -6652,6 +6885,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -6660,6 +6894,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -6728,6 +6963,7 @@
                         "biolink:Drug"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -6765,6 +7001,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_supplement": {
@@ -6807,6 +7044,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6849,6 +7087,7 @@
                         "biolink:DrugExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -6886,6 +7125,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -6910,6 +7150,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6940,6 +7181,7 @@
                         "biolink:DrugToGeneAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -6968,6 +7210,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -6992,6 +7235,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -7000,6 +7244,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -7053,6 +7298,7 @@
                         "biolink:DrugToGeneInteractionExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -7097,6 +7343,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -7121,6 +7368,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7162,6 +7410,7 @@
                         "biolink:DruggableGeneToDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7194,6 +7443,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -7222,6 +7472,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -7230,6 +7481,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -7298,6 +7550,7 @@
                         "biolink:EntityToDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7326,6 +7579,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -7350,6 +7604,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -7358,6 +7613,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -7422,6 +7678,7 @@
                         "biolink:EntityToPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7450,6 +7707,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -7474,6 +7732,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -7482,6 +7741,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -7535,6 +7795,7 @@
                         "biolink:EnvironmentalExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -7572,6 +7833,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -7596,6 +7858,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7619,6 +7882,7 @@
                         "biolink:EnvironmentalFeature"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -7641,6 +7905,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -7660,6 +7925,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7689,6 +7955,7 @@
                         "biolink:EnvironmentalFoodContaminant"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -7718,6 +7985,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_toxic": {
@@ -7749,6 +8017,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7771,6 +8040,7 @@
                         "biolink:EnvironmentalProcess"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -7793,6 +8063,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -7812,6 +8083,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7840,6 +8112,7 @@
                         "biolink:Event"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -7862,6 +8135,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -7881,6 +8155,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7903,6 +8178,7 @@
                         "biolink:EvidenceType"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -7933,6 +8209,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -7958,6 +8235,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -7987,6 +8265,7 @@
                         "biolink:Exon"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -8027,6 +8306,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -8062,6 +8342,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8091,6 +8372,7 @@
                         "biolink:ExonToTranscriptRelationship"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8119,6 +8401,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -8143,6 +8426,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -8151,6 +8435,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -8211,6 +8496,7 @@
                         "biolink:ExposureEventToOutcomeAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8239,6 +8525,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -8263,6 +8550,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -8275,6 +8563,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -8340,6 +8629,7 @@
                         "biolink:ExposureEventToPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8387,6 +8677,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -8415,6 +8706,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -8423,6 +8715,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -8524,6 +8817,7 @@
                         "biolink:Food"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -8561,6 +8855,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_supplement": {
@@ -8603,6 +8898,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8632,6 +8928,7 @@
                         "biolink:FoodAdditive"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -8661,6 +8958,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_toxic": {
@@ -8692,6 +8990,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8721,6 +9020,7 @@
                         "biolink:FunctionalAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8749,6 +9049,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -8773,6 +9074,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -8781,6 +9083,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -8834,6 +9137,7 @@
                         "biolink:Gene"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -8867,6 +9171,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -8897,6 +9202,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8926,6 +9232,7 @@
                         "biolink:GeneAsAModelOfDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -8958,6 +9265,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -8986,6 +9294,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -8994,6 +9303,7 @@
                 },
                 "predicate": {
                     "description": "The relationship to the disease",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -9051,6 +9361,7 @@
                         "biolink:GeneFamily"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -9087,6 +9398,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -9106,6 +9418,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -9135,6 +9448,7 @@
                         "biolink:GeneHasVariantThatContributesToDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -9167,6 +9481,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -9195,6 +9510,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -9203,6 +9519,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -9339,6 +9656,7 @@
                         "biolink:GeneToDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -9371,6 +9689,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -9399,6 +9718,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -9407,6 +9727,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -9471,6 +9792,7 @@
                         "biolink:GeneToExpressionSiteAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -9499,6 +9821,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -9523,6 +9846,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -9531,6 +9855,7 @@
                 },
                 "predicate": {
                     "description": "expression relationship",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -9599,6 +9924,7 @@
                         "biolink:GeneToGeneCoexpressionAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -9631,6 +9957,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -9655,6 +9982,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -9667,6 +9995,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -9735,6 +10064,7 @@
                         "biolink:GeneToGeneFamilyAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -9763,6 +10093,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -9787,6 +10118,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -9795,6 +10127,7 @@
                 },
                 "predicate": {
                     "description": "membership of the gene in the given gene family.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -9855,6 +10188,7 @@
                         "biolink:GeneToGeneHomologyAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -9883,6 +10217,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -9907,6 +10242,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -9915,6 +10251,7 @@
                 },
                 "predicate": {
                     "description": "homology relationship type",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -9975,6 +10312,7 @@
                         "biolink:GeneToGeneProductRelationship"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10003,6 +10341,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -10027,6 +10366,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -10035,6 +10375,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -10095,6 +10436,7 @@
                         "biolink:GeneToGoTermAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10123,6 +10465,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -10147,6 +10490,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -10155,6 +10499,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -10215,6 +10560,7 @@
                         "biolink:GeneToPathwayAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10243,6 +10589,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -10267,6 +10614,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -10275,6 +10623,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -10335,6 +10684,7 @@
                         "biolink:GeneToPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10382,6 +10732,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -10410,6 +10761,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -10418,6 +10770,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -10479,6 +10832,7 @@
                         "biolink:GeneticInheritance"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -10508,6 +10862,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -10527,6 +10882,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10549,6 +10905,7 @@
                         "biolink:Genome"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -10582,6 +10939,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -10601,6 +10959,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10623,6 +10982,7 @@
                         "biolink:GenomicBackgroundExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -10678,6 +11038,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -10702,6 +11063,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10732,6 +11094,7 @@
                         "biolink:GenomicSequenceLocalization"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10768,6 +11131,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -10792,6 +11156,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -10804,6 +11169,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -10865,6 +11231,7 @@
                         "biolink:Genotype"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -10901,6 +11268,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -10920,6 +11288,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10949,6 +11318,7 @@
                         "biolink:GenotypeAsAModelOfDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -10981,6 +11351,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -11009,6 +11380,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -11017,6 +11389,7 @@
                 },
                 "predicate": {
                     "description": "The relationship to the disease",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -11081,6 +11454,7 @@
                         "biolink:GenotypeToDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -11113,6 +11487,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -11141,6 +11516,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -11149,6 +11525,7 @@
                 },
                 "predicate": {
                     "description": "E.g. is pathogenic for",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -11213,6 +11590,7 @@
                         "biolink:GenotypeToGeneAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -11241,6 +11619,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -11265,6 +11644,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -11273,6 +11653,7 @@
                 },
                 "predicate": {
                     "description": "the relationship type used to connect genotype to gene",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -11333,6 +11714,7 @@
                         "biolink:GenotypeToGenotypePartAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -11361,6 +11743,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -11385,6 +11768,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -11393,6 +11777,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -11453,6 +11838,7 @@
                         "biolink:GenotypeToPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -11500,6 +11886,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -11528,6 +11915,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -11536,6 +11924,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -11604,6 +11993,7 @@
                         "biolink:GenotypeToVariantAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -11632,6 +12022,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -11656,6 +12047,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -11664,6 +12056,7 @@
                 },
                 "predicate": {
                     "description": "the relationship type used to connect genotype to gene",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -11717,6 +12110,7 @@
                         "biolink:GenotypicSex"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -11754,6 +12148,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -11773,6 +12168,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -11796,6 +12192,7 @@
                         "biolink:GeographicExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -11833,6 +12230,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -11857,6 +12255,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -11880,6 +12279,7 @@
                         "biolink:GeographicLocation"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -11902,6 +12302,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "latitude": {
@@ -11929,6 +12330,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -11951,6 +12353,7 @@
                         "biolink:GeographicLocationAtTime"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -11973,6 +12376,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "latitude": {
@@ -12005,6 +12409,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12027,6 +12432,7 @@
                         "biolink:GrossAnatomicalStructure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -12056,6 +12462,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -12075,6 +12482,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12097,6 +12505,7 @@
                         "biolink:Haplotype"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -12130,6 +12539,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -12149,6 +12559,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12171,6 +12582,7 @@
                         "biolink:Hospitalization"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -12193,6 +12605,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -12212,6 +12625,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12240,6 +12654,7 @@
                         "biolink:IndividualOrganism"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -12269,6 +12684,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -12288,6 +12704,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12317,6 +12734,7 @@
                         "biolink:InformationContentEntityToNamedThingAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12345,6 +12763,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -12369,6 +12788,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -12377,6 +12797,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -12430,6 +12851,7 @@
                         "biolink:InformationResource"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -12460,6 +12882,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -12485,6 +12908,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12507,6 +12931,7 @@
                         "biolink:LifeStage"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -12536,6 +12961,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -12555,6 +12981,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12587,6 +13014,7 @@
                         "biolink:MacromolecularComplex"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -12616,6 +13044,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -12635,6 +13064,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12664,6 +13094,7 @@
                         "biolink:MacromolecularMachineToBiologicalProcessAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12692,6 +13123,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -12716,6 +13148,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -12724,6 +13157,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -12784,6 +13218,7 @@
                         "biolink:MacromolecularMachineToCellularComponentAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12812,6 +13247,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -12836,6 +13272,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -12844,6 +13281,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -12904,6 +13342,7 @@
                         "biolink:MacromolecularMachineToMolecularActivityAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -12932,6 +13371,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -12956,6 +13396,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -12964,6 +13405,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -13017,6 +13459,7 @@
                         "biolink:MaterialSample"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -13039,6 +13482,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -13058,6 +13502,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13087,6 +13532,7 @@
                         "biolink:MaterialSampleDerivationAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13115,6 +13561,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -13139,6 +13586,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -13147,6 +13595,7 @@
                 },
                 "predicate": {
                     "description": "derivation relationship",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -13207,6 +13656,7 @@
                         "biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13235,6 +13685,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -13259,6 +13710,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -13267,6 +13719,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -13327,6 +13780,7 @@
                         "biolink:MicroRNA"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -13367,6 +13821,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -13409,6 +13864,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13431,6 +13887,7 @@
                         "biolink:MolecularActivity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -13481,6 +13938,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -13500,6 +13958,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13529,6 +13988,7 @@
                         "biolink:MolecularActivityToChemicalEntityAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13557,6 +14017,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -13581,6 +14042,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -13589,6 +14051,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -13649,6 +14112,7 @@
                         "biolink:MolecularActivityToMolecularActivityAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13677,6 +14141,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -13701,6 +14166,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -13709,6 +14175,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -13769,6 +14236,7 @@
                         "biolink:MolecularActivityToPathwayAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13797,6 +14265,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -13821,6 +14290,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -13829,6 +14299,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -13889,6 +14360,7 @@
                         "biolink:MolecularEntity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -13918,6 +14390,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -13953,6 +14426,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -13982,6 +14456,7 @@
                         "biolink:MolecularMixture"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14019,6 +14494,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_supplement": {
@@ -14061,6 +14537,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14089,6 +14566,7 @@
                         "biolink:NamedThing"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14111,6 +14589,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -14130,6 +14609,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14159,6 +14639,7 @@
                         "biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14187,6 +14668,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -14211,6 +14693,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -14219,6 +14702,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -14279,6 +14763,7 @@
                         "biolink:NoncodingRNAProduct"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14319,6 +14804,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -14361,6 +14847,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14390,6 +14877,7 @@
                         "biolink:NucleicAcidEntity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14430,6 +14918,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -14465,6 +14954,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14487,6 +14977,7 @@
                         "biolink:NucleicAcidSequenceMotif"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14516,6 +15007,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -14535,6 +15027,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14557,6 +15050,7 @@
                         "biolink:NucleosomeModification"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14590,6 +15084,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -14616,6 +15111,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14638,6 +15134,7 @@
                         "biolink:ObservedExpectedFrequencyAnalysisResult"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14668,6 +15165,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -14693,6 +15191,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14715,6 +15214,7 @@
                         "biolink:Onset"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14752,6 +15252,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -14771,6 +15272,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14794,6 +15296,7 @@
                         "biolink:OrganismAttribute"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14831,6 +15334,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -14850,6 +15354,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14873,6 +15378,7 @@
                         "biolink:OrganismTaxon"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -14895,6 +15401,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -14914,6 +15421,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14947,6 +15455,7 @@
                         "biolink:OrganismTaxonToOrganismTaxonInteraction"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -14975,6 +15484,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -14999,6 +15509,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -15007,6 +15518,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -15067,6 +15579,7 @@
                         "biolink:OrganismTaxonToOrganismTaxonSpecialization"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -15095,6 +15608,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -15119,6 +15633,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -15127,6 +15642,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -15187,6 +15703,7 @@
                         "biolink:OrganismToOrganismAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -15215,6 +15732,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -15239,6 +15757,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -15247,6 +15766,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -15307,6 +15827,7 @@
                         "biolink:OrganismalEntityAsAModelOfDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -15339,6 +15860,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -15367,6 +15889,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -15375,6 +15898,7 @@
                 },
                 "predicate": {
                     "description": "The relationship to the disease",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -15439,6 +15963,7 @@
                         "biolink:PairwiseGeneToGeneInteraction"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -15467,6 +15992,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -15491,6 +16017,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -15499,6 +16026,7 @@
                 },
                 "predicate": {
                     "description": "interaction relationship type",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -15559,6 +16087,7 @@
                         "biolink:PairwiseMolecularInteraction"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -15590,6 +16119,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -15614,6 +16144,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -15622,6 +16153,7 @@
                 },
                 "predicate": {
                     "description": "interaction relationship type",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -15675,6 +16207,7 @@
                         "biolink:PathologicalAnatomicalExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -15712,6 +16245,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -15736,6 +16270,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -15765,6 +16300,7 @@
                         "biolink:PathologicalAnatomicalStructure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -15794,6 +16330,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -15813,6 +16350,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -15835,6 +16373,7 @@
                         "biolink:PathologicalProcess"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -15885,6 +16424,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -15904,6 +16444,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -15926,6 +16467,7 @@
                         "biolink:PathologicalProcessExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -15963,6 +16505,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -15987,6 +16530,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16016,6 +16560,7 @@
                         "biolink:Pathway"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16066,6 +16611,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16085,6 +16631,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16117,6 +16664,7 @@
                         "biolink:Phenomenon"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16139,6 +16687,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16158,6 +16707,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16180,6 +16730,7 @@
                         "biolink:PhenotypicFeature"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16209,6 +16760,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16228,6 +16780,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16250,6 +16803,7 @@
                         "biolink:PhenotypicQuality"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16287,6 +16841,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16306,6 +16861,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16329,6 +16885,7 @@
                         "biolink:PhenotypicSex"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16366,6 +16923,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16385,6 +16943,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16408,6 +16967,7 @@
                         "biolink:PhysicalEntity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16430,6 +16990,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16449,6 +17010,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16471,6 +17033,7 @@
                         "biolink:PhysiologicalProcess"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16521,6 +17084,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16540,6 +17104,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16562,6 +17127,7 @@
                         "biolink:PlanetaryEntity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16584,6 +17150,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16603,6 +17170,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16625,6 +17193,7 @@
                         "biolink:Polypeptide"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16654,6 +17223,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16673,6 +17243,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16695,6 +17266,7 @@
                         "biolink:PopulationOfIndividualOrganisms"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16724,6 +17296,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16743,6 +17316,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16772,6 +17346,7 @@
                         "biolink:PopulationToPopulationAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -16800,6 +17375,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -16824,6 +17400,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -16832,6 +17409,7 @@
                 },
                 "predicate": {
                     "description": "A relationship type that holds between the subject and object populations. Standard mereological relations can be used. E.g. subject part-of object, subject overlaps object. Derivation relationships can also be used",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -16885,6 +17463,7 @@
                         "biolink:PosttranslationalModification"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -16914,6 +17493,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -16940,6 +17520,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17009,6 +17590,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "qualified_predicate": {
@@ -17054,6 +17636,7 @@
                         "biolink:Procedure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17076,6 +17659,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -17095,6 +17679,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17124,6 +17709,7 @@
                         "biolink:ProcessedMaterial"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17161,6 +17747,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_supplement": {
@@ -17203,6 +17790,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17225,6 +17813,7 @@
                         "biolink:Protein"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17254,6 +17843,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -17280,6 +17870,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17302,6 +17893,7 @@
                         "biolink:ProteinDomain"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17338,6 +17930,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -17357,6 +17950,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17379,6 +17973,7 @@
                         "biolink:ProteinFamily"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17415,6 +18010,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -17434,6 +18030,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17456,6 +18053,7 @@
                         "biolink:ProteinIsoform"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17485,6 +18083,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -17511,6 +18110,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17540,6 +18140,7 @@
                         "biolink:Publication"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17570,6 +18171,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "keywords": {
@@ -17585,6 +18187,7 @@
                 "mesh_terms": {
                     "description": "mesh terms tagging a publication",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17621,6 +18224,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17667,6 +18271,7 @@
                         "biolink:RNAProduct"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17707,6 +18312,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -17749,6 +18355,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17778,6 +18385,7 @@
                         "biolink:RNAProductIsoform"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -17818,6 +18426,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -17860,6 +18469,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17909,6 +18519,7 @@
                         "biolink:ReactionToCatalystAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -17937,6 +18548,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -17961,6 +18573,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -17969,6 +18582,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -18041,6 +18655,7 @@
                         "biolink:ReactionToParticipantAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18069,6 +18684,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -18093,6 +18709,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -18101,6 +18718,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -18166,6 +18784,7 @@
                         "biolink:ReagentTargetedGene"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -18199,6 +18818,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -18218,6 +18838,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18255,6 +18876,7 @@
                         "biolink:RelativeFrequencyAnalysisResult"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -18285,6 +18907,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -18310,6 +18933,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18339,6 +18963,7 @@
                         "biolink:SequenceAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18367,6 +18992,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -18391,6 +19017,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -18399,6 +19026,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -18468,6 +19096,7 @@
                         "biolink:SequenceFeatureRelationship"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18496,6 +19125,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -18520,6 +19150,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -18528,6 +19159,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -18581,6 +19213,7 @@
                         "biolink:SequenceVariant"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -18621,6 +19254,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -18640,6 +19274,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18669,6 +19304,7 @@
                         "biolink:Serial"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -18699,6 +19335,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "iso_abbreviation": {
@@ -18722,6 +19359,7 @@
                 "mesh_terms": {
                     "description": "mesh terms tagging a publication",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18762,6 +19400,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18785,6 +19424,7 @@
                         "biolink:SeverityValue"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -18822,6 +19462,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -18841,6 +19482,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18871,6 +19513,7 @@
                         "biolink:SiRNA"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -18911,6 +19554,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -18953,6 +19597,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -18982,6 +19627,7 @@
                         "biolink:SmallMolecule"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19011,6 +19657,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -19046,6 +19693,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19068,6 +19716,7 @@
                         "biolink:Snv"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19108,6 +19757,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -19127,6 +19777,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19149,6 +19800,7 @@
                         "biolink:SocioeconomicAttribute"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19186,6 +19838,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -19205,6 +19858,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19228,6 +19882,7 @@
                         "biolink:SocioeconomicExposure"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19265,6 +19920,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -19289,6 +19945,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19330,6 +19987,7 @@
                         "biolink:Study"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19360,6 +20018,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -19385,6 +20044,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19407,6 +20067,7 @@
                         "biolink:StudyPopulation"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19436,6 +20097,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -19455,6 +20117,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19477,6 +20140,7 @@
                         "biolink:StudyVariable"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19507,6 +20171,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -19532,6 +20197,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19561,6 +20227,7 @@
                         "biolink:TaxonToTaxonAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19589,6 +20256,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -19613,6 +20281,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -19621,6 +20290,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -19689,6 +20359,7 @@
                         "biolink:TextMiningResult"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19719,6 +20390,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "license": {
@@ -19744,6 +20416,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19773,6 +20446,7 @@
                         "biolink:Transcript"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -19813,6 +20487,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "is_metabolite": {
@@ -19848,6 +20523,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19877,6 +20553,7 @@
                         "biolink:TranscriptToGeneRelationship"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -19905,6 +20582,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -19929,6 +20607,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -19937,6 +20616,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -19990,6 +20670,7 @@
                         "biolink:Treatment"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -20033,6 +20714,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -20057,6 +20739,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -20086,6 +20769,7 @@
                         "biolink:VariantAsAModelOfDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -20118,6 +20802,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -20146,6 +20831,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -20154,6 +20840,7 @@
                 },
                 "predicate": {
                     "description": "The relationship to the disease",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -20218,6 +20905,7 @@
                         "biolink:VariantToDiseaseAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -20250,6 +20938,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -20278,6 +20967,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -20286,6 +20976,7 @@
                 },
                 "predicate": {
                     "description": "E.g. is pathogenic for",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -20350,6 +21041,7 @@
                         "biolink:VariantToGeneAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -20378,6 +21070,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -20402,6 +21095,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -20410,6 +21104,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -20470,6 +21165,7 @@
                         "biolink:VariantToGeneExpressionAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -20502,6 +21198,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -20526,6 +21223,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -20538,6 +21236,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -20606,6 +21305,7 @@
                         "biolink:VariantToPhenotypicFeatureAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -20653,6 +21353,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -20681,6 +21382,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -20689,6 +21391,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -20757,6 +21460,7 @@
                         "biolink:VariantToPopulationAssociation"
                     ],
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -20805,6 +21509,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "knowledge_source": {
@@ -20829,6 +21534,7 @@
                 },
                 "original_predicate": {
                     "description": "used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "original_subject": {
@@ -20837,6 +21543,7 @@
                 },
                 "predicate": {
                     "description": "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "primary_knowledge_source": {
@@ -20890,6 +21597,7 @@
                         "biolink:Virus"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -20919,6 +21627,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -20938,6 +21647,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"
@@ -20960,6 +21670,7 @@
                         "biolink:Zygosity"
                     ],
                     "items": {
+                        "format": "uri",
                         "pattern": "^biolink:\\d+$",
                         "type": "string"
                     },
@@ -20997,6 +21708,7 @@
                 },
                 "iri": {
                     "description": "An IRI for an entity. This is determined by the id using expansion rules.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "name": {
@@ -21016,6 +21728,7 @@
                 "xref": {
                     "description": "Alternate CURIEs for a thing",
                     "items": {
+                        "format": "uri",
                         "type": "string"
                     },
                     "type": "array"


### PR DESCRIPTION
Make JSON-Schema generation for URIs and CURIEs stricter by specifying the "string" format "uri" [1]. Since CURIEs (in contrast with SafeCURIEs [2]) are valid URIs, we can use this format.

Side-remark: SafeCURIEs are not valid URIs, but there is no space for ambiguity (is it a CURIE or an URI?). Should be change somewhen in the future to SafeCURIEs, we would need to change the generated JSON-Schema whenever CURIEs are involved.

Fixes #2211 

[1]: https://json-schema.org/understanding-json-schema/reference/string#resource-identifiers
[2]: https://www.w3.org/TR/2010/NOTE-curie-20101216/#P_safe_curie