### PR TITLE
simplify bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,4 +22,6 @@ A clear and concise description of what the bug is (including the error message 
 **Version of LinkML you are using**
 
 **Please provide a schema (and if applicable, a data file) that replicates the issue**
+You can include this in th issue if small, or provide a link e.g. to github.
+Ideally a minimal example that replicates the problem is ideal, but only if this is easy for you.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,23 +19,7 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is (including the error message that is printed, if any)
 
-**To reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**Version of LinkML you are using**
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Please provide a schema (and if applicable, a data file) that replicates the issue**
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**About your computer (if applicable, please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Additional context**
-Add any other context about the problem here.


### PR DESCRIPTION
fixes #2250

btw I don't understand why the chunk that starts "name: Bug report" is repeated twice verbatim, but leaving it that way in case it's needed.