### PR TITLE
fix 2279 - use base types in IfAbsentProcessor

### DIFF
--- a/linkml/generators/common/ifabsent_processor.py
+++ b/linkml/generators/common/ifabsent_processor.py
@@ -1,7 +1,13 @@
 import abc
 import re
+import sys
 from abc import ABC
-from typing import Any, Optional
+from typing import Any, Optional, Type, Union
+
+if sys.version_info.minor < 10:
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
 
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import (
@@ -18,6 +24,7 @@ from linkml_runtime.linkml_model import (
     String,
     Time,
     Uri,
+    types,
 )
 from linkml_runtime.linkml_model.types import (
     Curie,
@@ -30,6 +37,34 @@ from linkml_runtime.linkml_model.types import (
     Sparqlpath,
     Uriorcurie,
 )
+
+TYPES_TYPE: TypeAlias = Union[
+    Type[Boolean],
+    Type[Curie],
+    Type[Date],
+    Type[DateOrDatetime],
+    Type[Datetime],
+    Type[Decimal],
+    Type[Double],
+    Type[Float],
+    Type[Integer],
+    Type[Jsonpath],
+    Type[Jsonpointer],
+    Type[Ncname],
+    Type[Nodeidentifier],
+    Type[Objectidentifier],
+    Type[Sparqlpath],
+    Type[String],
+    Type[Time],
+    Type[Uri],
+    Type[Uriorcurie],
+]
+
+TYPES = [
+    t
+    for t in types.__dict__.values()
+    if isinstance(t, type) and t.__module__ == types.__name__ and hasattr(t, "type_name")
+]
 
 
 class IfAbsentProcessor(ABC):
@@ -61,10 +96,12 @@ class IfAbsentProcessor(ABC):
         if mapped:
             return custom_default_value
 
-        if slot.range == String.type_name:
+        base_type = self._base_type(slot.range)
+
+        if base_type is String:
             return self.map_string_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Boolean.type_name:
+        if base_type is Boolean:
             if re.match(r"^[Tt]rue$", ifabsent_default_value):
                 return self.map_boolean_true_default_value(slot, cls)
             elif re.match(r"^[Ff]alse$", ifabsent_default_value):
@@ -75,19 +112,19 @@ class IfAbsentProcessor(ABC):
                     f"value"
                 )
 
-        if slot.range == Integer.type_name:
+        if base_type is Integer:
             return self.map_integer_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Float.type_name:
+        if base_type is Float:
             return self.map_float_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Double.type_name:
+        if base_type is Double:
             return self.map_double_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Decimal.type_name:
+        if base_type is Decimal:
             return self.map_decimal_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Time.type_name:
+        if base_type is Time:
             match = re.match(r"^(\d{2}):(\d{2}):(\d{2}).*$", ifabsent_default_value)
             if match:
                 return self.map_time_default_value(match[1], match[2], match[3], slot, cls)
@@ -97,7 +134,7 @@ class IfAbsentProcessor(ABC):
                 )
 
         # TODO manage timezones and offsets
-        if slot.range == Date.type_name:
+        if base_type is Date:
             match = re.match(r"^(\d{4})-(\d{2})-(\d{2})$", ifabsent_default_value)
             if match:
                 return self.map_date_default_value(match[1], match[2], match[3], slot, cls)
@@ -107,7 +144,7 @@ class IfAbsentProcessor(ABC):
                 )
 
         # TODO manage timezones and offsets
-        if slot.range == Datetime.type_name:
+        if base_type is Datetime:
             match = re.match(r"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).*$", ifabsent_default_value)
             if match:
                 return self.map_datetime_default_value(
@@ -120,7 +157,7 @@ class IfAbsentProcessor(ABC):
                 )
 
         # TODO manage timezones and offsets
-        if slot.range == DateOrDatetime.type_name:
+        if base_type is DateOrDatetime:
             match = re.match(r"^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}):(\d{2}))?.*$", ifabsent_default_value)
             if match and (match[4] is None or match[5] is None or match[6] is None):
                 return self.map_date_default_value(match[1], match[2], match[3], slot, cls)
@@ -134,31 +171,31 @@ class IfAbsentProcessor(ABC):
                     f"datetime value"
                 )
 
-        if slot.range == Uri.type_name:
+        if base_type is Uri:
             return self.map_uri_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Curie.type_name:
+        if base_type is Curie:
             return self.map_curie_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Uriorcurie.type_name:
+        if base_type is Uriorcurie:
             return self.map_uri_or_curie_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Ncname.type_name:
+        if base_type is Ncname:
             return self.map_nc_name_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Objectidentifier.type_name:
+        if base_type is Objectidentifier:
             return self.map_object_identifier_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Nodeidentifier.type_name:
+        if base_type is Nodeidentifier:
             return self.map_node_identifier_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Jsonpointer.type_name:
+        if base_type is Jsonpointer:
             return self.map_json_pointer_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Jsonpath.type_name:
+        if base_type is Jsonpath:
             return self.map_json_path_default_value(ifabsent_default_value, slot, cls)
 
-        if slot.range == Sparqlpath.type_name:
+        if base_type is Sparqlpath:
             return self.map_sparql_path_default_value(ifabsent_default_value, slot, cls)
 
         # -----------------------
@@ -172,6 +209,42 @@ class IfAbsentProcessor(ABC):
                         return self.map_enum_default_value(enum_name, permissible_value_name, slot, cls)
 
         raise ValueError(f"The ifabsent value `{slot.ifabsent}` of the `{slot.name}` slot could not be processed")
+
+    def _base_type(self, range_: str) -> Optional[TYPES_TYPE]:
+        """
+        Find the linkml base type that corresponds to either a matching type_name or custom type
+
+        First check for an explicit match of the range == TypeDefinition.type_name
+        Then check for explicit inheritance via typeof
+        Finally check for implicit matching via matching base
+
+        Don't raise here, just return None in case another method of resolution like enums are
+        available
+        """
+        # first check for matching type using type_name - ie. range is already a base type
+
+        for typ in TYPES:
+            if range_ == typ.type_name:
+                return typ
+
+        # then check explicit descendents of types
+        # base types do not inherit from one another, so the last ancestor is always a base type
+        # if it is inheriting from a base type
+        ancestor = self.schema_view.type_ancestors(range_)[-1]
+        for typ in TYPES:
+            if ancestor == typ.type_name:
+                return typ
+
+        # finally check if we have a matching base
+        induced_typ = self.schema_view.induced_type(range_)
+        if induced_typ.repr is None and induced_typ.base is None:
+            return None
+        for typ in TYPES:
+            # types always inherit from a single type, and that type is their base
+            # our range can match it with repr or base
+            typ_base = typ.__mro__[1].__name__
+            if typ_base == induced_typ.base:
+                return typ
 
     @abc.abstractmethod
     def map_custom_default_values(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition) -> (bool, str):

--- a/linkml/generators/common/ifabsent_processor.py
+++ b/linkml/generators/common/ifabsent_processor.py
@@ -74,7 +74,7 @@ class IfAbsentProcessor(ABC):
     See `<https://w3id.org/linkml/ifabsent>`_.
     """
 
-    ifabsent_regex = re.compile("""(?:(?P<type>\w+)\()?[\"\']?(?P<default_value>[^\(\)\"\')]*)[\"\']?\)?""")
+    ifabsent_regex = re.compile(r"""(?:(?P<type>\w+)\()?[\"\']?(?P<default_value>[^\(\)\"\')]*)[\"\']?\)?""")
 
     def __init__(self, schema_view: SchemaView):
         self.schema_view = schema_view
@@ -226,6 +226,10 @@ class IfAbsentProcessor(ABC):
         for typ in TYPES:
             if range_ == typ.type_name:
                 return typ
+
+        # if we're not a type, return None to indicate that, e.g. if an enum's permissible_value
+        if range_ not in self.schema_view.all_types(imports=True):
+            return
 
         # then check explicit descendents of types
         # base types do not inherit from one another, so the last ancestor is always a base type

--- a/linkml/generators/common/ifabsent_processor.py
+++ b/linkml/generators/common/ifabsent_processor.py
@@ -4,7 +4,7 @@ import sys
 from abc import ABC
 from typing import Any, Optional, Type, Union
 
-if sys.version_info.minor < 10:
+if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
 else:
     from typing import TypeAlias

--- a/tests/test_generators/python/input/ifabsent_custom_types.yaml
+++ b/tests/test_generators/python/input/ifabsent_custom_types.yaml
@@ -1,0 +1,261 @@
+id: ifabsent-custom-types
+name: ifabsent-custom-types
+description: |
+  Test schema for IfAbsentProcessor that tests for support for custom types
+  by matching them to a base type
+imports:
+  - linkml:types
+prefixes:
+  ex: https://example.org/
+default_prefix: ex
+
+types:
+  # inheritance
+  inh_string:
+    typeof: string
+  inh_integer:
+    typeof: integer
+  inh_boolean:
+    typeof: boolean
+  inh_float:
+    typeof: float
+  inh_double:
+    typeof: double
+  inh_decimal:
+    typeof: decimal
+  inh_time:
+    typeof: time
+  inh_date:
+    typeof: date
+  inh_datetime:
+    typeof: datetime
+  inh_date_or_datetime:
+    typeof: date_or_datetime
+  inh_uriorcurie:
+    typeof: uriorcurie
+  inh_curie:
+    typeof: curie
+  inh_uri:
+    typeof: uri
+  inh_ncname:
+    typeof: ncname
+  inh_objectidentifier:
+    typeof: objectidentifier
+  inh_nodeidentifier:
+    typeof: nodeidentifier
+  inh_jsonpointer:
+    typeof: jsonpointer
+  inh_jsonpath:
+    typeof: jsonpath
+  inh_sparqlpath:
+    typeof: sparqlpath
+
+  # base
+  base_string:
+    base: str
+  base_integer:
+    base: int
+  base_boolean:
+    base: Bool
+  base_float:
+    base: float
+  base_double:
+    base: float
+  base_decimal:
+    base: Decimal
+  base_time:
+    base: XSDTime
+  base_date:
+    base: XSDDate
+  base_datetime:
+    base: XSDDateTime
+  base_date_or_datetime:
+    base: str
+  base_uriorcurie:
+    base: URIorCURIE
+  base_curie:
+    base: Curie
+  base_uri:
+    base: URI
+  base_ncname:
+    base: NCName
+  base_objectidentifier:
+    base: ElementIdentifier
+  base_nodeidentifier:
+    base: NodeIdentifier
+  base_jsonpointer:
+    base: str
+  base_jsonpath:
+    base: str
+  base_sparqlpath:
+    base: str
+
+classes:
+  Inheritance:
+    attributes:
+      string:
+        range: inh_string
+        ifabsent: string(a)
+        annotations:
+          value: '"a"'
+      integer:
+        range: inh_integer
+        ifabsent: int(1)
+        annotations:
+          value: '1'
+      boolean:
+        range: inh_boolean
+        ifabsent: true
+        annotations:
+          value: 'True'
+      float:
+        range: inh_float
+        ifabsent: float(0.5)
+        annotations:
+          value: '0.5'
+      double:
+        range: inh_double
+        ifabsent: double(0.7)
+        annotations:
+          value: '0.7'
+      decimal:
+        range: inh_decimal
+        ifabsent: decimal(18.9)
+        annotations:
+          value: '18.9'
+      time:
+        range: inh_time
+        ifabsent: time(08:13:04)
+        annotations:
+          value: "time(8, 13, 4)"
+      date:
+        range: inh_date
+        ifabsent: date(2024-06-26)
+        annotations:
+          value: "date(2024, 6, 26)"
+      datetime:
+        range: inh_datetime
+        ifabsent: datetime(2024-04-12T11:45:34)
+        annotations:
+          value: "datetime(2024, 4, 12, 11, 45, 34)"
+      date_or_datetime:
+        range: inh_date_or_datetime
+        ifabsent: datetime(2024-02-09T18:25:44Z)
+        annotations:
+          value: "datetime(2024, 2, 9, 18, 25, 44)"
+      uriorcurie:
+        range: inh_uriorcurie
+        ifabsent: "uri(https://example.org/class/123)"
+        annotations:
+          value: 'EX["class/123"]'
+      curie:
+        range: inh_curie
+        description: don't know how to test this
+      uri:
+        range: inh_uri
+        ifabsent: "uri(https://example.org/class/123)"
+        annotations:
+          value: 'EX["class/123"]'
+      ncname:
+        range: inh_ncname
+        description: don't know how to test this
+      objectidentifier:
+        range: inh_objectidentifier
+        description: don't know how to test this
+      nodeidentifier:
+        range: inh_nodeidentifier
+        description: don't know how to test this
+      jsonpointer:
+        range: inh_jsonpointer
+        description: don't know how to test this
+      jsonpath:
+        range: inh_jsonpath
+        description: don't know how to test this
+      sparqlpath:
+        range: inh_sparqlpath
+        description: don't know how to test this
+
+  Base:
+    attributes:
+      string:
+        range: base_string
+        ifabsent: string(a)
+        annotations:
+          value: '"a"'
+      integer:
+        range: base_integer
+        ifabsent: int(1)
+        annotations:
+          value: '1'
+      boolean:
+        range: base_boolean
+        ifabsent: true
+        annotations:
+          value: 'True'
+      float:
+        range: base_float
+        ifabsent: float(0.5)
+        annotations:
+          value: '0.5'
+      double:
+        range: base_double
+        ifabsent: double(0.7)
+        annotations:
+          value: '0.7'
+      decimal:
+        range: base_decimal
+        ifabsent: decimal(18.9)
+        annotations:
+          value: '18.9'
+      time:
+        range: base_time
+        ifabsent: time(08:13:04)
+        annotations:
+          value: "time(8, 13, 4)"
+      date:
+        range: base_date
+        ifabsent: date(2024-06-26)
+        annotations:
+          value: "date(2024, 6, 26)"
+      datetime:
+        range: base_datetime
+        ifabsent: datetime(2024-04-12T11:45:34)
+        annotations:
+          value: "datetime(2024, 4, 12, 11, 45, 34)"
+      date_or_datetime:
+        range: base_date_or_datetime
+        ifabsent: datetime(2024-02-09T18:25:44Z)
+        description: date_or_datetime has a base of string, so it's known to be processed incorrectly
+        annotations:
+          value: '"2024-02-09T18:25:44Z"'
+      uriorcurie:
+        range: base_uriorcurie
+        ifabsent: "uri(https://example.org/class/123)"
+        annotations:
+          value: 'EX["class/123"]'
+      curie:
+        range: base_curie
+        description: don't know how to test this
+      uri:
+        range: base_uri
+        ifabsent: "uri(https://example.org/class/123)"
+        annotations:
+          value: 'EX["class/123"]'
+      ncname:
+        range: base_ncname
+        description: don't know how to test this
+      objectidentifier:
+        range: base_objectidentifier
+        description: don't know how to test this
+      nodeidentifier:
+        range: base_nodeidentifier
+        description: don't know how to test this
+      jsonpointer:
+        range: base_jsonpointer
+        description: don't know how to test this
+      jsonpath:
+        range: base_jsonpath
+        description: don't know how to test this
+      sparqlpath:
+        range: base_sparqlpath
+        description: don't know how to test this

--- a/tests/test_generators/python/test_python_ifabsent_processor.py
+++ b/tests/test_generators/python/test_python_ifabsent_processor.py
@@ -437,3 +437,21 @@ def test_bnode_default_value():
         )
         == "bnode()"
     )
+
+
+@pytest.mark.parametrize("cls_name", ["Inheritance", "Base"])
+def test_custom_types(cls_name, input_path):
+    """
+    Custom types should have their defaults correctly resolved against
+    their ancestors or bases
+    """
+    schema = input_path("ifabsent_custom_types.yaml")
+    sv = SchemaView(schema)
+
+    cls = sv.induced_class(cls_name)
+    processor = PythonIfAbsentProcessor(sv)
+    for attr_name, attr in cls.attributes.items():
+        default = processor.process_slot(attr, cls)
+        if "value" not in attr.annotations:
+            continue
+        assert default == attr.annotations["value"].value


### PR DESCRIPTION
fix: https://github.com/linkml/linkml/issues/2279

hopefully self explanatory. i am seepy but can return to write more tmrw.

some of these i couldn't figure out how to actually test, but feel free to request changes and lmk on those.

edit: more complete description - we try and match the base type! I couldn't find a method for this in schemaview, where it probably belongs. matching with string names is implicit and incomplete, we want to actually get the relevant type so that we can handle custom types.
- first check to see if the range is already one of the base types, return if it is
- then we return early if it isn't a type at all (eg. for enums)
- then we try and find a matching type ancestor, returning if we do.
- and finally, as a last resort, we try and match the base type using the literal `mro` of the base types.

also fixed one minor warning that kept coming up because the regex pattern wasn't an `r''` string.