### PR TITLE
Appropriately handle linking of classes with slots that have a `range: None` asserted on them

### DIFF
--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -1,8 +1,10 @@
 {% macro slot_relationship(element, slot) %}
-    {% set range_element = gen.name(schemaview.get_element(slot.range)) %}
-    {% set relation_label = gen.name(slot) %}
-    {{ gen.name(element) }} --> "{{ gen.cardinality(slot) }}" {{ range_element }} : {{ relation_label }}
-    click {{ range_element }} href "../{{ range_element }}"
+    {% if slot.range is not none %}
+        {% set range_element = gen.name(schemaview.get_element(slot.range)) %}
+        {% set relation_label = gen.name(slot) %}
+        {{ gen.name(element) }} --> "{{ gen.cardinality(slot) }}" {{ range_element }} : {{ relation_label }}
+        click {{ range_element }} href "../{{ range_element }}"
+    {% endif %}
 {% endmacro %}
 
 {% if schemaview.class_parents(element.name) and schemaview.class_children(element.name) %}
@@ -22,7 +24,7 @@
       
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
-        {% if s.range not in gen.all_type_object_names() %}
+        {% if s.range is not none and s.range not in gen.all_type_object_names() %}
           {{ slot_relationship(element, s) }}
         {% endif %}
       {% endfor %}
@@ -38,7 +40,7 @@
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
-        {% if s.range not in gen.all_type_object_names() %}
+        {% if s.range is not none and s.range not in gen.all_type_object_names() %}
           {{ slot_relationship(element, s) }}
         {% endif %}
       {% endfor %}
@@ -54,7 +56,7 @@
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
-        {% if s.range not in gen.all_type_object_names() %}
+        {% if s.range is not none and s.range not in gen.all_type_object_names() %}
           {{ slot_relationship(element, s) }}
         {% endif %}
       {% endfor %}
@@ -66,7 +68,7 @@
     click {{ gen.name(element) }} href "../{{gen.name(element)}}"
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
-        {% if s.range not in gen.all_type_object_names() %}
+        {% if s.range is not none and s.range not in gen.all_type_object_names() %}
           {{ slot_relationship(element, s) }}
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
This PR is an attempt to handle schemas that are breaking due to problems computing the appropriate [slot_relationship()](https://github.com/linkml/linkml/blob/main/linkml/generators/docgen/class_diagram.md.jinja2#L1-L6) between a class and a slot. The error is occurring due to some slots having `range: None` asserted on them, so this is an attempt to fix that.

As described in the issue much of the logic living in the jinja templates needs to be moved over to `docgen.py`, and that's a larger undertaking, but will be taken up soon.

Fixes #2193 