### PR TITLE
Explicit `--materialize-attributes` and `--materialize-patterns` take precedence over `--materialize`

### DIFF
--- a/linkml/generators/linkmlgen.py
+++ b/linkml/generators/linkmlgen.py
@@ -114,8 +114,16 @@ def cli(
 ):
     # You can use the `--materialize` / `--no-materialize` for control
     # over both attribute and pattern materialization.
-    materialize_attributes = bool(materialize)
-    materialize_patterns = bool(materialize)
+
+    # If the user did not explicitly specify materialize_attributes,
+    # fall back to the umbrella materialize flag.
+    if materialize_attributes is None:
+        materialize_attributes = materialize
+
+    # If the user did not explicitly specify materialize_patterns,
+    # fall back to the umbrella materialize flag.
+    if materialize_patterns is None:
+        materialize_patterns = materialize
 
     gen = LinkmlGenerator(
         yamlfile,

--- a/tests/test_generators/test_linkmlgen.py
+++ b/tests/test_generators/test_linkmlgen.py
@@ -80,15 +80,20 @@ def test_structured_pattern(input_path):
 
 
 def test_default_pattern_materialization_true(input_path, tmp_path):
+    """
+    Test with `--materialize` set to True. Explicit flags override the umbrella flag:
+      - If user sets `--no-materialize-attributes` or `--no-materialize-patterns`,
+        then those take precedence (so nothing is materialized).
+      - If user sets `--materialize-attributes` and `--materialize-patterns`,
+        then both are materialized.
+    """
     runner = CliRunner()
     schema_path = str(input_path("pattern-example.yaml"))
     yaml_output_path = str(tmp_path / "pattern-materialized.yaml")
 
-    # Test with `--materialize` flag set to True.
-    # In this case, both attributes and structured patterns should be expanded.
-    # Regardless of whether the `--materialize-attributes` and `--materialize-patterns`
-    # flags are set to True or False, they will be treated as True if the `--materialize`
-    # flag is set to True.
+    # Scenario 1: User sets `--materialize` but explicitly sets both
+    # `--no-materialize-attributes` and `--no-materialize-patterns`.
+    # => Should NOT materialize patterns.
     result = runner.invoke(
         cli,
         [
@@ -100,14 +105,17 @@ def test_default_pattern_materialization_true(input_path, tmp_path):
             yaml_output_path,
         ],
     )
-
-    assert result.exit_code == 0, "Command failed with `--materialize` flag set to True."
-
+    assert result.exit_code == 0, (
+        "Command failed when `--materialize` is True but user also used "
+        "`--no-materialize-attributes` and `--no-materialize-patterns`."
+    )
     yobj = yaml.safe_load(open(yaml_output_path))
+    assert "pattern" not in yobj["slots"]["height"]
+    assert "pattern" not in yobj["slots"]["weight"]
 
-    assert yobj["slots"]["height"]["pattern"] == "\\d+[\\.\\d+] (centimeter|meter|inch)"
-    assert yobj["slots"]["weight"]["pattern"] == "\\d+[\\.\\d+] (kg|g|lbs|stone)"
-
+    # Scenario 2: User sets `--materialize` AND explicitly sets
+    # `--materialize-attributes` and `--materialize-patterns`.
+    # => Should materialize patterns.
     result = runner.invoke(
         cli,
         [
@@ -119,25 +127,31 @@ def test_default_pattern_materialization_true(input_path, tmp_path):
             yaml_output_path,
         ],
     )
-
-    assert result.exit_code == 0, "Command failed with `--materialize` flag set to True."
-
+    assert result.exit_code == 0, (
+        "Command failed when `--materialize` is True and user also used "
+        "`--materialize-attributes` and `--materialize-patterns`."
+    )
     yobj = yaml.safe_load(open(yaml_output_path))
-
     assert yobj["slots"]["height"]["pattern"] == "\\d+[\\.\\d+] (centimeter|meter|inch)"
     assert yobj["slots"]["weight"]["pattern"] == "\\d+[\\.\\d+] (kg|g|lbs|stone)"
 
 
 def test_default_pattern_materialization_false(input_path, tmp_path):
+    """
+    Test with `--no-materialize` set to True (meaning we do NOT materialize by default).
+    Again, explicit flags override:
+      - If user explicitly sets `--materialize-attributes` or `--materialize-patterns`
+        to True, they will be materialized despite `--no-materialize`.
+      - If user also sets `--no-materialize-attributes` and `--no-materialize-patterns`,
+        nothing is materialized.
+    """
     runner = CliRunner()
     schema_path = str(input_path("pattern-example.yaml"))
     yaml_output_path = str(tmp_path / "pattern-not-materialized.yaml")
 
-    # Test with `--no-materialize` flag set to False.
-    # In this case, only attributes should be expanded.
-    # Regardless of whether the `--materialize-attributes` and `--materialize-patterns`
-    # flags are set to True or False, they will be treated as False if the `--no-materialize`
-    # flag is set to False.
+    # Scenario 1: User sets `--no-materialize`, but explicitly sets
+    # `--materialize-attributes` and `--materialize-patterns`.
+    # => Patterns should be materialized, overriding the `--no-materialize`.
     result = runner.invoke(
         cli,
         [
@@ -149,14 +163,17 @@ def test_default_pattern_materialization_false(input_path, tmp_path):
             yaml_output_path,
         ],
     )
-
-    assert result.exit_code == 0, "Command failed with `--no-materialize` flag set to False."
-
+    assert result.exit_code == 0, (
+        "Command failed when `--no-materialize` is True but user also used "
+        "`--materialize-attributes` and `--materialize-patterns`."
+    )
     yobj = yaml.safe_load(open(yaml_output_path))
+    assert yobj["slots"]["height"]["pattern"] == "\\d+[\\.\\d+] (centimeter|meter|inch)"
+    assert yobj["slots"]["weight"]["pattern"] == "\\d+[\\.\\d+] (kg|g|lbs|stone)"
 
-    assert "pattern" not in yobj["slots"]["height"]
-    assert "pattern" not in yobj["slots"]["weight"]
-
+    # Scenario 2: User sets `--no-materialize` AND also explicitly sets
+    # `--no-materialize-attributes` and `--no-materialize-patterns`.
+    # => Should NOT materialize patterns at all.
     result = runner.invoke(
         cli,
         [
@@ -168,10 +185,10 @@ def test_default_pattern_materialization_false(input_path, tmp_path):
             yaml_output_path,
         ],
     )
-
-    assert result.exit_code == 0, "Command failed with `--no-materialize` flag set to False."
-
+    assert result.exit_code == 0, (
+        "Command failed when `--no-materialize` is True and user also used "
+        "`--no-materialize-attributes` and `--no-materialize-patterns`."
+    )
     yobj = yaml.safe_load(open(yaml_output_path))
-
     assert "pattern" not in yobj["slots"]["height"]
     assert "pattern" not in yobj["slots"]["weight"]


### PR DESCRIPTION
Fixes https://github.com/microbiomedata/nmdc-schema/issues/2345

If the `--materialize-attributes` and `--materialize-patterns` arguments/options are set explicitly in `gen-linkml` then we should give that preference over the default behavior being enforced by `--materialize`.