### PR TITLE
Add note admonition for abstract slots

### DIFF
--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -34,6 +34,10 @@ _{{ element_description_line }}_
 {% endfor %}
 {% endif %}
 
+{% if element.abstract %}
+* __NOTE__: this is an abstract slot and should not be instantiated directly
+{% endif %}
+
 URI: {{ gen.uri_link(element) }}
 
 

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -35,7 +35,7 @@ _{{ element_description_line }}_
 {% endif %}
 
 {% if element.abstract %}
-* __NOTE__: this is an abstract slot and should not be instantiated directly
+* __NOTE__: this is an abstract slot and should not be populated directly
 {% endif %}
 
 URI: {{ gen.uri_link(element) }}


### PR DESCRIPTION
Similar to how we have a _Note_ banner that gets rendered on class documentation pages when a class is asserted to be `abstract`, we need to replicate the behaviour for slots as well.

Example: https://microbiomedata.github.io/nmdc-schema/NamedThing/