### PR TITLE
fix autogen'd pydantic regex pattern validator

### DIFF
--- a/linkml/generators/pydanticgen/templates/validator.py.jinja
+++ b/linkml/generators/pydanticgen/templates/validator.py.jinja
@@ -3,7 +3,7 @@
         pattern=re.compile(r"{{pattern}}")
         if isinstance(v,list):
             for element in v:
-                if not pattern.match(element):
+                if isinstance(v, str) and not pattern.match(element):
                     raise ValueError(f"Invalid {{name}} format: {element}")
         elif isinstance(v,str):
             if not pattern.match(v):


### PR DESCRIPTION
With the current generated Pydantic validator, a nice thing about it is if you have a union of types (generated by an `any_of` field with different `range`s), then the validation will only check the appropriate types to see if they match the pattern. So if you have a field that accepts an int and a string, it will only see if strings will pass the regex pattern check and leave the ints alone. However, this behavior is not consistent when it is now a multivalued slot. This PR makes the behavior consistent. 