### PR TITLE
[pydanticgen] Sort `Imports`

### DIFF
--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -998,7 +998,8 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
 
         Args:
             rendered_module ( :class:`.PydanticModule` ): Optional, if schema was previously
-                rendered with :meth:`~.PydanticGenerator.render` , use that, otherwise :meth:`~.PydanticGenerator.render` fresh.
+                rendered with :meth:`~.PydanticGenerator.render` , use that,
+                otherwise :meth:`~.PydanticGenerator.render` fresh.
         """
         if rendered_module is not None:
             module = rendered_module

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -269,7 +269,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
     """
     sort_imports: bool = True
     """
-    Before returning from :meth:`.render`, sort imports with :meth:`.Imports.sort`
+    Before returning from :meth:`.PydanticGenerator.render`, sort imports with :meth:`.Imports.sort`
 
     Default ``True``, but optional in case import order must be explicitly given,
     eg. to avoid circular import errors in complex generator subclasses.
@@ -928,6 +928,9 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
         return Import(module=module, objects=[ObjectImport(name=camelcase(class_name))], is_schema=True)
 
     def render(self) -> PydanticModule:
+        """
+        Render the schema to a :class:`PydanticModule` model
+        """
         sv: SchemaView
         sv = self.schemaview
 
@@ -995,7 +998,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
 
         Args:
             rendered_module ( :class:`.PydanticModule` ): Optional, if schema was previously
-                rendered with :meth:`.render` , use that, otherwise :meth:`.render` fresh.
+                rendered with :meth:`~.PydanticGenerator.render` , use that, otherwise :meth:`~.PydanticGenerator.render` fresh.
         """
         if rendered_module is not None:
             module = rendered_module

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -267,6 +267,13 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
             from typing_extensions import Literal
 
     """
+    sort_imports: bool = True
+    """
+    Before returning from :meth:`.render`, sort imports with :meth:`.Imports.sort`
+
+    Default ``True``, but optional in case import order must be explicitly given,
+    eg. to avoid circular import errors in complex generator subclasses.
+    """
     metadata_mode: Union[MetadataMode, str, None] = MetadataMode.AUTO
     """
     How to include schema metadata in generated pydantic models.
@@ -965,13 +972,14 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
         class_results = self.after_generate_classes(class_results, sv)
 
         classes = {r.cls.name: r.cls for r in class_results}
-
         injected_classes = self._clean_injected_classes(injected_classes)
+
+        imports.render_sorted = self.sort_imports
 
         module = PydanticModule(
             metamodel_version=self.schema.metamodel_version,
             version=self.schema.version,
-            python_imports=imports.imports,
+            python_imports=imports,
             base_model=base_model,
             injected_classes=injected_classes,
             enums=enums,

--- a/linkml/generators/pydanticgen/templates/imports.py.jinja
+++ b/linkml/generators/pydanticgen/templates/imports.py.jinja
@@ -20,12 +20,20 @@ from {{ module }} import (
     {%- endif %}
 {%- endif %}
 {% endmacro %}
+{#- For when used with Import model -#}
 {%- if module %}
 {{ import_(module, alias, objects) }}
 {% endif -%}
 {#- For when used with Imports container -#}
 {%- if imports -%}
-{%- for i in imports -%}
-{{ i }}
-{%- endfor -%}
+    {%- if render_sorted -%}
+        {% for i in range(imports | length) %}
+{{ imports[i] }}
+{%- if not loop.last and import_groups[i] != import_groups[i+1] %}{{ '\n' }}{% endif -%}
+        {% endfor %}
+    {%- else -%}
+        {%- for import in imports -%}
+{{ import }}
+        {%- endfor -%}
+    {%- endif -%}
 {% endif -%}

--- a/linkml/generators/pydanticgen/templates/module.py.jinja
+++ b/linkml/generators/pydanticgen/templates/module.py.jinja
@@ -1,6 +1,4 @@
-{% for import in python_imports %}
-{{ import }}
-{%- endfor -%}
+{{ python_imports }}
 
 metamodel_version = "{{metamodel_version}}"
 version = "{{version if version else None}}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ skip = '.git,*.pdf,*.svg,./tests,pyproject.toml,*.dill,poetry.lock'
 # Ignore table where words could be split across rows
 # Ignore shortcut specifications like [Ff]alse
 ignore-regex = '(\|.*\|.*\|.*\||\[[A-Z][a-z]\][a-z][a-z])'
-ignore-words-list = 'mater,connexion,infarction'
+ignore-words-list = 'mater,connexion,infarction,thirdparty'
 quiet-level = 3
 
 [tool.black]

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -2389,3 +2389,26 @@ def test_lifecycle_slots(kitchen_sink_path):
             assert attr.description == "TEST MODIFYING SLOTS"
             assert attr.required
             assert attr.meta["extra_meta_field"]
+
+
+def test_crappy_stdlib_set_removed():
+    """
+    After support for <3.10 is dropped, remove the dang stdlib list stub
+
+    since this is just a tidiness test rather than a correctness test,
+    wrap the whole thing in a try and self-contain its imports
+    """
+    try:
+        from importlib.metadata import metadata
+
+        from packaging.specifiers import SpecifierSet
+        from packaging.version import Version
+
+        linkml_meta = metadata("linkml")
+        req_python = SpecifierSet(linkml_meta.json["requires_python"])
+        assert req_python.contains(
+            Version("3.9")
+        ), "REMOVE _some_stdlib_module_names from the bottom of pydanticgen/template.py, "
+        "and then REMOVE THIS TEST!"
+    except Exception:
+        pass

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -49,6 +49,7 @@ from linkml.utils.schema_builder import SchemaBuilder
 from .conftest import MyInjectedClass
 
 PACKAGE = "kitchen_sink"
+pytestmark = pytest.mark.pydanticgen
 
 
 def test_pydantic(kitchen_sink_path, tmp_path, input_path):
@@ -1046,7 +1047,7 @@ def test_imports_add():
     import_cond_a = ConditionalImport(module="module_a", condition="1 == 1", alternative=Import(module="module_b"))
     import_cond_b = ConditionalImport(module="module_a", condition="2 == 2", alternative=Import(module="module_c"))
 
-    imports = Imports() + import_a
+    imports = Imports(render_sorted=False) + import_a
 
     imports_1 = imports + import_b
     assert len(imports_1) == len(imports) + 1
@@ -1230,6 +1231,82 @@ def test_imports_contains():
 
     with pytest.raises(TypeError):
         _ = "a string!?!?" in imports
+
+
+def test_import_sort():
+    """
+    Import.sort should sort its objects alphabetically and according to capitalization
+    """
+    an_import = Import(
+        module="module_a",
+        objects=[
+            ObjectImport(name="A"),
+            ObjectImport(name="C"),
+            ObjectImport(name="a"),
+            ObjectImport(name="B", alias="Z"),
+        ],
+    )
+
+    an_import.sort()
+    obj_names = [o.name for o in an_import.objects]
+    assert obj_names == ["A", "B", "C", "a"]
+
+
+@pytest.mark.parametrize(
+    "module,group",
+    (
+        ("__future__", "future"),
+        ("typing", "stdlib"),
+        ("numpy", "thirdparty"),
+        (".mymodule", "local"),
+    ),
+)
+def test_import_group(module, group):
+    """Import.group should correctly identify import group"""
+    assert Import(module=module).group == group
+
+
+def test_imports_sort():
+    """
+    Imports.sort should sort like isort
+    """
+    imports = Imports(
+        imports=[
+            # ConditionalImports come last
+            ConditionalImport(module="aaa", condition="True", alternative=Import(module="bbb")),
+            # local modules come after thirdparty
+            Import(module=".mymodule"),
+            # thirdparty come after stdlib
+            Import(module="numpy"),
+            # __future__ always comes first
+            Import(module="__future__", objects=[ObjectImport(name="print")]),
+            Import(module="typing", objects=[ObjectImport(name="List")]),
+            # objects should be sorted within an Import
+            Import(module="datetime", objects=[ObjectImport(name="time"), ObjectImport(name="datetime")]),
+            # imports without objects come first within a group
+            Import(module="sys"),
+            Import(module="enum"),
+        ]
+    )
+    imports.sort()
+    module_order = [i.module for i in imports.imports]
+    assert module_order == ["__future__", "enum", "sys", "datetime", "typing", "numpy", ".mymodule", "aaa"]
+    assert [o.name for o in imports["datetime"].objects] == ["datetime", "time"]
+
+
+def test_imports_groups_rendering(kitchen_sink_path):
+    """
+    When rendering, python import groups should be rendered by newline-delimited groups
+    """
+    gen = PydanticGenerator(
+        kitchen_sink_path, imports=[Import(module=".mymodule"), Import(module="numpy")], sort_imports=True
+    )
+    rendered = gen.render()
+    rendered_imports = rendered.python_imports.render()
+    # yes line break between builtins and thirdparty
+    assert re.search(r"\)\n\nimport numpy", rendered_imports)
+    # no line break between builtins
+    assert re.search("import re\nimport sys", rendered_imports)
 
 
 def test_template_models_templates():


### PR DESCRIPTION
I got tired of my imports lookin silly, and inching towards a situation where i don't need to reformat my generated pydantic modules every time.

Sorts imports in an isort-like way (although i couldn't really get to the bottom of all the things isort does)

so currently imports are just rendered in the module-order in which they were added, which is not that bad most of the time because we manually sorted the `DEFAULT_IMPORTS`

```python
from __future__ import annotations 
from datetime import (
    datetime,
    date,
    time
)
from decimal import Decimal 
from enum import Enum 
import re
import sys
from typing import (
    Any,
    ClassVar,
    List,
    Literal,
    Dict,
    Optional,
    Union
)
from pydantic import (
    BaseModel,
    ConfigDict,
    Field,
    RootModel,
    field_validator
)
import .mymodule
import numpy

```

but it gets pretty bad when you are customizing build and adding additional imports and whatnot, so after this PR this gets rendered like

```python
from __future__ import annotations 

import re
import sys
from datetime import (
    date,
    datetime,
    time
)
from decimal import Decimal 
from enum import Enum 
from typing import (
    Any,
    ClassVar,
    Dict,
    List,
    Literal,
    Optional,
    Union
)

import numpy
from pydantic import (
    BaseModel,
    ConfigDict,
    Field,
    RootModel,
    field_validator
)

import .mymodule
```

I also made it optional in case there are times when someone needs tight control because eg. they need to duck circular import problems and import order is important. 