### PR TITLE
handle special ifabsent cases in python ifabsent processor

### DIFF
--- a/linkml/generators/common/ifabsent_processor.py
+++ b/linkml/generators/common/ifabsent_processor.py
@@ -1,7 +1,7 @@
 import abc
 import re
 from abc import ABC
-from typing import Any, Optional
+from typing import Any, Optional, Tuple, Union
 
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import (
@@ -48,7 +48,6 @@ class IfAbsentProcessor(ABC):
         if slot.ifabsent:
             ifabsent_match = self.ifabsent_regex.search(slot.ifabsent)
             ifabsent_default_value = ifabsent_match.group("default_value")
-
             return self._map_to_default_value(slot, ifabsent_default_value, cls)
 
         return None
@@ -174,7 +173,9 @@ class IfAbsentProcessor(ABC):
         raise ValueError(f"The ifabsent value `{slot.ifabsent}` of the `{slot.name}` slot could not be processed")
 
     @abc.abstractmethod
-    def map_custom_default_values(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition) -> (bool, str):
+    def map_custom_default_values(
+        self, default_value: str, slot: SlotDefinition, cls: ClassDefinition
+    ) -> Tuple[bool, Union[str, None]]:
         """
         Maps custom default values that aren't generic behaviours.
 

--- a/linkml/generators/python/python_ifabsent_processor.py
+++ b/linkml/generators/python/python_ifabsent_processor.py
@@ -1,3 +1,5 @@
+from typing import Tuple, Union
+
 from linkml_runtime.linkml_model import (
     ClassDefinition,
     EnumDefinitionName,
@@ -8,16 +10,23 @@ from linkml.generators.common.ifabsent_processor import IfAbsentProcessor
 
 
 class PythonIfAbsentProcessor(IfAbsentProcessor):
-    UNIMPLEMENTED_DEFAULT_VALUES = ["class_curie", "class_uri", "slot_uri", "slot_curie", "default_range", "default_ns"]
 
-    def map_custom_default_values(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition) -> (bool, str):
+    URI_SPECIAL_CASES = ("class_uri", "slot_uri")
+    CURIE_SPECIAL_CASES = ("class_curie", "slot_curie")
+    OTHER_SPECIAL_CASES = ("default_range",)
+    UNIMPLEMENTED_DEFAULT_VALUES = ("default_ns",)
+
+    def map_custom_default_values(
+        self, default_value: str, slot: SlotDefinition, cls: ClassDefinition
+    ) -> Tuple[bool, Union[str, None]]:
         if default_value in self.UNIMPLEMENTED_DEFAULT_VALUES:
             return True, None
-
-        if default_value == "bnode":
+        elif default_value in self.OTHER_SPECIAL_CASES:
+            return True, self._map_other_special_case(default_value, slot, cls)
+        elif default_value == "bnode":
             return True, "bnode()"
-
-        return False, None
+        else:
+            return False, None
 
     def map_string_default_value(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition):
         return self._strval(default_value)
@@ -60,12 +69,25 @@ class PythonIfAbsentProcessor(IfAbsentProcessor):
         return f"datetime({int(year)}, {int(month)}, {int(day)}, " f"{int(hour)}, {int(minutes)}, {int(seconds)})"
 
     def map_uri_or_curie_default_value(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition):
+        if default_value in self.URI_SPECIAL_CASES:
+            return self._map_uri_special_case(default_value, slot, cls)
+        if default_value in self.CURIE_SPECIAL_CASES:
+            return self._map_curie_special_case(default_value, slot, cls)
+
         return self._uri_for(default_value)
 
     def map_curie_default_value(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition):
+        if default_value in self.CURIE_SPECIAL_CASES:
+            return self._map_curie_special_case(default_value, slot, cls)
+        elif default_value in self.URI_SPECIAL_CASES:
+            return None
         return self._uri_for(default_value)
 
     def map_uri_default_value(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition):
+        if default_value in self.URI_SPECIAL_CASES:
+            return self._map_uri_special_case(default_value, slot, cls)
+        elif default_value in self.CURIE_SPECIAL_CASES:
+            return None
         return self._uri_for(default_value)
 
     def map_enum_default_value(
@@ -90,3 +112,33 @@ class PythonIfAbsentProcessor(IfAbsentProcessor):
 
     def map_sparql_path_default_value(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition):
         raise NotImplementedError()
+
+    def _map_uri_special_case(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition) -> str:
+        if default_value == "class_uri":
+            return self.schema_view.get_uri(cls, expand=True)
+        elif default_value == "slot_uri":
+            return self.schema_view.get_uri(slot, expand=True)
+        else:
+            raise ValueError(
+                f"Default value must be one of the URI special cases: {self.URI_SPECIAL_CASES}. Got: {default_value}"
+            )
+
+    def _map_curie_special_case(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition) -> str:
+        if default_value == "class_curie":
+            return self.schema_view.get_uri(cls, expand=False)
+        elif default_value == "slot_curie":
+            return self.schema_view.get_uri(slot, expand=False)
+        else:
+            raise ValueError(
+                f"Default value must be one of the curie special cases: {self.CURIE_SPECIAL_CASES}. "
+                f"Got: {default_value}"
+            )
+
+    def _map_other_special_case(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition) -> str:
+        if default_value == "default_range":
+            return self.schema_view.schema.default_range
+        else:
+            raise ValueError(
+                f"Default value must be one of the other special cases: {self.OTHER_SPECIAL_CASES}. "
+                f"Got: {default_value}"
+            )


### PR DESCRIPTION
Related to: https://github.com/linkml/linkml/pull/2329
Fixes one of the problems in : https://github.com/linkml/linkml/issues/2284

Basic issue is that `ifabsent` has several special cases:

```yaml
ifabsent:
  domain: slot_definition
  range: string
  inherited: true
  description: >-
    function that provides a default value for the slot.
      * [Tt]rue -- boolean True
      * [Ff]alse -- boolean False
      * bnode -- blank node identifier
      * class_curie -- CURIE for the containing class
      * class_uri -- URI for the containing class
      * default_ns -- schema default namespace
      * default_range -- schema default range
      * int(value) -- integer value
      * slot_uri -- URI for the slot
      * slot_curie -- CURIE for the slot
      * string(value) -- string value
      * EnumName(PermissibleValue) -- enum value
  close_mappings:
    - sh:defaultValue
  in_subset:
    - SpecificationSubset
  see_also:
    - linkml:equals_expression

```

This PR fixes
- `class_curie`
- `class_uri`
- `default_range`
- `slot_uri`
- `slot_curie`

for the python ifabsent generator. I didn't handle `default_ns` because i don't know what that is.

Previously the processor would just produce a `None` for each of these, which is incorrect.

Now you can observe via the tests that they are handled correctly.

I think that `ifabsent: default_range` is a special case that really only makes sense to use in exactly one place in the metamodel: https://github.com/linkml/linkml-model/blob/76bc3279981f00f9f6590caf7fbe5a1f15520f85/linkml_model/model/schema/meta.yaml#L1381

but hey might as well make the processor spec compliant even if it only applies in exactly one case. 

Leaving as a draft for now because i figure this will require some more massaging of the tests/regenerating snapshots but i hate running regenerate snapshots on my local machine unless i have to because it still makes a mess


