### PR TITLE
Modify test in `tests/test_generators/test_docgen.py` that checks `domain_of` duplicity

### DIFF
--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -313,11 +313,11 @@ def test_docgen(kitchen_sink_path, input_path, tmp_path):
     )
 
     # checks correctness of the YAML representation of source schema
-    person_source = gen.yaml(gen.schemaview.get_class("Person"))
+    person_source = gen.yaml(gen.schemaview.induced_class("Person"))
     person_dict = yaml.load(person_source, Loader=yaml.Loader)
     # consider the species name slot
     # species name has the Person class repeated multiple times in domain_of
-    domain_of_species_name = person_dict["slot_usage"]["species name"]["domain_of"]
+    domain_of_species_name = person_dict["attributes"]["species name"]["domain_of"]
     assert len(set(domain_of_species_name)) == len(domain_of_species_name)
 
 


### PR DESCRIPTION
Modify test in `tests/test_generators/test_docgen.py` so when https://github.com/linkml/linkml-runtime/pull/335 is merged in, it works with linkml upstream without any tests erroring out.

We can modify the test in one of two ways:

1. `person_source = gen.yaml(gen.schemaview.induced_class("Person"))`
2. `person_source = gen.yaml(gen.schemaview.get_class("Person"), inferred=True)`

Also, we need to look at `attributes` and not `slot_usage` to check `domain_of`.