### PR TITLE
Improve logging by replacing the use of the root logger by module-level loggers

### DIFF
--- a/linkml/generators/golanggen.py
+++ b/linkml/generators/golanggen.py
@@ -11,6 +11,8 @@ from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml._version import __version__
 from linkml.utils.generator import Generator, shared_arguments
 
+logger = logging.getLogger(__name__)
+
 type_map = {
     "str": "string",
     "int": "int",
@@ -175,7 +177,7 @@ class GolangGenerator(Generator):
                 if t.base and t.base in type_map:
                     return type_map[t.base]
                 else:
-                    logging.warning(f"Unknown type.base: {t.name}")
+                    logger.warning(f"Unknown type.base: {t.name}")
             return "string"
 
     @staticmethod

--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -24,6 +24,8 @@ from linkml._version import __version__
 from linkml.generators.common.type_designators import get_type_designator_value
 from linkml.utils.generator import Generator, shared_arguments
 
+logger = logging.getLogger(__name__)
+
 # Map from underlying python data type to json equivalent
 # Note: The underlying types are a union of any built-in python datatype + any type defined in
 #       linkml-runtime/utils/metamodelcore.py
@@ -222,14 +224,14 @@ class JsonSchemaGenerator(Generator):
 
     def __post_init__(self):
         if self.topClass:
-            logging.warning("topClass is deprecated - use top_class")
+            logger.warning("topClass is deprecated - use top_class")
             self.top_class = self.topClass
 
         super().__post_init__()
 
         if self.top_class:
             if self.schemaview.get_class(self.top_class) is None:
-                logging.warning(f"No class in schema named {self.top_class}")
+                logger.warning(f"No class in schema named {self.top_class}")
 
     def start_schema(self, inline: bool = False) -> JsonSchema:
         self.inline = inline

--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -40,6 +40,8 @@ from linkml import METAMODEL_NAMESPACE_NAME
 from linkml._version import __version__
 from linkml.utils.generator import Generator, shared_arguments
 
+logger = logging.getLogger(__name__)
+
 OWL_TYPE = URIRef  ## RDFS.Literal or OWL.Thing
 
 SWRL = rdflib.Namespace("http://www.w3.org/2003/11/swrl#")
@@ -270,7 +272,7 @@ class OwlSchemaGenerator(Generator):
                     # if isinstance(v, str):
                     #    obj = URIRef(msv.expand_curie(v))
                     # else:
-                    #    logging.debug(f"Skipping {uri} {metaslot_uri} => {v}")
+                    #    logger.debug(f"Skipping {uri} {metaslot_uri} => {v}")
                 else:
                     obj = Literal(v)
                 self.graph.add((uri, metaslot_uri, obj))
@@ -438,7 +440,7 @@ class OwlSchemaGenerator(Generator):
                 if slot:
                     own_slots.append(slot)
                 else:
-                    logging.warning(f"Unknown top-level slot {slot_name}")
+                    logger.warning(f"Unknown top-level slot {slot_name}")
         else:
             own_slots = []
         own_slots.extend(cls.slot_conditions.values())
@@ -695,7 +697,7 @@ class OwlSchemaGenerator(Generator):
         if element.equals_string is not None:
             equals_string = element.equals_string
             if is_literal is None:
-                logging.warning(f"ignoring equals_string={equals_string} as unable to tell if literal")
+                logger.warning(f"ignoring equals_string={equals_string} as unable to tell if literal")
             elif is_literal:
                 constraints[XSD.pattern] = equals_string
             else:
@@ -704,7 +706,7 @@ class OwlSchemaGenerator(Generator):
         if element.equals_string_in:
             equals_string_in = element.equals_string_in
             if is_literal is None:
-                logging.warning(f"ignoring equals_string={equals_string_in} as unable to tell if literal")
+                logger.warning(f"ignoring equals_string={equals_string_in} as unable to tell if literal")
             elif is_literal:
                 dt_exprs = [
                     self._datatype_restriction(XSD.string, [self._facet(XSD.pattern, s)]) for s in equals_string_in
@@ -770,7 +772,7 @@ class OwlSchemaGenerator(Generator):
                     if slot_uri == URIRef(att_uri):
                         n += 1
             if n > 1:
-                logging.warning(f"Ambiguous attribute: {slot.name} {slot_uri}")
+                logger.warning(f"Ambiguous attribute: {slot.name} {slot_uri}")
                 return
 
         self.add_metadata(slot, slot_uri)
@@ -906,7 +908,7 @@ class OwlSchemaGenerator(Generator):
             if pv_owl_type == RDFS.Literal:
                 pv_node = Literal(pv.text)
                 if pv.meaning:
-                    logging.warning(f"Meaning on literal {pv.text} in {e.name} is ignored")
+                    logger.warning(f"Meaning on literal {pv.text} in {e.name} is ignored")
             else:
                 pv_node = self._permissible_value_uri(pv, enum_uri, e)
             pv_uris.append(pv_node)
@@ -967,7 +969,7 @@ class OwlSchemaGenerator(Generator):
     def _add_rule(self, subject: Union[URIRef, BNode], rule: ClassRule, cls: ClassDefinition):
         if not self.use_swrl:
             return
-        logging.warning("SWRL support is experimental and incomplete")
+        logger.warning("SWRL support is experimental and incomplete")
         head = []
         body = []
         for pre in rule.preconditions:
@@ -1014,7 +1016,7 @@ class OwlSchemaGenerator(Generator):
                 owltypes.update(x_owltypes)
         owltypes.update(current)
         if len(owltypes) > 1:
-            logging.warning(f"Multiple owl types {owltypes}")
+            logger.warning(f"Multiple owl types {owltypes}")
             # if self.target_profile == OWLProfile.dl:
         return owltypes
 
@@ -1142,7 +1144,7 @@ class OwlSchemaGenerator(Generator):
     ) -> Optional[Union[BNode, URIRef]]:
         graph = self.graph
         if [x for x in exprs if x is None]:
-            logging.warning(f"Null expr in: {exprs} for {predicate} {node}")
+            logger.warning(f"Null expr in: {exprs} for {predicate} {node}")
             exprs = [x for x in exprs if x is not None]
         if len(exprs) == 0:
             return None
@@ -1268,10 +1270,10 @@ class OwlSchemaGenerator(Generator):
             return OWL.ObjectProperty
         is_literal_vals = self.slot_is_literal_map[slot.name]
         if len(is_literal_vals) > 1:
-            logging.warning(f"Ambiguous type for: {slot.name}")
+            logger.warning(f"Ambiguous type for: {slot.name}")
         if range is None:
             if not is_literal_vals:
-                logging.warning(f"Guessing type for {slot.name}")
+                logger.warning(f"Guessing type for {slot.name}")
                 return OWL.ObjectProperty
             if (list(is_literal_vals))[0]:
                 return OWL.DatatypeProperty

--- a/linkml/generators/projectgen.py
+++ b/linkml/generators/projectgen.py
@@ -26,6 +26,8 @@ from linkml.generators.sqltablegen import SQLTableGenerator
 from linkml.utils.cli_utils import log_level_option
 from linkml.utils.generator import Generator
 
+logger = logging.getLogger(__name__)
+
 PATH_FSTRING = str
 GENERATOR_NAME = str
 ARG_DICT = Dict[str, Any]
@@ -63,14 +65,14 @@ GEN_MAP = {
 
 @lru_cache()
 def get_local_imports(schema_path: str, dir: str):
-    logging.info(f"GETTING IMPORTS = {schema_path}")
+    logger.info(f"GETTING IMPORTS = {schema_path}")
     all_imports = [schema_path]
     with open(schema_path) as stream:
         with open(schema_path) as stream:
             schema = yaml.safe_load(stream)
             for imp in schema.get("imports", []):
                 imp_path = os.path.join(dir, imp) + ".yaml"
-                logging.info(f" IMP={imp} //  path={imp_path}")
+                logger.info(f" IMP={imp} //  path={imp_path}")
                 if os.path.isfile(imp_path):
                     all_imports += get_local_imports(imp_path, dir)
     return all_imports
@@ -105,23 +107,23 @@ class ProjectGenerator:
             all_schemas = [schema_path]
         else:
             all_schemas = get_local_imports(schema_path, os.path.dirname(schema_path))
-        logging.debug(f"ALL_SCHEMAS = {all_schemas}")
+        logger.debug(f"ALL_SCHEMAS = {all_schemas}")
         for gen_name, (gen_cls, gen_path_fmt, default_gen_args) in GEN_MAP.items():
             if config.includes is not None and config.includes != [] and gen_name not in config.includes:
-                logging.info(f"Skipping {gen_name} as not in inclusion list: {config.includes}")
+                logger.info(f"Skipping {gen_name} as not in inclusion list: {config.includes}")
                 continue
             if config.excludes is not None and gen_name in config.excludes:
-                logging.info(f"Skipping {gen_name} as it is in exclusion list")
+                logger.info(f"Skipping {gen_name} as it is in exclusion list")
                 continue
-            logging.info(f"Generating: {gen_name}")
+            logger.info(f"Generating: {gen_name}")
             for local_path in all_schemas:
-                logging.info(f" SCHEMA: {local_path}")
+                logger.info(f" SCHEMA: {local_path}")
                 name = os.path.basename(local_path).replace(".yaml", "")
                 gen_path = gen_path_fmt.format(name=name)
                 gen_path_full = f"{config.directory}/{gen_path}"
                 parts = gen_path_full.split("/")
                 parent_dir = "/".join(parts[0:-1])
-                logging.info(f" PARENT={parent_dir}")
+                logger.info(f" PARENT={parent_dir}")
                 Path(parent_dir).mkdir(parents=True, exist_ok=True)
                 gen_path_full = "/".join(parts)
                 all_gen_args = {
@@ -143,13 +145,13 @@ class ProjectGenerator:
                     if isinstance(v, str):
                         v = v.format(name=name, parent=parent_dir)
                     serialize_args[k] = v
-                logging.info(f" {gen_name} ARGS: {serialize_args}")
+                logger.info(f" {gen_name} ARGS: {serialize_args}")
                 gen_dump = gen.serialize(**serialize_args)
 
                 if gen_name != "excel":
                     if parts[-1] != "":
                         # markdowngen does not write to a file
-                        logging.info(f"  WRITING TO: {gen_path_full}")
+                        logger.info(f"  WRITING TO: {gen_path_full}")
                         with open(gen_path_full, "w", encoding="UTF-8") as stream:
                             stream.write(gen_dump)
                 else:
@@ -249,7 +251,7 @@ def cli(
             project_config.generator_args = yaml.safe_load(generator_arguments)
         except Exception:
             raise Exception("Argument must be a valid YAML blob")
-        logging.info(f"generator args: {project_config.generator_args}")
+        logger.info(f"generator args: {project_config.generator_args}")
     if dir is not None:
         project_config.directory = dir
     project_config.mergeimports = mergeimports

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -45,6 +45,9 @@ from linkml.generators.python.python_ifabsent_processor import PythonIfAbsentPro
 from linkml.utils import deprecation_warning
 from linkml.utils.generator import shared_arguments
 
+logger = logging.getLogger(__name__)
+
+
 if int(PYDANTIC_VERSION[0]) == 1:
     deprecation_warning("pydantic-v1")
 
@@ -189,7 +192,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
     template_dir: Optional[Union[str, Path]] = None
     """
     Override templates for each PydanticTemplateModel.
-    
+
     Directory with templates that override the default :attr:`.PydanticTemplateModel.template`
     for each class. If a matching template is not found in the override directory,
     the default templates will be used.
@@ -365,8 +368,8 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
         try:
             return compile_python(pycode)
         except NameError as e:
-            logging.error(f"Code:\n{pycode}")
-            logging.error(f"Error compiling generated python code: {e}")
+            logger.error(f"Code:\n{pycode}")
+            logger.error(f"Error compiling generated python code: {e}")
             raise e
 
     def _get_classes(self, sv: SchemaView) -> Tuple[List[ClassDefinition], Optional[List[ClassDefinition]]]:
@@ -673,7 +676,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
         else:
             # TODO: default ranges in schemagen
             # pyrange = 'str'
-            # logging.error(f'range: {s.range} is unknown')
+            # logger.error(f'range: {s.range} is unknown')
             raise Exception(f"range: {slot_range}")
         return pyrange
 
@@ -1160,9 +1163,9 @@ def _ensure_inits(paths: List[Path]):
     help="""
 Optional jinja2 template directory to use for class generation.
 
-Pass a directory containing templates with the same name as any of the default 
-:class:`.PydanticTemplateModel` templates to override them. The given directory will be 
-searched for matching templates, and use the default templates as a fallback 
+Pass a directory containing templates with the same name as any of the default
+:class:`.PydanticTemplateModel` templates to override them. The given directory will be
+searched for matching templates, and use the default templates as a fallback
 if an override is not found
 
 Available templates to override:

--- a/linkml/generators/pythongen.py
+++ b/linkml/generators/pythongen.py
@@ -32,6 +32,8 @@ from linkml._version import __version__
 from linkml.generators.python.python_ifabsent_processor import PythonIfAbsentProcessor
 from linkml.utils.generator import Generator, shared_arguments
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class PythonGenerator(Generator):
@@ -57,10 +59,10 @@ class PythonGenerator(Generator):
     dataclass_repr: bool = False
     """
     Whether generated dataclasses should also generate a default __repr__ method.
-    
+
     Default ``False`` so that the parent :class:`linkml_runtime.utils.yamlutils.YAMLRoot` 's
     ``__repr__`` method is inherited for model pretty printing.
-    
+
     References:
         - https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass
     """
@@ -75,7 +77,7 @@ class PythonGenerator(Generator):
         if self.format is None:
             self.format = self.valid_formats[0]
         if self.schema.default_prefix == "linkml" and not self.genmeta:
-            logging.error("Generating metamodel without --genmeta is highly inadvisable!")
+            logger.error("Generating metamodel without --genmeta is highly inadvisable!")
         if not self.schema.source_file and isinstance(self.sourcefile, str) and "\n" not in self.sourcefile:
             self.schema.source_file = os.path.basename(self.sourcefile)
 
@@ -88,8 +90,8 @@ class PythonGenerator(Generator):
         try:
             return compile_python(pycode)
         except NameError as e:
-            logging.error(f"Code:\n{pycode}")
-            logging.error(f"Error compiling generated python code: {e}")
+            logger.error(f"Code:\n{pycode}")
+            logger.error(f"Error compiling generated python code: {e}")
             raise e
 
     def visit_schema(self, **kwargs) -> None:
@@ -944,11 +946,11 @@ dataclasses._init_fn = dataclasses_init_fn_with_kwargs
 
     def forward_reference(self, slot_range: str, owning_class: str) -> bool:
         """Determine whether slot_range is a forward reference"""
-        # logging.info(f"CHECKING: {slot_range} {owning_class}")
+        # logger.info(f"CHECKING: {slot_range} {owning_class}")
         if (slot_range in self.schema.classes and self.schema.classes[slot_range].imported_from) or (
             slot_range in self.schema.enums and self.schema.enums[slot_range].imported_from
         ):
-            logging.info(
+            logger.info(
                 f"FALSE: FORWARD: {slot_range} {owning_class} // IMP={self.schema.classes[slot_range].imported_from}"
             )
             return False
@@ -957,10 +959,10 @@ dataclasses._init_fn = dataclasses_init_fn_with_kwargs
         clist = [x.name for x in self._sort_classes(self.schema.classes.values())]
         for cname in clist:
             if cname == owning_class:
-                logging.info(f"TRUE: OCCURS SAME: {cname} == {slot_range} owning: {owning_class}")
+                logger.info(f"TRUE: OCCURS SAME: {cname} == {slot_range} owning: {owning_class}")
                 return True  # Occurs on or after
             elif cname == slot_range:
-                logging.info(f"FALSE: OCCURS BEFORE: {cname} == {slot_range} owning: {owning_class}")
+                logger.info(f"FALSE: OCCURS BEFORE: {cname} == {slot_range} owning: {owning_class}")
                 return False  # Occurs before
         return True
 
@@ -1214,7 +1216,7 @@ def cli(
     )
     if validate:
         mod = gen.compile_module()
-        logging.info(f"Module {mod} compiled successfully")
+        logger.info(f"Module {mod} compiled successfully")
     print(gen.serialize(emit_metadata=head, **args))
 
 

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -18,6 +18,8 @@ from linkml.generators.shacl.shacl_data_type import ShaclDataType
 from linkml.generators.shacl.shacl_ifabsent_processor import ShaclIfAbsentProcessor
 from linkml.utils.generator import Generator, shared_arguments
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class ShaclGenerator(Generator):
@@ -244,7 +246,7 @@ class ShaclGenerator(Generator):
             if rt.annotations and self.include_annotations:
                 self._add_annotations(func, rt)
         else:
-            logging.error(f"No URI for type {rt.name}")
+            logger.error(f"No URI for type {rt.name}")
 
     def _and_equals_string(self, g: Graph, func: Callable, values: List) -> None:
         pv_node = BNode()

--- a/linkml/generators/sparqlgen.py
+++ b/linkml/generators/sparqlgen.py
@@ -14,6 +14,8 @@ from linkml_runtime.utils.schemaview import SchemaView
 from linkml._version import __version__
 from linkml.utils.generator import Generator, shared_arguments
 
+logger = logging.getLogger(__name__)
+
 template = """
 {% for pfxn, pfx in schema.prefixes.items() -%}
 PREFIX {{pfxn}}: <{{pfx.prefix_reference}}>
@@ -150,7 +152,7 @@ class SparqlGenerator(Generator):
         extra = ""
         if named_graphs is not None:
             extra += f'FILTER( ?graph in ( {",".join(named_graphs)} ))'
-        logging.info(f"Named Graphs = {named_graphs} // extra={extra}")
+        logger.info(f"Named Graphs = {named_graphs} // extra={extra}")
         if limit is not None and isinstance(limit, int):
             limit = f"LIMIT {limit}"
         else:

--- a/linkml/generators/sqlalchemygen.py
+++ b/linkml/generators/sqlalchemygen.py
@@ -21,6 +21,8 @@ from linkml.generators.sqltablegen import SQLTableGenerator
 from linkml.transformers.relmodel_transformer import ForeignKeyPolicy, RelationalModelTransformer
 from linkml.utils.generator import Generator, shared_arguments
 
+logger = logging.getLogger(__name__)
+
 
 class TemplateEnum(Enum):
     DECLARATIVE = "declarative"
@@ -84,7 +86,7 @@ class SQLAlchemyGenerator(Generator):
         template_obj = Template(template_str)
         if model_path is None:
             model_path = self.schema.name
-        logging.info(f"Package for dataclasses ==  {model_path}")
+        logger.info(f"Package for dataclasses ==  {model_path}")
         backrefs = defaultdict(list)
         for m in tr_result.mappings:
             backrefs[m.source_class].append(m)
@@ -113,7 +115,7 @@ class SQLAlchemyGenerator(Generator):
             is_join_table=lambda c: any(tag for tag in c.annotations.keys() if tag == "linkml:derived_from"),
             classes=rel_schema_classes_ordered,
         )
-        logging.debug(f"# Generated code:\n{code}")
+        logger.debug(f"# Generated code:\n{code}")
         return code
 
     def serialize(self, **kwargs) -> str:
@@ -173,7 +175,7 @@ class SQLAlchemyGenerator(Generator):
     def skip(cls: ClassDefinition) -> bool:
         is_skip = len(cls.attributes) == 0
         if is_skip:
-            logging.error(f"SKIPPING: {cls.name}")
+            logger.error(f"SKIPPING: {cls.name}")
         return is_skip
 
     # TODO: move this

--- a/linkml/generators/sqltablegen.py
+++ b/linkml/generators/sqltablegen.py
@@ -16,6 +16,8 @@ from linkml.transformers.relmodel_transformer import ForeignKeyPolicy, Relationa
 from linkml.utils.generator import Generator, shared_arguments
 from linkml.utils.schemaloader import SchemaLoader
 
+logger = logging.getLogger(__name__)
+
 
 class SqlNamingPolicy(Enum):
     preserve = "preserve"
@@ -262,12 +264,12 @@ class SQLTableGenerator(Generator):
         elif range is None:
             return Text()
         else:
-            logging.error(f"Unknown range: {range} for {slot.name} = {slot.range}")
+            logger.error(f"Unknown range: {range} for {slot.name} = {slot.range}")
             return Text()
         if range_base in RANGEMAP:
             return RANGEMAP[range_base]
         else:
-            logging.error(f"UNKNOWN range base: {range_base} for {slot.name} = {slot.range}")
+            logger.error(f"UNKNOWN range base: {range_base} for {slot.name} = {slot.range}")
             return Text()
 
     @staticmethod

--- a/linkml/generators/typescriptgen.py
+++ b/linkml/generators/typescriptgen.py
@@ -19,6 +19,9 @@ from linkml._version import __version__
 from linkml.generators.oocodegen import OOCodeGenerator
 from linkml.utils.generator import shared_arguments
 
+logger = logging.getLogger(__name__)
+
+
 type_map = {
     "str": "string",
     "int": "number",
@@ -207,7 +210,7 @@ class TypescriptGenerator(OOCodeGenerator):
                 elif t.typeof and t.typeof in type_map:
                     tsrange = type_map[t.typeof]
                 else:
-                    logging.warning(f"Unknown type.base: {t.name}")
+                    logger.warning(f"Unknown type.base: {t.name}")
                 if slot.multivalued:
                     tsrange = f"{tsrange}[]"
                 return tsrange
@@ -241,7 +244,7 @@ class TypescriptGenerator(OOCodeGenerator):
                 elif t.typeof and t.typeof in type_map:
                     return type_init_map[t.typeof]
                 else:
-                    logging.warning(f"Unknown type.base: {t.name}")
+                    logger.warning(f"Unknown type.base: {t.name}")
                 return "null"
             return "null"
 

--- a/linkml/transformers/logical_model_transformer.py
+++ b/linkml/transformers/logical_model_transformer.py
@@ -360,13 +360,13 @@ class LogicalModelTransformer(ModelTransformer):
         target_schema = target_schemaview.schema
         for tn, typ in target_schema.types.items():
             ancs = sv.type_ancestors(tn, reflexive=False)
-            logging.debug(f"Unrolling type {tn}, merging {len(ancs)}")
+            logger.debug(f"Unrolling type {tn}, merging {len(ancs)}")
             if ancs:
                 for type_anc in ancs:
                     self._merge_type_ancestors(target=typ, source=sv.get_type(type_anc))
         for sn, slot in target_schema.slots.items():
             ancs = sv.slot_ancestors(sn, reflexive=False)
-            logging.debug(f"Unrolling slot {sn}, merging {len(ancs)}")
+            logger.debug(f"Unrolling slot {sn}, merging {len(ancs)}")
             if ancs:
                 for slot_anc in ancs:
                     self._merge_slot_ancestors(target=slot, source=target_schema.slots[slot_anc])
@@ -379,7 +379,7 @@ class LogicalModelTransformer(ModelTransformer):
                 depth_first=False,
             )
             ancs = list(reversed(ancs))
-            logging.debug(f"Unrolling class {cn}, merging {len(ancs)}")
+            logger.debug(f"Unrolling class {cn}, merging {len(ancs)}")
             self._roll_down(target_schema, cn, ancs)
         self.apply_defaults(target_schema)
         if simplify:

--- a/linkml/transformers/relmodel_transformer.py
+++ b/linkml/transformers/relmodel_transformer.py
@@ -15,6 +15,8 @@ from linkml_runtime.linkml_model import (
 from linkml_runtime.utils.schemaview import SchemaView, SlotDefinitionName
 from sqlalchemy import Enum
 
+logger = logging.getLogger(__name__)
+
 
 class RelationalAnnotations(Enum):
     PRIMARY_KEY = "primary_key"
@@ -215,11 +217,11 @@ class RelationalModelTransformer:
         for cn in target_sv.all_classes():
             pk = self.get_direct_identifier_attribute(target_sv, cn)
             if self.foreign_key_policy == ForeignKeyPolicy.NO_FOREIGN_KEYS:
-                logging.info(f"Will not inject any PKs, and policy == {self.foreign_key_policy}")
+                logger.info(f"Will not inject any PKs, and policy == {self.foreign_key_policy}")
             else:
                 if pk is None:
                     pk = self.add_primary_key(cn, target_sv)
-                    logging.info(f"Added primary key {cn}.{pk.name}")
+                    logger.info(f"Added primary key {cn}.{pk.name}")
                 for link in links:
                     if link.target_class == cn:
                         link.target_slot = pk.name
@@ -233,7 +235,7 @@ class RelationalModelTransformer:
                 continue
             pk_slot = self.get_direct_identifier_attribute(target_sv, cn)
             # if self.is_skip(c) and len(incoming_links) == 0:
-            #    logging.info(f'Skipping class: {c.name}')
+            #    logger.info(f'Skipping class: {c.name}')
             #    del target.classes[cn]
             #    continue
             for src_slot in list(c.attributes.values()):
@@ -375,7 +377,7 @@ class RelationalModelTransformer:
             removed_ucs = []
             for uc_name, uc in c.unique_keys.items():
                 if any(sn in multivalued_slots_original for sn in uc.unique_key_slots):
-                    logging.warning(
+                    logger.warning(
                         f"Cannot represent uniqueness constraint {uc_name}. "
                         f"one of the slots {uc.unique_key_slots} is multivalued"
                     )

--- a/linkml/utils/converter.py
+++ b/linkml/utils/converter.py
@@ -23,6 +23,8 @@ from linkml.utils.datautils import (
     infer_root_class,
 )
 
+logger = logging.getLogger(__name__)
+
 
 @click.command(name="convert")
 @click.option("--module", "-m", help="Path to python datamodel module")
@@ -119,7 +121,7 @@ def cli(
                 sv.set_modified()
     if target_class is None and target_class_from_path:
         target_class = os.path.basename(input).split("-")[0]
-        logging.info(f"inferred target class = {target_class} from {input}")
+        logger.info(f"inferred target class = {target_class} from {input}")
     if target_class is None:
         target_class = infer_root_class(sv)
     if target_class is None:

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -54,6 +54,8 @@ from linkml.utils.mergeutils import alias_root
 from linkml.utils.schemaloader import SchemaLoader
 from linkml.utils.typereferences import References
 
+logger = logging.getLogger(__name__)
+
 
 @lru_cache
 def _resolved_metamodel(mergeimports):
@@ -61,7 +63,7 @@ def _resolved_metamodel(mergeimports):
         raise AssertionError(f"{LOCAL_METAMODEL_YAML_FILE} not found")
 
     base_dir = str(Path(str(LOCAL_METAMODEL_YAML_FILE)).parent)
-    logging.debug(f"BASE={base_dir}")
+    logger.debug(f"BASE={base_dir}")
     metamodel = SchemaLoader(
         LOCAL_METAMODEL_YAML_FILE,
         importmap={"linkml": base_dir},
@@ -203,7 +205,7 @@ class Generator(metaclass=abc.ABCMeta):
         if self.uses_schemaloader:
             self._initialize_using_schemaloader(schema)
         else:
-            logging.info(f"Using SchemaView with im={self.importmap} // base_dir={self.base_dir}")
+            self.logger.info(f"Using SchemaView with im={self.importmap} // base_dir={self.base_dir}")
             self.schemaview = SchemaView(schema, importmap=self.importmap, base_dir=self.base_dir)
             if self.include:
                 if isinstance(self.include, (str, Path)):
@@ -840,7 +842,7 @@ class Generator(metaclass=abc.ABCMeta):
             if ":" not in mapping or len(mapping.split(":")) != 2:
                 raise ValueError(f"Definition {defn.name} - unrecognized mapping: {mapping}")
             ns = mapping.split(":")[0]
-            logging.debug(f"Adding {ns} from {mapping} // {defn}")
+            self.logger.debug(f"Adding {ns} from {mapping} // {defn}")
             if ns:
                 self.add_prefix(ns)
 

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -181,7 +181,7 @@ class Generator(metaclass=abc.ABCMeta):
 
     def __post_init__(self) -> None:
         if not self.logger:
-            self.logger = logging.getLogger()
+            self.logger = logging.getLogger(f"{__name__}.{type(self).__name__}")
         if self.log_level is not None:
             self.logger.setLevel(self.log_level)
         if self.format is None:

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -181,7 +181,7 @@ class Generator(metaclass=abc.ABCMeta):
 
     def __post_init__(self) -> None:
         if not self.logger:
-            self.logger = logging.getLogger(f"{__name__}.{type(self).__name__}")
+            self.logger = logger
         if self.log_level is not None:
             self.logger.setLevel(self.log_level)
         if self.format is None:

--- a/linkml/utils/mergeutils.py
+++ b/linkml/utils/mergeutils.py
@@ -18,6 +18,8 @@ from linkml_runtime.utils.namespaces import Namespaces
 from linkml_runtime.utils.yamlutils import extended_str
 from rdflib import URIRef
 
+logger = logging.getLogger(__name__)
+
 
 def merge_schemas(
     target: SchemaDefinition,
@@ -72,7 +74,7 @@ def merge_namespaces(target: SchemaDefinition, mergee: SchemaDefinition, namespa
             # We cannot resolve this to an absolute path, so we have to assume that
             # this prefix is already defined correctly in the target
             if prefix.prefix_prefix not in namespaces:
-                logging.info(
+                logger.info(
                     "Adding an unadjusted relative prefix for %s from %s, "
                     + "as the prefix is not yet defined, even as we cannot adjust it relative to the final file. "
                     + "If it cannot be resolved, add the prefix definition to the input schema!",
@@ -85,7 +87,7 @@ def merge_namespaces(target: SchemaDefinition, mergee: SchemaDefinition, namespa
                     prefix.prefix_prefix in target.prefixes
                     and target.prefixes[prefix.prefix_prefix].prefix_reference != prefix.prefix_reference
                 ):
-                    logging.info(
+                    logger.info(
                         "Ignoring different relative prefix for %s from %s, "
                         + "as we cannot adjust it relative to the final file. "
                         + "Assuming the first found location is correct: %s!",

--- a/linkml/utils/schema_fixer.py
+++ b/linkml/utils/schema_fixer.py
@@ -94,7 +94,7 @@ class SchemaFixer:
         tree_roots = [c for c in sv.all_classes().values() if c.tree_root]
         if len(tree_roots) > 0:
             if force:
-                logging.info("Forcing addition of containers")
+                logger.info("Forcing addition of containers")
             else:
                 raise ValueError(f"Schema already has containers: {tree_roots}")
         container = ClassDefinition(class_name, tree_root=True)
@@ -228,7 +228,7 @@ class SchemaFixer:
             # slots within that are redundant
             slot_usage_keys = list(cls.slot_usage.keys())
             for slot_usage_key in slot_usage_keys:
-                logging.debug(f"TESTING: {class_name}.{slot_usage_key}")
+                logger.debug(f"TESTING: {class_name}.{slot_usage_key}")
                 slot_usage_value = cls.slot_usage[slot_usage_key]
                 # perform a deletion test: what can be retrieved by inference
                 del cls.slot_usage[slot_usage_key]
@@ -236,7 +236,7 @@ class SchemaFixer:
                 try:
                     induced_slot = sv.induced_slot(slot_usage_key, class_name)
                 except ValueError:
-                    logging.warning(f"slot_usage with no slot: {slot_usage_key}")
+                    logger.warning(f"slot_usage with no slot: {slot_usage_key}")
                     continue
                 # restore value
                 cls.slot_usage[slot_usage_key] = slot_usage_value
@@ -258,7 +258,7 @@ class SchemaFixer:
                         continue
                     induced_v = getattr(induced_slot, metaslot_name, None)
                     if v is not None and v != [] and v != {} and v == induced_v:
-                        logging.info(f"REDUNDANT: {class_name}.{slot_usage_key}[{metaslot_name}] = {v}")
+                        logger.info(f"REDUNDANT: {class_name}.{slot_usage_key}[{metaslot_name}] = {v}")
                         to_delete.append(metaslot_name)
                 for metaslot_name in to_delete:
                     del slot_usage_value[metaslot_name]
@@ -302,7 +302,7 @@ class SchemaFixer:
                 if len(vals_strs) == 1:
                     harmonized_slot[k] = vals.pop()
                 elif len(vals_strs) > 1:
-                    logging.info(f"Variable values in {slot_name}.{k}: {vals_strs}")
+                    logger.info(f"Variable values in {slot_name}.{k}: {vals_strs}")
             new_slots[str(slot_name)] = harmonized_slot
         return new_slots
 

--- a/linkml/utils/schemaloader.py
+++ b/linkml/utils/schemaloader.py
@@ -176,7 +176,7 @@ class SchemaLoader:
                     # mangled names are overwritten if a schema with attributes is passed in
                     # TODO: handle this in a more graceful way
                     #  see https://github.com/linkml/linkml/issues/872
-                    logging.warning(
+                    self.logger.warning(
                         f'Class: "{cls.name}" attribute "{attribute.name}" - '
                         f"mangled name: {mangled_slot_name} already exists",
                     )
@@ -770,7 +770,7 @@ class SchemaLoader:
             if slotname in self.schema.slots:
                 base_slot = self.schema.slots[slotname]
             else:
-                logging.error(f"slot_usage for undefined slot: {slotname}")
+                self.logger.error(f"slot_usage for undefined slot: {slotname}")
                 base_slot = None
             parent_slot = self.schema.slots.get(slot_usage.is_a)
             # Follow the ancestry of the class to get the most proximal parent

--- a/linkml/utils/schemaloader.py
+++ b/linkml/utils/schemaloader.py
@@ -57,7 +57,7 @@ class SchemaLoader:
         :param source_file_date: modification of source file
         :param source_file_size: size of source file
         """
-        self.logger = logger if logger is not None else logging.getLogger(self.__class__.__name__)
+        self.logger = logger if logger is not None else logging.getLogger(f"{__name__}.{type(self).__name__}")
         if isinstance(data, SchemaDefinition):
             self.schema = data
         else:

--- a/linkml/utils/schemaloader.py
+++ b/linkml/utils/schemaloader.py
@@ -29,6 +29,8 @@ from linkml.utils.mergeutils import merge_classes, merge_schemas, merge_slots, s
 from linkml.utils.rawloader import load_raw_schema
 from linkml.utils.schemasynopsis import SchemaSynopsis
 
+lgr = logging.getLogger(__name__)
+
 
 class SchemaLoader:
     def __init__(
@@ -57,7 +59,7 @@ class SchemaLoader:
         :param source_file_date: modification of source file
         :param source_file_size: size of source file
         """
-        self.logger = logger if logger is not None else logging.getLogger(f"{__name__}.{type(self).__name__}")
+        self.logger = logger if logger is not None else lgr
         if isinstance(data, SchemaDefinition):
             self.schema = data
         else:

--- a/linkml/utils/sqlutils.py
+++ b/linkml/utils/sqlutils.py
@@ -40,6 +40,8 @@ from linkml.utils.datautils import (
     infer_root_class,
 )
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class SQLStore:
@@ -376,7 +378,7 @@ def dump(
 
         inputs = [item for input in inputs for item in glob.glob(input)]
     for input in inputs:
-        logging.info(f"Loading: {input}")
+        logger.info(f"Loading: {input}")
         input_format = _get_format(input, input_format)
         loader = get_loader(input_format)
 

--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -19,6 +19,8 @@ from linkml.generators.pythongen import PythonGenerator
 from linkml.utils import datautils
 from linkml.utils.datavalidator import DataValidator
 
+logger = logging.getLogger(__name__)
+
 
 class HashableSchemaDefinition(SchemaDefinition):
     def __hash__(self) -> int:
@@ -27,7 +29,7 @@ class HashableSchemaDefinition(SchemaDefinition):
 
 @lru_cache(maxsize=None)
 def _generate_jsonschema(schema, top_class, closed, include_range_class_descendants):
-    logging.debug("Generating JSON Schema")
+    logger.debug("Generating JSON Schema")
     not_closed = not closed
     return JsonSchemaGenerator(
         schema=schema,

--- a/linkml/validators/sparqlvalidator.py
+++ b/linkml/validators/sparqlvalidator.py
@@ -15,6 +15,8 @@ from linkml.reporting import CheckResult, Report
 from linkml.utils.datautils import _get_format, dumpers_loaders, get_dumper
 from linkml.utils.datavalidator import DataValidator
 
+logger = logging.getLogger(__name__)
+
 
 def sparqljson2dict(row: dict):
     return {k: v["value"] for k, v in row.items()}
@@ -55,7 +57,7 @@ class SparqlDataValidator(DataValidator):
                 for row in qres:
                     invalid += row
             except Exception:
-                logging.error(f"FAILED: {qn}")
+                logger.error(f"FAILED: {qn}")
         return invalid
 
     def validate_endpoint(self, url: str, **kwargs):
@@ -65,8 +67,8 @@ class SparqlDataValidator(DataValidator):
         report = Report()
         for qn, q in self.queries.items():
             q += " LIMIT 20"
-            logging.debug(f"QUERY: {qn}")
-            logging.debug(f"{q}")
+            logger.debug(f"QUERY: {qn}")
+            logger.debug(f"{q}")
             sw = SPARQLWrapper(url)
             sw.setQuery(q)
             sw.setReturnFormat(JSON)

--- a/linkml/workspaces/example_runner.py
+++ b/linkml/workspaces/example_runner.py
@@ -24,6 +24,8 @@ from linkml._version import __version__
 from linkml.generators.pythongen import PythonGenerator
 from linkml.validator import Validator, _get_default_validator
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class SummaryDocument:
@@ -134,7 +136,7 @@ class ExampleRunner:
             input_examples = glob.glob(os.path.join(str(input_dir), f"*.{fmt}"))
             input_counter_examples = glob.glob(os.path.join(str(counter_example_dir), f"*.{fmt}"))
             if not input_counter_examples:
-                logging.warning(f"No counter examples found in {self.counter_example_input_directory}")
+                logger.warning(f"No counter examples found in {self.counter_example_input_directory}")
             self.process_examples_from_list(input_examples, fmt, False)
             self.process_examples_from_list(input_counter_examples, fmt, True)
 

--- a/tests/test_compliance/conftest.py
+++ b/tests/test_compliance/conftest.py
@@ -3,8 +3,10 @@ import logging
 from tests import WITH_OUTPUT
 from tests.test_compliance.helper import report
 
+logger = logging.getLogger(__name__)
+
 
 def pytest_sessionfinish(session, exitstatus) -> None:
-    logging.info(f"finishing session: {session} {exitstatus}")
+    logger.info(f"finishing session: {session} {exitstatus}")
     if exitstatus == 0 and WITH_OUTPUT:
         report()

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -16,6 +16,8 @@ from linkml_runtime.utils.schemaview import SchemaView
 
 from linkml.generators.docgen import DocGenerator
 
+logger = logging.getLogger(__name__)
+
 
 def assert_mdfile_does_not_contain(*args, **kwargs) -> None:
     assert_mdfile_contains(*args, **kwargs, invert=True)
@@ -48,14 +50,14 @@ def assert_mdfile_contains(
                             todo = todo[1:]
                     if len(todo) > 0:
                         if not invert:
-                            logging.error(f"Did not find: {todo}")
+                            logger.error(f"Did not find: {todo}")
                         assert invert
                     else:
                         return
             if after is not None and after in line:
                 is_after = True
     if not found and not invert:
-        logging.error(f"Failed to find {text} in {filename}")
+        logger.error(f"Failed to find {text} in {filename}")
     if invert:
         assert not found
     else:

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -13,6 +13,8 @@ from linkml_runtime.loaders import yaml_loader
 from linkml.generators.jsonschemagen import JsonSchemaGenerator
 from tests.test_generators.test_pythongen import make_python
 
+logger = logging.getLogger(__name__)
+
 pytestmark = pytest.mark.jsonschemagen
 
 
@@ -39,11 +41,11 @@ def test_jsonschema_integration(kitchen_sink_path, input_path):
     ok_metadata = True
     for p in inst.persons:
         for a in p.addresses:
-            logging.debug(f"{p.id} address = {a.street}")
+            logger.debug(f"{p.id} address = {a.street}")
             if a.street.startswith("1 foo"):
                 ok_address = True
         for h in p.has_medical_history:
-            logging.debug(f"{p.id} history = {h}")
+            logger.debug(f"{p.id} history = {h}")
             if h.in_location == "GEO:1234" and h.diagnosis.name == "headache":
                 ok_history = True
             # test the metadata slot, which has an unconstrained range

--- a/tests/test_generators/test_sqlalchemygen.py
+++ b/tests/test_generators/test_sqlalchemygen.py
@@ -11,6 +11,8 @@ from linkml.generators.sqlalchemygen import SQLAlchemyGenerator, TemplateEnum
 from linkml.generators.sqltablegen import SQLTableGenerator
 from linkml.utils.schema_builder import SchemaBuilder
 
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture
 def schema(input_path):
@@ -286,9 +288,9 @@ def test_sqla_declarative_exec(schema):
     persons = q.all()
     for person in persons:
         assert isinstance(person, mod.NamedThing)
-        logging.info(f"Person={person}")
+        logger.info(f"Person={person}")
         for a in person.aliases:
-            logging.info(f"  ALIAS={a}")
+            logger.info(f"  ALIAS={a}")
         for e in person.has_medical_history:
             assert e.duration > 0
             assert isinstance(e, mod.Event)

--- a/tests/test_prefixes/test_prefixes.py
+++ b/tests/test_prefixes/test_prefixes.py
@@ -19,6 +19,8 @@ PM_OUTPUT = env.expected_path("prefixtest.prefixmap.json")
 CONTEXT_OUTPUT = env.expected_path("prefixtest.context.jsonld")
 TSV_OUTPUT = env.expected_path("prefix_map_prefixtest.tsv")
 
+logger = logging.getLogger(__name__)
+
 
 class PrefixTestCase(unittest.TestCase):
     def test_owlgen(self):
@@ -82,10 +84,10 @@ class PrefixTestCase(unittest.TestCase):
         for k, v in expected.items():
             if k in obj:
                 if v != obj[k]:
-                    logging.error(f"{k} = {v} expected {expected[k]}")
+                    logger.error(f"{k} = {v} expected {expected[k]}")
                     fails += 1
             else:
-                logging.error(f"Missing key: {k}")
+                logger.error(f"Missing key: {k}")
                 fails += 1
         assert fails == 0
 
@@ -148,10 +150,10 @@ class PrefixTestCase(unittest.TestCase):
             if k in obj:
                 if v != obj[k]:
                     if not ("@id" in v and "@id" in obj[k] and v["@id"] == obj[k]["@id"]):
-                        logging.error(f"{k} = {v} expected {expected[k]}")
+                        logger.error(f"{k} = {v} expected {expected[k]}")
                         fails += 1
             else:
-                logging.error(f"Missing key: {k}")
+                logger.error(f"Missing key: {k}")
                 fails += 1
         assert fails == 0
 
@@ -186,11 +188,11 @@ class PrefixTestCase(unittest.TestCase):
                     expected.remove(v)
         for v in exceptions:
             if v in expected:
-                logging.warning(f"TODO: figure why {v} not present")
+                logger.warning(f"TODO: figure why {v} not present")
                 expected.remove(v)
         if len(expected) > 0:
             for e in expected:
-                logging.error(f"Did not find {e}")
+                logger.error(f"Did not find {e}")
             assert False
         else:
             assert True


### PR DESCRIPTION
This PR improve logging by replacing the use of the root logger by module-level loggers. I.e., it addresses #2297.


Notes:
1. The changes touch many lines that are not tested previously. Thus, the low patch coverage.


