### PR TITLE
converted test_rewrite_rules to pytest and unskipped

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,7 +59,7 @@ SKIP_RDF_COMPARE_REASON = test_settings.get(
 SKIP_REMOTE_SPARQL_TESTS = test_settings.getboolean("SKIP_REMOTE_SPARQL_TESTS", True)
 
 # Skip Rewrite rules tests -- these only get re-tested when we change the w3id.org server
-SKIP_REWRITE_RULES = test_settings.getboolean("SKIP_REWRITE_RULES", True)
+SKIP_REWRITE_RULES = test_settings.getboolean("SKIP_REWRITE_RULES", False)
 SKIP_REWRITE_RULES_REASON = test_settings.get(
     "SKIP_REWRITE_RULES_REASON", "tests/__init__.py SKIP_REWRITE_RULES is True"
 )

--- a/tests/test_rewrite_rules/test_rewrite_rules.py
+++ b/tests/test_rewrite_rules/test_rewrite_rules.py
@@ -1,17 +1,14 @@
 import os
-import sys
-import unittest
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
+import pytest
 import requests
 from rdflib import Namespace, URIRef
 
-if __name__ == "__main__":
-    sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-
 from tests import SKIP_REWRITE_RULES, SKIP_REWRITE_RULES_REASON
 
+# see README.md
 W3ID_SERVER = "https://w3id.org/"
 DEFAULT_SERVER = W3ID_SERVER
 # DEFAULT_SERVER = "http://localhost:8091/"
@@ -32,141 +29,134 @@ class TestEntry:
 
 def build_test_entry_set(input_url: Namespace, model: str) -> List[TestEntry]:
     return [
-        TestEntry(input_url, f"includes/{model}"),
-        TestEntry(input_url, f"includes/{model}.yaml", "text/yaml"),
-        TestEntry(input_url, f"includes/{model}.ttl", "text/turtle"),
-        TestEntry(input_url, f"includes/{model}.jsonld", "application/json"),
-        TestEntry(input_url, f"includes/{model}.shex", "text/shex"),
-        TestEntry(input_url[".context.jsonld"], f"includes/{model}.context.jsonld"),
-        TestEntry(input_url[".owl"], f"includes/{model}.owl"),
-        TestEntry(input_url["/"], f"includes/{model}/"),
+        TestEntry(input_url, f"linkml-model/docs/{model}"),
+        TestEntry(input_url, f"linkml-model/linkml_model/model/schema/{model}.yaml", "text/yaml"),
+        TestEntry(input_url, f"linkml-model/linkml_model/rdf/{model}.ttl", "text/turtle"),
+        TestEntry(input_url, f"linkml-model/linkml_model/json/{model}.json", "application/json"),
+        TestEntry(input_url, f"linkml-model/linkml_model/shex/{model}.shex", "text/shex"),
+        TestEntry(input_url[".context.jsonld"], f"linkml-model/linkml_model/jsonld/{model}.context.jsonld"),
+        TestEntry(input_url[".owl"], f"linkml-model/linkml_model/owl/{model}.owl.ttl"),
+        TestEntry(input_url["/"], f"linkml-model/{model}/"),
     ]
 
 
-class TestLists:
-    __test__ = False
+def generate_fixture_lists():
+    server = os.environ.get("SERVER", DEFAULT_SERVER)
+    if not server.endswith(("#", "/")):
+        server += "/"
+    linkml = server + "linkml/"
+    types = Namespace(linkml + "types")
+    mappings = Namespace(linkml + "mappings")
+    extensions = Namespace(linkml + "extensions")
+    annotations = Namespace(linkml + "annotations")
+    metas = Namespace(linkml + "meta")
+    type_ = Namespace(linkml + "type/")
+    mapping = Namespace(linkml + "mapping/")
+    meta = Namespace(linkml + "meta/")
 
-    def __init__(self, server: str) -> None:
-        if not server.endswith(("#", "/")):
-            server += "/"
-        self.linkml = server + "linkml/"
-        self.types = Namespace(self.linkml + "types")
-        self.mappings = Namespace(self.linkml + "mappings")
-        self.extensions = Namespace(self.linkml + "extensions")
-        self.annotations = Namespace(self.linkml + "annotations")
-        self.metas = Namespace(self.linkml + "meta")
-        self.type = Namespace(self.linkml + "type/")
-        self.mapping = Namespace(self.linkml + "mapping/")
-        self.meta = Namespace(self.linkml + "meta/")
+    meta_entries: List[TestEntry] = []
+    meta_entries += build_test_entry_set(types, "types")
+    meta_entries += build_test_entry_set(mappings, "mappings")
+    meta_entries += build_test_entry_set(extensions, "extensions")
+    meta_entries += build_test_entry_set(annotations, "annotations")
 
-        self.meta_entries: List[TestEntry] = []
+    vocab_entries: List[TestEntry] = [
+        TestEntry(type_["index"], "linkml-model/docs/type/index"),
+        TestEntry(type_.Element, "linkml-model/linkml_model/model/schema/type/Element.yaml/Element.yaml", "text/yaml"),
+        TestEntry(type_.Element, "linkml-model/linkml_model/rdf/type/Element.ttl/Element.ttl", "text/turtle"),
+        TestEntry(type_.slots, "linkml-model/linkml_model/json/type/slots.json/slots.json", "application/json"),
+        TestEntry(mapping["index"], "linkml-model/docs/mapping/index"),
+    ]
 
-        self.meta_entries += build_test_entry_set(self.types, "types")
-        self.meta_entries += build_test_entry_set(self.mappings, "mappings")
-        self.meta_entries += build_test_entry_set(self.extensions, "extensions")
-        self.meta_entries += build_test_entry_set(self.annotations, "annotations")
+    meta_model_entries: List[TestEntry] = [
+        TestEntry(metas, "linkml-model/docs/meta"),
+        TestEntry(metas, "linkml-model/linkml_model/model/schema/meta.yaml", "text/yaml"),
+        TestEntry(metas, "linkml-model/linkml_model/rdf/meta.ttl", "text/turtle"),
+        TestEntry(metas, "linkml-model/linkml_model/json/meta.json", "application/json"),
+        TestEntry(metas, "linkml-model/linkml_model/shex/meta.shex", "text/shex"),
+        TestEntry(metas[".owl"], "linkml-model/linkml_model/owl/meta.owl.ttl"),
+        TestEntry(metas[".foo"], "linkml-model/meta.foo"),
+        TestEntry(linkml + "context.jsonld", "linkml-model/linkml_model/jsonld/context.jsonld"),
+        TestEntry(linkml + "contextn.jsonld", "linkml-model/contextn.jsonld"),
+    ]
+    meta_vocab_entries: List[TestEntry] = [
+        TestEntry(meta.Element, "linkml-model/docs/meta/Element"),
+        TestEntry(meta.slot, "linkml-model/docs/meta/slot"),
+        TestEntry(meta.Element, "linkml-model/linkml_model/model/schema/meta/Element.yaml/Element.yaml", "text/yaml"),
+        TestEntry(meta.Element, "linkml-model/linkml_model/rdf/meta/Element.ttl/Element.ttl", "text/turtle"),
+        TestEntry(meta.Element, "linkml-model/linkml_model/json/meta/Element.json/Element.json", "application/json"),
+        TestEntry(meta.Element, "linkml-model/linkml_model/shex/meta/Element.shex/Element.shex", "text/shex"),
+        TestEntry(meta.Element, "linkml-model/meta/Element", "text/foo"),
+    ]
 
-        self.vocab_entries: List[TestEntry] = [
-            TestEntry(self.type["index"], "docs/types/index"),
-            TestEntry(self.type.Element, "docs/types/Element.yaml", "text/yaml"),
-            TestEntry(self.type.Element, "docs/types/Element.ttl", "text/turtle"),
-            TestEntry(self.type.slots, "docs/types/slots.jsonld", "application/json"),
-            TestEntry(self.mapping["index"], "docs/mappings/index"),
-        ]
-
-        self.meta_model_entries: List[TestEntry] = [
-            TestEntry(self.metas, "meta"),
-            TestEntry(self.metas, "meta.yaml", "text/yaml"),
-            TestEntry(self.metas, "meta.ttl", "text/turtle"),
-            TestEntry(self.metas, "meta.jsonld", "application/json"),
-            TestEntry(self.metas, "meta.shex", "text/shex"),
-            TestEntry(self.metas[".owl"], "meta.owl"),
-            TestEntry(self.metas[".foo"], "meta.foo"),
-            TestEntry(self.linkml + "context.jsonld", "context.jsonld"),
-            TestEntry(self.linkml + "contextn.jsonld", "contextn.jsonld"),
-        ]
-        self.meta_vocab_entries: List[TestEntry] = [
-            TestEntry(self.meta.Element, "docs/Element"),
-            TestEntry(self.meta.slot, "docs/slot"),
-            TestEntry(self.meta.Element, "docs/Element.yaml", "text/yaml"),
-            TestEntry(self.meta.Element, "docs/Element.ttl", "text/turtle"),
-            TestEntry(self.meta.Element, "docs/Element.jsonld", "application/json"),
-            TestEntry(self.meta.Element, "docs/Element.shex", "text/shex"),
-            TestEntry(self.meta.Element, "docs/Element", "text/foo"),
-        ]
+    return {
+        "meta_entries": meta_entries,
+        "vocab_entries": vocab_entries,
+        "meta_model_entries": meta_model_entries,
+        "meta_vocab_entries": meta_vocab_entries,
+    }
 
 
-FAIL_ON_ERROR = True
+@pytest.fixture
+def fail_on_error():
+    return os.environ.get("FAIL_ON_ERROR", "False") == "True"
 
 
-@unittest.skipIf(SKIP_REWRITE_RULES, SKIP_REWRITE_RULES_REASON)
-class RewriteRuleTestCase(unittest.TestCase):
-    SERVER = DEFAULT_SERVER  # Can be overwritten with a startup parameter
-    results: Set[Tuple[str, str, str]] = None
+@pytest.fixture(scope="class")
+def results() -> Set[Tuple[str, str, str]]:
+    return set()  # from, to, format
 
-    @classmethod
-    def setUpClass(cls):
-        cls.tests = TestLists(cls.SERVER)
-        cls.results = set()  # from, to, format
 
-    @classmethod
-    def tearDownClass(cls):
-        for from_url, _, _ in sorted(list(cls.results)):
-            if DEFAULT_SERVER != W3ID_SERVER:
-                from_url = from_url.replace(DEFAULT_SERVER, W3ID_SERVER)
+def record_results(results, from_url: str, accept_header, to_url: str) -> None:
+    results.add((from_url, to_url, accept_header.split(",")[0]))
 
-    def record_results(self, from_url: str, accept_header, to_url: str) -> None:
-        self.results.add((from_url, to_url, accept_header.split(",")[0]))
 
-    def rule_test(self, entries: List[TestEntry]) -> None:
-        def test_it(e: TestEntry, accept_header: str) -> bool:
-            expected = github_io + e.expected_url
-            resp = requests.head(e.input_url, headers={"accept": accept_header}, verify=False)
+fixture_lists = generate_fixture_lists()
 
-            # w3id.org uses a 301 to go from http: to https:
-            if resp.status_code == 301 and "location" in resp.headers:
-                resp = requests.head(
-                    resp.headers["location"],
-                    headers={"accept": accept_header},
-                    verify=False,
-                )
-            actual = (
-                resp.headers["location"]
-                if resp.status_code == 302 and "location" in resp.headers
-                else f"Error: {resp.status_code}"
+
+@pytest.mark.network
+@pytest.mark.skipif(SKIP_REWRITE_RULES, reason=SKIP_REWRITE_RULES_REASON)
+@pytest.mark.parametrize(
+    "entries",
+    [
+        pytest.param(fixture_lists["meta_entries"], id="meta_entries"),
+        pytest.param(fixture_lists["vocab_entries"], id="vocab_entries"),
+        pytest.param(fixture_lists["meta_model_entries"], id="meta_model_entries"),
+        pytest.param(fixture_lists["meta_vocab_entries"], id="meta_vocab_entries"),
+    ],
+)
+def test_rewrite_rules(entries: List[TestEntry], results, fail_on_error) -> None:
+    def test_it(e: TestEntry, accept_header: str) -> bool:
+        expected = github_io + e.expected_url
+        resp = requests.head(e.input_url, headers={"accept": accept_header}, verify=False)
+
+        # w3id.org uses a 301 to go from http: to https:
+        if resp.status_code == 301 and "location" in resp.headers:
+            resp = requests.head(
+                resp.headers["location"],
+                headers={"accept": accept_header},
+                verify=False,
             )
-            if FAIL_ON_ERROR:
-                self.assertEqual(expected, actual, f"redirect for: {resp.url}")
-                self.record_results(e.input_url, accept_header, actual)
-                return True
-            elif expected != actual:
-                print(f"{e.input_url} ({accept_header}):\n expected {expected} - got {actual}")
-                return False
-            self.record_results(e.input_url, accept_header, actual)
+        actual = (
+            resp.headers["location"]
+            if resp.status_code == 302 and "location" in resp.headers
+            else f"Error: {resp.status_code}"
+        )
+        if fail_on_error:
+            assert expected == actual, f"redirect for: {resp.url}"
+            record_results(results, e.input_url, accept_header, actual)
             return True
+        elif expected != actual:
+            print(f"{e.input_url} ({accept_header}):\n expected {expected} - got {actual}")
+            return False
+        record_results(results, e.input_url, accept_header, actual)
+        return True
 
-        def ev_al(entry: TestEntry) -> bool:
-            if not entry.accept_header:
-                return test_it(entry, default_header)
-            else:
-                r1 = test_it(entry, entry.accept_header)
-                return test_it(entry, entry.accept_header + "," + default_header) and r1
+    def ev_al(entry: TestEntry) -> bool:
+        if not entry.accept_header:
+            return test_it(entry, default_header)
+        else:
+            r1 = test_it(entry, entry.accept_header)
+            return test_it(entry, entry.accept_header + "," + default_header) and r1
 
-        self.assertTrue(all([ev_al(entry) for entry in entries]))
-
-    def test_type_meta(self):
-        self.rule_test(self.tests.meta_entries)
-
-    def test_type_entry(self):
-        self.rule_test(self.tests.vocab_entries)
-
-    def test_meta_meta(self):
-        self.rule_test(self.tests.meta_model_entries)
-
-    def test_meta_entry(self):
-        self.rule_test(self.tests.meta_vocab_entries)
-
-
-if __name__ == "__main__":
-    RewriteRuleTestCase.SERVER = os.environ.get("SERVER", RewriteRuleTestCase.SERVER)
-    unittest.main()
+    assert all([ev_al(entry) for entry in entries])


### PR DESCRIPTION
This is a fairly straightforward unittest -> pyunit conversion. The diff is minimal **when viewed in VS Code**

**Note** that in build_test_entry_set() and generate_fixture_lists() I had to **modify all of the expected URLs** to get the tests to pass. I am not entirely certain that the modifications are appropriate. Please let me know if someone specific should be on the review list.

Details:

- I changed SKIP_REWRITE_RULES to False, but left the code in.
- The TestsList class is now a method that creates parametrized test inputs, but basically the same shape.
- The setup and teardown methods are fixtures and top-level methods (I'm not sure that record_results has an effect, but I left it in.
- There's a single parametrized test now, but it's still split into the same four categories as previously.
- I used pytest skip, but also marked the test with 'network'
- removed the main clause.

