### PR TITLE
Add (limited) multivalued support for multivalued SimpleDict values to pydanticgen

### DIFF
--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -758,8 +758,11 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
                         if len(non_id_slots) == 1:
                             value_slot = non_id_slots[0]
                             value_slot_range_type = self.schemaview.get_type(value_slot.range)
-                            if value_slot_range_type is not None:
-                                return _get_pyrange(value_slot_range_type, self.schemaview)
+                            value_slot_pyrange = _get_pyrange(value_slot_range_type, self.schemaview)
+                            if value_slot_range_type is not None and not value_slot.multivalued:
+                                return value_slot_pyrange
+                            else:
+                                return f"List[{value_slot_pyrange}]"
         return None
 
     def _template_environment(self) -> Environment:

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -202,6 +202,47 @@ slots:
     assert "not_inlined_things: Optional[List[str]] = Field(default=None" in code
 
 
+def test_simpledict_with_list_value():
+    schema_str = """
+id: test_schema
+name: test_info
+description: just testing
+default_range: string
+prefixes:
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+
+imports:
+  - linkml:types
+
+classes:
+    A:
+        slots:
+            - things
+    Thing:
+        slots:
+            - key
+            - values
+slots:
+    key:
+        range: string
+        identifier: true
+    values: 
+        range: string
+        multivalued: true
+        inlined_as_list: true
+    things:
+        range: Thing
+        multivalued: true
+        inlined: true
+
+"""
+    gen = PydanticGenerator(schema_str, package=PACKAGE, metadata_mode=MetadataMode.NONE)
+    code = gen.serialize()
+    print(code)
+    assert "things: Optional[Dict[str, Union[List[str], Thing]]] = Field(default=None)" in code
+
+
 @pytest.mark.parametrize(
     "range,multivalued,inlined,inlined_as_list,B_has_identifier,expected,notes",
     [


### PR DESCRIPTION
Adds a check for multivalued values of a SimpleDict range generated by pydanticgen, and wraps the pyrange in a List[] if the slot is multivalued, plus a test.   