### PR TITLE
fix(jsonldcontextgen): avoid shadowing dataclass fields

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonldcontextgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldcontextgen.py
@@ -330,7 +330,7 @@ def cli(yamlfile, emit_frame, embed_context_in_frame, output, **args):
         gen.embed_context_in_frame = True
     else:
         gen.emit_frame = emit_frame
-    print(gen.serialize(output=output, **args))
+    print(gen.serialize(output=output))
 
 
 if __name__ == "__main__":

--- a/packages/linkml/src/linkml/generators/jsonldgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldgen.py
@@ -178,7 +178,7 @@ class JSONLDGenerator(Generator):
             # TODO: The _visit function above alters the schema in situ
             # force some context_kwargs
             context_kwargs["metadata"] = False
-            add_prefixes = ContextGenerator(self.original_schema, **context_kwargs).serialize()
+            add_prefixes = ContextGenerator(self.original_schema, prefixes=True, **context_kwargs).serialize()
             add_prefixes_json = loads(add_prefixes)
             metamodel_ctx = self.metamodel_context or METAMODEL_CONTEXT_URI
             context = [metamodel_ctx, add_prefixes_json["@context"]]

--- a/packages/linkml/src/linkml/generators/jsonldgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldgen.py
@@ -3,7 +3,7 @@
 import os
 from collections.abc import Sequence
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import click
@@ -57,10 +57,10 @@ class JSONLDGenerator(Generator):
     original_schema: SchemaDefinition = None
     """See https://github.com/linkml/linkml/issues/871"""
 
-    context: str = None
+    context: str | list[str] | None = field(default_factory=list)
     """Path to a JSONLD context file"""
 
-    metamodel_context: str = None
+    metamodel_context: str | None = None
     """Override for metamodel context URI/path. When None, uses METAMODEL_CONTEXT_URI."""
 
     def __post_init__(self) -> None:
@@ -170,7 +170,7 @@ class JSONLDGenerator(Generator):
         # TODO: fix this, see https://github.com/linkml/linkml/issues/871
         # JSON LD adjusts context reference using '@base'.  If context is supplied and not a URI, generate an
         # absolute URI for it
-        if context is None and self.format == "jsonld":
+        if not context and self.format == "jsonld":
             # TODO: Once we get pyld running w/ relative contexts, we need to figure out how to generate and add
             #       the relative (?) context reference below
             # model_context = self.schema.source_file.replace('.yaml', '.prefixes.context.jsonld')
@@ -219,11 +219,16 @@ class JSONLDGenerator(Generator):
         return super().serialize(context=context, context_kwargs=context_kwargs, **kwargs)
 
 
+# Option "context" can be specified multiple times.
+# Using a callback to process "context" to get a list instead of a tuple,
+# because the context can get extended later on.
 @shared_arguments(JSONLDGenerator)
 @click.command(name="jsonld")
 @click.option(
     "--context",
     multiple=True,
+    type=click.STRING,
+    callback=lambda ctx, param, value: list(value),
     help=f"JSONLD context file (default: {METAMODEL_CONTEXT_URI} and <model>.prefixes.context.jsonld)",
 )
 @click.option(

--- a/packages/linkml/src/linkml/generators/jsonldgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldgen.py
@@ -178,7 +178,7 @@ class JSONLDGenerator(Generator):
             # TODO: The _visit function above alters the schema in situ
             # force some context_kwargs
             context_kwargs["metadata"] = False
-            add_prefixes = ContextGenerator(self.original_schema, prefixes=True, **context_kwargs).serialize()
+            add_prefixes = ContextGenerator(self.original_schema, **context_kwargs).serialize()
             add_prefixes_json = loads(add_prefixes)
             metamodel_ctx = self.metamodel_context or METAMODEL_CONTEXT_URI
             context = [metamodel_ctx, add_prefixes_json["@context"]]

--- a/tests/linkml/test_scripts/__snapshots__/genjsonld/simple_uri_test.jsonld
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonld/simple_uri_test.jsonld
@@ -494,7 +494,35 @@
       },
       "foo": "http://samples.r.us/foo#",
       "linkml": "https://w3id.org/linkml/",
-      "simple_uri_test": "https://raw.githubusercontent.com/linkml/linkml/main/tests/test_scripts/input/simple_uri_test/"
+      "simple_uri_test": "https://raw.githubusercontent.com/linkml/linkml/main/tests/test_scripts/input/simple_uri_test/",
+      "@vocab": "https://raw.githubusercontent.com/linkml/linkml/main/tests/test_scripts/input/simple_uri_test/",
+      "tag": {
+        "@type": "xsd:anyURI",
+        "@id": "linkml:tag"
+      },
+      "value": {
+        "@type": "linkml:Any",
+        "@id": "linkml:value"
+      },
+      "extensions": {
+        "@type": "linkml:Extension",
+        "@id": "linkml:extensions"
+      },
+      "state": {
+        "@id": "foo:state"
+      },
+      "AnyValue": {
+        "@id": "linkml:Any"
+      },
+      "Extensible": {
+        "@id": "linkml:Extensible"
+      },
+      "Extension": {
+        "@id": "linkml:Extension"
+      },
+      "Model": {
+        "@id": "foo:model"
+      }
     },
     "https://w3id.org/linkml/extensions.context.jsonld",
     "simple_slots.context.jsonld",

--- a/tests/linkml/test_scripts/test_gen_jsonld.py
+++ b/tests/linkml/test_scripts/test_gen_jsonld.py
@@ -63,6 +63,42 @@ def test_simple_uris(input_path, snapshot):
     assert result.output == snapshot("genjsonld/simple_uri_test.jsonld")
 
 
+@pytest.mark.parametrize(
+    "arguments,mock_context_paths, context",
+    [
+        (
+            ["-f", "jsonld"],
+            ["context.jsonld", "just_another.context.jsonld"],
+            [
+                "context.jsonld",
+                "just_another.context.jsonld",
+                "https://w3id.org/linkml/extensions.context.jsonld",
+                "simple_slots.context.jsonld",
+                "includes/simple_types.context.jsonld",
+                "https://w3id.org/linkml/types.context.jsonld",
+                {
+                    "@base": "https://raw.githubusercontent.com/linkml/linkml/main/tests/test_scripts/input/simple_uri_test/"
+                },
+            ],
+        ),
+    ],
+)
+def test_context(input_path, arguments, mock_context_paths, context):
+    """Test generation of meta.yaml JSON"""
+
+    if mock_context_paths:
+        context_opt = "--context"
+        context_args = [x for pair in zip([context_opt] * len(mock_context_paths), mock_context_paths) for x in pair]
+        extended_arguments = arguments + context_args + [str(input_path("simple_uri_test.yaml"))]
+    else:
+        extended_arguments = arguments + [str(input_path("simple_uri_test.yaml"))]
+
+    runner = CliRunner()
+    result = runner.invoke(cli, extended_arguments)
+    assert result.exit_code == 0
+    assert json.loads(result.output)["@context"] == context
+
+
 def check_size(
     g: Graph,
     g2: Graph,


### PR DESCRIPTION
~‼️ NOTE: this PR builds upon #2621 and is not expected to work before that PR has been merged, it will be rebased on the branch of that PR to ensure that it does not break current tests~

Assignation of non-None default values to "end_schema" is shadowing the values assigned to the corresponding dataclass fields in the constructor. This patch fixes it.

After this fix values assigned in the dataclass constructor will be taken, unless different values are provided to "end_schema" directly. Otherwise default values are used.

Fixes #2623 