### PR TITLE
[jsonschemagen] Add lifecycle methods to jsonschemagen

### DIFF
--- a/linkml/generators/common/build.py
+++ b/linkml/generators/common/build.py
@@ -5,7 +5,6 @@ Models for intermediate build results
 """
 
 import dataclasses
-from abc import abstractmethod
 from typing import Any, TypeVar
 
 try:
@@ -57,11 +56,11 @@ class BuildResult(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    @abstractmethod
     def merge(self, other: T) -> T:
         """
         Build results should have some means of merging results of a like kind
         """
+        raise NotImplementedError("This build result doesn't know how to merge!")
 
 
 class SchemaResult(BuildResult):

--- a/linkml/generators/common/lifecycle.py
+++ b/linkml/generators/common/lifecycle.py
@@ -13,7 +13,7 @@ from linkml_runtime.linkml_model.meta import (
     TypeDefinition,
 )
 
-from linkml.generators.common.build import ClassResult, RangeResult, SchemaResult, SlotResult, TypeResult
+from linkml.generators.common.build import ClassResult, EnumResult, RangeResult, SchemaResult, SlotResult, TypeResult
 from linkml.generators.common.template import TemplateModel
 
 TSchema = TypeVar("TSchema", bound=SchemaResult)
@@ -21,7 +21,7 @@ TClass = TypeVar("TClass", bound=ClassResult)
 TSlot = TypeVar("TSlot", bound=SlotResult)
 TRange = TypeVar("TRange", bound=RangeResult)
 TType = TypeVar("TType", bound=TypeResult)
-TEnum = TypeVar("TEnum", bound=EnumDefinition)
+TEnum = TypeVar("TEnum", bound=EnumResult)
 TTemplate = TypeVar("TTemplate", bound=TemplateModel)
 
 
@@ -91,6 +91,22 @@ class LifecycleMixin:
         return slot
 
     def after_generate_slots(self, slot: Iterable[TSlot], sv: SchemaView) -> Iterable[TSlot]:
+        return slot
+
+    def before_generate_class_slot(self, slot: SlotDefinition, cls: ClassDefinition, sv: SchemaView) -> SlotDefinition:
+        return slot
+
+    def after_generate_class_slot(self, slot: TSlot, cls: ClassDefinition, sv: SchemaView) -> TSlot:
+        return slot
+
+    def before_generate_class_slots(
+        self, slot: Iterable[SlotDefinition], cls: ClassDefinition, sv: SchemaView
+    ) -> Iterable[SlotDefinition]:
+        return slot
+
+    def after_generate_class_slots(
+        self, slot: Iterable[TSlot], cls: ClassDefinition, sv: SchemaView
+    ) -> Iterable[TSlot]:
         return slot
 
     def before_generate_type(self, typ: TypeDefinition, sv: SchemaView) -> TypeDefinition:

--- a/tests/test_generators/test_jsonschemagen.py
+++ b/tests/test_generators/test_jsonschemagen.py
@@ -1,13 +1,14 @@
 import json
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 import jsonschema
 import pytest
 import yaml
+from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import json_dumper
-from linkml_runtime.linkml_model import SchemaDefinition
+from linkml_runtime.linkml_model import ClassDefinition, SchemaDefinition, SlotDefinition
 from linkml_runtime.loaders import yaml_loader
 
 from linkml.generators.jsonschemagen import JsonSchemaGenerator
@@ -327,6 +328,77 @@ def test_slot_not_required_nullability(input_path, not_closed):
             assert "null" in prop["type"], f"{key} does not allow null"
         elif "anyOf" in prop:
             assert {"type": "null"} in prop["anyOf"], f"{key} does not allow null"
+
+
+def test_lifecycle_classes(kitchen_sink_path):
+    """We can modify the generation process by subclassing lifecycle hooks"""
+
+    class TestJsonSchemaGen(JsonSchemaGenerator):
+        def before_generate_classes(self, cls: Iterable[ClassDefinition], sv: SchemaView) -> Iterable[ClassDefinition]:
+            cls = [c for c in cls]
+
+            # delete a class and make sure we don't get it in the output
+            assert cls[0].name == "activity"
+            del cls[0]
+            return cls
+
+        def before_generate_class(self, cls: ClassDefinition, sv: SchemaView) -> ClassDefinition:
+            # change all the descriptions, idk
+            cls.description = "TEST MODIFYING CLASSES"
+            return cls
+
+        def after_generate_class(self, cls, sv: SchemaView):
+            # make additionalProperties True
+            cls.schema_["additionalProperties"] = True
+            return cls
+
+    generator = TestJsonSchemaGen(kitchen_sink_path, mergeimports=True, top_class="Dataset", not_closed=False)
+    schema = json.loads(generator.serialize())
+    assert "Activity" not in schema["$defs"]
+    for cls in schema["$defs"].values():
+        if "enum" in cls:
+            continue
+        assert cls["additionalProperties"]
+        assert cls["description"] == "TEST MODIFYING CLASSES"
+
+
+def test_lifecycle_slots(kitchen_sink_path):
+    """We can modify the generation process by subclassing lifecycle hooks"""
+
+    class TestJsonSchemaGen(JsonSchemaGenerator):
+        def before_generate_class_slots(
+            self, slot: Iterable[SlotDefinition], cls, sv: SchemaView
+        ) -> Iterable[SlotDefinition]:
+            # make a new slot that's the number of slots for some reason
+            slot = [s for s in slot]
+            slot.append(SlotDefinition(name="number_of_slots", range="integer", ifabsent=f"integer({len(slot)})"))
+            return slot
+
+        def before_generate_class_slot(self, slot: SlotDefinition, cls, sv: SchemaView) -> SlotDefinition:
+            slot.description = "TEST MODIFYING SLOTS"
+            return slot
+
+        def after_generate_class_slot(self, slot, cls, sv: SchemaView):
+            # make em all required
+            if "type" not in slot.schema_:
+                slot.schema_["type"] = ["faketype"]
+            elif isinstance(slot.schema_["type"], list):
+                slot.schema_["type"].append("faketype")
+            else:
+                slot.schema_["type"] = [slot.schema_["type"], "faketype"]
+
+            return slot
+
+    generator = TestJsonSchemaGen(kitchen_sink_path, mergeimports=True, top_class="Dataset", not_closed=False)
+    schema = json.loads(generator.serialize())
+
+    for cls in schema["$defs"].values():
+        if "enum" in cls:
+            continue
+        assert "number_of_slots" in cls["properties"]
+        for prop in cls["properties"].values():
+            assert prop["description"] == "TEST MODIFYING SLOTS"
+            assert "faketype" in prop["type"]
 
 
 # **********************************************************


### PR DESCRIPTION
Related to: https://github.com/linkml/linkml/issues/2339

Lifecycle methods in generators are a great way to allow people to modify the generation process in ways that might not have a place in the main in-library generators while not having to override methods that would cause subclasses to get out of date with changes in in-library generators. 

In this case the request was to add special terms for a json schema dialect for UI elements. Adding lifecycle hooks allows them to experiment with making that work - and if it is something that we might want to integrate upstream then we have a clear, packaged way of doing that that cleanly divides the additional parts into separate methods rather than intercalating them in the other parts of the generator.

As usual, i could only implement some of the lifecycle hooks (eg. the `after` methods for the collective `classes` methods can't be done because the results aren't returned, but directly added to a shared dict), but i added which to the docstring. 

Added `before/after_generate_class_slot` because those seem different enough from generating a slot by itself to be worth a separate method that also passes the class that the slot is being built in the context of. will save swapping pydanticgen over to those for another PR.

Build results classes here are trivial since jsonschemagen doesn't use the builder pattern, used `model_construct` since there's no actual validation to be done and i wasn't sure if the pydantic validator would take extra time with a custom `dict` subclass.

