### PR TITLE
Introduce a docgen subfolder type separation argument

### DIFF
--- a/linkml/generators/docgen/index.md.jinja2
+++ b/linkml/generators/docgen/index.md.jinja2
@@ -21,11 +21,11 @@ Name: {{ schema.name }}
 | --- | --- |
 {% if gen.hierarchical_class_view -%}
 {% for u, v in gen.class_hierarchy_as_tuples() -%}
-| {{ "&nbsp;"|safe*u*8 }}{{ gen.link(schemaview.get_class(v)) }} | {{ schemaview.get_class(v).description }} |
+| {{ "&nbsp;"|safe*u*8 }}{{ gen.link(schemaview.get_class(v), True) }} | {{ schemaview.get_class(v).description }} |
 {% endfor %}
 {% else -%}
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(c)}} | {{c.description|enshorten}} |
+| {{gen.link(c, True)}} | {{c.description|enshorten}} |
 {% endfor %}
 {% endif %}
 
@@ -34,7 +34,7 @@ Name: {{ schema.name }}
 | Slot | Description |
 | --- | --- |
 {% for s in gen.all_slot_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(s)}} | {{s.description|enshorten}} |
+| {{gen.link(s, True)}} | {{s.description|enshorten}} |
 {% endfor %}
 
 ## Enumerations
@@ -42,7 +42,7 @@ Name: {{ schema.name }}
 | Enumeration | Description |
 | --- | --- |
 {% for e in gen.all_enum_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(e)}} | {{e.description|enshorten}} |
+| {{gen.link(e, True)}} | {{e.description|enshorten}} |
 {% endfor %}
 
 ## Types
@@ -50,7 +50,7 @@ Name: {{ schema.name }}
 | Type | Description |
 | --- | --- |
 {% for t in gen.all_type_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(t)}} | {{t.description|enshorten}} |
+| {{gen.link(t, True)}} | {{t.description|enshorten}} |
 {% endfor %}
 
 ## Subsets
@@ -58,5 +58,5 @@ Name: {{ schema.name }}
 | Subset | Description |
 | --- | --- |
 {% for ss in schemaview.all_subsets().values()|sort(attribute='name') -%}
-| {{gen.link(ss)}} | {{ss.description|enshorten}} |
+| {{gen.link(ss, True)}} | {{ss.description|enshorten}} |
 {% endfor %}

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -127,7 +127,7 @@ class ShaclGenerator(Generator):
                     # slot definition, as both are mapped to sh:in in SHACL
                     if s.equals_string or s.equals_string_in:
                         error = "'equals_string'/'equals_string_in' and 'any_of' are mutually exclusive"
-                        raise ValueError(f'{TypedNode.yaml_loc(s, suffix="")} {error}')
+                        raise ValueError(f'{TypedNode.yaml_loc(str(s), suffix="")} {error}')
 
                     or_node = BNode()
                     prop_pv(SH["or"], or_node)


### PR DESCRIPTION
This pull request originates from a concrete use case in the Gaia-X project.

### Before this change

Initially the Gaia-X ontology documentation website used to look something like this:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c31433e1-6490-4aa8-8688-145b08a04f7b">

Classes, enums, types, slots and others were all hosted in the same folder and differentiated by a title prefix representing their type as you can see in the left navigation bar.

### Tackling the issue

To fix this issue, I propose to introduce a `--subfolder-type-separation` argument to the `gen-doc` generator. Once argument is provided, the generator will create a subfolder per type (classes, types, enums, slots and subsets) and generate the corresponding pages in those subfolders.

The result is the following on the [Gaia-X ontology documentation website](https://w3id.org/gaia-x):

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/18afd0d3-487e-447c-8ebe-3f4259688617">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f3b7c24a-c5c3-47a5-ad67-3a52e5653ce5">

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/dd493bf4-0fac-4e15-a2f9-ea91c8528752">

The result can be seen at https://w3id.org/gaia-x.

### Caveats 

It is important to state that the Gaia-X ontology documentation website uses custom templates to remove the type prefix and some other elements that are to our liking.

I chose not to implement those changes in the LinkML project as templates should be tweaked by users in my opinion.