### PR TITLE
Add action to run tests with selected linkml-runtime branches

### DIFF
--- a/.github/workflows/test-with-unreleased-runtime.yaml
+++ b/.github/workflows/test-with-unreleased-runtime.yaml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       upstream_repo:
-        description: "Upstream linkml-runtime repository to test against"
+        description: "Upstream linkml-runtime repository to test with."
         required: true
         default: "linkml/linkml-runtime"
       upstream_branch:
-        description: "Upstream linkml-runtime branch to test against"
+        description: "Upstream linkml-runtime branch to test with."
         required: true
         default: "main"
 

--- a/.github/workflows/test-with-unreleased-runtime.yaml
+++ b/.github/workflows/test-with-unreleased-runtime.yaml
@@ -139,9 +139,9 @@ jobs:
         working-directory: linkml
         run: poetry add ../linkml-runtime
 
-      - name: Install linkml
+      - name: Update environment according to lockfile
         working-directory: linkml
-        run: poetry install --no-interaction -E tests
+        run: poetry sync --no-interaction --all-extras
 
       - name: print linkml-runtime version
         working-directory: linkml
@@ -150,6 +150,3 @@ jobs:
       - name: run tests
         working-directory: linkml
         run: poetry run python -m pytest --with-slow
-
-
-

--- a/.github/workflows/test-with-unreleased-runtime.yaml
+++ b/.github/workflows/test-with-unreleased-runtime.yaml
@@ -1,0 +1,155 @@
+name: Run tests with unreleased linkml-runtime
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      upstream_repo:
+        description: "Upstream linkml-runtime repository to test against"
+        required: true
+        default: "linkml/linkml-runtime"
+      upstream_branch:
+        description: "Upstream linkml-runtime branch to test against"
+        required: true
+        default: "main"
+
+jobs:
+  test_with_unreleased_runtime:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        exclude:
+          - os: windows-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.11"
+    runs-on: ${{ matrix.os }}
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: true
+
+    steps:
+      - name: Get upstream branch and repo from first lines of PR Body
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set +e
+          set +o pipefail
+          
+          UPSTREAM_BRANCH=$( \
+            echo "$PR_BODY" | \
+            head -2 | \
+            grep upstream_branch | \
+            cut -d ":" -f 2 | \
+            awk '{$1=$1};1' \
+          )
+          echo "Got upstream branch:"
+          echo $UPSTREAM_BRANCH
+          
+          if [[ -z "$UPSTREAM_BRANCH" ]]; then
+            echo "Using main as default"
+            UPSTREAM_BRANCH="main"
+          fi
+          
+          UPSTREAM_REPO=$( \
+            echo "$PR_BODY" | \
+            head -2 | \
+            grep upstream_repo | \
+            cut -d ":" -f 2 | \
+            awk '{$1=$1};1' \
+          )
+          echo "Got upstream repo:"
+          echo $UPSTREAM_REPO
+          
+          if [[ -z "$UPSTREAM_REPO" ]]; then
+            echo "Using linkml/linkml-runtime as default"
+            UPSTREAM_REPO="linkml/linkml-runtime"
+          fi
+
+          echo "upstream_branch=$UPSTREAM_BRANCH" >> "$GITHUB_ENV"
+          echo "upstream_repo=$UPSTREAM_REPO" >> "$GITHUB_ENV"
+
+      - name: Get upstream branch from workflow dispatch
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          echo "upstream_branch=${{ inputs.upstream_branch }}" >> "$GITHUB_ENV"
+          echo "upstream_repo=${{ inputs.upstream_repo }}" >> "$GITHUB_ENV"
+
+      - name: checkout upstream linkml-runtime
+        uses: actions/checkout@v4
+        with:
+          repository: "${{ env.upstream_repo }}"
+          path: linkml-runtime
+          ref: "${{ env.upstream_branch }}"
+          fetch-depth: 0
+
+      - name: checkout linkml
+        uses: actions/checkout@v4
+        with:
+          # don't specify repository like this or else we won't get pull request branches correctly
+          # repository: linkml/linkml
+          path: linkml
+          fetch-depth: 0
+
+      - name: Ensure tags for linkml-runtime upstream if a different one than linkml/linkml-runtime is specified
+        if: "${{ env.upstream_repo != 'linkml/linkml-runtime' }}"
+        working-directory: linkml-runtime
+        run: |
+          git remote add upstream https://github.com/linkml/linkml-runtime
+          git fetch upstream --tags
+
+      - name: Ensure tags for linkml if not run from main repo
+        if: github.repository != 'linkml/linkml'
+        working-directory: linkml
+        run: |
+          git remote add upstream https://github.com/linkml/linkml
+          git fetch upstream --tags
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Install dynamic versioning plugin
+        run: pipx inject poetry poetry-dynamic-versioning
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: linkml/.venv
+          key: venv-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      # note that we run the installation step always, even if we restore a venv,
+      # the cache will restore the old version of linkml, but the lockfile
+      # will only store the directory dependency (and thus will reinstall it)
+      # the cache will still speedup the rest of the installation
+      - name: Add checked-out linkml-runtime
+        working-directory: linkml
+        run: poetry add ../linkml-runtime
+
+      - name: Install linkml
+        working-directory: linkml
+        run: poetry install --no-interaction -E tests
+
+      - name: print linkml-runtime version
+        working-directory: linkml
+        run: poetry run python -c 'from importlib.metadata import version; print(version("linkml-runtime"))'
+
+      - name: run tests
+        working-directory: linkml
+        run: poetry run python -m pytest --with-slow
+
+
+

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -109,11 +109,6 @@ To run all tests:
 
 As of August 2023 this project has started converting its test suite from being based on the native [unittest module](https://docs.python.org/3/library/unittest.html) to being based on [pytest](https://docs.pytest.org/en/stable/index.html). Because of the presence of both styles of test in the codebase, it is recommended that you always use `pytest` to run tests.
 
-Currently, the following test directories have been entirely converted to pytest:
-
-* `tests/test_compliance`
-* `tests/test_issues`
-
 New tests in any directory should be written using pytest.
 
 ### Custom pytest fixtures
@@ -144,7 +139,36 @@ New tests in any directory should be written using pytest.
   The updated snapshot files should be checked in to Git alongside your other code changes.
 
   Debugging tip: sometimes a snapshot-based test may fail on GitHub actions, but may appear to pass locally. This can happen if the test is marked as a slow test,
-in which case you may need to use `--generate-snapshots` in combination with `--with-slow` (see below).
+  in which case you may need to use `--generate-snapshots` in combination with `--with-slow` (see below).
+
+### Testing linkml PRs with development versions of linkml-runtime
+
+`linkml` is tightly coupled to upstream `linkml-runtime`.
+
+In some circumstances, paired changes need to be made against *both* `linkml` and `linkml-runtime`.
+Then testing with the last release of `linkml-runtime` is insufficient.
+
+In such cases, you can specify that your PR needs to be tested with a specific linkml-runtime branch and repository.
+Specifying this information in the first two lines of your pull request´s opening message like this:
+
+> upstream_repo: user-or-org-name/linkml-runtime<BR>
+> upstream_branch: some-complicated-feature
+>
+> Hey everyone ... (PR continues)
+
+The order of the lines with `upstream_repo` and `upstream_branch` tags does not matter,
+but they must be the first two lines of the pull request comment.
+
+Maintainers can also specify upstream branches to test against when dispatching the `test_with_unreleased_runtime` workflow manually via the GUI prompt.
+
+Testing against an unverified upstream branch is not necessarily dangerous.
+The [input is stored as a variable first and not executed as untrusted code](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).
+But maintainers should take care to verify that the upstream branch and repo are correct and expected given the context of the PR.
+
+### Testing linkml-runtime PRs against any upstream linkml repository/branch
+
+For linkml-runtime a similar action as above is available allowing you to select a linkml repository to test against.
+For more see [linkml-runtime/CONRBUTING](https://github.com/linkml/linkml-runtime/blob/main/CONTRIBUTING.md).
 
 ## Code formatting and linting
 


### PR DESCRIPTION
The code is almost a copy of https://github.com/linkml/linkml-runtime/pull/367

However, here it enables running the linkml tests agains a linkml-runtime branch.

As in the linkml-runtime repository only developers with sufficient permissions can use this.  The motivation is to make testing of PRs possible which rely on a non-released version of the linkml-runtime (e.g. https://github.com/linkml/linkml/pull/2562).
