### PR TITLE
Generator template fixes: ensure multiline descriptions are dealt with correctly

### DIFF
--- a/linkml/generators/docgen/index.md.jinja2
+++ b/linkml/generators/docgen/index.md.jinja2
@@ -21,7 +21,7 @@ Name: {{ schema.name }}
 | --- | --- |
 {% if gen.hierarchical_class_view -%}
 {% for u, v in gen.class_hierarchy_as_tuples() -%}
-| {{ "&nbsp;"|safe*u*8 }}{{ gen.link(schemaview.get_class(v), True) }} | {{ schemaview.get_class(v).description }} |
+| {{ "&nbsp;"|safe*u*8 }}{{ gen.link(schemaview.get_class(v), True) }} | {{ schemaview.get_class(v).description|enshorten }} |
 {% endfor %}
 {% else -%}
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}

--- a/linkml/generators/pydanticgen/templates/enum.py.jinja
+++ b/linkml/generators/pydanticgen/templates/enum.py.jinja
@@ -7,7 +7,7 @@ class {{ name }}(str{% if values %}, Enum{% endif %}):
 {% if values %}
     {% for pv in values.values() -%}
         {% if pv.description %}
-    # {{pv.description}}
+    """{{pv.description}}"""
         {% endif %}
     {{pv.label}} = "{{pv.value}}"
     {% endfor %}

--- a/linkml/generators/pydanticgen/templates/enum.py.jinja
+++ b/linkml/generators/pydanticgen/templates/enum.py.jinja
@@ -7,7 +7,9 @@ class {{ name }}(str{% if values %}, Enum{% endif %}):
 {% if values %}
     {% for pv in values.values() -%}
         {% if pv.description %}
-    """{{pv.description}}"""
+    """
+    {{ pv.description | indent(width=4) }}
+    """
         {% endif %}
     {{pv.label}} = "{{pv.value}}"
     {% endfor %}

--- a/linkml/generators/pydanticgen/templates/enum.py.jinja
+++ b/linkml/generators/pydanticgen/templates/enum.py.jinja
@@ -6,12 +6,12 @@ class {{ name }}(str{% if values %}, Enum{% endif %}):
 {% endif %}
 {% if values %}
     {% for pv in values.values() -%}
+    {{pv.label}} = "{{pv.value}}"
         {% if pv.description %}
     """
     {{ pv.description | indent(width=4) }}
     """
         {% endif %}
-    {{pv.label}} = "{{pv.value}}"
     {% endfor %}
 {% else %}
     pass

--- a/linkml/generators/pydanticgen/templates/enum.py.jinja
+++ b/linkml/generators/pydanticgen/templates/enum.py.jinja
@@ -5,14 +5,14 @@ class {{ name }}(str{% if values %}, Enum{% endif %}):
     """
 {% endif %}
 {% if values %}
-    {% for pv in values.values() -%}
+{% for pv in values.values() %}
     {{pv.label}} = "{{pv.value}}"
-        {% if pv.description %}
+{% if pv.description %}
     """
     {{ pv.description | indent(width=4) }}
     """
-        {% endif %}
-    {% endfor %}
+{% endif %}
+{% endfor %}
 {% else %}
     pass
 {% endif %}

--- a/linkml/generators/pydanticgen/templates/enum.py.jinja
+++ b/linkml/generators/pydanticgen/templates/enum.py.jinja
@@ -5,14 +5,14 @@ class {{ name }}(str{% if values %}, Enum{% endif %}):
     """
 {% endif %}
 {% if values %}
-{% for pv in values.values() %}
+    {% for pv in values.values() %}
     {{pv.label}} = "{{pv.value}}"
-{% if pv.description %}
+        {% if pv.description %}
     """
     {{ pv.description | indent(width=4) }}
     """
-{% endif %}
-{% endfor %}
+        {% endif %}
+    {% endfor %}
 {% else %}
     pass
 {% endif %}

--- a/linkml/generators/sqltablegen.py
+++ b/linkml/generators/sqltablegen.py
@@ -97,7 +97,7 @@ class SQLTableGenerator(Generator):
 
     If the range of the slot is an enum or type, then a new linktable is created, and a backref added
 
-    E.g. if a class User has a multivalues slot alias whose range is a string,
+    E.g. if a class User has a multivalued slot alias whose range is a string,
     then create a table user_aliases, with two columns (1) alias [a string] and (2) a backref to user
 
     Each mapped slot C.S has a range R

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -354,9 +354,7 @@ classes:
 
         and a lot more madness
 """
-    gen = DocGenerator(
-        str(test_schema), mergeimports=True, hierarchical_class_view=True
-    )
+    gen = DocGenerator(str(test_schema), mergeimports=True, hierarchical_class_view=True)
     gen.serialize(directory=str(tmp_path))
 
     # these lines are generated if the description is not enshortened

--- a/tests/test_generators/test_docgen.py
+++ b/tests/test_generators/test_docgen.py
@@ -322,6 +322,68 @@ def test_docgen(kitchen_sink_path, input_path, tmp_path):
     assert len(set(domain_of_species_name)) == len(domain_of_species_name)
 
 
+def test_docgen_multiline_description_hierarchical_view(tmp_path) -> None:
+    """Ensure that having a multiline description does not break the hierarchical table view."""
+    test_schema = """
+id: unit_test
+name: unit_test
+
+prefixes:
+  ex: https://example.org/
+default_prefix: ex
+
+classes:
+  no_description:
+  single_line:
+    description: A single line description. Easy!
+  multi_line:
+    description:
+        Why restrict yourself to a single line
+
+        when there are so many
+
+        other lines available for your description?
+  multi_line_preserve_whitespace:
+    description: |
+        Multi Line Madness is a bit like
+
+                Multi Level Marketing
+        (at least initially)
+        but involves more lines
+
+
+        and a lot more madness
+"""
+    gen = DocGenerator(
+        str(test_schema), mergeimports=True, hierarchical_class_view=True
+    )
+    gen.serialize(directory=str(tmp_path))
+
+    # these lines are generated if the description is not enshortened
+    forbidden = [
+        "| [MultiLine](MultiLine.md) | Why restrict yourself to a single line\n",
+        "when there are so many\n",
+        "other lines available for your description? |\n",
+        "| [MultiLinePreserveWhitespace](MultiLinePreserveWhitespace.md) | Multi Line Madness is a bit like\n",
+        "        Multi Level Marketing\n",
+        "and a lot more madness\n",
+    ]
+
+    for f in forbidden:
+        assert_mdfile_does_not_contain(tmp_path / "index.md", f)
+
+    # the class index should contain these lines
+    ix = [
+        "| [MultiLine](MultiLine.md) | Why restrict yourself to a single line |\n",
+        "| [MultiLinePreserveWhitespace](MultiLinePreserveWhitespace.md) | Multi Line Madness is a bit like |\n",
+        "| [NoDescription](NoDescription.md) |  |\n",
+        "| [SingleLine](SingleLine.md) | A single line description |\n",
+    ]
+
+    for line in ix:
+        assert_mdfile_contains(tmp_path / "index.md", line)
+
+
 def test_docgen_no_mergeimports(kitchen_sink_path, tmp_path):
     """Tests when imported schemas are not folded into main schema"""
     gen = DocGenerator(kitchen_sink_path, mergeimports=False, no_types_dir=True)

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -2495,9 +2495,9 @@ def test_generate_split_pattern(input_path):
     for an_import in should_have:
         assert an_import in imports, "Missed a necessary import when generating from a pattern"
     for an_import in shouldnt_have:
-        assert an_import not in imports, (
-            "Got one of the imports with the default template instead of the supplied pattern"
-        )
+        assert (
+            an_import not in imports
+        ), "Got one of the imports with the default template instead of the supplied pattern"
 
 
 @pytest.mark.pydanticgen_split

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -50,6 +50,7 @@ from linkml.utils.schema_builder import SchemaBuilder
 
 from .conftest import MyInjectedClass
 
+INDENT = " " * 4
 PACKAGE = "kitchen_sink"
 pytestmark = pytest.mark.pydanticgen
 
@@ -117,6 +118,16 @@ enums:
     assert enum["values"]["PLUS_SIGN"]["value"] == "+"
     assert enum["values"]["This_AMPERSAND_that_plus_maybe_a_TOP_HAT"]["value"] == "This & that, plus maybe a 🎩"
     assert enum["values"]["Ohio"]["value"] == "Ohio"
+    gen_output = gen.serialize()
+    expected_lines = [
+        "class TestEnum(str, Enum):",
+        f'{INDENT}number_123 = "123"',
+        f'{INDENT}PLUS_SIGN = "+"',
+        f'{INDENT}This_AMPERSAND_that_plus_maybe_a_TOP_HAT = "This & that, plus maybe a 🎩"',
+        f'{INDENT}Ohio = "Ohio"',
+    ]
+    for line in expected_lines:
+        assert f"\n{line}\n" in gen_output
 
 
 def test_pydantic_enum_titles():
@@ -149,6 +160,16 @@ enums:
     assert enum["values"]["label2"]["value"] == "value2"
     assert enum["values"]["value3"]["value"] == "value3"
     assert enum["values"]["label_4"]["value"] == "value4"
+    gen_output = gen.serialize()
+    expected_lines = [
+        "class TestEnum(str, Enum):",
+        f'{INDENT}label1 = "value1"',
+        f'{INDENT}label2 = "value2"',
+        f'{INDENT}value3 = "value3"',
+        f'{INDENT}label_4 = "value4"',
+    ]
+    for line in expected_lines:
+        assert f"\n{line}\n" in gen_output
 
 
 def test_pydantic_enum_descriptions():
@@ -183,7 +204,6 @@ enums:
 
               Madness!
 """
-    INDENT = " " * 4
     sv = SchemaView(unit_test_schema)
     gen = PydanticGenerator(schema=unit_test_schema)
     enums = gen.generate_enums(sv.all_enums())
@@ -206,7 +226,20 @@ enums:
     for line_type in DESCRIPTION:
         # if the line doesn't have any content, there is no indent;
         # otherwise, there is the standard 4-space indent
-        assert "\n".join([f"{INDENT}{line}" if len(line) > 0 else "" for line in DESCRIPTION[line_type]]) in gen_output
+        assert (
+            "\n".join(
+                [
+                    f"{INDENT}{line}" if len(line) > 0 else ""
+                    for line in [
+                        f'{line_type} = "{line_type}"',
+                        '"""',
+                        *DESCRIPTION[line_type],
+                        '"""',
+                    ]
+                ]
+            )
+            in gen_output
+        )
 
 
 def test_pydantic_any_of():

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -136,6 +136,8 @@ enums:
       value2:
         title: label2
       value3:
+      value4:
+        title: label 4
     """
     sv = SchemaView(unit_test_schema)
     gen = PydanticGenerator(schema=unit_test_schema)
@@ -146,6 +148,50 @@ enums:
     assert enum["values"]["label1"]["value"] == "value1"
     assert enum["values"]["label2"]["value"] == "value2"
     assert enum["values"]["value3"]["value"] == "value3"
+    assert enum["values"]["label_4"]["value"] == "value4"
+
+
+def test_pydantic_enum_descriptions():
+    unit_test_schema = """
+id: unit_test
+name: unit_test
+
+prefixes:
+  ex: https://example.org/
+default_prefix: ex
+
+enums:
+  TestEnum:
+    permissible_values:
+      no_description:
+      single_line:
+        description: A single line description. Easy!
+      multi_line:
+        description:
+          Sometimes
+
+            one line
+
+                isn't enough
+
+          for a "description".
+      multi_line_preserve_whitespace:
+        description: |
+          Multi
+
+                    Line
+
+          Madness!
+"""
+    sv = SchemaView(unit_test_schema)
+    gen = PydanticGenerator(schema=unit_test_schema)
+    enums = gen.generate_enums(sv.all_enums())
+    assert "TestEnum" in enums
+    enum = enums["TestEnum"]
+    assert enum["values"]["no_description"]["description"] is None
+    assert enum["values"]["single_line"]["description"] == "A single line description. Easy!"
+    assert enum["values"]["multi_line"]["description"] == 'Sometimes\none line\nisn\'t enough\nfor a "description".'
+    assert enum["values"]["multi_line_preserve_whitespace"]["description"] == "Multi\n\n          Line\n\nMadness!\n"
 
 
 def test_pydantic_any_of():


### PR DESCRIPTION
Two minor edits to ensure that multi-line descriptions are dealt with appropriately.

The QC failure was not from code that I edited.