### PR TITLE
fix(gen-jsonld): handle multiple contexts

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonldgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldgen.py
@@ -3,7 +3,7 @@
 import os
 from collections.abc import Sequence
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import click
@@ -57,7 +57,7 @@ class JSONLDGenerator(Generator):
     original_schema: SchemaDefinition = None
     """See https://github.com/linkml/linkml/issues/871"""
 
-    context: str = None
+    context: Sequence[str] | None = field(default_factory=list)
     """Path to a JSONLD context file"""
 
     metamodel_context: str = None
@@ -158,7 +158,9 @@ class JSONLDGenerator(Generator):
     def visit_subset(self, ss: SubsetDefinition) -> None:
         self._visit(ss)
 
-    def end_schema(self, context: str | Sequence[str] | None = None, context_kwargs: dict | None = None, **_) -> str:
+    def end_schema(
+        self, context: str | list[str] | tuple[str, ...] = [], context_kwargs: dict | None = None, **_
+    ) -> str:
         default_context_kwargs = {"model": False}
         if context_kwargs is None:
             context_kwargs = default_context_kwargs
@@ -168,10 +170,13 @@ class JSONLDGenerator(Generator):
         self._add_type(self.schema)
         base_prefix = self.default_prefix()
 
+        # `context` can be a `str`, a `list[str]` or a `tuple[str]`
+        # since the context might need to get extended, `context_list` must be `list[str]`
+        context_list: list[str] = []
         # TODO: fix this, see https://github.com/linkml/linkml/issues/871
         # JSON LD adjusts context reference using '@base'.  If context is supplied and not a URI, generate an
         # absolute URI for it
-        if context is None and self.format == "jsonld":
+        if not context and self.format == "jsonld":
             # TODO: Once we get pyld running w/ relative contexts, we need to figure out how to generate and add
             #       the relative (?) context reference below
             # model_context = self.schema.source_file.replace('.yaml', '.prefixes.context.jsonld')
@@ -187,23 +192,26 @@ class JSONLDGenerator(Generator):
             add_prefixes = ContextGenerator(self.original_schema, **context_kwargs).serialize()
             add_prefixes_json = loads(add_prefixes)
             metamodel_ctx = self.metamodel_context or METAMODEL_CONTEXT_URI
-            context = [metamodel_ctx, add_prefixes_json["@context"]]
+            context_list = [metamodel_ctx, add_prefixes_json["@context"]]
         elif isinstance(context, str):  # Some of the older code doesn't do multiple contexts
-            context = [context]
+            context_list = [context]
         elif isinstance(context, tuple):
-            context = list(context)
+            context_list = list(context)
+        else:
+            context_list = context
+
         for imp in list(self.loaded.values())[1:]:
-            context.append(imp[0] + ".context.jsonld")
+            context_list.append(imp[0] + ".context.jsonld")
 
         # Absolute file paths have to have a prefix
-        for ci in range(0, len(context)):
-            if isinstance(context[ci], str) and context[ci].startswith(
+        for ci in range(0, len(context_list)):
+            if isinstance(context_list[ci], str) and context_list[ci].startswith(
                 "/"
             ):  # TODO: how do we deal with absolute DOS paths?
-                context[ci] = "file://" + context[ci]
+                context_list[ci] = "file://" + context_list[ci]
 
         if self.format == "jsonld":
-            self.schema["@context"] = context[0] if len(context) == 1 and not base_prefix else context
+            self.schema["@context"] = context_list[0] if len(context_list) == 1 and not base_prefix else context_list
             if base_prefix:
                 self.schema["@context"].append({"@base": base_prefix})
         # json_obj["@id"] = self.schema.id
@@ -211,9 +219,7 @@ class JSONLDGenerator(Generator):
         self.schema = self.original_schema
         return out
 
-    def serialize(
-        self, context: str | Sequence[str] | None = None, context_kwargs: dict | None = None, **kwargs
-    ) -> str:
+    def serialize(self, context: Sequence[str] | None = None, context_kwargs: dict | None = None, **kwargs) -> str:
         """
         Serialize the model to JSON-LD
 
@@ -225,11 +231,13 @@ class JSONLDGenerator(Generator):
         return super().serialize(context=context, context_kwargs=context_kwargs, **kwargs)
 
 
+# Option "context" can be specified multiple times.
 @shared_arguments(JSONLDGenerator)
 @click.command(name="jsonld")
 @click.option(
     "--context",
     multiple=True,
+    type=click.STRING,
     help=f"JSONLD context file (default: {METAMODEL_CONTEXT_URI} and <model>.prefixes.context.jsonld)",
 )
 @click.option(
@@ -254,9 +262,6 @@ def cli(yamlfile, context_kwargs: list[tuple[str, bool]], context: tuple[str], *
         context_kwargs = dict(context_kwargs)
     else:
         context_kwargs = {}
-
-    if not context:
-        context = None
 
     print(JSONLDGenerator(yamlfile, **kwargs).serialize(context=context, context_kwargs=context_kwargs, **kwargs))
 

--- a/tests/linkml/test_scripts/test_gen_jsonld.py
+++ b/tests/linkml/test_scripts/test_gen_jsonld.py
@@ -64,6 +64,42 @@ def test_simple_uris(input_path, snapshot):
     assert result.output == snapshot("genjsonld/simple_uri_test.jsonld")
 
 
+@pytest.mark.parametrize(
+    "arguments,mock_context_paths, context",
+    [
+        (
+            ["-f", "jsonld"],
+            ["context.jsonld", "just_another.context.jsonld"],
+            [
+                "context.jsonld",
+                "just_another.context.jsonld",
+                "https://w3id.org/linkml/extensions.context.jsonld",
+                "simple_slots.context.jsonld",
+                "includes/simple_types.context.jsonld",
+                "https://w3id.org/linkml/types.context.jsonld",
+                {
+                    "@base": "https://raw.githubusercontent.com/linkml/linkml/main/tests/test_scripts/input/simple_uri_test/"
+                },
+            ],
+        ),
+    ],
+)
+def test_context(input_path, arguments, mock_context_paths, context):
+    """Test @context assembly when multiple --context files are passed."""
+
+    if mock_context_paths:
+        context_opt = "--context"
+        context_args = [x for pair in zip([context_opt] * len(mock_context_paths), mock_context_paths) for x in pair]
+        extended_arguments = arguments + context_args + [str(input_path("simple_uri_test.yaml"))]
+    else:
+        extended_arguments = arguments + [str(input_path("simple_uri_test.yaml"))]
+
+    runner = CliRunner()
+    result = runner.invoke(cli, extended_arguments)
+    assert result.exit_code == 0
+    assert json.loads(result.output)["@context"] == context
+
+
 def check_size(
     g: Graph,
     g2: Graph,


### PR DESCRIPTION
CLI supports multiple context files (what returns a tuple), but code mostly expecting a single context (and therefore only a string).
IDEs and linters recognize the inconsistency thanks to typing.

The context can get extended , therefore converting the tuple into a list.

~[Update]: trying to analyze some unexpected changes in the resulting JSON-LD I think I have uncovered an unknown issue:~
~- [the context of the JSON-LD generated WITHOUT this patch](https://github.com/linkml/linkml/blob/8e5f3223ca3b551418bdf9e44684ddd1ea73e769/tests/test_scripts/__snapshots__/genjsonld/simple_uri_test.jsonld#L493) does not correspond the result of a [...]~
~- [direct context generation with `linkml generate jsonldcontext`](https://github.com/linkml/linkml/blob/8e5f3223ca3b551418bdf9e44684ddd1ea73e769/tests/test_scripts/__snapshots__/genjsonld/simple_uri_test.context.jsonld#L7), [...]~
~- whereas [the context of the JSON-LD generated WITH the patch](https://github.com/linkml/linkml/blob/fix-json-ld-context-typing/tests/test_scripts/__snapshots__/genjsonld/simple_uri_test.jsonld#L493) looks almost the same.~

~Pending the confirmation of an expert, I am the impression that the patch is correct and fixing both the types inconsistencies and the context generation.~

I wonder what's the reason for the lack of code-sharing for `@context` generation between [jsonldgen.py](https://github.com/linkml/linkml/blob/main/linkml/generators/jsonldgen.py) and [jsonldcontextgen.py](https://github.com/linkml/linkml/blob/main/linkml/generators/jsonldcontextgen.py).

Closes #2625