### PR TITLE
Bundle originating error/object to `linkml.validator.report.ValidationResult`

### DIFF
--- a/linkml/validator/plugins/jsonschema_validation_plugin.py
+++ b/linkml/validator/plugins/jsonschema_validation_plugin.py
@@ -55,4 +55,5 @@ class JsonschemaValidationPlugin(ValidationPlugin):
                 instantiates=context.target_class,
                 message=f"{best_error.message} in /{'/'.join(str(p) for p in best_error.absolute_path)}",
                 context=error_context,
+                source=best_error,
             )

--- a/linkml/validator/report.py
+++ b/linkml/validator/report.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Severity(str, Enum):
@@ -29,6 +29,9 @@ class ValidationResult(BaseModel):
     instance_index: Optional[int] = None
     instantiates: Optional[str] = None
     context: List[str] = []
+
+    # The source object that caused this validation result
+    source: Any = Field(None, description="The source of this validation result", exclude=True)
 
 
 class ValidationReport(BaseModel):


### PR DESCRIPTION
The change in this PR is a possible solution to https://github.com/linkml/linkml/issues/2362. It allows an object of any type to be attached to a `linkml.validator.report.ValidationResult` at the `source` field and excludes the `source` field from the serialization of a `ValidationResult` object. 

This PR utilizes the `source` field in `JsonschemaValidationPlugin` only. If this PR is approved, other validation plugins should use the source field to attach the originating object to the `ValidationResult` as well.

If we want to enforce the utilization of the `source` field for all validation plugins. We should modify the following line

```py
source: Any = Field(None, description="The source of this validation result", exclude=True)
```

to

```py
source: Any = Field(description="The source of this validation result", exclude=True)
``` 

