### PR TITLE
feat(generators): option to use CURIEs instead of names in JSON-Schema and JSON-LD context

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonldcontextgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldcontextgen.py
@@ -76,6 +76,9 @@ class ContextGenerator(Generator):
     _local_slots: set | None = field(default=None, repr=False)
     _external_classes: set | None = field(default=None, repr=False)
     _external_slots: set | None = field(default=None, repr=False)
+    use_curies: bool = False
+    """If true, use class_uri/slot_uri CURIEs as context keys instead of element names."""
+
     xsd_anyuri_as_iri: bool = False
     """Map xsd:anyURI-typed ranges (uri, uriorcurie) to ``@type: @id`` instead of ``@type: xsd:anyURI``.
 
@@ -238,6 +241,16 @@ class ContextGenerator(Generator):
 
         return str(as_json(context)) + "\n"
 
+    def _curie(self, element: ClassDefinition | SlotDefinition) -> str:
+        if self.schemaview is None:
+            source = self.schema.source_file or self.schema
+            if isinstance(source, str) and self.base_dir and not Path(source).is_absolute():
+                source = str(Path(self.base_dir) / source)
+            sv = SchemaView(source, importmap=self.importmap, base_dir=self.base_dir)
+        else:
+            sv = self.schemaview
+        return sv.get_curie(element)
+
     def visit_class(self, cls: ClassDefinition) -> bool:
         if self.exclude_imports and cls.name not in self._local_classes:
             return False
@@ -245,7 +258,10 @@ class ContextGenerator(Generator):
             return False
 
         class_def = {}
-        cn = camelcase(cls.name)
+        if self.use_curies:
+            cn = self._curie(cls)
+        else:
+            cn = camelcase(cls.name)
         self.add_mappings(cls)
 
         self._build_element_id(class_def, cls.class_uri)
@@ -412,7 +428,10 @@ class ContextGenerator(Generator):
                 self._build_element_id(slot_def, slot.slot_uri)
                 self.add_mappings(slot)
         if slot_def:
-            key = underscore(aliased_slot_name)
+            if self.use_curies:
+                key = self._curie(slot)
+            else:
+                key = underscore(aliased_slot_name)
             self.context_body[key] = slot_def
 
             # collect @embed only for object-valued slots (range is a class)
@@ -460,7 +479,10 @@ class ContextGenerator(Generator):
             self._build_element_id(entry, global_slot.slot_uri)
             if override_type is not None:
                 entry["@type"] = override_type
-            scoped[underscore(slot_name)] = entry
+            if self.use_curies:
+                scoped[self._curie(global_slot)] = entry
+            else:
+                scoped[underscore(slot_name)] = entry
 
         # Check attributes that shadow global slots
         for attr_name, attr in cls.attributes.items():
@@ -578,6 +600,12 @@ class ContextGenerator(Generator):
     default=False,
     show_default=True,
     help="Map xsd:anyURI-typed ranges (uri, uriorcurie) to @type: @id instead of @type: xsd:anyURI.",
+)
+@click.option(
+    "--use-curies/--not-use-curies",
+    default=False,
+    show_default=True,
+    help="Use class_uri/slot_uri CURIEs as context keys instead of element names.",
 )
 @click.version_option(__version__, "-V", "--version")
 def cli(yamlfile, emit_frame, embed_context_in_frame, output, **args):

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -25,6 +25,7 @@ from linkml_runtime.linkml_model.meta import (
     AnonymousSlotExpression,
     ClassDefinition,
     ClassDefinitionName,
+    Element,
     EnumDefinition,
     Example,
     PermissibleValue,
@@ -217,8 +218,8 @@ class JsonSchema(dict):
         super().__init__(*args, **kwargs)
         self._lax_forward_refs = {}
 
-    def add_def(self, name: str, subschema: "JsonSchema") -> None:
-        canonical_name = name if self.PRESERVE_NAMES else camelcase(name)
+    def add_def(self, name: str, subschema: "JsonSchema", is_curie: bool = False) -> None:
+        canonical_name = name if self.PRESERVE_NAMES or is_curie else camelcase(name)
 
         if "$defs" not in self:
             self["$defs"] = {}
@@ -453,6 +454,9 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
     slot's range type (CURIE for uriorcurie, full URI for uri, snake_case for string).
     """
 
+    use_curies: bool = False
+    """If true, use class_uri/slot_uri CURIEs instead of calculated URIs."""
+
     def __post_init__(self):
         if self.materialize_patterns is not None:
             deprecation_warning(MATERIALIZE_PATTERNS_GENERATOR_OPTION, stack_level=4)
@@ -462,6 +466,8 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
             self.top_class = self.topClass
 
         super().__post_init__()
+        if self.namespaces is None:
+            raise TypeError("Schema text must be supplied to JSON schema generator.  Preparsed schema will not work")
 
         # Set the class variable for JsonSchema to use
         JsonSchema.PRESERVE_NAMES = self.preserve_names
@@ -490,6 +496,9 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                 "additionalProperties": top_additional_properties,
             }
         )
+
+    def _curie(self, element: Element) -> str:
+        return self.schemaview.get_curie(element)
 
     def handle_class(self, cls: ClassDefinition) -> None:
         cls = self.before_generate_class(cls, self.schemaview)
@@ -596,7 +605,10 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
             if class_examples:
                 class_subschema.add_keyword("examples", class_examples)
 
-        self.top_level_schema.add_def(cls.name, class_subschema)
+        if self.use_curies:
+            self.top_level_schema.add_def(self._curie(cls), class_subschema, True)
+        else:
+            self.top_level_schema.add_def(cls.name, class_subschema)
 
         if (
             self.top_class is not None
@@ -620,6 +632,10 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
 
         subschema = JsonSchema()
         for slot in cls.slot_conditions.values():
+            if self.use_curies:
+                prop_name = self._curie(slot)
+            else:
+                prop_name = self.aliased_slot_name(slot)
             prop = self.get_subschema_for_slot(slot, omit_type=True, include_null=False)
             # Anonymous slot expressions don't carry the underlying slot's `multivalued` flag,
             # so look it up on the schema's slot definition and wrap so item-level constraints apply.
@@ -637,9 +653,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                 value_required = slot.required
             else:
                 value_required = properties_required
-            subschema.add_property(
-                self.aliased_slot_name(slot), prop, value_required=value_required, value_disallowed=value_disallowed
-            )
+            subschema.add_property(prop_name, prop, value_required=value_required, value_disallowed=value_disallowed)
 
         if cls.any_of is not None and len(cls.any_of) > 0:
             subschema["anyOf"] = [self.get_subschema_for_anonymous_class(c, properties_required) for c in cls.any_of]
@@ -960,14 +974,15 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         )
         value_disallowed = slot.value_presence == PresenceEnum(PresenceEnum.ABSENT)
 
-        aliased_slot_name = self.aliased_slot_name(slot)
+        if self.use_curies:
+            prop_name = self._curie(slot)
+        else:
+            prop_name = self.aliased_slot_name(slot)
         prop = self.get_subschema_for_slot(slot, include_null=self.include_null)
         prop = self.after_generate_class_slot(
             SlotResult.model_construct(schema_=prop, source=slot), cls, self.schemaview
         ).schema_
-        subschema.add_property(
-            aliased_slot_name, prop, value_required=value_required, value_disallowed=value_disallowed
-        )
+        subschema.add_property(prop_name, prop, value_required=value_required, value_disallowed=value_disallowed)
 
         if slot.designates_type:
             if "uriorcurie" in self.schemaview.type_ancestors(slot.range):
@@ -1039,6 +1054,14 @@ Top level class; slots of this class will become top level properties in the jso
     show_default=True,
     help="""
 Set additionalProperties=False if closed otherwise true if not closed at the global level
+""",
+)
+@click.option(
+    "--use-curies/--not-use-curies",
+    default=False,
+    show_default=True,
+    help="""
+Instead of using the element names, use the corresponding CURIEs, based on the corresponding class_uri/slot_uri
 """,
 )
 @click.option(

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -274,11 +274,17 @@ class Generator(metaclass=abc.ABCMeta):
             self.namespaces = Namespaces()
             if isinstance(self.schema.prefixes, dict):
                 for key, value in self.schema.prefixes.items():
-                    self.namespaces[key] = value
+                    if hasattr(value, "prefix_reference"):
+                        self.namespaces[key] = value.prefix_reference
+                    else:
+                        self.namespaces[key] = value
             elif isinstance(self.schema.prefixes, JsonObj):
                 prefixes = vars(self.schema.prefixes)
                 for key, value in prefixes.items():
-                    self.namespaces[key] = value
+                    if hasattr(value, "prefix_reference"):
+                        self.namespaces[key] = value.prefix_reference
+                    else:
+                        self.namespaces[key] = value
             else:
                 for prefix in self.schema.prefixes.values():
                     self.namespaces[prefix.prefix_prefix] = prefix.prefix_reference

--- a/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 import uuid
 import warnings
@@ -43,6 +44,7 @@ from linkml_runtime.utils.context_utils import map_import, parse_import_map
 from linkml_runtime.utils.formatutils import camelcase, is_empty, sfx, underscore
 from linkml_runtime.utils.namespaces import Namespaces
 from linkml_runtime.utils.pattern import PatternResolver
+from linkml_runtime.utils.uri_validator import validate_curie, validate_uri
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -1454,6 +1456,34 @@ class SchemaView:
             return self.expand_curie(uri)
         return uri
 
+    def get_curie(
+        self,
+        element: ElementName | Element,
+        imports: bool = True,
+    ) -> str:
+        """Return the CURIE for a schema element, compressing full URIs where possible.
+
+        This is the CURIE-returning companion to :meth:`get_uri`.  It first resolves
+        the element's declared URI via :meth:`get_uri`, then compresses it to a CURIE
+        using the schema's registered prefixes via :meth:`compress_uri`.
+
+        When the declared URI is already a CURIE (the common case) it is returned
+        unchanged.  When no URI is declared, :meth:`get_uri` constructs the fallback
+        ``"<default_prefix>:<element_name>"`` CURIE, which is then returned as-is.
+        When the URI is a full URI that cannot be compressed, a :exc:`ValueError` is
+        raised.
+
+        :param element: Name of schema element or element object.
+        :param imports: Include imports closure when resolving the element.
+        :return: A CURIE string such as ``"schema:Event"`` or ``"ex:something_else"``.
+        :raises ValueError: When the element's URI is a fully-qualified URI with no
+            matching prefix registered in the schema, or when it is not a valid URI or
+            CURIE.
+        """
+        e = self.get_element(element, imports=imports)
+        uri = self.get_uri(e, imports=imports)
+        return self.compress_uri(uri)
+
     def expand_curie(self, uri: str) -> str:
         """Expand a URI or CURIE to a full URI.
 
@@ -1468,6 +1498,43 @@ class SchemaView:
                 if pfx in ns:
                     return ns[pfx] + local_id
         return uri
+
+    def compress_uri(self, uri: str) -> str:
+        """Compress a URI or CURIE to a CURIE string using the schema's registered prefixes.
+
+        This is the inverse of :meth:`expand_curie`.
+
+        Resolution order:
+
+        1. Try to compress *uri* with
+           :meth:`~linkml_runtime.utils.namespaces.Namespaces.curie_for`.
+        2. If compression fails but *uri* is already a valid CURIE, return it as-is
+           (emitting a warning when it looks like a plain ``http(s)://`` URL to alert
+           callers that disambiguation is impossible).
+        3. If *uri* is a fully-qualified URI with no matching prefix, raise
+           :exc:`ValueError`.
+        4. If *uri* is neither a valid URI nor a valid CURIE, raise :exc:`ValueError`.
+
+        :param uri: A URI or CURIE string.
+        :return: A CURIE string such as ``"schema:Event"`` or ``"ex:something_else"``.
+        :raises ValueError: When *uri* is a fully-qualified URI whose namespace is not
+            registered, or when it is not a syntactically valid URI or CURIE.
+        """
+        ns = self.namespaces()
+        curie = ns.curie_for(uri) if validate_uri(uri) else None
+        if curie:
+            return curie
+        if validate_curie(uri):
+            if re.match("https?://.*", uri):
+                logger.warning(
+                    f"'{uri}' looks like a URL but no registered prefix matches it; "
+                    "it cannot be unambiguously compressed to a CURIE."
+                )
+            return uri
+        elif validate_uri(uri):
+            raise ValueError(f"'{uri}' cannot be converted to a CURIE, corresponding prefix not defined")
+        else:
+            raise ValueError(f"'{uri}' does not seem to be either a valid URI or a valid CURIE")
 
     @lru_cache(CACHE_SIZE)
     def get_elements_applicable_by_identifier(self, identifier: str) -> list[str]:

--- a/tests/linkml/test_generators/input/multiple-ontologies.yaml
+++ b/tests/linkml/test_generators/input/multiple-ontologies.yaml
@@ -1,0 +1,38 @@
+id: https://example.org/namespacing/
+name: namespacing
+prefixes:
+  - schema: http://schema.org/
+  - s4city: https://saref.etsi.org/saref4city/
+  - s4ehaw: https://saref.etsi.org/saref4ehaw/
+  - linkml: https://w3id.org/linkml/
+  - ex: https://example.org/namespacing/
+imports:
+  - linkml:types
+
+default_prefix: ex
+default_range: string
+
+classes:
+  SchemaEvent:
+    class_uri: schema:Event
+    slots:
+      - schema_location
+
+  SarefEvent:
+    class_uri: s4city:Event
+    slots:
+      - saref_location
+      - rendezvous_location
+      - something_else
+
+slots:
+  schema_location:
+    slot_uri: schema:location
+
+  saref_location:
+    slot_uri: https://saref.etsi.org/saref4ehaw/hasLocation
+
+  rendezvous_location:
+    slot_uri: https://saref.etsi.org/saref4auto/RendezvousLocation
+
+  something_else:

--- a/tests/linkml/test_generators/test_jsonldcontextgen.py
+++ b/tests/linkml/test_generators/test_jsonldcontextgen.py
@@ -1,4 +1,5 @@
 import json
+import re
 import textwrap
 
 import pytest
@@ -1624,6 +1625,37 @@ def test_eligible_enum_structured_value_still_works(tmp_path):
     # The meaning → @id mapping makes the structured value a node with @id
     assert isinstance(subjects[0], URIRef), f"Expected URIRef, got {type(subjects[0]).__name__}: {subjects[0]}"
     assert str(subjects[0]) == "https://example.org/myns/Red"
+
+
+@pytest.mark.parametrize("use_curies", [True, False])
+def test_use_uris(caplog, input_path, use_curies):
+    schema = input_path("multiple-ontologies.yaml")
+    generator = ContextGenerator(schema, mergeimports=True, use_curies=use_curies)
+    generated = json.loads(generator.serialize())
+    ctx = generated["@context"]
+    if use_curies:
+        assert "schema:Event" in ctx
+        assert "schema:location" in ctx
+        assert "s4city:Event" in ctx
+        assert "s4ehaw:hasLocation" in ctx
+        assert "ex:something_else" in ctx
+
+        expected_warning = False
+        for log_record in caplog.records:
+            if log_record.levelname == "WARNING" and re.match(
+                ".*https://saref.etsi.org/saref4auto/RendezvousLocation.*",
+                log_record.message,
+            ):
+                expected_warning = True
+        assert expected_warning
+
+        assert "SarefEvent" not in ctx
+        assert "schema_location" not in ctx
+    else:
+        assert "SchemaEvent" in ctx
+        assert "schema_location" in ctx
+        assert "SarefEvent" in ctx
+        assert "saref_location" in ctx
 
 
 def test_kitchen_sink_employment_event_type_falls_back(kitchen_sink_path):

--- a/tests/linkml/test_generators/test_jsonschemagen.py
+++ b/tests/linkml/test_generators/test_jsonschemagen.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -1096,3 +1097,33 @@ def test_add_lax_def_missing_required():
     schema["$defs"]["NormalClass"] = {"type": "object", "properties": {"id": {}}, "required": ["id", "name"]}
     schema.add_lax_def("NormalClass", "id")
     assert schema["$defs"]["NormalClass__identifier_optional"]["required"] == ["name"]
+
+
+@pytest.mark.parametrize("use_curies", [True, False])
+def test_use_uris(caplog, input_path, use_curies):
+    schema = input_path("multiple-ontologies.yaml")
+    generator = JsonSchemaGenerator(schema, mergeimports=True, use_curies=use_curies)
+    generated = json.loads(generator.serialize())
+    if use_curies:
+        assert "schema:Event" in generated["$defs"]
+        assert "schema:location" in generated["$defs"]["schema:Event"]["properties"]
+        assert "s4city:Event" in generated["$defs"]
+        assert "s4ehaw:hasLocation" in generated["$defs"]["s4city:Event"]["properties"]
+        assert "ex:something_else" in generated["$defs"]["s4city:Event"]["properties"]
+
+        expected_warning = False
+        for log_record in caplog.records:
+            if (
+                log_record.levelname == "WARNING"
+                and re.match(".*https://saref.etsi.org/saref4auto/RendezvousLocation.*", log_record.message) is not None
+            ):
+                expected_warning = True
+        assert expected_warning
+
+        assert "SchemaEvent" not in generated["$defs"]
+        assert "schema_location" not in generated["$defs"]["schema:Event"]["properties"]
+    else:
+        assert "SchemaEvent" in generated["$defs"]
+        assert "schema_location" in generated["$defs"]["SchemaEvent"]["properties"]
+        assert "SarefEvent" in generated["$defs"]
+        assert "saref_location" in generated["$defs"]["SarefEvent"]["properties"]


### PR DESCRIPTION
## Summary

Fixes #3801

Adds a `--use-curies` flag to `gen-json-schema` and `gen-jsonld-context`. When enabled, generated JSON-Schema property/`$defs` keys and JSON-LD `@context` keys are **CURIEs** (compact IRIs such as `schema:location`) derived from each element's `class_uri` / `slot_uri`, instead of the element *names* (`location`).

CURIEs are compact IRIs, not full URIs/IRIs — the earlier "use uris" title/wording was imprecise. Full URIs are never emitted as keys; they are always compressed to CURIEs via the schema's registered prefixes.

**Why:** CURIE keys enable JSON-LD [compact-IRI](https://www.w3.org/TR/json-ld11/#compact-iris) form, which resolves term clashes automatically when mixing vocabularies (e.g. `ical:location` vs `schema:location`) while keeping the compacted JSON readable. A JSON-Schema generated with the same CURIE keys can then validate that compacted JSON-LD.

**Behavior:**

- `--use-curies` / `--not-use-curies` (default: off) on both generators.
- Keys resolved via `SchemaView.get_curie()`: `get_uri()` → `compress_uri()`.
- Elements **with** `class_uri`/`slot_uri`: declared URI compressed to CURIE.
- Elements **without** declared URI: native CURIE synthesized from `default_prefix` + normalized name (`prefix:CamelCase` classes, `prefix:snake_case` slots).
- Full URI with no matching prefix → `ValueError`; URL-like value with no prefix → warning.

This PR introduces the strict `compress_uri()` contract (raise on an unregistered prefix or an invalid URI/CURIE). Applying the same level of strictness to the inverse operation, `expand_curie()`, is intentionally left out of scope here and will be addressed in a separate follow-up PR, since it requires fixing several callers that currently rely on its lenient pass-through behavior.

## How was this tested?

- New tests: `test_jsonschemagen.py` and `test_jsonldcontextgen.py` cover the `--use-curies` option (incl. multi-ontology input `multiple-ontologies.yaml`).
- Full fast + slow suite for `linkml` and `linkml-runtime`.

## Areas of uncertainty

- **Mixed key styles:** in schemas where some elements declare a URI and others don't, output keys mix real CURIEs (`schema:Event`) with synthesized `<default_prefix>:<name>`. Is this acceptable, or should it warn/normalize?
- Warning-vs-error policy for URL-like values that can't be compressed.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.