### PR TITLE
gen-typescript print to stdout if output not specified

### DIFF
--- a/linkml/generators/typescriptgen.py
+++ b/linkml/generators/typescriptgen.py
@@ -280,7 +280,9 @@ def cli(yamlfile, gen_type_utils=False, include_induced_slots=False, output=None
     gen = TypescriptGenerator(
         yamlfile, gen_type_utils=gen_type_utils, include_induced_slots=include_induced_slots, **args
     )
-    gen.serialize(output=output)
+    serialized = gen.serialize(output=output)
+    if output is None:
+        print(serialized)
 
 
 if __name__ == "__main__":

--- a/tests/test_generators/test_typescriptgen.py
+++ b/tests/test_generators/test_typescriptgen.py
@@ -1,7 +1,9 @@
+from mock import patch
+from click.testing import CliRunner
+
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import SlotDefinition
-
-from linkml.generators.typescriptgen import TypescriptGenerator
+from linkml.generators.typescriptgen import TypescriptGenerator, cli
 from linkml.utils.schema_builder import SchemaBuilder
 
 
@@ -97,3 +99,21 @@ def test_output_option(kitchen_sink_path, tmp_path):
 
     tss.serialize(output=tmp_path / "kitchen_sink.ts")
     assert (tmp_path / "kitchen_sink.ts").exists()
+
+def test_cli_print_stdout_without_output(kitchen_sink_path):
+    # assert that print is called when output is None
+
+    runner = CliRunner()
+    with patch("builtins.print") as mock_print:
+        result = runner.invoke(cli, [kitchen_sink_path])
+        assert result.exit_code == 0
+        mock_print.assert_called_once()
+
+def test_cli_no_print_with_output(kitchen_sink_path, tmp_path):
+    # assert that print is not called when output is set
+
+    runner = CliRunner()
+    with patch("builtins.print") as mock_print:
+        result = runner.invoke(cli, [kitchen_sink_path, "--output", tmp_path / "kitchen_sink.ts"])
+        assert result.exit_code == 0
+        mock_print.assert_not_called()

--- a/tests/test_generators/test_typescriptgen.py
+++ b/tests/test_generators/test_typescriptgen.py
@@ -1,8 +1,8 @@
-from mock import patch
 from click.testing import CliRunner
-
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import SlotDefinition
+from mock import patch
+
 from linkml.generators.typescriptgen import TypescriptGenerator, cli
 from linkml.utils.schema_builder import SchemaBuilder
 
@@ -100,6 +100,7 @@ def test_output_option(kitchen_sink_path, tmp_path):
     tss.serialize(output=tmp_path / "kitchen_sink.ts")
     assert (tmp_path / "kitchen_sink.ts").exists()
 
+
 def test_cli_print_stdout_without_output(kitchen_sink_path):
     # assert that print is called when output is None
 
@@ -108,6 +109,7 @@ def test_cli_print_stdout_without_output(kitchen_sink_path):
         result = runner.invoke(cli, [kitchen_sink_path])
         assert result.exit_code == 0
         mock_print.assert_called_once()
+
 
 def test_cli_no_print_with_output(kitchen_sink_path, tmp_path):
     # assert that print is not called when output is set


### PR DESCRIPTION
Restores the print to stdout behavior, but only when output isn't specified. I also added tests to ensure that print is called when output is None and that print isn't called when the output file is specified. 