### PR TITLE
Multiple tag/value pairs in `annotations` schema block should appear on different lines

### DIFF
--- a/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/linkml/generators/docgen/common_metadata.md.jinja2
@@ -62,7 +62,7 @@ Instances of this class *should* have identifiers with one of the following pref
 {% for a in element.annotations -%}
 {%- if a|string|first != '_' -%}
 | {{ a }} | {{ element.annotations[a].value }} |
-{%- endif -%}
+{% endif -%}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
The changes in this PR modify the usage of whitespace control (`-`) operators in the [common_metadata.md.jinja2](https://github.com/linkml/linkml/blob/main/linkml/generators/docgen/common_metadata.md.jinja2) file such that, if there are multiple `annotations` that are asserted in a schema, then these _annotations_ should be rendered on separate lines in the Markdown and in the HTML.