### PR TITLE
add link to LinkML repo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,8 @@ schemas in YAML that describe the structure of your data. Additionally, it is a 
 of formats (JSON, RDF, TSV), with generators for compiling LinkML
 schemas to other frameworks.
 
+LinkML is open source (licensed under the Apache-2.0 license) and community-driven. You can find the code on `GitHub https://github.com/linkml/`_.
+
 
 Documentation
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ schemas in YAML that describe the structure of your data. Additionally, it is a 
 of formats (JSON, RDF, TSV), with generators for compiling LinkML
 schemas to other frameworks.
 
-LinkML is open source (licensed under the Apache-2.0 license) and community-driven. You can find the code on `GitHub https://github.com/linkml/`_.
+LinkML is open source (licensed under the Apache-2.0 license) and community-driven. You can find the code on `GitHub <https://github.com/linkml/>`_.
 
 
 Documentation


### PR DESCRIPTION
it seemed weird to me that the github link wasn't front and center (it's on the "at a glance" page, but I think it should be on this page as well).

I also mentioned its OS license.