### PR TITLE
Windows testing fixes

### DIFF
--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -1061,7 +1061,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
         # interpret all imported schema paths as relative to that
         output_path.parent.mkdir(parents=True, exist_ok=True)
         serialized = generator.serialize(rendered_module=rendered)
-        with open(output_path, "w") as ofile:
+        with open(output_path, "w", encoding="utf-8") as ofile:
             ofile.write(serialized)
 
         results.append(
@@ -1080,7 +1080,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
             rel_path = _import_to_path(generated_import.module)
             abs_path = (output_path.parent / rel_path).resolve()
             abs_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(abs_path, "w") as ofile:
+            with open(abs_path, "w", encoding="utf-8") as ofile:
                 ofile.write(serialized)
 
             results.append(
@@ -1123,7 +1123,7 @@ def _ensure_inits(paths: List[Path]):
     common_path = Path(os.path.commonpath(paths))
 
     if not (ipath := (common_path / "__init__.py")).exists():
-        with open(ipath, "w") as ifile:
+        with open(ipath, "w", encoding="utf-8") as ifile:
             ifile.write(" \n")
 
     for path in paths:
@@ -1131,7 +1131,7 @@ def _ensure_inits(paths: List[Path]):
         path = path.parent
         while path != common_path:
             if not (ipath := (path / "__init__.py")).exists():
-                with open(ipath, "w") as ifile:
+                with open(ipath, "w", encoding="utf-8") as ifile:
                     ifile.write(" \n")
             path = path.parent
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,7 +238,9 @@ def patch_requests_cache(pytestconfig):
         urls_expire_after={"localhost": requests_cache.DO_NOT_CACHE},
     )
     requests_cache.clear()
-    yield
+    with requests_cache.enabled():
+        yield
+    requests_cache.uninstall_cache()
     # delete cache file unless we have requested it to persist for inspection
     if not pytestconfig.getoption("--with-output"):
         cache_file.unlink(missing_ok=True)

--- a/tests/test_notebooks/test_examples.py
+++ b/tests/test_notebooks/test_examples.py
@@ -17,7 +17,7 @@ class NotebookTests(unittest.TestCase):
         output_file.parent.mkdir(parents=True, exist_ok=True)
         with redirect_stdout(output):
             importlib.import_module(import_module)
-        with open(output_file, "w") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             f.write(
                 re.sub(
                     r'Generation date: .*?(["\n])',

--- a/tests/test_notebooks/test_notebooks.py
+++ b/tests/test_notebooks/test_notebooks.py
@@ -43,7 +43,7 @@ class NotebookTestCase(TestEnvironmentTestCase):
             )
             and self.env.fail_on_error
         ):
-            with open(nbenv.temp_file_path(nbname), "w") as actualf:
+            with open(nbenv.temp_file_path(nbname), "w", encoding="utf-8") as actualf:
                 actualf.write(outf.getvalue())
 
     def test_redo_notebooks(self):

--- a/tests/test_utils/test_deprecation.py
+++ b/tests/test_utils/test_deprecation.py
@@ -177,7 +177,7 @@ def test_deprecation_props(deprecated, deprecated_val, removed, removed_val, lin
     if removed is not None:
         remver = SemVer(major=linkml_version.major + removed)
 
-    dep = Deprecation(name="test-dep", message="testing our properites", deprecated_in=depver, removed_in=remver)
+    dep = Deprecation(name="test-dep", message="testing our properties", deprecated_in=depver, removed_in=remver)
     assert dep.deprecated == deprecated_val
     assert dep.removed == removed_val
 


### PR DESCRIPTION
This fixes the pytest fixture for `requests_cache` to close the SQLite file and allow file-removal also on Windows.

`This also adds encoding to utf-8 where it was missing.

Closes #2270