### PR TITLE
fix(run-examples): handle inlined dictionaries

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -25,6 +25,7 @@ from linkml.generators.common import build
 from linkml.generators.common.lifecycle import LifecycleMixin
 from linkml.generators.common.type_designators import get_type_designator_value
 from linkml.utils.generator import Generator, shared_arguments
+from linkml.utils.helpers import get_range_associated_slots
 
 logger = logging.getLogger(__name__)
 
@@ -545,7 +546,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                         range_id_slot,
                         range_simple_dict_value_slot,
                         range_required_slots,
-                    ) = self._get_range_associated_slots(slot)
+                    ) = get_range_associated_slots(self.schemaview, slot.range)
                     # if the range class has an ID and the slot is not inlined as a list, then we need to consider
                     # various inlined as dict formats
                     if range_id_slot is not None and not slot.inlined_as_list:
@@ -690,53 +691,6 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
 
     def serialize(self, **kwargs) -> str:
         return self.generate().to_json(sort_keys=True, indent=self.indent if self.indent > 0 else None)
-
-    def _get_range_associated_slots(
-        self, slot: SlotDefinition
-    ) -> Tuple[Union[SlotDefinition, None], Union[SlotDefinition, None], Union[List[SlotDefinition], None]]:
-        range_class = self.schemaview.get_class(slot.range)
-        if range_class is None:
-            return None, None, None
-
-        range_class_id_slot = self.schemaview.get_identifier_slot(range_class.name, use_key=True)
-        if range_class_id_slot is None:
-            return None, None, None
-
-        non_id_slots = [
-            s for s in self.schemaview.class_induced_slots(range_class.name) if s.name != range_class_id_slot.name
-        ]
-        non_id_required_slots = [s for s in non_id_slots if s.required]
-
-        # Some lists of objects can be serialized as SimpleDicts.
-        # A SimpleDict is serialized as simple key-value pairs where the value is atomic.
-        # The key must be declared as a key, and the value must satisfy one of the following conditions:
-        # 1. The value slot is the only other slot in the object other than the key
-        # 2. The value slot is explicitly annotated as a simple_dict_value
-        # 3. The value slot is the only non-key that is required
-        # See also: https://github.com/linkml/linkml/issues/1250
-        range_simple_dict_value_slot = None
-        if len(non_id_slots) == 1:
-            range_simple_dict_value_slot = non_id_slots[0]
-        elif len(non_id_slots) > 1:
-            candidate_non_id_slots = []
-            for non_id_slot in non_id_slots:
-                if isinstance(non_id_slot.annotations, dict):
-                    is_simple_dict_value = non_id_slot.annotations.get("simple_dict_value", False)
-                else:
-                    is_simple_dict_value = getattr(non_id_slot.annotations, "simple_dict_value", False)
-                if is_simple_dict_value:
-                    candidate_non_id_slots.append(non_id_slot)
-            if len(candidate_non_id_slots) == 1:
-                range_simple_dict_value_slot = candidate_non_id_slots[0]
-            else:
-                candidate_non_id_slots = []
-                for non_id_slot in non_id_slots:
-                    if non_id_slot.required:
-                        candidate_non_id_slots.append(non_id_slot)
-                if len(candidate_non_id_slots) == 1:
-                    range_simple_dict_value_slot = candidate_non_id_slots[0]
-
-        return range_class_id_slot, range_simple_dict_value_slot, non_id_required_slots
 
 
 @shared_arguments(JsonSchemaGenerator)

--- a/linkml/utils/helpers.py
+++ b/linkml/utils/helpers.py
@@ -1,4 +1,5 @@
 import re
+from functools import lru_cache
 from typing import List, Tuple, Union
 
 from linkml_runtime import SchemaView
@@ -24,6 +25,7 @@ def convert_to_snake_case(str):
     return "".join(str.lower())
 
 
+@lru_cache(None)
 def get_range_associated_slots(
     schemaview: SchemaView, range_class: ClassDefinition
 ) -> Tuple[Union[SlotDefinition, None], Union[SlotDefinition, None], Union[List[SlotDefinition], None]]:
@@ -69,3 +71,11 @@ def get_range_associated_slots(
                 range_simple_dict_value_slot = candidate_non_id_slots[0]
 
     return range_class_id_slot, range_simple_dict_value_slot, non_id_required_slots
+
+
+def is_simple_dict(schemaview: SchemaView, slot: SlotDefinition) -> bool:
+    if not slot.multivalued or not slot.inlined or slot.inlined_as_list:
+        return False
+    else:
+        _, range_simple_dict_value_slot, _ = get_range_associated_slots(schemaview, slot.range)
+        return range_simple_dict_value_slot is not None

--- a/linkml/utils/helpers.py
+++ b/linkml/utils/helpers.py
@@ -1,4 +1,12 @@
 import re
+from typing import List, Tuple, Union
+
+from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model.meta import (
+    ClassDefinition,
+    ElementName,
+    SlotDefinition,
+)
 
 
 def remove_duplicates(lst):
@@ -14,3 +22,50 @@ def write_to_file(file_path, data, mode="w", encoding="utf-8"):
 def convert_to_snake_case(str):
     str = re.sub(r"(?<=[a-z])(?=[A-Z])|[^a-zA-Z]", " ", str).strip().replace(" ", "_")
     return "".join(str.lower())
+
+
+def get_range_associated_slots(
+    schemaview: SchemaView, range_class: ClassDefinition
+) -> Tuple[Union[SlotDefinition, None], Union[SlotDefinition, None], Union[List[SlotDefinition], None]]:
+    if isinstance(range_class, ElementName):
+        range_class = schemaview.get_class(range_class)
+    if range_class is None:
+        return None, None, None
+
+    range_class_id_slot = schemaview.get_identifier_slot(range_class.name, use_key=True)
+    if range_class_id_slot is None:
+        return None, None, None
+
+    non_id_slots = [s for s in schemaview.class_induced_slots(range_class.name) if s.name != range_class_id_slot.name]
+    non_id_required_slots = [s for s in non_id_slots if s.required]
+
+    # Some lists of objects can be serialized as SimpleDicts.
+    # A SimpleDict is serialized as simple key-value pairs where the value is atomic.
+    # The key must be declared as a key, and the value must satisfy one of the following conditions:
+    # 1. The value slot is the only other slot in the object other than the key
+    # 2. The value slot is explicitly annotated as a simple_dict_value
+    # 3. The value slot is the only non-key that is required
+    # See also: https://github.com/linkml/linkml/issues/1250
+    range_simple_dict_value_slot = None
+    if len(non_id_slots) == 1:
+        range_simple_dict_value_slot = non_id_slots[0]
+    elif len(non_id_slots) > 1:
+        candidate_non_id_slots = []
+        for non_id_slot in non_id_slots:
+            if isinstance(non_id_slot.annotations, dict):
+                is_simple_dict_value = non_id_slot.annotations.get("simple_dict_value", False)
+            else:
+                is_simple_dict_value = getattr(non_id_slot.annotations, "simple_dict_value", False)
+            if is_simple_dict_value:
+                candidate_non_id_slots.append(non_id_slot)
+        if len(candidate_non_id_slots) == 1:
+            range_simple_dict_value_slot = candidate_non_id_slots[0]
+        else:
+            candidate_non_id_slots = []
+            for non_id_slot in non_id_slots:
+                if non_id_slot.required:
+                    candidate_non_id_slots.append(non_id_slot)
+            if len(candidate_non_id_slots) == 1:
+                range_simple_dict_value_slot = candidate_non_id_slots[0]
+
+    return range_class_id_slot, range_simple_dict_value_slot, non_id_required_slots

--- a/linkml/workspaces/example_runner.py
+++ b/linkml/workspaces/example_runner.py
@@ -22,6 +22,7 @@ from linkml_runtime.utils.formatutils import camelcase
 
 from linkml._version import __version__
 from linkml.generators.pythongen import PythonGenerator
+from linkml.utils.helpers import get_range_associated_slots
 from linkml.validator import Validator, _get_default_validator
 
 logger = logging.getLogger(__name__)
@@ -244,10 +245,28 @@ class ExampleRunner:
                     raise ValueError(f"Cannot find unique class for URI {target_class}; got: {target_classes}")
                 target_class = target_classes[0]
             new_dict_obj = {}
+
             for k, v in dict_obj.items():
                 if v is not None:
                     islot = sv.induced_slot(k, target_class)
-                    v2 = self._load_from_dict(v, target_class=islot.range)
+                    # if slot is a dictionary, repeat key in dictionary value object
+                    if islot.multivalued and islot.inlined and not islot.inlined_as_list:
+                        (range_id_slot, range_simple_dict_value_slot, _) = get_range_associated_slots(
+                            self.schemaview, islot.range
+                        )
+                        v_as_list = []
+                        for ik, iv in v.items():
+                            # simple dictionaries can be simply created
+                            if range_simple_dict_value_slot is not None:
+                                value = {range_id_slot.name: ik, range_simple_dict_value_slot.name: iv}
+                            # other dictionaries => simply add the identifier to the dictionary
+                            else:
+                                value = iv
+                                value[range_id_slot.name] = ik
+                            v_as_list.append(value)
+                        v2 = self._load_from_dict(v_as_list, target_class=islot.range)
+                    else:
+                        v2 = self._load_from_dict(v, target_class=islot.range)
                     new_dict_obj[k] = v2
             py_target_class = getattr(self.python_module, camelcase(target_class))
             return py_target_class(**new_dict_obj)

--- a/tests/test_utils/test_helpers.py
+++ b/tests/test_utils/test_helpers.py
@@ -1,0 +1,59 @@
+from linkml_runtime.linkml_model import ClassDefinition, SchemaDefinition, SlotDefinition
+from linkml_runtime.utils.schemaview import SchemaView
+
+from linkml.utils.helpers import is_simple_dict
+from linkml.utils.schema_builder import SchemaBuilder
+
+SCHEMA = SchemaDefinition(
+    id="testschema",
+    name="testschema",
+    classes=[
+        ClassDefinition(name="MyClass"),
+    ],
+)
+
+
+def test_is_simple_dict():
+    sb = SchemaBuilder()
+    sb.add_class(
+        "SimpleDictItem",
+        [
+            SlotDefinition("id", identifier=True),
+            SlotDefinition("value", range="string"),
+        ],
+        use_attributes=True,
+    )
+    sb.add_class(
+        "DictionaryItem1",
+        [
+            SlotDefinition("id", identifier=True),
+            SlotDefinition("value", range="string"),
+            SlotDefinition("another_value", range="string"),
+        ],
+        use_attributes=True,
+    )
+    sb.add_class(
+        "DictionaryItem2",
+        [
+            SlotDefinition("id", range="string"),
+            SlotDefinition("value", range="string"),
+            SlotDefinition("another_value", range="string"),
+        ],
+        use_attributes=True,
+    )
+    simple_dict_slot = SlotDefinition(
+        "simple_dict", inlined=True, inlined_as_list=False, multivalued=True, range="SimpleDictItem"
+    )
+    no_simple_dict_slot_1 = SlotDefinition(
+        "no_simple_dict1", inlined=True, inlined_as_list=False, multivalued=True, range="DictionaryItem1"
+    )
+    no_simple_dict_slot_2 = SlotDefinition(
+        "no_simple_dict2", inlined=True, inlined_as_list=False, multivalued=True, range="DictionaryItem2"
+    )
+    sb.add_class("C", [simple_dict_slot, no_simple_dict_slot_1, no_simple_dict_slot_2])
+
+    sv = SchemaView(sb.schema)
+
+    assert is_simple_dict(sv, simple_dict_slot)
+    assert not is_simple_dict(sv, no_simple_dict_slot_1)
+    assert not is_simple_dict(sv, no_simple_dict_slot_2)

--- a/tests/test_workspaces/input/examples/Container-001.yaml
+++ b/tests/test_workspaces/input/examples/Container-001.yaml
@@ -26,7 +26,7 @@ persons:
 #      street: 1 foo street
 #      city: foo city
 organizations:
-  - id: ROR:1
+  ROR:1:
     name: foo
 
   

--- a/tests/test_workspaces/input/examples/Container-002.json
+++ b/tests/test_workspaces/input/examples/Container-002.json
@@ -37,10 +37,10 @@
       ]
     }
   ],
-  "organizations": [
-    {
-      "id": "ROR:1",
-      "name": "foo"
-    }
-  ]
+  "organizations": {
+    "ROR:1":
+      {
+        "name": "foo"
+      }
+  }
 }

--- a/tests/test_workspaces/input/personinfo.yaml
+++ b/tests/test_workspaces/input/personinfo.yaml
@@ -236,7 +236,7 @@ slots:
     multivalued: true
   organizations:
     range: Organization
-    inlined_as_list: true
+    inlined_as_list: false
     inlined: true
     multivalued: true
     


### PR DESCRIPTION
run-examples was not capable of handling inlined dictionaries correctly. This patch fixes it.

This PR overrides PR #2424 

TODOS:

- [x] Add regression tests

Fixes #2423
Fixes #2425 