### PR TITLE
[docgen] improve methods configurability for derived schemas

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -760,8 +760,9 @@ class DocGenerator(Generator):
         :return: iterator
         """
         if imports is None:
-            imports = self.mergeimports
-        elts = self.schemaview.all_classes(imports=imports).values()
+            elts = self.schemaview.all_classes().values()
+        else:
+            elts = self.schemaview.all_classes(imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e
@@ -774,8 +775,9 @@ class DocGenerator(Generator):
         :return: iterator
         """
         if imports is None:
-            imports = self.mergeimports
-        elts = self.schemaview.all_slots(imports=imports).values()
+            elts = self.schemaview.all_slots().values()
+        else:
+            elts = self.schemaview.all_slots(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e
@@ -788,8 +790,9 @@ class DocGenerator(Generator):
         :return: iterator
         """
         if imports is None:
-            imports = self.mergeimports
-        elts = self.schemaview.all_types(imports=imports).values()
+            elts = self.schemaview.all_types().values()
+        else:
+            elts = self.schemaview.all_types(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e
@@ -805,8 +808,9 @@ class DocGenerator(Generator):
         :return: iterator
         """
         if imports is None:
-            imports = self.mergeimports
-        elts = self.schemaview.all_enums(imports=imports).values()
+            elts = self.schemaview.all_enums().values()
+        else:
+            elts = self.schemaview.all_enums(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e
@@ -819,8 +823,9 @@ class DocGenerator(Generator):
         :return: iterator
         """
         if imports is None:
-            imports = self.mergeimports
-        elts = self.schemaview.all_subsets(imports=imports).values()
+            elts = self.schemaview.all_subsets().values()
+        else:
+            elts = self.schemaview.all_subsets(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e

--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -752,38 +752,44 @@ class DocGenerator(Generator):
         for e in elts:
             yield e
 
-    def all_class_objects(self) -> Iterator[ClassDefinition]:
+    def all_class_objects(self, imports=None) -> Iterator[ClassDefinition]:
         """
         all class objects in schema
 
         Ensures rank is non-null
         :return: iterator
         """
-        elts = self.schemaview.all_classes(imports=self.mergeimports).values()
+        if imports is None:
+            imports = self.mergeimports
+        elts = self.schemaview.all_classes(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e
 
-    def all_slot_objects(self) -> Iterator[SlotDefinition]:
+    def all_slot_objects(self, imports=None) -> Iterator[SlotDefinition]:
         """
         all slot objects in schema
 
         Ensures rank is non-null
         :return: iterator
         """
-        elts = self.schemaview.all_slots(imports=self.mergeimports).values()
+        if imports is None:
+            imports = self.mergeimports
+        elts = self.schemaview.all_slots(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e
 
-    def all_type_objects(self) -> Iterator[TypeDefinition]:
+    def all_type_objects(self, imports=None) -> Iterator[TypeDefinition]:
         """
         all type objects in schema
 
         Ensures rank is non-null
         :return: iterator
         """
-        elts = self.schemaview.all_types(imports=self.mergeimports).values()
+        if imports is None:
+            imports = self.mergeimports
+        elts = self.schemaview.all_types(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e
@@ -791,26 +797,30 @@ class DocGenerator(Generator):
     def all_type_object_names(self) -> List[TypeDefinitionName]:
         return [t.name for t in list(self.all_type_objects())]
 
-    def all_enum_objects(self) -> Iterator[EnumDefinition]:
+    def all_enum_objects(self, imports=None) -> Iterator[EnumDefinition]:
         """
         all enum objects in schema
 
         Ensures rank is non-null
         :return: iterator
         """
-        elts = self.schemaview.all_enums(imports=self.mergeimports).values()
+        if imports is None:
+            imports = self.mergeimports
+        elts = self.schemaview.all_enums(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e
 
-    def all_subset_objects(self) -> Iterator[SubsetDefinition]:
+    def all_subset_objects(self, imports=None) -> Iterator[SubsetDefinition]:
         """
         all enum objects in schema
 
         Ensures rank is non-null
         :return: iterator
         """
-        elts = self.schemaview.all_subsets(imports=self.mergeimports).values()
+        if imports is None:
+            imports = self.mergeimports
+        elts = self.schemaview.all_subsets(imports=imports).values()
         _ensure_ranked(elts)
         for e in elts:
             yield e

--- a/tests/test_generators/input/core.yaml
+++ b/tests/test_generators/input/core.yaml
@@ -16,6 +16,9 @@ prefixes:
 default_prefix: core
 license: https://creativecommons.org/publicdomain/zero/1.0/
 
+subsets:
+  subset X:
+
 types:
   phone number type:
     pattern: ^[\\+\\d+ +][\\d\\- ]+$
@@ -103,3 +106,9 @@ slots:
     range: agent
     multivalued: true
     inlined_as_list: true
+
+enums:
+  KitchenStatus:
+    permissible_values:
+      DIRTY:
+      CLEAN: 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -742,3 +742,27 @@ def test_uml_diagram_classr(kitchen_sink_path, tmp_path):
         "# Class: Person",
         followed_by=["```puml", "@startuml", 'class "Person" [[{A person, living or dead}]] {', "@enduml"],
     )
+
+
+def test_derived_schema_view(kitchen_sink_path, tmp_path):
+    """Test to check if class table view on index page follows hierarchical view"""
+    gen = DocGenerator(kitchen_sink_path, mergeimports=False, hierarchical_class_view=True)
+
+    test_sets = {
+        "class": "activity",
+        "slot": "used",
+        "type": "phone number type",
+        "subset": "subset X",
+        "enum": "KitchenStatus",
+    }
+
+    # iterators cannot see elements from derived schema when no import
+    for k, v in test_sets.items():
+        gen_iter = getattr(gen, f"all_{k}_objects")
+        assert v not in [x.name for x in list(gen_iter())]
+        assert v not in [x.name for x in list(gen_iter(imports=False))]
+
+    # iterators can see elements from derived schema when import
+    for k, v in test_sets.items():
+        gen_iter = getattr(gen, f"all_{k}_objects")
+        assert v in [x.name for x in list(gen_iter(imports=True))]

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -746,8 +746,6 @@ def test_uml_diagram_classr(kitchen_sink_path, tmp_path):
 
 def test_derived_schema_view(kitchen_sink_path, tmp_path):
     """Test to check if class table view on index page follows hierarchical view"""
-    gen = DocGenerator(kitchen_sink_path, mergeimports=False, hierarchical_class_view=True)
-
     test_sets = {
         "class": "activity",
         "slot": "used",
@@ -756,13 +754,37 @@ def test_derived_schema_view(kitchen_sink_path, tmp_path):
         "enum": "KitchenStatus",
     }
 
+    gen = DocGenerator(
+        kitchen_sink_path,
+        mergeimports=False,
+        hierarchical_class_view=True,
+    )
+
     # iterators cannot see elements from derived schema when no import
     for k, v in test_sets.items():
         gen_iter = getattr(gen, f"all_{k}_objects")
         assert v not in [x.name for x in list(gen_iter())]
-        assert v not in [x.name for x in list(gen_iter(imports=False))]
+
+    gen = DocGenerator(
+        kitchen_sink_path,
+        mergeimports=False,
+        render_imports=False,
+        hierarchical_class_view=True,
+    )
+
+    # iterators cannot see elements from derived schema when no import
+    for k, v in test_sets.items():
+        gen_iter = getattr(gen, f"all_{k}_objects")
+        assert v not in [x.name for x in list(gen_iter())]
+
+    gen = DocGenerator(
+        kitchen_sink_path,
+        mergeimports=False,
+        render_imports=True,
+        hierarchical_class_view=True,
+    )
 
     # iterators can see elements from derived schema when import
     for k, v in test_sets.items():
         gen_iter = getattr(gen, f"all_{k}_objects")
-        assert v in [x.name for x in list(gen_iter(imports=True))]
+        assert v in [x.name for x in list(gen_iter())]

--- a/tests/test_scripts/__snapshots__/genjsonld/meta.json
+++ b/tests/test_scripts/__snapshots__/genjsonld/meta.json
@@ -102,6 +102,11 @@
         "B"
       ],
       "rank": 1
+    },
+    {
+      "name": "subset_X",
+      "definition_uri": "https://w3id.org/linkml/tests/core/SubsetX",
+      "from_schema": "https://w3id.org/linkml/tests/core"
     }
   ],
   "types": [
@@ -515,6 +520,19 @@
         {
           "text": "indifferent",
           "description": "not overly friendly nor obnoxiously spiteful"
+        }
+      ]
+    },
+    {
+      "name": "KitchenStatus",
+      "definition_uri": "https://w3id.org/linkml/tests/core/KitchenStatus",
+      "from_schema": "https://w3id.org/linkml/tests/core",
+      "permissible_values": [
+        {
+          "text": "DIRTY"
+        },
+        {
+          "text": "CLEAN"
         }
       ]
     }

--- a/tests/test_scripts/__snapshots__/genjsonld/meta.jsonld
+++ b/tests/test_scripts/__snapshots__/genjsonld/meta.jsonld
@@ -104,6 +104,12 @@
       ],
       "rank": 1,
       "@type": "SubsetDefinition"
+    },
+    {
+      "name": "subset_X",
+      "definition_uri": "https://w3id.org/linkml/tests/core/SubsetX",
+      "from_schema": "https://w3id.org/linkml/tests/core",
+      "@type": "SubsetDefinition"
     }
   ],
   "types": [
@@ -538,6 +544,19 @@
         {
           "text": "indifferent",
           "description": "not overly friendly nor obnoxiously spiteful"
+        }
+      ]
+    },
+    {
+      "name": "KitchenStatus",
+      "definition_uri": "https://w3id.org/linkml/tests/core/KitchenStatus",
+      "from_schema": "https://w3id.org/linkml/tests/core",
+      "permissible_values": [
+        {
+          "text": "DIRTY"
+        },
+        {
+          "text": "CLEAN"
         }
       ]
     }

--- a/tests/test_scripts/__snapshots__/genjsonschema/meta.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/meta.json
@@ -650,6 +650,15 @@
             "title": "FamilialRelationshipType",
             "type": "string"
         },
+        "KitchenStatus": {
+            "description": "",
+            "enum": [
+                "DIRTY",
+                "CLEAN"
+            ],
+            "title": "KitchenStatus",
+            "type": "string"
+        },
         "LifeStatusEnum": {
             "description": "",
             "enum": [

--- a/tests/test_scripts/__snapshots__/genjsonschema/meta_inline.json
+++ b/tests/test_scripts/__snapshots__/genjsonschema/meta_inline.json
@@ -650,6 +650,15 @@
             "title": "FamilialRelationshipType",
             "type": "string"
         },
+        "KitchenStatus": {
+            "description": "",
+            "enum": [
+                "DIRTY",
+                "CLEAN"
+            ],
+            "title": "KitchenStatus",
+            "type": "string"
+        },
         "LifeStatusEnum": {
             "description": "",
             "enum": [

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl.jsonld
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl.jsonld
@@ -6529,6 +6529,54 @@
             "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
           }
         ]
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
+        "@type": [
+          "http://www.w3.org/2002/07/owl#Class"
+        ],
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+          }
+        ]
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
+        "@type": [
+          "http://www.w3.org/2002/07/owl#Class"
+        ],
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+          }
+        ]
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
+        "@type": [
+          "http://www.w3.org/2002/07/owl#Class"
+        ],
+        "http://www.w3.org/2002/07/owl#unionOf": [
+          {
+            "@list": [
+              {
+                "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+              },
+              {
+                "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+              }
+            ]
+          }
+        ],
+        "https://w3id.org/linkml/permissible_values": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+          }
+        ]
       }
     ],
     "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl"

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl.n3
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl.n3
@@ -511,6 +511,19 @@ ks:FamilialRelationship a owl:Class ;
     rdfs:label "SIBLING_OF" ;
     rdfs:subClassOf ks:FamilialRelationshipType .
 
+ks:KitchenStatus a owl:Class ;
+    owl:unionOf ( <https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY> <https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN> ) ;
+    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN>,
+        <https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY> .
+
+<https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN> a owl:Class ;
+    rdfs:label "CLEAN" ;
+    rdfs:subClassOf ks:KitchenStatus .
+
+<https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY> a owl:Class ;
+    rdfs:label "DIRTY" ;
+    rdfs:subClassOf ks:KitchenStatus .
+
 <https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD> a owl:Class ;
     rdfs:label "DEAD" ;
     rdfs:subClassOf ks:LifeStatusEnum .

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl.ttl
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl.ttl
@@ -511,6 +511,19 @@ ks:FamilialRelationship a owl:Class ;
     rdfs:label "SIBLING_OF" ;
     rdfs:subClassOf ks:FamilialRelationshipType .
 
+ks:KitchenStatus a owl:Class ;
+    owl:unionOf ( <https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY> <https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN> ) ;
+    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN>,
+        <https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY> .
+
+<https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN> a owl:Class ;
+    rdfs:label "CLEAN" ;
+    rdfs:subClassOf ks:KitchenStatus .
+
+<https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY> a owl:Class ;
+    rdfs:label "DIRTY" ;
+    rdfs:subClassOf ks:KitchenStatus .
+
 <https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD> a owl:Class ;
     rdfs:label "DEAD" ;
     rdfs:subClassOf ks:LifeStatusEnum .

--- a/tests/test_scripts/__snapshots__/genpython/meta.py
+++ b/tests/test_scripts/__snapshots__/genpython/meta.py
@@ -1013,6 +1013,15 @@ class CordialnessEnum(EnumDefinitionImpl):
         name="CordialnessEnum",
     )
 
+class KitchenStatus(EnumDefinitionImpl):
+
+    DIRTY = PermissibleValue(text="DIRTY")
+    CLEAN = PermissibleValue(text="CLEAN")
+
+    _defn = EnumDefinition(
+        name="KitchenStatus",
+    )
+
 # Slots
 class slots:
     pass

--- a/tests/test_scripts/__snapshots__/genyaml/meta.yaml
+++ b/tests/test_scripts/__snapshots__/genyaml/meta.yaml
@@ -84,6 +84,10 @@ subsets:
     aliases:
     - B
     rank: 1
+  subset X:
+    name: subset X
+    definition_uri: https://w3id.org/linkml/tests/core/SubsetX
+    from_schema: https://w3id.org/linkml/tests/core
 types:
   string:
     name: string
@@ -444,6 +448,15 @@ enums:
       indifferent:
         text: indifferent
         description: not overly friendly nor obnoxiously spiteful
+  KitchenStatus:
+    name: KitchenStatus
+    definition_uri: https://w3id.org/linkml/tests/core/KitchenStatus
+    from_schema: https://w3id.org/linkml/tests/core
+    permissible_values:
+      DIRTY:
+        text: DIRTY
+      CLEAN:
+        text: CLEAN
 slots:
   employed at:
     name: employed at

--- a/tests/test_scripts/test_gen_doc.py
+++ b/tests/test_scripts/test_gen_doc.py
@@ -1,0 +1,68 @@
+import os.path
+import re
+
+from click.testing import CliRunner
+
+from linkml.generators.docgen import cli
+
+from ..conftest import KITCHEN_SINK_PATH
+
+
+def test_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert re.search("Generate documentation folder from a LinkML YAML schema", result.output)
+
+
+def test_metamodel(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["-d", tmp_path, KITCHEN_SINK_PATH])
+    assert result.exit_code == 0
+
+
+def test_mergeimports(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "-d",
+            tmp_path,
+            "--mergeimports",
+            KITCHEN_SINK_PATH,
+        ],
+    )
+    assert result.exit_code == 0
+
+    index_path = os.path.join(tmp_path, "index.md")
+    assert (
+        re.search(
+            r"\s*\|\s*\[Agent\]\(Agent\.md\)\s*\|\s*",
+            open(index_path).read(),
+        )
+        is not None
+    )
+
+
+def test_no_mergeimports(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "-d",
+            tmp_path,
+            "--no-mergeimports",
+            KITCHEN_SINK_PATH,
+        ],
+    )
+    assert result.exit_code == 0
+
+    index_path = os.path.join(tmp_path, "index.md")
+    assert (
+        re.search(
+            r"\s*\|\s*\[Agent\]\(Agent\.md\)\s*\|\s*",
+            open(index_path).read(),
+        )
+        is None
+    )
+
+

--- a/tests/test_scripts/test_gen_doc.py
+++ b/tests/test_scripts/test_gen_doc.py
@@ -66,3 +66,50 @@ def test_no_mergeimports(tmp_path):
     )
 
 
+def test_no_render_imports(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "-d",
+            tmp_path,
+            "--no-mergeimports",
+            "--no-render-imports",
+            KITCHEN_SINK_PATH,
+        ],
+    )
+    assert result.exit_code == 0
+
+    index_path = os.path.join(tmp_path, "index.md")
+    assert (
+        re.search(
+            r"\s*\|\s*\[Agent\]\(Agent\.md\)\s*\|\s*",
+            open(index_path).read(),
+        )
+        is None
+    )
+
+
+def test_render_imports(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "-d",
+            tmp_path,
+            "--no-mergeimports",
+            "--render-imports",
+            KITCHEN_SINK_PATH,
+        ],
+    )
+    assert result.exit_code == 0
+
+    index_path = os.path.join(tmp_path, "index.md")
+
+    assert (
+        re.search(
+            r"\s*\|\s*\[Agent\]\(Agent\.md\)\s*\|\s*",
+            open(index_path).read(),
+        )
+        is not None
+    )


### PR DESCRIPTION
docgen.py methods providing iterators for SchemaView methods listing the different schema elements could not be configured in any way. This patch enables the possibility of passing the `imports` parameter of the original `SchemaView` method.

I am using derived schemas and would like the documentation to be able to show differentiated output for elements of the derived schema and those of the base schema. I want imports to be merged so that I can have a "merged" view, but in order to have the mentioned differentiation I need the element iterators (`all_...`) to be able to show the elements without merging. Otherwise imported elements cannot be differentiated.

The provided test shows that if `SchemaView` is instantiated with `mergeimports=False` (to be able to differentiate base and derived schema), then the iterators cannot see the elements of the base schema.

This issue originates from the conflict between the need of avoiding imports merging to be able to differentiate where belongs which element (see below following separation line to understand it better) and the need of being able to list elements from imported schemas.

---

Why not instantiating `SchemaView` with `mergeimports=True`?

If we have following base schema
``` yaml
id: https://examples.org/base
name: base
imports:
  - linkml:types
classes:
  base class:
```
and following derived schema
``` yaml
id: https://examples.org/derived
name: derived
imports:
  - linkml:types
  - base
classes:
  derived class:
```

Following Python program demonstrates the issue
``` python
#!/usr/bin/env python

from linkml_runtime.utils.schemaview import SchemaView

derv_sv = SchemaView("derived.yaml", merge_imports=False)
print("*** NOT Merging imports *** ")
print(f"type 'base class' is in schema '{derv_sv.in_schema('base class')}'")

derv_sv = SchemaView("derived.yaml", merge_imports=True)
print("*** Merging imports *** ")
print(f"type 'base class' is in schema '{derv_sv.in_schema('base class')}'")
```

This is the resulting output:
```
*** NOT Merging imports ***
type 'base class' is in schema 'base'
*** Merging imports ***
type 'base class' is in schema 'derived'
```

Observe that instantiating `SchemaView` to merge the imports results in the class `base class` from the `base` schema being seen as part of the `derived` schema, as expected (that is the meaning of merging, right?).