### PR TITLE
Fix nested relative imports

### DIFF
--- a/linkml/utils/mergeutils.py
+++ b/linkml/utils/mergeutils.py
@@ -17,6 +17,9 @@ from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml_runtime.utils.namespaces import Namespaces
 from linkml_runtime.utils.yamlutils import extended_str
 from rdflib import URIRef
+from pathlib import Path
+import os
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +36,7 @@ def merge_schemas(
     if target.license is None:
         target.license = mergee.license
 
-    target.imports += [imp for imp in mergee.imports if imp not in target.imports]
+    resolve_merged_imports(target, mergee, imported_from)
     set_from_schema(mergee)
 
     if namespaces:
@@ -232,3 +235,48 @@ def merge_enums(
     """
     # TODO: Finish enumeration merge code
     pass
+
+
+def resolve_merged_imports(
+    target: SchemaDefinition,
+    mergee: SchemaDefinition,
+    imported_from: Optional[str] = None
+) -> None:
+    """Merge the imports in source into target
+
+    :param target: Containing schema
+    :param mergee: mergee
+    :param imported_from: file that the mergee was imported from
+    :param at_end: True means add mergee to the end.  False to the front
+    """
+
+    for imp in mergee.imports:
+        if imp is None:
+            continue
+
+        # Skip if already imported
+        if imp in target.imports:
+            continue
+
+        # Leave as-is if the import has a scheme (e.g. http://)
+        elif urlparse(imp).scheme:
+            target.imports.append(imp)
+            continue
+
+        # Leave as-is if the import is an absolute path
+        elif Path(imp).is_absolute():
+            target.imports.append(imp)
+            continue
+
+        # Adjust relative imports to be relative to the importing file
+        elif imp.startswith("."):
+            if imported_from is None:
+                Warning(f"Cannot resolve relative import: {imp}")
+                target.imports.append(imp)
+            else:
+                resolved_imp = os.path.normpath(str(Path(imported_from).parent / Path(imp)))
+                target.imports.append(resolved_imp)
+
+        # By default, add the import as-is
+        else:
+            target.imports.append(imp)

--- a/tests/test_utils/input/relative_import_test/child/grandchild/greatgrandchild/index.yaml
+++ b/tests/test_utils/input/relative_import_test/child/grandchild/greatgrandchild/index.yaml
@@ -1,0 +1,4 @@
+id: https://example.com/schema/greatgrandchild
+name: greatgrandchild
+title: greatgrandchild
+

--- a/tests/test_utils/input/relative_import_test/child/grandchild/index.yaml
+++ b/tests/test_utils/input/relative_import_test/child/grandchild/index.yaml
@@ -1,0 +1,5 @@
+id: https://example.com/schema/grandchild
+name: grandchild
+title: grandchild
+imports:
+  - ./greatgrandchild/index

--- a/tests/test_utils/input/relative_import_test/child/index.yaml
+++ b/tests/test_utils/input/relative_import_test/child/index.yaml
@@ -1,0 +1,5 @@
+id: https://example.com/schema/child
+name: child
+title: child
+imports:
+  - ./grandchild/index

--- a/tests/test_utils/input/relative_import_test/main.yaml
+++ b/tests/test_utils/input/relative_import_test/main.yaml
@@ -1,0 +1,5 @@
+id: https://example.com/schema/main
+name: main
+title: main
+imports:
+  - ./child/index

--- a/tests/test_utils/test_schemaloader.py
+++ b/tests/test_utils/test_schemaloader.py
@@ -38,6 +38,9 @@ def test_imports(input_path, snapshot):
     assert as_json(loader.resolve()) == snapshot("base.json")
     assert loader.synopsis.errors() == []
 
+def test_imports_relative(input_path):
+    loader = SchemaLoader(input_path("relative_import_test/main.yaml"))
+    loader.resolve()
 
 @pytest.mark.skip(reason="Re-enable this once we get fully migrated")
 def test_error_paths(input_path):


### PR DESCRIPTION
Was getting error in the schema loader when importing with several levels of nesting. Similar to error in linkml-runtime (see [this PR](https://github.com/linkml/linkml-runtime/pull/368)).

Fix: updated mergeutils, so that import resolution is done at time of schema merging.

Tests on local machine:
- Before: 269 failed, 7271 passed
- After: 269 failed, 7272 passed