### PR TITLE
Addresses issues #2450 and #2200

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -203,6 +203,9 @@ class DocGenerator(Generator):
             "diagram_type": self.diagram_type.value if self.diagram_type else None,
             "include_top_level_diagram": self.include_top_level_diagram,
         }
+        self.logger.debug("Validating ranges")
+        for slot in sv.all_slots():
+            self.inject_slot_info(slot)
         self.logger.debug("Processing Index")
         template = self._get_template("index")
         out_str = template.render(gen=self, schema=sv.schema, schemaview=sv, **template_vars)


### PR DESCRIPTION
Hi there - I think this code will fix the error being thrown by gen-doc when it tries to generate documentation with no range. I could not figure out how to test on my local machine, so my apologies for this. Applies method inject_slot_info to the schema ahead of template generation which applies default range to each slot that doesn't have a range.