### PR TITLE
Global Config

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -1,0 +1,24 @@
+{#linkml-config-cli}
+# `linkml config`
+
+```{eval-rst} 
+.. click:: linkml.cli.config:config
+    :prog: linkml config
+    :nested: short
+```
+
+## `linkml config get`
+
+```{eval-rst} 
+.. click:: linkml.cli.config:get
+    :prog: linkml config get
+    :nested: short
+```  
+
+## `linkml config set`
+
+```{eval-rst} 
+.. click:: linkml.cli.config:set
+    :prog: linkml config set
+    :nested: short
+```  

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -7,6 +7,7 @@
     :nested: short
 ```
 
+{#linkml-config-get-cli}
 ## `linkml config get`
 
 ```{eval-rst} 
@@ -15,6 +16,7 @@
     :nested: short
 ```  
 
+{#linkml-config-set-cli}
 ## `linkml config set`
 
 ```{eval-rst} 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,6 +2,7 @@
 
 The CLI interface to LinkML is currently divided into two styles:
 - One combined cli underneath [`linkml`](./linkml.md)
+  - [`linkml config`](./config.md) 
   - [`linkml generate`](./generate.md) 
   - [`linkml lint`](./lint.md)
   - [`linkml validate`](./validate.md)
@@ -12,6 +13,7 @@ The CLI interface to LinkML is currently divided into two styles:
 maxdepth: 1
 ---
 linkml
+config
 generate
 lint
 validate

--- a/docs/cli/linkml.md
+++ b/docs/cli/linkml.md
@@ -11,6 +11,7 @@
 
 See subpages for further details on commands:
 
+- [`linkml config`](./config.md)
 - [`linkml generate`](./generate.md)
 - [`linkml lint`](./lint.md)
 - [`linkml validate`](./validate.md)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'sphinx_design',
     'matplotlib.sphinxext.plot_directive',
     'sphinx_jinja',
+    'sphinxcontrib.autodoc_pydantic'
 ]
 
 # The suffix(es) of source filenames.

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -14,8 +14,8 @@ priorities override lower priorities)
 * in a `linkml_config.yaml` file in the working directory
 * in the `tool.linkml.config` table in a `pyproject.toml` file in the working directory
 * in the global `linkml_config.yaml` file in the platform-specific data directory
-  (use `linkml config get global_config` to find its location)
-* the default values in the :class:`.Config` model
+  (use `linkml config get config_file` to find its location)
+* the default values in the {class}`~linkml.utils.config.GlobalConfig` model
 
 Parent directories are _not_ checked.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1,0 +1,151 @@
+# Configuration
+
+Global configuration in linkml uses [`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)
+
+
+## Sources
+
+Config values can be set (in order of priority from high to low, where higher
+priorities override lower priorities)
+
+* in the arguments passed to the class constructor (not user configurable)
+* in environment variables like `export LINKML_LOG_DIR=~/`
+* in a `.env` file in the working directory
+* in a `linkml_config.yaml` file in the working directory
+* in the `tool.linkml.config` table in a `pyproject.toml` file in the working directory
+* in the global `linkml_config.yaml` file in the platform-specific data directory
+  (use `linkml config get global_config` to find its location)
+* the default values in the :class:`.Config` model
+
+Parent directories are _not_ checked.
+
+## Keys
+
+### Prefix
+
+Keys for environment variables (i.e. set in a shell with e.g. `export` or in a `.env` file)
+are prefixed with `LINKML_` to not shadow other environment variables.
+Keys in `toml` or `yaml` files are not prefixed with `LINKML_` .
+
+### Nesting
+
+Keys for nested models are separated by a `__` double underscore in `.env`
+files or environment variables (eg. `LINKML_LOG__DIR`)
+
+Keys in `toml` or `yaml` files do not have a dunder separator because
+they can represent the nesting directly (see examples below)
+
+When setting values from the cli, keys for nested models are separated with a `.`.
+
+### Case
+
+Keys are case-insensitive, i.e. these are equivalent::
+
+    export LINKML_LOG__DIR=~/
+    export linkml_log__dir=~/
+
+## CLI
+
+Global settings can be gotten and set via the CLI, for example:
+
+### Getting values
+
+```{command-output} linkml config get
+---
+ellipsis: 5
+---
+``` 
+
+Index nested config models with `.`
+
+```{command-output} linkml config get log.level
+```
+
+### Setting values
+
+Values are set in the global `linkml_config.yaml` file with a similar syntax
+
+```{note}
+Values set via the CLI are set in the global `linkml_config.yaml`
+file, which is the lowest priority source of settings, and will thus be
+overridden by any local configs in `.env` files or otherwise.
+```
+
+```{command-output} linkml config set log.level WARNING
+```
+
+```{command-output} linkml config get log.level
+```
+
+
+
+
+## Examples
+
+
+`````{tab-set}
+````{tab-item} linkml_config.yaml
+```{code-block} yaml
+user_dir: ~/.config/linkml
+config_file: linkml_config.yaml
+log:
+  dir: /var/log/linkml
+  level_file: INFO
+  level_stream: WARNING
+  file_n: 5
+``` 
+````
+````{tab-item} env vars
+```{code-block} bash
+export LINKML_USER_DIR='~/.config/linkml'
+export LINKML_CONFIG_FILE='linkml_config.yaml'
+export LINKML_LOG__DIR='/var/log/linkml'
+export LINKML_LOG__LEVEL_FILE='INFO'
+export LINKML_LOG__LEVEL_STREAM='WARNING'
+export LINKML_LOG__FILE_N=5
+```
+````
+````{tab-item} .env file
+```{code-block} python
+LINKML_USER_DIR='~/.config/linkml'
+LINKML_CONFIG_FILE='linkml_config.yaml'
+LINKML_LOG__DIR='/var/log/linkml'
+LINKML_LOG__LEVEL_FILE='INFO'
+LINKML_LOG__LEVEL_STREAM='WARNING'
+LINKML_LOG__FILE_N=5
+```
+````
+````{tab-item} pyproject.toml
+```{code-block} toml
+[tool.linkml.config]
+user_dir = "~/.config/linkml"
+config_file = "linkml_config.yaml"
+
+[tool.linkml.config.log]
+dir = "/var/log/linkml"
+level_file = "INFO"
+level_stream = "WARNING"
+file_n = 5
+
+``` 
+````
+````{tab-item} cli
+```{code-block} bash
+linkml config set user_dir '~/.config/linkml'
+linkml config set config_file 'linkml_config.yaml'
+linkml config set log.dir '/var/log/linkml'
+linkml config set log.level_file 'info'
+linkml config set log.level_stream 'warning'
+linkml config set log.file_n 5
+``` 
+````
+`````
+
+
+## API
+
+```{eval-rst}
+.. automodule:: linkml.utils.config
+    :members:
+    
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ for you:
    cli/index
    developers/index
    code/index
+   config/index
 
 
 

--- a/linkml/__init__.py
+++ b/linkml/__init__.py
@@ -5,11 +5,15 @@ from linkml_runtime.linkml_model import linkml_files
 from linkml_runtime.linkml_model.linkml_files import Format, Source
 from rdflib.plugins.serializers.turtle import TurtleSerializer
 
+from linkml.utils.config import GlobalConfig
+
 assert sys.version_info > (
     3,
     7,
     0,
 ), f"LinkML requires python 3.7.1 or later to run.  Current version: {sys.version_info}"
+
+CONFIG = GlobalConfig()
 
 MODULE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 

--- a/linkml/cli/config.py
+++ b/linkml/cli/config.py
@@ -91,8 +91,11 @@ def set(key, value=None):
     """
     config = GlobalConfig()
     global_config_file = config.config_file
-    with open(global_config_file, "r") as f:
-        global_config = yaml.safe_load(f)
+    if global_config_file.exists():
+        with open(global_config_file, "r") as f:
+            global_config = yaml.safe_load(f)
+    else:
+        global_config = {}
 
     subkeys = key.split(".")
     if len(subkeys) == 1:

--- a/linkml/cli/config.py
+++ b/linkml/cli/config.py
@@ -1,0 +1,120 @@
+"""
+CLI for global config
+
+See docs/config/index.md for documentation
+"""
+
+import json
+
+import click
+import yaml
+from pydantic import BaseModel
+
+from linkml.utils.config import GlobalConfig
+
+
+@click.group("config")
+def config():
+    """
+    LinkML Global Configuration
+    """
+
+
+@config.command(name="get")
+@click.argument("key", required=False)
+def get(key=None):
+    """
+    Get a configuration value. If no setting name is passed, show entire config
+
+    Examples:
+    ---------
+
+    .. code-block:: shell
+
+        $ linkml config get
+
+    .. code-block:: yaml
+
+        \b
+        user_dir: /Users/jonny/Library/Application Support/linkml
+        config_file: /Users/jonny/Library/Application Support/linkml/linkml_config.yaml
+        log:
+          dir: /Users/jonny/Library/Logs/linkml
+          file_name: linkml.log
+          level: WARNING
+          # ...
+
+    .. code-block:: shell
+
+        $ linkml config get log
+
+    .. code-block:: yaml
+
+        \b
+        dir: /Users/jonny/Library/Logs/linkml
+        file_name: linkml.log
+        level: WARNING
+        # ...
+
+    .. code-block:: shell
+
+        $ linkml config get log.level
+
+    .. code-block::
+
+        WARNING
+
+
+    """
+    config = GlobalConfig()
+    if key is not None:
+        subkeys = key.split(".")
+        for subkey in subkeys:
+            config = getattr(config, subkey)
+
+    if isinstance(config, BaseModel):
+        config = config.model_dump_json()
+        config = json.loads(config)
+        print(yaml.safe_dump(config, sort_keys=False))
+    else:
+        print(config)
+
+
+@config.command(name="set")
+@click.argument("key")
+@click.argument("value", required=False)
+def set(key, value=None):
+    """
+    Set a configuration value in the global `linkml_config.yaml` file.
+
+    If a ``value`` is absent, the key is deleted from the global yaml config.
+    """
+    config = GlobalConfig()
+    global_config_file = config.config_file
+    with open(global_config_file, "r") as f:
+        global_config = yaml.safe_load(f)
+
+    subkeys = key.split(".")
+    if len(subkeys) == 1:
+        if value is None and subkeys[0] in global_config:
+            del global_config[subkeys[0]]
+        elif value is not None:
+            global_config[subkeys[0]] = value
+
+    else:
+        config = global_config
+        for subkey in subkeys[:-1]:
+            config = config.setdefault(subkey, {})
+        if value is None and subkeys[-1] in config:
+            del config[subkeys[-1]]
+        elif value is not None:
+            config[subkeys[-1]] = value
+
+    # validate model
+
+    _ = GlobalConfig.model_validate(global_config)
+
+    with open(global_config_file, "w") as f:
+        yaml.safe_dump(global_config, f)
+
+    print(f"Updated linkml config:\nkey: {key}\nvalue: {value}\nconfig file: {str(global_config_file)}")

--- a/linkml/cli/main.py
+++ b/linkml/cli/main.py
@@ -7,6 +7,7 @@ Gathers all the other linkml click entrypoints and puts them under ``linkml`` :)
 import click
 
 from linkml._version import __version__
+from linkml.cli.config import config
 from linkml.generators.csvgen import cli as gen_csv
 from linkml.generators.docgen import cli as gen_doc
 from linkml.generators.dotgen import cli as gen_graphviz
@@ -89,6 +90,7 @@ linkml.add_command(linkml_sqldb, name="sqldb")
 linkml.add_command(linkml_schema_fixer, name="fix")
 linkml.add_command(linkml_run_examples, name="examples")
 linkml.add_command(linkml_validate, name="validate")
+linkml.add_command(config, name="config")
 
 # Generators
 generate.add_command(gen_jsonld_context, name="jsonld-context")

--- a/linkml/utils/config.py
+++ b/linkml/utils/config.py
@@ -40,7 +40,7 @@ class _GlobalYamlConfigSource(YamlConfigSettingsSource):
         return config_file
 
     @property
-    def global_config(self) -> dict[str, Any]:
+    def global_config(self) -> Dict[str, Any]:
         """
         Contents of the global config file
         """
@@ -51,7 +51,7 @@ class _GlobalYamlConfigSource(YamlConfigSettingsSource):
                 self._global_config = {}
         return self._global_config
 
-    def __call__(self) -> dict[str, Any]:
+    def __call__(self) -> Dict[str, Any]:
         return (
             TypeAdapter(Dict[str, Any]).dump_python(self.global_config)
             if self.nested_model_default_partial_update

--- a/linkml/utils/config.py
+++ b/linkml/utils/config.py
@@ -1,0 +1,171 @@
+"""
+Session-global configuration (see docs/config/index.md for documentation)
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Literal, Optional
+
+from platformdirs import PlatformDirs
+from pydantic import BaseModel, Field, TypeAdapter, field_validator, model_validator
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    PyprojectTomlConfigSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
+
+LOG_LEVELS = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
+_dirs = PlatformDirs("linkml", "linkml")
+
+
+class _GlobalYamlConfigSource(YamlConfigSettingsSource):
+    """Yaml config source that gets the location of the global settings file from the prior sources"""
+
+    def __init__(self, *args, **kwargs):
+        self._global_config = None
+        super().__init__(*args, **kwargs)
+
+    @property
+    def global_config_path(self) -> Path:
+        """
+        Location of the global ``linkml_config.yaml`` file,
+        given the current state of prior config sources
+        """
+        current_state = self.current_state
+        config_file = Path(current_state.get("config_file", "linkml_config.yaml"))
+        user_dir = Path(current_state.get("user_dir", _dirs.user_config_dir))
+        if not config_file.is_absolute():
+            config_file = (user_dir / config_file).resolve()
+        return config_file
+
+    @property
+    def global_config(self) -> dict[str, Any]:
+        """
+        Contents of the global config file
+        """
+        if self._global_config is None:
+            self._global_config = self._read_files(self.global_config_path)
+        return self._global_config
+
+    def __call__(self) -> dict[str, Any]:
+        return (
+            TypeAdapter(Dict[str, Any]).dump_python(self.global_config)
+            if self.nested_model_default_partial_update
+            else self.global_config
+        )
+
+
+class LogConfig(BaseModel):
+    """
+    Config params for logging
+    """
+
+    dir: Path = Field(default=_dirs.user_log_dir, description="Directory where logs are stored")
+    file_name: str = Field("linkml.log", description="Base name to use for rotating file logs")
+    level: LOG_LEVELS = Field(
+        "INFO",
+        description="Base level to use for loggers. "
+        "If more specific settings are not present (ie. level_file), use this as a default.",
+    )
+    level_file: Optional[LOG_LEVELS] = Field(None, description="Log level for file logging")
+    level_stream: Optional[LOG_LEVELS] = Field(None, description="Log level for stdout/stderr stream logging")
+    file_n: int = Field(5, description="Number of log files to rotate through")
+    file_size: int = Field(2**22, description="Maximum size of log files (bytes)")
+
+    @field_validator("level", "level_file", "level_stream", mode="before")
+    @classmethod
+    def uppercase_levels(cls, value: Optional[str] = None) -> Optional[str]:
+        """
+        Ensure log level strings are uppercased
+        """
+        if value is not None:
+            value = value.upper()
+        return value
+
+    @model_validator(mode="after")
+    def inherit_base_level(self) -> "LogConfig":
+        """
+        If loglevels for specific output streams are unset, set from base :attr:`.level`
+        """
+        levels = ("level_file", "level_stream")
+        for level_name in levels:
+            if getattr(self, level_name) is None:
+                setattr(self, level_name, self.level)
+        return self
+
+
+class GlobalConfig(BaseSettings):
+    """
+    Global LinkML configuration that determines the behavior of linkml in a given shell session.
+
+    Distinct from generator and project configs,
+    which control the behavior of specific generators and projects, respectively.
+    """
+
+    user_dir: Path = Field(_dirs.user_config_dir, description="Directory containing linkml config files")
+    config_file: Path = Field(
+        Path("linkml_config.yaml"),
+        description="Location of global linkml config file. "
+        "If a relative path, interpreted as a relative to ``user_dir``",
+    )
+    log: LogConfig = LogConfig()
+
+    model_config = SettingsConfigDict(
+        env_prefix="linkml_",
+        env_file=".env",
+        env_nested_delimiter="__",
+        extra="ignore",
+        nested_model_default_partial_update=True,
+        yaml_file="linkml_config.yaml",
+        pyproject_toml_table_header=("tool", "linkml", "config"),
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """
+        Read config settings from, in order of priority from high to low, where
+        high priorities override lower priorities:
+
+        * in the arguments passed to the class constructor (not user configurable)
+        * in environment variables like ``export LINKML_LOG_DIR=~/``
+        * in a ``.env`` file in the working directory
+        * in a ``linkml_config.yaml`` file in the working directory
+        * in the ``tool.linkml.config`` table in a ``pyproject.toml`` file in the working directory
+        * in the global ``linkml_config.yaml`` file in the platform-specific data directory
+          (use ``linkml config get global_config`` to find its location)
+        * the default values in the :class:`.Config` model
+        """
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlConfigSettingsSource(settings_cls),
+            PyprojectTomlConfigSettingsSource(settings_cls),
+            _GlobalYamlConfigSource(settings_cls),
+        )
+
+    @field_validator("user_dir", mode="after")
+    @classmethod
+    def user_dir_exists(cls, v: Path) -> Path:
+        """Ensure user_dir exists, make it otherwise"""
+        v = Path(v)
+        v.mkdir(exist_ok=True, parents=True)
+        assert v.exists(), f"{v} does not exist!"
+        return v
+
+    @model_validator(mode="after")
+    def config_file_is_absolute(self) -> "GlobalConfig":
+        """
+        If ``config_file`` is relative, make it absolute underneath user_dir
+        """
+        if not self.config_file.is_absolute():
+            self.config_file = self.user_dir / self.config_file
+        return self

--- a/linkml/utils/config.py
+++ b/linkml/utils/config.py
@@ -45,7 +45,10 @@ class _GlobalYamlConfigSource(YamlConfigSettingsSource):
         Contents of the global config file
         """
         if self._global_config is None:
-            self._global_config = self._read_files(self.global_config_path)
+            if self.global_config_path.exists():
+                self._global_config = self._read_files(self.global_config_path)
+            else:
+                self._global_config = {}
         return self._global_config
 
     def __call__(self) -> dict[str, Any]:

--- a/linkml/utils/config.py
+++ b/linkml/utils/config.py
@@ -3,7 +3,7 @@ Session-global configuration (see docs/config/index.md for documentation)
 """
 
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional, Tuple, Type
 
 from platformdirs import PlatformDirs
 from pydantic import BaseModel, Field, TypeAdapter, field_validator, model_validator
@@ -127,12 +127,12 @@ class GlobalConfig(BaseSettings):
     @classmethod
     def settings_customise_sources(
         cls,
-        settings_cls: type[BaseSettings],
+        settings_cls: Type[BaseSettings],
         init_settings: PydanticBaseSettingsSource,
         env_settings: PydanticBaseSettingsSource,
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
-    ) -> tuple[PydanticBaseSettingsSource, ...]:
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
         """
         Read config settings from, in order of priority from high to low, where
         high priorities override lower priorities:

--- a/linkml/utils/config.py
+++ b/linkml/utils/config.py
@@ -140,8 +140,8 @@ class GlobalConfig(BaseSettings):
         * in a ``linkml_config.yaml`` file in the working directory
         * in the ``tool.linkml.config`` table in a ``pyproject.toml`` file in the working directory
         * in the global ``linkml_config.yaml`` file in the platform-specific data directory
-          (use ``linkml config get global_config`` to find its location)
-        * the default values in the :class:`.Config` model
+          (use ``linkml config get config_file`` to find its location)
+        * the default values in the :class:`.GlobalConfig` model
         """
         return (
             init_settings,

--- a/poetry.lock
+++ b/poetry.lock
@@ -103,6 +103,30 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "autodoc-pydantic"
+version = "2.2.0"
+description = "Seamlessly integrate pydantic models in your Sphinx documentation."
+optional = false
+python-versions = "<4.0.0,>=3.8.1"
+files = [
+    {file = "autodoc_pydantic-2.2.0-py3-none-any.whl", hash = "sha256:8c6a36fbf6ed2700ea9c6d21ea76ad541b621fbdf16b5a80ee04673548af4d95"},
+]
+
+[package.dependencies]
+importlib-metadata = {version = ">1", markers = "python_version <= \"3.8\""}
+pydantic = ">=2.0,<3.0.0"
+pydantic-settings = ">=2.0,<3.0.0"
+Sphinx = ">=4.0"
+
+[package.extras]
+docs = ["myst-parser (>=3.0.0,<4.0.0)", "sphinx-copybutton (>=0.5.0,<0.6.0)", "sphinx-rtd-theme (>=2.0.0,<3.0.0)", "sphinx-tabs (>=3,<4)", "sphinxcontrib-mermaid (>=0.9.0,<0.10.0)"]
+erdantic = ["erdantic (<2.0)"]
+linting = ["ruff (>=0.4.0,<0.5.0)"]
+security = ["pip-audit (>=2.7.2,<3.0.0)"]
+test = ["coverage (>=7,<8)", "defusedxml (>=0.7.1)", "pytest (>=8.0.0,<9.0.0)", "pytest-sugar (>=1.0.0,<2.0.0)"]
+type-checking = ["mypy (>=1.9,<2.0)", "types-docutils (>=0.20,<0.21)", "typing-extensions (>=4.11,<5.0)"]
+
+[[package]]
 name = "babel"
 version = "2.16.0"
 description = "Internationalization utilities"
@@ -2725,6 +2749,26 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.5.2"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pydantic_settings-2.5.2-py3-none-any.whl", hash = "sha256:2c912e55fd5794a59bf8c832b9de832dcfdf4778d79ff79b708744eed499a907"},
+    {file = "pydantic_settings-2.5.2.tar.gz", hash = "sha256:f90b139682bee4d2065273d5185d71d37ea46cfe57e1b5ae184fc6a0b2484ca0"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2919,6 +2963,20 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytrie"
@@ -4031,6 +4089,17 @@ files = [
 ]
 
 [[package]]
+name = "tomli-w"
+version = "1.0.0"
+description = "A lil' TOML writer"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli_w-1.0.0-py3-none-any.whl", hash = "sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463"},
+    {file = "tomli_w-1.0.0.tar.gz", hash = "sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9"},
+]
+
+[[package]]
 name = "tornado"
 version = "6.4.1"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
@@ -4370,4 +4439,4 @@ tests = ["black", "numpydantic", "pyshacl"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "52daaf525a5c339c19023627c20663c1be72040570fa9f7f1e6f76e8820e51c1"
+content-hash = "9991fe453ae6a091bf838fe698c53572a6a039a4ac316d4408319927be1ebf83"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4439,4 +4439,4 @@ tests = ["black", "numpydantic", "pyshacl"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "9991fe453ae6a091bf838fe698c53572a6a039a4ac316d4408319927be1ebf83"
+content-hash = "aa330c46792f6c733e074b771a23e6696e4c4aec582478d36264b3f9a7ef065e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,8 @@ pyshacl = { version = "^0.25.0", optional = true }
 black = { version=">=24.0.0", optional = true }
 typing-extensions = { version=">=4.4.0", python="<3.9" }
 numpydantic = { version=">=1.6.1", python = ">=3.9", optional = true}
+pydantic-settings = ">=2.5.2"
+platformdirs = ">=4.3.6"
 
 [tool.poetry.group.dev.dependencies]
 chardet = "*"
@@ -136,9 +138,6 @@ nbformat = "*"
 coverage = "^6.4.1"
 tox = "^4"
 requests-cache = "^1.2.0"
-myst-nb = {version=">=1.0.0", python=">=3.9"}
-sphinx-design = "^0.5.0"
-rich = "^13.7.1"
 
 [tool.poetry.group.tests.dependencies]
 pytest = "^7.4.0"
@@ -150,6 +149,7 @@ numpy = [
 requests-cache = "^1.2.0"
 mock = "^5.1.0"
 testcontainers = "3.7.1"
+tomli-w = "^1.0.0"
 
 [tool.poetry.extras]
 black = ["black"]
@@ -170,6 +170,10 @@ myst-parser = "*"
 matplotlib = ">=3.7"
 sphinx-jinja = "^2.0.2"
 sphinxcontrib-programoutput = "^0.17"
+autodoc-pydantic = "^2.2.0"
+myst-nb = {version=">=1.0.0", python=">=3.9"}
+sphinx-design = "^0.5.0"
+rich = "^13.7.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,7 @@ select = [
   "E",  # pycodestyle errors
   "F",  # Pyflakes
   "I",  # isort
+  "FA102", # Subscripted types like dict[str, str]
 ]
 # Assume Python 3.8
 target-version = "py38"

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -69,7 +69,7 @@ def set_env(monkeypatch) -> Callable[[Dict[str, Any]], None]:
     matching a GlobalConfig.model_dump()
     """
 
-    def _set_env(config: dict[str, Any]) -> None:
+    def _set_env(config: Dict[str, Any]) -> None:
         for key, value in _flatten(config).items():
             key = "LINKML_" + key.upper()
             monkeypatch.setenv(key, str(value))
@@ -84,7 +84,7 @@ def set_dotenv(tmp_cwd) -> Callable[[Dict[str, Any]], Path]:
     """
     dotenv_path = tmp_cwd / ".env"
 
-    def _set_dotenv(config: dict[str, Any]) -> Path:
+    def _set_dotenv(config: Dict[str, Any]) -> Path:
         with open(dotenv_path, "w") as dfile:
             for key, value in _flatten(config).items():
                 key = "LINKML_" + key.upper()
@@ -101,7 +101,7 @@ def set_pyproject(tmp_cwd) -> Callable[[Dict[str, Any]], Path]:
     """
     toml_path = tmp_cwd / "pyproject.toml"
 
-    def _set_pyproject(config: dict[str, Any]) -> Path:
+    def _set_pyproject(config: Dict[str, Any]) -> Path:
         config = {"tool": {"linkml": {"config": config}}}
 
         with open(toml_path, "wb") as tfile:
@@ -119,7 +119,7 @@ def set_local_yaml(tmp_cwd) -> Callable[[Dict[str, Any]], Path]:
     """
     yaml_path = tmp_cwd / "linkml_config.yaml"
 
-    def _set_local_yaml(config: dict[str, Any]) -> Path:
+    def _set_local_yaml(config: Dict[str, Any]) -> Path:
         with open(yaml_path, "w") as yfile:
             yaml.safe_dump(config, yfile)
         return yaml_path
@@ -140,7 +140,7 @@ def set_global_yaml() -> Callable[[Dict[str, Any]], Path]:
         if restore_backup:
             global_config_path.rename(backup_path)
 
-        def _set_global_yaml(config: dict[str, Any]) -> Path:
+        def _set_global_yaml(config: Dict[str, Any]) -> Path:
             with open(global_config_path, "w") as gfile:
                 yaml.safe_dump(config, gfile)
             return global_config_path

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -1,0 +1,261 @@
+"""
+Test configuration settings
+"""
+
+from collections.abc import MutableMapping
+from pathlib import Path
+from typing import Any, Callable, Dict
+
+import pytest
+import tomli_w
+import yaml
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from linkml.cli.config import get as cli_get
+from linkml.cli.config import set as cli_set
+from linkml.utils.config import GlobalConfig, LogConfig, _dirs
+
+
+def _flatten(d, parent_key="", separator="__") -> dict:
+    """https://stackoverflow.com/a/6027615/13113166"""
+    items = []
+    for key, value in d.items():
+        new_key = parent_key + separator + key if parent_key else key
+        if isinstance(value, MutableMapping):
+            items.extend(_flatten(value, new_key, separator=separator).items())
+        else:
+            items.append((new_key, value))
+    return dict(items)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def dodge_existing_global_config(tmp_path_factory):
+    """
+    Suspend any existing global config file during config tests
+    """
+    tmp_path = tmp_path_factory.mktemp("config_backup")
+    default_global_config_path = Path(_dirs.user_config_dir) / "linkml_config.yaml"
+    backup_global_config_path = tmp_path / "linkml_config.yaml.bak"
+
+    configured_global_config_path = GlobalConfig().config_file
+    backup_configured_global_path = tmp_path / "linkml_config_custom.yaml.bak"
+
+    if default_global_config_path.exists():
+        default_global_config_path.rename(backup_global_config_path)
+    if configured_global_config_path.exists():
+        default_global_config_path.rename(backup_configured_global_path)
+
+    yield
+
+    if backup_global_config_path.exists():
+        default_global_config_path.unlink(missing_ok=True)
+        backup_global_config_path.rename(default_global_config_path)
+    if backup_configured_global_path.exists():
+        configured_global_config_path.unlink(missing_ok=True)
+        backup_configured_global_path.rename(configured_global_config_path)
+
+
+@pytest.fixture()
+def tmp_cwd(tmp_path, monkeypatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture()
+def set_env(monkeypatch) -> Callable[[Dict[str, Any]], None]:
+    """
+    Function fixture to set environment variables using a nested dict
+    matching a GlobalConfig.model_dump()
+    """
+
+    def _set_env(config: dict[str, Any]) -> None:
+        for key, value in _flatten(config).items():
+            key = "LINKML_" + key.upper()
+            monkeypatch.setenv(key, str(value))
+
+    return _set_env
+
+
+@pytest.fixture()
+def set_dotenv(tmp_cwd) -> Callable[[Dict[str, Any]], Path]:
+    """
+    Function fixture to set config variables in a .env file
+    """
+    dotenv_path = tmp_cwd / ".env"
+
+    def _set_dotenv(config: dict[str, Any]) -> Path:
+        with open(dotenv_path, "w") as dfile:
+            for key, value in _flatten(config).items():
+                key = "LINKML_" + key.upper()
+                dfile.write(f"{key}={value}\n")
+        return dotenv_path
+
+    return _set_dotenv
+
+
+@pytest.fixture()
+def set_pyproject(tmp_cwd) -> Callable[[Dict[str, Any]], Path]:
+    """
+    Function fixture to set config variables in a pyproject.toml file
+    """
+    toml_path = tmp_cwd / "pyproject.toml"
+
+    def _set_pyproject(config: dict[str, Any]) -> Path:
+        config = {"tool": {"linkml": {"config": config}}}
+
+        with open(toml_path, "wb") as tfile:
+            tomli_w.dump(config, tfile)
+
+        return toml_path
+
+    return _set_pyproject
+
+
+@pytest.fixture()
+def set_local_yaml(tmp_cwd) -> Callable[[Dict[str, Any]], Path]:
+    """
+    Function fixture to set config variables in a local linkml_config.yaml file
+    """
+    yaml_path = tmp_cwd / "linkml_config.yaml"
+
+    def _set_local_yaml(config: dict[str, Any]) -> Path:
+        with open(yaml_path, "w") as yfile:
+            yaml.safe_dump(config, yfile)
+        return yaml_path
+
+    return _set_local_yaml
+
+
+@pytest.fixture()
+def set_global_yaml() -> Callable[[Dict[str, Any]], Path]:
+    """
+    Function fixture to reversibly set config variables in a global linkml_config.yaml file
+    """
+    global_config_path = Path(_dirs.user_config_dir) / "linkml_config.yaml"
+    backup_path = Path(_dirs.user_config_dir) / "linkml_config.yaml.bak"
+    restore_backup = global_config_path.exists()
+
+    try:
+        if restore_backup:
+            global_config_path.rename(backup_path)
+
+        def _set_global_yaml(config: dict[str, Any]) -> Path:
+            with open(global_config_path, "w") as gfile:
+                yaml.safe_dump(config, gfile)
+            return global_config_path
+
+        yield _set_global_yaml
+
+    finally:
+        global_config_path.unlink(missing_ok=True)
+        if restore_backup:
+            backup_path.rename(global_config_path)
+
+
+def test_log_level_propagates():
+    """
+    the level field should propagate to the individual `level_file` etc settings
+    when they aren't set
+    """
+    log_config = LogConfig(level="WARNING", level_file=None, level_stream=None)
+    assert log_config.level == "WARNING"
+    assert log_config.level_file == "WARNING"
+    assert log_config.level_stream == "WARNING"
+
+
+@pytest.mark.parametrize(
+    "setter",
+    ["set_env", "set_dotenv", "set_pyproject", "set_local_yaml", "set_global_yaml"],
+)
+def test_config_sources(setter, request):
+    """
+    Base test that each of the settings sources in isolation can set values
+    """
+    assert GlobalConfig().log.level != "WARNING"
+
+    setting = {"log": {"level": "WARNING"}}
+    fixture_fn = request.getfixturevalue(setter)
+    fixture_fn(setting)
+    config = GlobalConfig()
+    assert config.log.level == "WARNING"
+
+
+def test_config_sources_overrides(set_env, set_dotenv, set_pyproject, set_local_yaml, set_global_yaml):
+    """Test that the different config sources are overridden in the correct order"""
+    set_global_yaml({"log": {"file_n": 0}})
+    assert GlobalConfig().log.file_n == 0
+    set_pyproject({"log": {"file_n": 1}})
+    assert GlobalConfig().log.file_n == 1
+    set_local_yaml({"log": {"file_n": 2}})
+    assert GlobalConfig().log.file_n == 2
+    set_dotenv({"log": {"file_n": 3}})
+    assert GlobalConfig().log.file_n == 3
+    set_env({"log": {"file_n": 5}})
+    assert GlobalConfig().log.file_n == 5
+    assert GlobalConfig(**{"log": {"file_n": 6}}).log.file_n == 6
+
+
+def test_cli_get_config():
+    """
+    linkml config get <key> can get config values
+    """
+
+    config = GlobalConfig()
+
+    # get all values in yaml-serializable form
+    runner = CliRunner()
+    result = runner.invoke(cli_get)
+    printed_value = yaml.safe_load(result.stdout)
+    assert GlobalConfig(**printed_value) == config
+
+    # get single value in base model
+    runner = CliRunner()
+    result = runner.invoke(cli_get, ["user_dir"])
+    assert result.stdout.strip() == str(config.user_dir)
+
+    # and a single value in a nested model
+    runner = CliRunner()
+    result = runner.invoke(cli_get, ["log.level"])
+    assert result.stdout.strip() == str(config.log.level)
+
+
+def test_cli_set_config(set_global_yaml, set_dotenv):
+    """
+    linkml config set <key> <value> can set config values
+    """
+
+    set_global_yaml({"log": {"level": "INFO"}})
+
+    config = GlobalConfig()
+    global_config_file = config.config_file
+
+    with open(global_config_file, "r") as gfile:
+        assert yaml.safe_load(gfile)["log"]["level"] == "INFO"
+
+    # Setting a value in a nested model
+    runner = CliRunner()
+    result = runner.invoke(cli_set, ["log.level", "WARNING"])
+    with open(global_config_file, "r") as gfile:
+        assert yaml.safe_load(gfile)["log"]["level"] == "WARNING"
+
+    # Ensure we validate models
+
+    runner = CliRunner()
+    result = runner.invoke(cli_set, ["log.level", "INVALID_VALUE"])
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValidationError)
+
+    # Key with no value sets to null, even if `NULL` is not an allowable value
+    runner = CliRunner()
+    result = runner.invoke(cli_set, ["log.level"])
+    assert result.exit_code == 0
+    with open(global_config_file, "r") as gfile:
+        assert "level" not in yaml.safe_load(gfile)["log"]
+
+    # Can delete multiple times without choking
+    runner = CliRunner()
+    result = runner.invoke(cli_set, ["log.level"])
+    assert result.exit_code == 0
+    with open(global_config_file, "r") as gfile:
+        assert "level" not in yaml.safe_load(gfile)["log"]


### PR DESCRIPTION
Fix: https://github.com/linkml/linkml/issues/2331

alright here's a global config.

At the moement it's not hooked up into anything, but if we like this then i can continue the lovely work in https://github.com/linkml/linkml/pull/2323 and make it control log levels and whatnot as the config object suggests should be possible.

It should be all spelled out in the docs, but just for the good of the order here's the impl:

## Motivation

We want to be able to configure logging at first, but generally have a tidy way to specify behavior that might need to be customized in a per-system, per-session, and per-project way.

This is probably extremely overengineered, but i'm also laying groundwork for [`linkml build`](https://github.com/linkml/linkml/pull/2263) with a project-level config that can get sourced from one of potentially several places in several formats, so that's why. In the future i would anticipate additional global config stuff including whether we should try to resolve schema via url, location of cache directories, etc. so this sets us up for any of that.

## Implementation

Use `pydantic-settings`. 

Specifically, create a `GlobalConfig` class that sources from the following locations, in order of priority from high to low, where higher priority sources override lower priority

* in the arguments passed to the class constructor (not user configurable)
* in environment variables like ``export LINKML_LOG_DIR=~/``
* in a ``.env`` file in the working directory
* in a ``linkml_config.yaml`` file in the working directory
* in the ``tool.linkml.config`` table in a ``pyproject.toml`` file in the working directory
* in the global ``linkml_config.yaml`` file in the platform-specific data directory
  (use ``linkml config get config_file`` to find its location)
* the default values in the `GlobalConfig` model

There is an example of each kind of configuration in the docs in a tab group.

We can use nested models here, and imo we should do that to keep config reasonable instead of turning into a junk drawer, so I added an initial set of config options for handling stream and file logging to demo that. Descriptions of how to handle nested models are also in the docs.

I also added some cli commands to get and set global config values. values are printed as yaml so they can be re-parsed if needed (i did when writing tests)

```shell
$ linkml config get

user_dir: /Users/jonny/Library/Application Support/linkml
config_file: /Users/jonny/Library/Application Support/linkml/linkml_config.yaml
log:
  dir: /Users/jonny/Library/Logs/linkml
  file_name: linkml.log
  level: WARNING
  # ...
```

```shell
$ linkml config get log.level
WARNING
```

Setting values handles `None` to delete keys, nested models, and does model validation as well. We shouldn't be trying to set nonscalar/anything that doesn't have an unambiguous representation in a shell in the config, so hopefully that's as complex as we need it to be.

```shell
$ linkml config set log.level WARNING
Updated linkml config:
key: log.level
value: WARNING
config file: /Users/jonny/Library/Application Support/linkml/linkml_config.yaml
```

## Caveats

There's bound to be a bit of stickiness where people want to specify where the global config file lives. There's a sort of chicken and egg problem here, where we want the global config to be the lowest priority source of config, but then we should have read it and applied it before we reach the shell/cwd-based config options that might want to override it. That might need more consideration in the future, but for now i'm assuming that people will just use the local config options rather than trying to reposition the global config

There's also probably going to be some confusion like "what the heck i called `linkml config set <key> <value>`" and it didn't set my config! when people have some conflicting config file in the cwd. I didn't want to rig up a whole `linkml config set global <key> <value>` like eg. `pyenv` does at the moment, but that might be what we need to do if that starts happening. Tried to flag that clearly in the docs but we'll see.

## Re: Deps

I added two required deps:
- `pydantic-settings`
- `platformdirs`

`pydantic-settings` has one additional non-pydantic dep, `python-dotenv`, which is pretty light, and `platformdirs` has no additional deps and is extremely common (it's probably already in our dep tree somewhere).

imo it's worth it - since we're already installing pydantic, `pydantic-settings` doesn't add a lot more.

I also moved some docs deps that were hanging out in the `dev` group down into the `docs` group and added a package to show pydantic models cleanly (because the config models looked like total garbage without it)

## Tests

Added the basic tests that i thought we might want, but lmk if i missed something.

what ya think?