### PR TITLE
Add documentation on using URI as class for slot range

### DIFF
--- a/docs/schemas/advanced.md
+++ b/docs/schemas/advanced.md
@@ -206,3 +206,8 @@ Documentation of the expression language is available [here](../schemas/expressi
 
 See the developer documentation on [inference](../developers/inference) for
 details of how to use this in code.
+
+## URI or CURIE as a range
+In some cases, you may want to use a URI or CURIE as a range. To do this,
+create a class with `class_uri` set to the URI or CURIE and use that class
+as the range.

--- a/docs/schemas/slots.md
+++ b/docs/schemas/slots.md
@@ -47,6 +47,8 @@ The range must be one of:
  * An [EnumDefinition](https://w3id.org/linkml/EnumDefinition), when the value of the slot is a token that represents a vocabulary element
  * A boolean combination of the above
 
+To use a URI or CURIE as a range, create a class with class_uri set to the URI or CURIE and use that class as the range.
+
 Examples:
 
 ```yaml


### PR DESCRIPTION
Tiny patch to add documentation that you need to create a class from a URI or CURIE in order to use it as a range.