### PR TITLE
[pydanticgen] Don't include meta if empty

### DIFF
--- a/linkml/generators/pydanticgen/templates/attribute.py.jinja
+++ b/linkml/generators/pydanticgen/templates/attribute.py.jinja
@@ -7,6 +7,6 @@
     {%- if minimum_value != None %}, ge={{minimum_value}}{% endif -%}
     {%- if maximum_value != None %}, le={{maximum_value}}{% endif -%}
 {%- endif -%}
-{%- if meta != None -%}
+{%- if meta -%}
     , json_schema_extra = { "linkml_meta": {{ meta | pprint | indent(width=8) }} }
 {%- endif -%})

--- a/linkml/generators/pydanticgen/templates/class.py.jinja
+++ b/linkml/generators/pydanticgen/templates/class.py.jinja
@@ -4,7 +4,7 @@ class {{ name }}({% if bases is string %}{{ bases }}{% else %}{{ bases | join(',
     {{ description | indent(width=4) }}
     """
     {% endif -%}
-    {% if meta != None %}
+    {% if meta %}
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({{ meta | pprint | indent(width=8) }})
 
     {% endif %}

--- a/linkml/generators/pydanticgen/templates/module.py.jinja
+++ b/linkml/generators/pydanticgen/templates/module.py.jinja
@@ -14,7 +14,7 @@ version = "{{version if version else None}}"
 {{ c }}
     {% endfor %}
 {% endif %}
-{% if meta != None %}
+{% if meta %}
 linkml_meta = LinkMLMeta({{ meta | pprint | indent(width=4) }} )
 {% else %}
 linkml_meta = None


### PR DESCRIPTION
Currently, metadata is included in pydanticgen if it is not `None`. But when there is no metadata for a slot/class/schema that is included (eg. because one is using the `auto` mode or otherwise filtering out metadata terms), it is still included which makes for unnecessarily noisy models:

```python
class ElectricalSeries(TimeSeries):
    """
    A time series of acquired voltage data from extracellular recordings. The data field is an int or float array storing data in volts. The first dimension should always represent time. The second dimension, if present, should represent channels.
    """

    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "core.nwb.ecephys", "tree_root": True})

    name: str = Field(..., json_schema_extra={"linkml_meta": {}})
    filtering: Optional[str] = Field(
        None,
        description="""Filtering applied to all channels of the data. For example, if this ElectricalSeries represents high-pass-filtered data (also known as AP Band), then this value could be \"High-pass 4-pole Bessel filter at 500 Hz\". If this ElectricalSeries represents low-pass-filtered LFP data and the type of filter is unknown, then this value could be \"Low-pass filter at 300 Hz\". If a non-standard filter type is used, provide as much detail about the filter properties as possible.""",
        json_schema_extra={"linkml_meta": {}},
    )
    data: Union[
        NDArray[Shape["* num_times"], np.number],
        NDArray[Shape["* num_times, * num_channels"], np.number],
        NDArray[Shape["* num_times, * num_channels, * num_samples"], np.number],
    ] = Field(..., description="""Recorded voltage data.""", json_schema_extra={"linkml_meta": {}})
    # ...
    description: Optional[str] = Field(
        None, description="""Description of the time series.""", json_schema_extra={"linkml_meta": {}}
    )
    comments: Optional[str] = Field(
        None,
        description="""Human-readable comments about the TimeSeries. This second descriptive field can be used to store additional information, or descriptive information if the primary description field is populated with a computer-readable string.""",
        json_schema_extra={"linkml_meta": {}},
    )
    starting_time: Optional[TimeSeriesStartingTime] = Field(
        None,
        description="""Timestamp of the first sample in seconds. When timestamps are uniformly spaced, the timestamp of the first sample can be specified and all subsequent ones calculated from the sampling rate attribute.""",
        json_schema_extra={"linkml_meta": {}},
    )
    # ...
    sync: Optional[TimeSeriesSync] = Field(
        None,
        description="""Lab-specific time and sync information as provided directly from hardware devices and that is necessary for aligning all acquired time information to a common timebase. The timestamp array stores time in the common timebase. This group will usually only be populated in TimeSeries that are stored external to the NWB file, in files storing raw data. Once timestamp data is calculated, the contents of 'sync' are mostly for archival purposes.""",
        json_schema_extra={"linkml_meta": {}},
    )
```

so this PR does...


```python
class ElectricalSeries(TimeSeries):
    """
    A time series of acquired voltage data from extracellular recordings. The data field is an int or float array storing data in volts. The first dimension should always represent time. The second dimension, if present, should represent channels.
    """

    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "core.nwb.ecephys", "tree_root": True})

    name: str = Field(...)
    filtering: Optional[str] = Field(
        None,
        description="""Filtering applied to all channels of the data. For example, if this ElectricalSeries represents high-pass-filtered data (also known as AP Band), then this value could be \"High-pass 4-pole Bessel filter at 500 Hz\". If this ElectricalSeries represents low-pass-filtered LFP data and the type of filter is unknown, then this value could be \"Low-pass filter at 300 Hz\". If a non-standard filter type is used, provide as much detail about the filter properties as possible.""",
    )
    data: Union[
        NDArray[Shape["* num_times"], np.number],
        NDArray[Shape["* num_times, * num_channels"], np.number],
        NDArray[Shape["* num_times, * num_channels, * num_samples"], np.number],
    ] = Field(..., description="""Recorded voltage data.""")
    description: Optional[str] = Field(None, description="""Description of the time series.""")
    comments: Optional[str] = Field(
        None,
        description="""Human-readable comments about the TimeSeries. This second descriptive field can be used to store additional information, or descriptive information if the primary description field is populated with a computer-readable string.""",
    )
    starting_time: Optional[TimeSeriesStartingTime] = Field(
        None,
        description="""Timestamp of the first sample in seconds. When timestamps are uniformly spaced, the timestamp of the first sample can be specified and all subsequent ones calculated from the sampling rate attribute.""",
    )
    # ...
    sync: Optional[TimeSeriesSync] = Field(
        None,
        description="""Lab-specific time and sync information as provided directly from hardware devices and that is necessary for aligning all acquired time information to a common timebase. The timestamp array stores time in the common timebase. This group will usually only be populated in TimeSeries that are stored external to the NWB file, in files storing raw data. Once timestamp data is calculated, the contents of 'sync' are mostly for archival purposes.""",
    )
```

not rendering empty meta dicts but doing so if there is anything in there