### PR TITLE
Add deprecation banner/message to element documentation page titles – round 2

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -21,7 +21,7 @@
     {%- endif -%}
 {% endmacro %}
 
-# Class: {{ title }}
+# Class: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {%- if header -%}
 {{header}}

--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -1,4 +1,4 @@
-# Enum: {{ gen.name(element) }}
+# Enum: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}

--- a/linkml/generators/docgen/schema.md.jinja2
+++ b/linkml/generators/docgen/schema.md.jinja2
@@ -1,4 +1,4 @@
-# {{ schema.name }}
+# {{ schema.name }} {% if schema.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {{ schema.description }}
 

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -21,7 +21,7 @@
     {%- endif -%}
 {% endmacro %}
 
-# Slot: {{ title }}
+# Slot: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {%- if header -%}
 {{header}}

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -1,4 +1,4 @@
-# Subset: {{ gen.name(element) }}
+# Subset: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {%- if header -%}
 {{ header }}

--- a/linkml/generators/docgen/type.md.jinja2
+++ b/linkml/generators/docgen/type.md.jinja2
@@ -1,4 +1,4 @@
-# Type: {{ gen.name(element) }}
+# Type: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}

--- a/tests/test_issues/conftest.py
+++ b/tests/test_issues/conftest.py
@@ -2,6 +2,11 @@ import pytest
 
 
 @pytest.fixture
+def personinfo_path(input_path):
+    return str(input_path("personinfo.yaml"))
+
+
+@pytest.fixture
 def type_hierarchy_schema_str():
     return """
 id: http://example.org

--- a/tests/test_issues/input/personinfo.yaml
+++ b/tests/test_issues/input/personinfo.yaml
@@ -233,6 +233,15 @@ slots:
     range: ProcedureConcept
     inlined: true
 
+  # Note: It's not recommended to tweak other slots willy-nilly because
+  # it might break other tests. So we're adding a dummy slot here called
+  # deprecation_test_slot to check if the slot documentation page will
+  # have a banner called "DEPRECATED".
+  deprecation_test_slot:
+    deprecated: >- 
+      This is a dummy slot that we are deprecating for testing purposes. 
+      Deprecated on 3/24/2025.
+
   ended_at_time:
     slot_uri: prov:endedAtTime
     range: date

--- a/tests/test_issues/test_linkml_issue_deprecation_banner.py
+++ b/tests/test_issues/test_linkml_issue_deprecation_banner.py
@@ -1,0 +1,15 @@
+import logging
+
+from linkml.generators.docgen import DocGenerator
+from tests.test_generators.test_docgen import assert_mdfile_contains
+
+logger = logging.getLogger(__name__)
+
+
+def test_deprecation(personinfo_path, tmp_path):
+    gen = DocGenerator(personinfo_path, mergeimports=True, no_types_dir=True)
+    gen.serialize(directory=str(tmp_path))
+
+    # check that the slot markdown page for "deprecation_test_slot"
+    # contains the expected deprecation banner
+    assert_mdfile_contains(tmp_path / "deprecation_test_slot.md", "(DEPRECATED)")


### PR DESCRIPTION
This is a PR to update the base jinja templates in the linkml library so it has the ability to render deprecation messages/banners on element documentation pages when the [deprecated](https://linkml.io/linkml-model/latest/docs/deprecated/) slot has been asserted on that element.

An example of what a deprecated element page would look like is here:

![image](https://github.com/user-attachments/assets/e92cc151-d0a8-4fa7-82b7-733d41b3de28)

Note: this PR has been created in favor of https://github.com/linkml/linkml/pull/2514 because that was modifying the kitchen sink schema which is a more "brittle" schema in the test infrastructure than other schemas (like personinfo).
