### PR TITLE
Use URIs with element type for gen-doc option --subfolder-type-separation

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -384,6 +384,10 @@ class DocGenerator(Generator):
         if isinstance(element, (EnumDefinition, SubsetDefinition)):
             # TODO: fix schema view to handle URIs for enums and subsets
             return self.name(element)
+
+        if self.hierarchical_class_view:
+            return self.schemaview.get_uri(element, expand=expand, use_element_type=True)
+
         return self.schemaview.get_uri(element, expand=expand)
 
     def uri_link(self, element: Union[Element, str]) -> str:

--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -385,7 +385,7 @@ class DocGenerator(Generator):
             # TODO: fix schema view to handle URIs for enums and subsets
             return self.name(element)
 
-        if self.hierarchical_class_view:
+        if self.subfolder_type_separation:
             return self.schemaview.get_uri(element, expand=expand, use_element_type=True)
 
         return self.schemaview.get_uri(element, expand=expand)

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -683,10 +683,26 @@ def test_hierarchical_class_view(kitchen_sink_path, tmp_path):
 
     # check that the URIs for classes and slots contain the element type
     assert_mdfile_contains(
-        tmp_path / "Activity.md", "[ks:class/Activity](https://w3id.org/linkml/tests/kitchen_sink/class/Activity)"
+        tmp_path / "Activity.md", "[ks:Activity](https://w3id.org/linkml/tests/kitchen_sink/Activity)"
     )
     assert_mdfile_contains(
-        tmp_path / "activities.md", "[ks:slot/activities](https://w3id.org/linkml/tests/kitchen_sink/slot/activities)"
+        tmp_path / "activities.md", "[ks:activities](https://w3id.org/linkml/tests/kitchen_sink/activities)"
+    )
+
+
+def test_subfolder_type_separation(kitchen_sink_path, tmp_path):
+    """Test to check if class table view on index page follows hierarchical view"""
+    gen = DocGenerator(kitchen_sink_path, mergeimports=True, subfolder_type_separation=True)
+
+    gen.serialize(directory=str(tmp_path))
+    # check that the URIs for classes and slots contain the element type
+    assert_mdfile_contains(
+        tmp_path / "classes" / "Activity.md",
+        "[ks:class/Activity](https://w3id.org/linkml/tests/kitchen_sink/class/Activity)",
+    )
+    assert_mdfile_contains(
+        tmp_path / "slots" / "activities.md",
+        "[ks:slot/activities](https://w3id.org/linkml/tests/kitchen_sink/slot/activities)",
     )
 
 

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -681,6 +681,14 @@ def test_hierarchical_class_view(kitchen_sink_path, tmp_path):
 
     assert_mdfile_contains(tmp_path / "index.md", "MarriageEvent", after="EmploymentEvent")
 
+    # check that the URIs for classes and slots contain the element type
+    assert_mdfile_contains(
+        tmp_path / "Activity.md", "[ks:class/Activity](https://w3id.org/linkml/tests/kitchen_sink/class/Activity)"
+    )
+    assert_mdfile_contains(
+        tmp_path / "activities.md", "[ks:slot/activities](https://w3id.org/linkml/tests/kitchen_sink/slot/activities)"
+    )
+
 
 def test_uml_diagram_er(kitchen_sink_path, tmp_path):
     gen = DocGenerator(


### PR DESCRIPTION
This requires a change in linkml-runtime in order to request URIs with element type information.

The tests will fail here until 
- [x] the corresponding PR linkml/linkml-runtime#375 is merged and
- [x] a new linkml-runtime release is made (since the actions use the latest release of the runtime but not the current main branch).

Closes #2561