### PR TITLE
Add some additional information to documentation generated for deprecated classes, slots, and enums

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -8,6 +8,17 @@
     {%- endif -%}
 {%- endif -%}
 
+{%- if element.deprecated %}
+    {%- set title = '~~' ~ title ~ '~~' -%}
+    {%- set title = 'Class: ' ~ title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
+{%- endif -%}
+{%- if element.abstract %}
+    {%- set title = title ~ ' <span style="color: pink;"><strong><small> (Abstract) </small></strong></span> ' -%}
+{%- endif -%}
+{%- if element.multivalued %}
+    {%- set title = title ~ ' (multivalued)' %}
+{%- endif -%}
+
 {% macro compute_range(slot) -%}
     {%- if slot.any_of or slot.exactly_one_of -%}
         {%- for subslot_range in schemaview.slot_range_as_union(slot) -%}
@@ -21,7 +32,7 @@
     {%- endif -%}
 {% endmacro %}
 
-# Class: {{ title }}
+# {{ title }}
 
 {%- if header -%}
 {{header}}
@@ -37,6 +48,12 @@ _{{ element_description_line }}_
 
 {% if element.abstract %}
 * __NOTE__: this is an abstract class and should not be instantiated directly
+{% endif %}
+
+{% if element.deprecated %}
+* __NOTE__ this element has been deprecated with the following note:
+    * *{{ element.deprecated }}*
+    {% if element.deprecated_element_has_exact_replacement %}* Element has been replaced by {{ gen.link(element.deprecated_element_has_exact_replacement) }}{% endif %}
 {% endif %}
 
 URI: {{ gen.uri_link(element) }}
@@ -68,12 +85,12 @@ URI: {{ gen.uri_link(element) }}
 | ---  | --- | --- | --- |
 {% if gen.get_direct_slots(element)|length > 0 %}
 {%- for slot in gen.get_direct_slots(element) -%}
-| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | direct |
+| {% if slot.deprecated -%}~~{{ gen.link(slot) }}~~{% else -%}{{ gen.link(slot) }}{% endif %} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | direct |
 {% endfor -%}
 {% endif -%}
 {% if gen.get_indirect_slots(element)|length > 0 %}
 {%- for slot in gen.get_indirect_slots(element) -%}
-| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
+| {% if slot.deprecated -%}~~{{ gen.link(slot) }}~~{% else -%}{{ gen.link(slot) }}{% endif %} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
 {% endfor -%}
 {% endif %}
 

--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -1,3 +1,5 @@
+{%- set header = 'Class:' -%}
+
 {%- if element.title %}
     {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
 {%- else %}
@@ -10,7 +12,7 @@
 
 {%- if element.deprecated %}
     {%- set title = '~~' ~ title ~ '~~' -%}
-    {%- set title = 'Class: ' ~ title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
+    {%- set title = title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
 {%- endif -%}
 {%- if element.abstract %}
     {%- set title = title ~ ' <span style="color: pink;"><strong><small> (Abstract) </small></strong></span> ' -%}
@@ -32,7 +34,7 @@
     {%- endif -%}
 {% endmacro %}
 
-# {{ title }}
+# {{ header }} {{ title }}
 
 {%- if header -%}
 {{header}}

--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -1,3 +1,5 @@
+{%- set header = 'Enum:' -%}
+
 {%- if element.title %}
     {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
 {%- else %}
@@ -10,7 +12,7 @@
 
 {%- if element.deprecated %}
     {%- set title = '~~' ~ title ~ '~~' -%}
-    {%- set title = 'Enum: ' ~ title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
+    {%- set title = title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
 {%- endif -%}
 {%- if element.abstract %}
     {%- set title = title ~ ' <span style="color: pink;"><strong><small> (Abstract) </small></strong></span> ' -%}
@@ -19,7 +21,7 @@
     {%- set title = title ~ ' (multivalued)' %}
 {%- endif -%}
 
-# {{ title }}
+# {{ header }} {{ title }}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}

--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -1,10 +1,37 @@
-# Enum: {{ gen.name(element) }}
+{%- if element.title %}
+    {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
+{%- else %}
+    {%- if gen.use_enum_uris -%}
+        {%- set title = element.name -%}
+    {%- else -%}
+        {%- set title = gen.name(element) -%}
+    {%- endif -%}
+{%- endif -%}
+
+{%- if element.deprecated %}
+    {%- set title = '~~' ~ title ~ '~~' -%}
+    {%- set title = 'Enum: ' ~ title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
+{%- endif -%}
+{%- if element.abstract %}
+    {%- set title = title ~ ' <span style="color: pink;"><strong><small> (Abstract) </small></strong></span> ' -%}
+{%- endif -%}
+{%- if element.multivalued %}
+    {%- set title = title ~ ' (multivalued)' %}
+{%- endif -%}
+
+# {{ title }}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}
 {% for element_description_line in element_description_lines %}
 _{{ element_description_line }}_
 {% endfor %}
+{% endif %}
+
+{% if element.deprecated %}
+* __NOTE__ this element has been deprecated with the following note:
+    * *{{ element.deprecated }}*
+    {% if element.deprecated_element_has_exact_replacement %}* Element has been replaced by {{ gen.link(element.deprecated_element_has_exact_replacement) }}{% endif %}
 {% endif %}
 
 URI: {{ gen.link(element) }}

--- a/linkml/generators/docgen/index.md.jinja2
+++ b/linkml/generators/docgen/index.md.jinja2
@@ -21,11 +21,11 @@ Name: {{ schema.name }}
 | --- | --- |
 {% if gen.hierarchical_class_view -%}
 {% for u, v in gen.class_hierarchy_as_tuples() -%}
-| {{ "&nbsp;"|safe*u*8 }}{{ gen.link(schemaview.get_class(v)) }} | {{ schemaview.get_class(v).description }} |
+| {{ "&nbsp;"|safe*u*8 }}{% if schemaview.get_class(v).deprecated -%}~~{{ gen.link(schemaview.get_class(v)) }}~~{% else -%}{{ gen.link(schemaview.get_class(v)) }}{% endif %} | {% if schemaview.get_class(v).deprecated %}*(Deprecated)* {% endif %}{{ schemaview.get_class(v).description }} |
 {% endfor %}
 {% else -%}
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(c)}} | {{c.description|enshorten}} |
+| {% if c.deprecated -%}~~{{gen.link(c)}}~~{% else -%}{{gen.link(c)}}{% endif %} | {% if c.deprecated %}*(Deprecated)* {% endif %}{{c.description|enshorten}} |
 {% endfor %}
 {% endif %}
 
@@ -34,7 +34,7 @@ Name: {{ schema.name }}
 | Slot | Description |
 | --- | --- |
 {% for s in gen.all_slot_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(s)}} | {{s.description|enshorten}} |
+| {% if s.deprecated -%}~~{{gen.link(s)}}~~{% else -%}{{gen.link(s)}}{% endif %} | {% if s.deprecated %}*(Deprecated)* {% endif %}{{s.description|enshorten}} |
 {% endfor %}
 
 ## Enumerations
@@ -42,7 +42,7 @@ Name: {{ schema.name }}
 | Enumeration | Description |
 | --- | --- |
 {% for e in gen.all_enum_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(e)}} | {{e.description|enshorten}} |
+| {% if e.deprecated -%}~~{{gen.link(e)}}~~{% else -%}{{gen.link(e)}}{% endif %} | {% if e.deprecated %}*(Deprecated)* {% endif %}{{e.description|enshorten}} |
 {% endfor %}
 
 ## Types
@@ -50,7 +50,7 @@ Name: {{ schema.name }}
 | Type | Description |
 | --- | --- |
 {% for t in gen.all_type_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(t)}} | {{t.description|enshorten}} |
+| {% if t.deprecated -%}~~{{gen.link(t)}}~~{% else -%}{{gen.link(t)}}{% endif %} | {% if t.deprecated %}*(Deprecated)* {% endif %}{{t.description|enshorten}} |
 {% endfor %}
 
 ## Subsets
@@ -58,5 +58,5 @@ Name: {{ schema.name }}
 | Subset | Description |
 | --- | --- |
 {% for ss in schemaview.all_subsets().values()|sort(attribute='name') -%}
-| {{gen.link(ss)}} | {{ss.description|enshorten}} |
+| {% if ss.deprecated -%}~~{{gen.link(ss)}}~~{% else -%}{{gen.link(ss)}}{% endif %} | {% if ss.deprecated %}*(Deprecated)* {% endif %}{{ss.description|enshorten}} |
 {% endfor %}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -8,6 +8,17 @@
     {%- endif -%}
 {%- endif -%}
 
+{%- if element.deprecated %}
+    {%- set title = '~~' ~ title ~ '~~' -%}
+    {%- set title = 'Slot: ' ~ title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
+{%- endif -%}
+{%- if element.abstract %}
+    {%- set title = title ~ ' <span style="color: pink;"><strong><small> (Abstract) </small></strong></span> ' -%}
+{%- endif -%}
+{%- if element.multivalued %}
+    {%- set title = title ~ ' (multivalued)' %}
+{%- endif -%}
+
 {% macro compute_range(slot) -%}
     {%- if slot.any_of or slot.exactly_one_of -%}
         {%- for subslot_range in schemaview.slot_range_as_union(slot) -%}
@@ -21,7 +32,7 @@
     {%- endif -%}
 {% endmacro %}
 
-# Slot: {{ title }}
+# {{ title }}
 
 {%- if header -%}
 {{header}}
@@ -36,6 +47,12 @@ _{{ element_description_line }}_
 
 {% if element.abstract %}
 * __NOTE__: this is an abstract slot and should not be populated directly
+{% endif %}
+
+{% if element.deprecated %}
+* __NOTE__ this element has been deprecated with the following note:
+    * *{{ element.deprecated }}*
+    {% if element.deprecated_element_has_exact_replacement %}* Element has been replaced by {{ gen.link(element.deprecated_element_has_exact_replacement) }}{% endif %}
 {% endif %}
 
 URI: {{ gen.uri_link(element) }}

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -1,3 +1,5 @@
+{%- set header = 'Slot:' -%}
+
 {%- if element.title %}
     {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
 {%- else %}
@@ -10,7 +12,7 @@
 
 {%- if element.deprecated %}
     {%- set title = '~~' ~ title ~ '~~' -%}
-    {%- set title = 'Slot: ' ~ title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
+    {%- set title = title ~ '<span style="color: #ff5252;"><strong> (DEPRECATED) </strong></span>' -%}
 {%- endif -%}
 {%- if element.abstract %}
     {%- set title = title ~ ' <span style="color: pink;"><strong><small> (Abstract) </small></strong></span> ' -%}
@@ -32,7 +34,7 @@
     {%- endif -%}
 {% endmacro %}
 
-# {{ title }}
+# {{ header }} {{ title }}
 
 {%- if header -%}
 {{header}}

--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -321,6 +321,9 @@ classes:
     deprecated: this is not a real class, we are using it to test deprecation
     attributes:
       test_attribute:
+      test_deprecated_attribute:
+        deprecated: true
+        deprecated_element_has_exact_replacement: test_attribute
 
   class with spaces:
     attributes:

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -617,6 +617,7 @@ def test_class_slots_inheritance(kitchen_sink_path):
 
     assert expected_result == actual_result
 
+
 def test_deprecated(kitchen_sink_path, input_path, tmp_path):
     tdir = input_path("docgen_html_templates")
     gen = DocGenerator(
@@ -631,32 +632,27 @@ def test_deprecated(kitchen_sink_path, input_path, tmp_path):
 
     # this is a deprecated class
     assert_mdfile_contains(
-        tmp_path / "FakeClass.md", 
+        tmp_path / "FakeClass.md",
         "# Class: ~~FakeClass~~",
     )
     assert_mdfile_contains(
-        tmp_path / "FakeClass.md",
-        "__NOTE__ this element has been deprecated with the following note:"
+        tmp_path / "FakeClass.md", "__NOTE__ this element has been deprecated with the following note:"
     )
 
     # check that deprecated slot has strikethrough on class page
     assert_mdfile_contains(
-        tmp_path / "FakeClass.md", 
-        "~~[test_deprecated_attribute](test_deprecated_attribute.md)~~", 
-        after="## Slots"
+        tmp_path / "FakeClass.md", "~~[test_deprecated_attribute](test_deprecated_attribute.md)~~", after="## Slots"
     )
 
     # check that deprecated slot has strikethrough title
     assert_mdfile_contains(
-        tmp_path / "test_deprecated_attribute.md", 
+        tmp_path / "test_deprecated_attribute.md",
         "# Slot: ~~test_deprecated_attribute~~",
     )
 
     # check deprecated class strikethrough and note in index.md
     assert_mdfile_contains(
-        tmp_path / "index.md",
-        "| ~~[FakeClass](FakeClass.md)~~ | *(Deprecated)*  |",
-        after="| [Event](Event.md) |  |"
+        tmp_path / "index.md", "| ~~[FakeClass](FakeClass.md)~~ | *(Deprecated)*  |", after="| [Event](Event.md) |  |"
     )
 
 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -617,6 +617,48 @@ def test_class_slots_inheritance(kitchen_sink_path):
 
     assert expected_result == actual_result
 
+def test_deprecated(kitchen_sink_path, input_path, tmp_path):
+    tdir = input_path("docgen_html_templates")
+    gen = DocGenerator(
+        kitchen_sink_path,
+        mergeimports=True,
+        no_types_dir=True,
+        template_directory=str(tdir),
+        use_slot_uris=True,
+    )
+
+    gen.serialize(directory=str(tmp_path))
+
+    # this is a deprecated class
+    assert_mdfile_contains(
+        tmp_path / "FakeClass.md", 
+        "# Class: ~~FakeClass~~",
+    )
+    assert_mdfile_contains(
+        tmp_path / "FakeClass.md",
+        "__NOTE__ this element has been deprecated with the following note:"
+    )
+
+    # check that deprecated slot has strikethrough on class page
+    assert_mdfile_contains(
+        tmp_path / "FakeClass.md", 
+        "~~[test_deprecated_attribute](test_deprecated_attribute.md)~~", 
+        after="## Slots"
+    )
+
+    # check that deprecated slot has strikethrough title
+    assert_mdfile_contains(
+        tmp_path / "test_deprecated_attribute.md", 
+        "# Slot: ~~test_deprecated_attribute~~",
+    )
+
+    # check deprecated class strikethrough and note in index.md
+    assert_mdfile_contains(
+        tmp_path / "index.md",
+        "| ~~[FakeClass](FakeClass.md)~~ | *(Deprecated)*  |",
+        after="| [Event](Event.md) |  |"
+    )
+
 
 def test_use_slot_uris(kitchen_sink_path, input_path, tmp_path):
     tdir = input_path("docgen_html_templates")


### PR DESCRIPTION
I was surprised to see there was no information about deprecation in the default docgen templates. Looking at https://biolink.github.io/biolink-model/genetic_association/, I was inspired to make some changes to our local templates that maybe are of use upstream.

The styles/colors are hard-coded in, which isn't great, but I wasn't sure if there was a way to make that match a particular theme, or a better way to do it. I think my implementation is also non-exhaustive, but perhaps it's a start. Here's an example of what it looks like:

Deprecated classes and slots are strikethrough'ed and a "deprecated" note is added:
![image](https://github.com/user-attachments/assets/bf499f1a-cd83-4c41-afcc-37aed0da2b12)

Headers clearly indicate when an item is deprecated or abstract, with a link to the exact replacement if present:
![image](https://github.com/user-attachments/assets/85524d06-ff2e-484f-be9c-1a5dbe335d01)

![image](https://github.com/user-attachments/assets/1fa99065-7495-46f1-a955-7505e2cdf2a1)

I also added some basic tests following the example of the other docgen tests.