### PR TITLE
handle schemaview's prefixes as JsonObj instead of dict in gen-linkml

### DIFF
--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -24,9 +24,10 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Callable, ClassVar, Dict, List, Mapping, Optional, Set, TextIO, Type, Union, cast
-
+from jsonasobj2 import JsonObj
 import click
 from click import Argument, Command, Option
+from jsonasobj2 import JsonObj
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
@@ -265,8 +266,16 @@ class Generator(metaclass=abc.ABCMeta):
     def _init_namespaces(self):
         if self.namespaces is None:
             self.namespaces = Namespaces()
-            for prefix in self.schema.prefixes.values():
-                self.namespaces[prefix.prefix_prefix] = prefix.prefix_reference
+            if isinstance(self.schema.prefixes, dict):
+                for key, value in self.schema.prefixes.items():
+                    self.namespaces[key] = value
+            elif isinstance(self.schema.prefixes, JsonObj):
+                prefixes = vars(self.schema.prefixes)
+                for key, value in prefixes.items():
+                    self.namespaces[key] = value
+            else:
+                for prefix in self.schema.prefixes.values():
+                    self.namespaces[prefix.prefix_prefix] = prefix.prefix_reference
 
     def serialize(self, **kwargs) -> str:
         """

--- a/tests/test_generators/test_linkmlgen.py
+++ b/tests/test_generators/test_linkmlgen.py
@@ -1,8 +1,34 @@
 import yaml
 from click.testing import CliRunner
 from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model import SchemaDefinition
 
 from linkml.generators.linkmlgen import LinkmlGenerator, cli
+
+
+
+def test_linkmlgen_prefixes():
+    schema = SchemaDefinition(
+        name="EquipmentSchema",
+        description="",
+        id="equipment_schema",
+        default_prefix="equipment_schema"
+    )
+
+    schema.default_range = "string"
+    schema.prefixes = {"equipment_schema": "https://example.org/equipment_schema/",
+                       "linkml": "https://w3id.org/linkml/",
+                       "xsd": "http://www.w3.org/2001/XMLSchema#"}
+
+    sv = SchemaView(schema)
+    print(sv.schema.prefixes)
+    print(type(sv.schema.prefixes))
+    lml_gen = LinkmlGenerator(schema=schema, format='yaml')
+    yaml_text = lml_gen.serialize()
+
+    with open("output.yaml", "w") as f:
+        f.write(yaml_text)
+
 
 
 def test_generate(kitchen_sink_path):


### PR DESCRIPTION
fixes #2462 - schemaview returns schema.prefixes as a JsonObj that needs to be processed as such in the generator.  