### PR TITLE
[plantuml] mark and skip plantuml docker tests when docker not present

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,8 @@ markers = [
   "slow: mark test as slow to run",
   "no_asserts: tests that don't have meaningful asserts, but are only snapshot comparisons, or historically had print statements, or other non-erroring behavior",
   "strcmp: tests that compare stringified values rather than the values themselves",
+  "docker: tests that require a running docker server",
+  "plantumlgen: Tests for the plantuml generator",
   "pydanticgen_split: Split module generation in pydanticgen",
   "pydanticgen_npd: tests for the numpydantic array generator",
   "pythongen: Tests for python generator",
@@ -222,7 +224,7 @@ markers = [
   "rdfgen: Tests for the RDFGenerator",
   "sqlddlgen: Tests for SQL DDL generator",
   "sqlddlpostgresgen: Tests for SQL DDL postgres generator",
-  "owlgen: Tests for OWL generator"
+  "owlgen: Tests for OWL generator",
 ]
 
 [tool.ruff]

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -59,9 +59,11 @@ def kroki_url(request):
 
         return f"http://{kroki_container.get_container_host_ip()}:{kroki_container.get_exposed_port(8000)}"
     except ImageNotFound:
-        print("Kroki container cannot be started, falling back to the Kroki official servers")
-
-    return "https://kroki.io/"
+        pytest.skip(
+            'PlantUML Kroki Container image could not be started, but docker tests were not skipped! '
+            'Either fix the docker invocation, the _docker_server_running function, '
+            'or find a more reliable way to test PlantUML!'
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -60,9 +60,9 @@ def kroki_url(request):
         return f"http://{kroki_container.get_container_host_ip()}:{kroki_container.get_exposed_port(8000)}"
     except ImageNotFound:
         pytest.skip(
-            'PlantUML Kroki Container image could not be started, but docker tests were not skipped! '
-            'Either fix the docker invocation, the _docker_server_running function, '
-            'or find a more reliable way to test PlantUML!'
+            "PlantUML Kroki Container image could not be started, but docker tests were not skipped! "
+            "Either fix the docker invocation, the _docker_server_running function, "
+            "or find a more reliable way to test PlantUML!"
         )
 
 

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -8,6 +8,8 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 from linkml.generators.plantumlgen import PlantumlGenerator
 
+pytestmark = [pytest.mark.plantumlgen, pytest.mark.docker]
+
 MARKDOWN_HEADER = """@startuml
 skinparam nodesep 10
 hide circle


### PR DESCRIPTION
fix: https://github.com/linkml/linkml/issues/2342
fix: https://github.com/linkml/linkml/issues/1956
fix: https://github.com/linkml/linkml/issues/1917

let us be done with the plantuml tests being flaky. the tests run in ci where docker is present, but are skipped when running locally where it is not. we are no longer dependent on web requests to remote servers, so If Those For Whom PlantUML Is A Needed Feature May Adopt It, Allow Us To Delegate Its Health To Them.

we have some tests remaining that rely on network access, it is true, but we have cached most of them. the last things to do here would be to fully cache VCR requests and swap out hbreader for `requests` and then we'll have a hermetically sealed test system