### PR TITLE
fix(jsonldgen): use correct ContextGenerator field

### DIFF
--- a/linkml/generators/jsonldgen.py
+++ b/linkml/generators/jsonldgen.py
@@ -162,7 +162,7 @@ class JSONLDGenerator(Generator):
             # model_context = self.schema.source_file.replace('.yaml', '.prefixes.context.jsonld')
             # context = [METAMODEL_CONTEXT_URI, f'file://./{model_context}']
             # TODO: The _visit function above alters the schema in situ
-            add_prefixes = ContextGenerator(self.original_schema, model=False, metadata=False).serialize()
+            add_prefixes = ContextGenerator(self.original_schema, model=False, emit_metadata=False).serialize()
             add_prefixes_json = loads(add_prefixes)
             context = [METAMODEL_CONTEXT_URI, add_prefixes_json["@context"]]
         elif isinstance(context, str):  # Some of the older code doesn't do multiple contexts


### PR DESCRIPTION
Instantiation of ContextGenerator is passing a field that doesn't exist: [`metadata`](
https://github.com/linkml/linkml/blob/bf5861b56088e84a799f20ec9b16dee7f5691627/linkml/generators/jsonldgen.py#L165). The right one appears to be [`emit_metadata`](https://github.com/linkml/linkml/blob/bf5861b56088e84a799f20ec9b16dee7f5691627/linkml/generators/jsonldcontextgen.py#L46).

The issue does not have any observable effect, because the value being passed to `metadata` is hard-coded to `False` and the default of the correct field `emit_metadata` is also `False`. It is nevertheless an error that should get fixed or may otherwise bite us in the future.

Fixes #2620