### PR TITLE
Shacl generator: Include slot annotations when if `any_of` is used

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -198,14 +198,15 @@ class ShaclGenerator(Generator):
                         add_simple_data_type(prop_pv, r)
                     if s.pattern:
                         prop_pv(SH.pattern, Literal(s.pattern))
-                    if s.annotations and self.include_annotations:
-                        self._add_annotations(prop_pv, s)
                     if s.equals_string:
                         # Map equal_string and equal_string_in to sh:in
                         self._and_equals_string(g, prop_pv, [s.equals_string])
                     if s.equals_string_in:
                         # Map equal_string and equal_string_in to sh:in
                         self._and_equals_string(g, prop_pv, s.equals_string_in)
+
+                if s.annotations and self.include_annotations:
+                    self._add_annotations(prop_pv, s)
 
                 default_value = ifabsent_processor.process_slot(s, c)
                 if default_value:

--- a/tests/test_generators/input/shaclgen_boolean_constraints.yaml
+++ b/tests/test_generators/input/shaclgen_boolean_constraints.yaml
@@ -1,0 +1,19 @@
+id: https://w3id.org/linkml/examples/boolean_constraints
+name: test_boolean_constraints
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://w3id.org/linkml/examples/boolean_constraints/
+imports:
+  - linkml:types
+default_range: string
+default_prefix: ex
+
+classes:
+  AnyOfSimpleType:
+    attributes:
+      attribute1:
+        any_of:
+          - range: string
+          - range: integer
+        annotations:
+          resting: supine

--- a/tests/test_generators/test_shaclgen.py
+++ b/tests/test_generators/test_shaclgen.py
@@ -485,3 +485,25 @@ def test_ignore_subclass_properties(input_path):
     assert frozenset(ignored_properties[URIRef("https://w3id.org/linkml/examples/animals/Bat")]) == frozenset(
         [URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")]
     )
+
+
+def test_slot_with_annotations_and_any_of(input_path):
+    shacl = ShaclGenerator(
+        input_path("shaclgen_boolean_constraints.yaml"), mergeimports=True, include_annotations=True
+    ).serialize()
+
+    g = rdflib.Graph()
+    g.parse(data=shacl)
+    print(shacl)
+
+    class_properties = g.objects(
+        URIRef("https://w3id.org/linkml/examples/boolean_constraints/AnyOfSimpleType"), SH.property
+    )
+    attribute_node = next(class_properties, None)
+    assert attribute_node
+
+    assert (
+        attribute_node,
+        rdflib.term.Literal("resting", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
+        rdflib.term.Literal("supine", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
+    ) in g

--- a/tests/test_generators/test_shaclgen.py
+++ b/tests/test_generators/test_shaclgen.py
@@ -437,6 +437,28 @@ def test_custom_class_range_is_blank_node_or_iri(input_path):
     assert (persons_node, SH.nodeKind, SH.BlankNodeOrIRI) in g
 
 
+def test_slot_with_annotations_and_any_of(input_path):
+    shacl = ShaclGenerator(
+        input_path("shaclgen_boolean_constraints.yaml"), mergeimports=True, include_annotations=True
+    ).serialize()
+
+    g = rdflib.Graph()
+    g.parse(data=shacl)
+    print(shacl)
+
+    class_properties = g.objects(
+        URIRef("https://w3id.org/linkml/examples/boolean_constraints/AnyOfSimpleType"), SH.property
+    )
+    attribute_node = next(class_properties, None)
+    assert attribute_node
+
+    assert (
+        attribute_node,
+        rdflib.term.Literal("resting", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
+        rdflib.term.Literal("supine", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
+    ) in g
+
+
 def test_ignore_subclass_properties(input_path):
     shacl = ShaclGenerator(input_path("shaclgen_subclass_ignored_properties.yaml"), mergeimports=True).serialize()
 
@@ -485,25 +507,3 @@ def test_ignore_subclass_properties(input_path):
     assert frozenset(ignored_properties[URIRef("https://w3id.org/linkml/examples/animals/Bat")]) == frozenset(
         [URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")]
     )
-
-
-def test_slot_with_annotations_and_any_of(input_path):
-    shacl = ShaclGenerator(
-        input_path("shaclgen_boolean_constraints.yaml"), mergeimports=True, include_annotations=True
-    ).serialize()
-
-    g = rdflib.Graph()
-    g.parse(data=shacl)
-    print(shacl)
-
-    class_properties = g.objects(
-        URIRef("https://w3id.org/linkml/examples/boolean_constraints/AnyOfSimpleType"), SH.property
-    )
-    attribute_node = next(class_properties, None)
-    assert attribute_node
-
-    assert (
-        attribute_node,
-        rdflib.term.Literal("resting", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
-        rdflib.term.Literal("supine", datatype=rdflib.term.URIRef("http://www.w3.org/2001/XMLSchema#string")),
-    ) in g


### PR DESCRIPTION
Fixes #2417 .