### PR TITLE
add 'linke' and 'moxon' to list of words to ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,14 @@ version = "0.0.0"
 description = "Linked Open Data Modeling Language"
 authors = [
     "Chris Mungall <cjmungall@lbl.gov>",
-    "Harold Solbrig <solbrig@jhu.edu>",
-    "Sujay Patil <spatil@lbl.gov>",
-    "Harshad Hegde <hhegde@lbl.gov>",
     "Sierra Moxon <smoxon@lbl.gov>",
+    "Harold Solbrig",
+    "Sujay Patil <spatil@lbl.gov>",
+    "Harshad Hegde",
     "Mark Andrew Miller <MAM@lbl.gov>",
-    "Deepak Unni <deepak.unni3@lbl.gov>",
-    "Bill Duncan <wdduncan@gmail.com>",
-    "Joseph Eugene Flack IV <joeflack4@gmail.com>",
+    "Deepak Unni",
     "Gaurav Vaidya <gaurav@renci.org>",
-    "Kevin Schaper <kevinschaper@gmail.com>",
+    "Kevin Schaper <kevin@tislab.org>",
 ]
 
 readme = "README.md"
@@ -182,7 +180,7 @@ skip = '.git,*.pdf,*.svg,./tests,pyproject.toml,*.dill,poetry.lock'
 # Ignore table where words could be split across rows
 # Ignore shortcut specifications like [Ff]alse
 ignore-regex = '(\|.*\|.*\|.*\||\[[A-Z][a-z]\][a-z][a-z])'
-ignore-words-list = 'mater,connexion,infarction,thirdparty'
+ignore-words-list = 'mater,connexion,infarction,thirdparty,moxon,linke'
 quiet-level = 3
 
 [tool.black]


### PR DESCRIPTION
codespell objected to the name 'Linke', thinking it was meant to be one of these: Linked, Link, Links, Like, Line It also sometimes (?) objects to "Moxon" for some reason. @sierra-moxon suggested I add those to the ignore list.

Also updated the author list a bit.