### PR TITLE
Add deprecation warnings to validators

### DIFF
--- a/linkml/utils/deprecation.py
+++ b/linkml/utils/deprecation.py
@@ -222,6 +222,16 @@ DEPRECATIONS = (
         recommendation="Update dependent packages to use pydantic>=2",
         issue=1925,
     ),
+    Deprecation(
+        name="validators",
+        deprecated_in=SemVer.from_str("1.8.6"),
+        removed_in=SemVer.from_str("1.9.0"),
+        message=(
+            "linkml.validators and linkml.utils.validation are the older versions "
+            "of linkml.validator and have unmaintained, duplicated functionality"
+        ),
+        recommendation="Update to use linkml.validator",
+    ),
 )  # type: tuple[Deprecation, ...]
 
 EMITTED = set()  # type: set[str]

--- a/linkml/utils/validation.py
+++ b/linkml/utils/validation.py
@@ -7,6 +7,7 @@ from linkml_runtime.linkml_model import SchemaDefinition
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
 from linkml.generators.jsonschemagen import JsonSchemaGenerator
+from linkml.utils.deprecation import deprecation_warning
 
 
 def _as_dict(inst):
@@ -16,7 +17,6 @@ def _as_dict(inst):
     return inst_dict
 
 
-# Deprecated: use validators module
 def validate_object(
     data: YAMLRoot,
     schema: Union[str, TextIO, SchemaDefinition],
@@ -32,6 +32,7 @@ def validate_object(
     :param closed:
     :return:
     """
+    deprecation_warning('validators')
     if target_class is None:
         target_class = type(data)
     inst_dict = _as_dict(data)

--- a/linkml/utils/validation.py
+++ b/linkml/utils/validation.py
@@ -32,7 +32,7 @@ def validate_object(
     :param closed:
     :return:
     """
-    deprecation_warning('validators')
+    deprecation_warning("validators")
     if target_class is None:
         target_class = type(data)
     inst_dict = _as_dict(data)

--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -18,6 +18,7 @@ from linkml.generators.jsonschemagen import JsonSchemaGenerator
 from linkml.generators.pythongen import PythonGenerator
 from linkml.utils import datautils
 from linkml.utils.datavalidator import DataValidator
+from linkml.utils.deprecation import deprecation_warning
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ class HashableSchemaDefinition(SchemaDefinition):
 
 @lru_cache(maxsize=None)
 def _generate_jsonschema(schema, top_class, closed, include_range_class_descendants):
+    deprecation_warning('validators')
     logger.debug("Generating JSON Schema")
     not_closed = not closed
     return JsonSchemaGenerator(
@@ -42,6 +44,7 @@ def _generate_jsonschema(schema, top_class, closed, include_range_class_descenda
 
 class JsonSchemaDataValidatorError(Exception):
     def __init__(self, validation_messages: List[str]) -> None:
+        deprecation_warning('validators')
         super().__init__("\n".join(validation_messages))
         self.validation_messages = validation_messages
 
@@ -56,6 +59,7 @@ class JsonSchemaDataValidator(DataValidator):
     _hashable_schema: Union[str, HashableSchemaDefinition] = field(init=False, repr=False)
 
     def __setattr__(self, __name: str, __value: Any) -> None:
+        deprecation_warning('validators')
         if __name == "schema":
             if isinstance(__value, SchemaDefinition):
                 self._hashable_schema = HashableSchemaDefinition(**asdict(__value))
@@ -65,6 +69,7 @@ class JsonSchemaDataValidator(DataValidator):
 
     def validate_file(self, input: str, format: str = "json", **kwargs):
         # return self.validate_object(obj)
+        deprecation_warning('validators')
         pass
 
     def validate_object(self, data: YAMLRoot, target_class: Type[YAMLRoot] = None, closed: bool = True) -> None:
@@ -76,6 +81,7 @@ class JsonSchemaDataValidator(DataValidator):
         :param closed:
         :return:
         """
+        deprecation_warning('validators')
         if target_class is None:
             target_class = type(data)
         inst_dict = as_simple_dict(data)
@@ -90,6 +96,7 @@ class JsonSchemaDataValidator(DataValidator):
         :param closed:
         :return:
         """
+        deprecation_warning('validators')
         results = list(self.iter_validate_dict(data, target_class, closed))
         if results:
             raise JsonSchemaDataValidatorError(results)
@@ -97,6 +104,7 @@ class JsonSchemaDataValidator(DataValidator):
     def iter_validate_dict(
         self, data: dict, target_class_name: ClassDefinitionName = None, closed: bool = True
     ) -> Iterable[str]:
+        deprecation_warning('validators')
         if self.schema is None:
             raise ValueError("schema object must be set")
         if target_class_name is None:
@@ -159,6 +167,8 @@ def cli(
     """
     Validates instance data
     """
+    deprecation_warning('validators')
+
     if module is None:
         if schema is None:
             raise Exception("must pass one of module OR schema")

--- a/linkml/validators/jsonschemavalidator.py
+++ b/linkml/validators/jsonschemavalidator.py
@@ -30,7 +30,7 @@ class HashableSchemaDefinition(SchemaDefinition):
 
 @lru_cache(maxsize=None)
 def _generate_jsonschema(schema, top_class, closed, include_range_class_descendants):
-    deprecation_warning('validators')
+    deprecation_warning("validators")
     logger.debug("Generating JSON Schema")
     not_closed = not closed
     return JsonSchemaGenerator(
@@ -44,7 +44,7 @@ def _generate_jsonschema(schema, top_class, closed, include_range_class_descenda
 
 class JsonSchemaDataValidatorError(Exception):
     def __init__(self, validation_messages: List[str]) -> None:
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         super().__init__("\n".join(validation_messages))
         self.validation_messages = validation_messages
 
@@ -59,7 +59,7 @@ class JsonSchemaDataValidator(DataValidator):
     _hashable_schema: Union[str, HashableSchemaDefinition] = field(init=False, repr=False)
 
     def __setattr__(self, __name: str, __value: Any) -> None:
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         if __name == "schema":
             if isinstance(__value, SchemaDefinition):
                 self._hashable_schema = HashableSchemaDefinition(**asdict(__value))
@@ -69,7 +69,7 @@ class JsonSchemaDataValidator(DataValidator):
 
     def validate_file(self, input: str, format: str = "json", **kwargs):
         # return self.validate_object(obj)
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         pass
 
     def validate_object(self, data: YAMLRoot, target_class: Type[YAMLRoot] = None, closed: bool = True) -> None:
@@ -81,7 +81,7 @@ class JsonSchemaDataValidator(DataValidator):
         :param closed:
         :return:
         """
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         if target_class is None:
             target_class = type(data)
         inst_dict = as_simple_dict(data)
@@ -96,7 +96,7 @@ class JsonSchemaDataValidator(DataValidator):
         :param closed:
         :return:
         """
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         results = list(self.iter_validate_dict(data, target_class, closed))
         if results:
             raise JsonSchemaDataValidatorError(results)
@@ -104,7 +104,7 @@ class JsonSchemaDataValidator(DataValidator):
     def iter_validate_dict(
         self, data: dict, target_class_name: ClassDefinitionName = None, closed: bool = True
     ) -> Iterable[str]:
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         if self.schema is None:
             raise ValueError("schema object must be set")
         if target_class_name is None:
@@ -167,7 +167,7 @@ def cli(
     """
     Validates instance data
     """
-    deprecation_warning('validators')
+    deprecation_warning("validators")
 
     if module is None:
         if schema is None:

--- a/linkml/validators/sparqlvalidator.py
+++ b/linkml/validators/sparqlvalidator.py
@@ -14,11 +14,13 @@ from linkml.generators.sparqlgen import SparqlGenerator
 from linkml.reporting import CheckResult, Report
 from linkml.utils.datautils import _get_format, dumpers_loaders, get_dumper
 from linkml.utils.datavalidator import DataValidator
+from linkml.utils.deprecation import deprecation_warning
 
 logger = logging.getLogger(__name__)
 
 
 def sparqljson2dict(row: dict):
+    deprecation_warning('validators')
     return {k: v["value"] for k, v in row.items()}
 
 
@@ -37,11 +39,13 @@ class SparqlDataValidator(DataValidator):
     queries: dict = None
 
     def validate_file(self, input: str, format: str = "turtle", **kwargs):
+        deprecation_warning('validators')
         g = Graph()
         g.parse(input, format=format)
         return self.validate_graph(g, **kwargs)
 
     def validate_graph(self, g: Graph, **kwargs):
+        deprecation_warning('validators')
         if self.queries is None:
             self.queries = SparqlGenerator(self.schema, **kwargs).queries
         invalid = []
@@ -61,6 +65,7 @@ class SparqlDataValidator(DataValidator):
         return invalid
 
     def validate_endpoint(self, url: str, **kwargs):
+        deprecation_warning('validators')
         if self.queries is None:
             self.queries = SparqlGenerator(self.schema, **kwargs).queries
         invalid = []
@@ -81,6 +86,7 @@ class SparqlDataValidator(DataValidator):
         return report
 
     def load_schema(self, schema: Union[str, SchemaDefinition]):
+        deprecation_warning('validators')
         self.schemaview = SchemaView(schema)
         self.schema = self.schemaview.schema
         # self.schema = YAMLGenerator(schema).schema
@@ -124,6 +130,7 @@ def cli(
 
         linkml-sparql-validate -U http://sparql.hegroup.org/sparql -s tests/test_validation/input/omo.yaml
     """
+    deprecation_warning('validators')
     validator = SparqlDataValidator(schema)
     if endpoint_url is not None:
         results = validator.validate_endpoint(endpoint_url, limit=limit, named_graphs=named_graph)

--- a/linkml/validators/sparqlvalidator.py
+++ b/linkml/validators/sparqlvalidator.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def sparqljson2dict(row: dict):
-    deprecation_warning('validators')
+    deprecation_warning("validators")
     return {k: v["value"] for k, v in row.items()}
 
 
@@ -39,13 +39,13 @@ class SparqlDataValidator(DataValidator):
     queries: dict = None
 
     def validate_file(self, input: str, format: str = "turtle", **kwargs):
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         g = Graph()
         g.parse(input, format=format)
         return self.validate_graph(g, **kwargs)
 
     def validate_graph(self, g: Graph, **kwargs):
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         if self.queries is None:
             self.queries = SparqlGenerator(self.schema, **kwargs).queries
         invalid = []
@@ -65,7 +65,7 @@ class SparqlDataValidator(DataValidator):
         return invalid
 
     def validate_endpoint(self, url: str, **kwargs):
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         if self.queries is None:
             self.queries = SparqlGenerator(self.schema, **kwargs).queries
         invalid = []
@@ -86,7 +86,7 @@ class SparqlDataValidator(DataValidator):
         return report
 
     def load_schema(self, schema: Union[str, SchemaDefinition]):
-        deprecation_warning('validators')
+        deprecation_warning("validators")
         self.schemaview = SchemaView(schema)
         self.schema = self.schemaview.schema
         # self.schema = YAMLGenerator(schema).schema
@@ -130,7 +130,7 @@ def cli(
 
         linkml-sparql-validate -U http://sparql.hegroup.org/sparql -s tests/test_validation/input/omo.yaml
     """
-    deprecation_warning('validators')
+    deprecation_warning("validators")
     validator = SparqlDataValidator(schema)
     if endpoint_url is not None:
         results = validator.validate_endpoint(endpoint_url, limit=limit, named_graphs=named_graph)


### PR DESCRIPTION
Related to: https://github.com/linkml/linkml/issues/2384

Add deprecation warnings to `linkml.validators` and `linkml.utils.validation` - they're already marked as deprecated. As far as I can tell `linkml.validators` is not used anywhere except tests, and `linkml.utils.validation` is only used in 

- converter: https://github.com/linkml/linkml/pull/2385
- sqlutils (are these also deprecated?)