### PR TITLE
Behavior of `alias` in case it is asserted on slot in schema file

### DIFF
--- a/docs/faq/modeling.md
+++ b/docs/faq/modeling.md
@@ -628,6 +628,34 @@ To see examples, Biolink uses id_prefixes extensively. For example, the [Molecul
 
 For more, see [URIs and Mappings](https://linkml.io/linkml/schemas/uris-and-mappings.html)
 
+## How to use the `alias` metamodel construct?
+
+The [alias](https://linkml.io/linkml-model/latest/docs/alias/) construct from the metamodel is an element that can be asserted on slot definitions in the schema. If *alias* is asserted on a slot and the slot is asserted on a class then, we would need to use the alias name to refer to the slot in the instance file (CSV/TSV, YAML, JSON, etc.).
+
+For example:
+
+Snippet of schema file:
+
+```yaml
+classes:
+  Sample:
+    slots:
+      - id
+      - altitude
+slots:
+  altitude_in_meters:
+    alias: alt_in_m
+    unit:
+      ucum_code: m
+```
+
+Instance file (as YAML):
+
+```yaml
+- id: EX-123
+  alt_in_m: 5
+```
+
 ## When is it important to have mappings?
 
 Any element in a LinkML schema can have any number of *mappings* associated with it

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -40,6 +40,9 @@ _{{ element_description_line }}_
 
 URI: {{ gen.uri_link(element) }}
 
+{%- if element.alias %}
+Alias: {{ element.alias }}
+{% endif -%}
 
 {% if schemaview.slot_parents(element.name) or schemaview.slot_children(element.name, mixins=False) %}
 

--- a/tests/test_issues/input/personinfo.yaml
+++ b/tests/test_issues/input/personinfo.yaml
@@ -55,6 +55,7 @@ classes:
       - age_in_years
       - gender
       - current_address
+      - color_of_hair
       - has_employment_history
       - has_familial_relationships
       - has_medical_history
@@ -232,6 +233,11 @@ slots:
   procedure:
     range: ProcedureConcept
     inlined: true
+  color_of_hair:
+    description: >-
+      The color of a person's hair.
+    range: HairColorEnum
+    alias: hair_color
 
   # Note: It's not recommended to tweak other slots willy-nilly because
   # it might break other tests. So we're adding a dummy slot here called
@@ -281,6 +287,15 @@ enums:
       cisgender woman:
         meaning: GSSO:000385
   DiagnosisType:
+  # Not meant to be an exhaustive list of hair colors.
+  # Can be expanded as needed.
+  HairColorEnum:
+    permissible_values:
+      BLACK:
+      BROWN:
+      BLONDE:
+      RED:
+      GRAY:
 
 subsets:
   basic_subset:

--- a/tests/test_issues/input/personinfo_person_inst_01.yaml
+++ b/tests/test_issues/input/personinfo_person_inst_01.yaml
@@ -1,0 +1,52 @@
+id: P:001
+name: John Doe
+description: A sample person
+primary_email: john.doe@example.com
+birth_date: 1980-01-15
+age_in_years: 44
+gender: cisgender man
+aliases:
+  - Johnny
+  - J.D.
+# Note that we don't use the slot name verbatim here – color_of_hair
+# but instead we use the alias – hair_color, in the instance file.
+hair_color: BROWN
+current_address:
+  street: 123 Main Street
+  city: Anytown
+  postal_code: "12345"
+has_employment_history:
+  - employed_at:
+      id: ROR:001
+      name: Tech Company Inc.
+    started_at_time: 2010-06-01
+    ended_at_time: 2020-12-31
+    is_current: false
+  - employed_at:
+      id: ROR:002
+      name: Data Science Corp
+    started_at_time: 2021-01-15
+    is_current: true
+has_familial_relationships:
+  - related_to:
+      id: P:002
+      name: Jane Doe
+    type: SIBLING_OF
+    started_at_time: 1980-01-15
+  - related_to:
+      id: P:003
+      name: Sam Doe
+    type: PARENT_OF
+    started_at_time: 2010-05-10
+has_medical_history:
+  - started_at_time: 2022-03-15
+    ended_at_time: 2022-03-20
+    in_location:
+      id: GEO:001
+      name: General Hospital
+    diagnosis:
+      id: CODE:D123
+      name: Seasonal Allergy
+    procedure:
+      id: CODE:P456
+      name: Allergy Testing

--- a/tests/test_issues/test_linkml_issue_2316.py
+++ b/tests/test_issues/test_linkml_issue_2316.py
@@ -1,5 +1,6 @@
-from linkml.validator.validator import Validator
 from linkml_runtime.loaders import yaml_loader
+
+from linkml.validator.validator import Validator
 from tests.test_generators.test_pythongen import make_python
 
 

--- a/tests/test_issues/test_linkml_issue_2316.py
+++ b/tests/test_issues/test_linkml_issue_2316.py
@@ -1,0 +1,23 @@
+from linkml.validator.validator import Validator
+from linkml_runtime.loaders import yaml_loader
+from tests.test_generators.test_pythongen import make_python
+
+
+def test_validate_person_instance_from_personinfo(input_path, personinfo_path):
+    personinfo_python = make_python(personinfo_path)
+
+    # Path to instance YAML file which contains one instance of Person class
+    # from personinfo schema
+    instance_path = input_path("personinfo_person_inst_01.yaml")
+
+    # Load Person instance
+    instance_data = yaml_loader.load(instance_path, target_class=personinfo_python.Person)
+
+    # Initialize validator with personinfo schema
+    validator = Validator(personinfo_path)
+
+    # Validate Person instance against personinfo schema using validator
+    validation_results = validator.validate(instance_data, target_class=personinfo_python.Person)
+
+    # Check that no errors are captured in the returned ValidationReport
+    assert validation_results.results == []


### PR DESCRIPTION
This PR seeks to accomplish the following –

- [x] Display/render information about whether a slot is an `alias` or not explicitly on a slot documentation page
- [x] Test case to demonstrate behavior/usage of `alias` in instance file in case it is asserted on a slot in the schema file
- [x] Add FAQ entry to document above behavior

This PR has been created in favor of https://github.com/linkml/linkml/pull/2444

Fixes https://github.com/linkml/linkml/issues/2316