### PR TITLE
[perf] minor pydanticgen perf boosts - remove unnecessary object creation

### DIFF
--- a/linkml/generators/pydanticgen/build.py
+++ b/linkml/generators/pydanticgen/build.py
@@ -51,9 +51,8 @@ class BuildResult(BaseModel):
                 self_copy.imports = other.imports
         if other.injected_classes:
             if self_copy.injected_classes is not None:
-                if self_copy.injected_classes == other.injected_classes:
-                    pass
-                else:
+                # only combine and dedupe when injected_classes don't match
+                if self_copy.injected_classes != other.injected_classes:
                     self_copy.injected_classes.extend(other.injected_classes)
                     self_copy.injected_classes = list(dict.fromkeys(self_copy.injected_classes))
             else:

--- a/linkml/generators/pydanticgen/build.py
+++ b/linkml/generators/pydanticgen/build.py
@@ -51,8 +51,11 @@ class BuildResult(BaseModel):
                 self_copy.imports = other.imports
         if other.injected_classes:
             if self_copy.injected_classes is not None:
-                self_copy.injected_classes.extend(other.injected_classes)
-                self_copy.injected_classes = list(dict.fromkeys(self_copy.injected_classes))
+                if self_copy.injected_classes == other.injected_classes:
+                    pass
+                else:
+                    self_copy.injected_classes.extend(other.injected_classes)
+                    self_copy.injected_classes = list(dict.fromkeys(self_copy.injected_classes))
             else:
                 self_copy.injected_classes = other.injected_classes
         return self_copy

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -312,9 +312,9 @@ class PydanticGenerator(OOCodeGenerator):
 
     def generate_slot(self, slot: SlotDefinition, cls: ClassDefinition) -> SlotResult:
         slot_args = {
-            k: slot._as_dict.get(k, None)
+            k: getattr(slot, k, None)
             for k in PydanticAttribute.model_fields.keys()
-            if slot._as_dict.get(k, None) is not None
+            if getattr(slot, k, None) is not None
         }
         slot_args["name"] = underscore(slot.name)
         slot_args["description"] = slot.description.replace('"', '\\"') if slot.description is not None else None


### PR DESCRIPTION
i was dismayed to see that the pydantic generator had bad runtime characteristics in two places 

<img width="902" alt="Screenshot 2024-07-22 at 7 52 24 PM" src="https://github.com/user-attachments/assets/19378e8e-74f8-4ba7-8d5d-e151632524a4">

- one dictionary comprehension that was expensive because of [casting to a dict](https://github.com/linkml/linkml/issues/2217) 
- the `merge` method that combined injected classes, but most of the time these are identical (from the default value).

edit: so i fixed them