### PR TITLE
Add deprecation banner/message to element documentation page titles

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -21,7 +21,7 @@
     {%- endif -%}
 {% endmacro %}
 
-# Class: {{ title }}
+# Class: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {%- if header -%}
 {{header}}

--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -1,4 +1,4 @@
-# Enum: {{ gen.name(element) }}
+# Enum: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}

--- a/linkml/generators/docgen/schema.md.jinja2
+++ b/linkml/generators/docgen/schema.md.jinja2
@@ -1,4 +1,4 @@
-# {{ schema.name }}
+# {{ schema.name }} {% if schema.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {{ schema.description }}
 

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -21,7 +21,7 @@
     {%- endif -%}
 {% endmacro %}
 
-# Slot: {{ title }}
+# Slot: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {%- if header -%}
 {{header}}

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -1,4 +1,4 @@
-# Subset: {{ gen.name(element) }}
+# Subset: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {%- if header -%}
 {{ header }}

--- a/linkml/generators/docgen/type.md.jinja2
+++ b/linkml/generators/docgen/type.md.jinja2
@@ -1,4 +1,4 @@
-# Type: {{ gen.name(element) }}
+# Type: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ skip = '.git,*.pdf,*.svg,./tests,pyproject.toml,*.dill,poetry.lock,./notebooks/D
 # Ignore table where words could be split across rows
 # Ignore shortcut specifications like [Ff]alse
 ignore-regex = '(\|.*\|.*\|.*\||\[[A-Z][a-z]\][a-z][a-z])'
-ignore-words-list = 'mater,connexion,infarction,thirdparty,linke'
+ignore-words-list = 'mater,connexion,infarction,thirdparty,linke,anc,disjointness'
 quiet-level = 3
 
 [tool.black]

--- a/tests/test_generators/input/kitchen_sink.yaml
+++ b/tests/test_generators/input/kitchen_sink.yaml
@@ -429,6 +429,7 @@ slots:
     mixin: true
   life_status:
     range: LifeStatusEnum
+    deprecated: This slot is not asserted on any classes yet
   cordialness:
   altitude:
     range: decimal

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -322,6 +322,8 @@ def test_docgen(kitchen_sink_path, input_path, tmp_path):
     domain_of_species_name = person_dict["attributes"]["species name"]["domain_of"]
     assert len(set(domain_of_species_name)) == len(domain_of_species_name)
 
+    assert_mdfile_contains(tmp_path / "life_status.md", "(DEPRECATED)")
+
 
 def test_docgen_no_mergeimports(kitchen_sink_path, tmp_path):
     """Tests when imported schemas are not folded into main schema"""


### PR DESCRIPTION
This is a PR to update the base jinja templates in the linkml library so it has the ability to render deprecation messages/banners on element documentation pages when the [deprecated](https://linkml.io/linkml-model/latest/docs/deprecated/) slot has been asserted on that element.

An example of what a deprecated element page would look like is here:

<img width="1792" alt="Screenshot 2025-01-28 at 3 46 30 PM" src="https://github.com/user-attachments/assets/e38b4326-b735-4b76-a3a7-22bf93b09120" />

Let me know if you think this needs a test. Happy to add it.