### PR TITLE
[QoL] fix deprecation warnings

### DIFF
--- a/linkml/linter/linter.py
+++ b/linkml/linter/linter.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, Union
 import jsonschema
 import yaml
 from jsonschema.exceptions import best_match
+from jsonschema.protocols import Validator
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SchemaDefinition
@@ -35,7 +36,7 @@ def get_named_config(name: str) -> Dict[str, Any]:
 
 
 @lru_cache
-def get_metamodel_validator() -> jsonschema.Validator:
+def get_metamodel_validator() -> Validator:
     meta_json_gen = JsonSchemaGenerator(LOCAL_METAMODEL_YAML_FILE, not_closed=False)
     meta_json_schema = meta_json_gen.generate()
     validator_cls = jsonschema.validators.validator_for(meta_json_schema, default=jsonschema.Draft7Validator)

--- a/linkml/validator/plugins/pydantic_validation_plugin.py
+++ b/linkml/validator/plugins/pydantic_validation_plugin.py
@@ -37,7 +37,7 @@ class PydanticValidationPlugin(ValidationPlugin):
         """
         pydantic_model = context.pydantic_model(closed=self.closed)
         try:
-            instance = pydantic_model.parse_obj(instance)
+            instance = pydantic_model.model_validate(instance)
         except Exception as e:
             yield ValidationResult(
                 type="Pydantic validation",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import sys
 from abc import ABC, abstractmethod
@@ -15,6 +16,9 @@ from tests.utils.compare_rdf import compare_rdf
 from tests.utils.dirutils import are_dir_trees_equal
 
 KITCHEN_SINK_PATH = str(Path(__file__).parent / "test_generators" / "input" / "kitchen_sink.yaml")
+
+# avoid an error from nbconvert -> jupyter_core. remove this after jupyter_core v6
+os.environ["JUPYTER_PLATFORM_DIRS"] = "1"
 
 
 def normalize_line_endings(string: str):

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -27,7 +27,7 @@ from linkml_runtime.loaders import rdflib_loader
 from linkml_runtime.utils.compile_python import compile_python
 from linkml_runtime.utils.introspection import package_schemaview
 from linkml_runtime.utils.yamlutils import YAMLRoot
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from linkml.transformers.logical_model_transformer import UnsatisfiableAttribute
 
@@ -132,13 +132,12 @@ class Feature(BaseModel):
     A category of tests that can be implemented by multiple frameworks.
     """
 
+    model_config = ConfigDict(use_enum_values=True)
+
     name: str
     description: str
     implementations: Dict[FRAMEWORK, ValidationBehavior]
     num_tests: int = 0
-
-    class Config:
-        use_enum_values = True
 
     def set_framework_behavior(self, framework: FRAMEWORK, behavior: ValidationBehavior) -> ValidationBehavior:
         if framework not in self.implementations:
@@ -418,7 +417,8 @@ def _schema_out_path(schema: Dict, parent=False) -> Path:
 
 @lru_cache
 def _get_linkml_types() -> dict:
-    type_schema = yaml.safe_load(open(linkml_runtime.SCHEMA_DIRECTORY / "types.yaml"))
+    with open(linkml_runtime.SCHEMA_DIRECTORY / "types.yaml", "r") as tfile:
+        type_schema = yaml.safe_load(tfile)
     for typ in type_schema.get("types", {}).values():
         typ["from_schema"] = "https://w3id.org/linkml/types"
     return type_schema


### PR DESCRIPTION
I am a known [disliker of noisy warnings](https://github.com/linkml/linkml/pull/1939)

so here i'm fixin some more

```
E   DeprecationWarning: Importing Validator directly from the jsonschema package is deprecated and will become an ImportError. Import it from jsonschema.protocols instead.
```

```
PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.8/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

```

```
Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write

```

```
DeprecatedSince20: The `parse_obj` method is deprecated; use `model_validate` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.8/migration/
    warnings.warn(

```