### PR TITLE
Deprecate `gen-markdown` generator

### DIFF
--- a/docs/generators/markdown.rst
+++ b/docs/generators/markdown.rst
@@ -65,15 +65,17 @@ Docs
 Command Line
 ^^^^^^^^^^^^
 
-.. currentmodule:: linkml.generators.markdowngen
+.. currentmodule:: linkml.generators.docgen
 
-.. click:: linkml.generators.markdowngen:cli
-    :prog: gen-markdown
+.. click:: linkml.generators.docgen:cli
+    :prog: gen-doc
     :nested: short
 
 Code
 ^^^^
 
+.. autoclass:: DocGenerator
+    :members: serialize
 
 .. autoclass:: MarkdownGenerator
     :members: serialize

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -18,9 +18,9 @@ from linkml_runtime.utils.formatutils import be, camelcase, underscore
 
 from linkml._version import __version__
 from linkml.generators.yumlgen import YumlGenerator
+from linkml.utils.deprecation import deprecation_warning
 from linkml.utils.generator import Generator, shared_arguments
 from linkml.utils.typereferences import References
-from linkml.utils.deprecation import deprecation_warning
 
 
 @dataclass

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -20,6 +20,7 @@ from linkml._version import __version__
 from linkml.generators.yumlgen import YumlGenerator
 from linkml.utils.generator import Generator, shared_arguments
 from linkml.utils.typereferences import References
+from linkml.utils.deprecation import deprecation_warning
 
 
 @dataclass
@@ -40,6 +41,7 @@ class MarkdownGenerator(Generator):
     """
 
     def __post_init__(self) -> None:
+        deprecation_warning("gen-markdown")
         super().__post_init__()
 
     # ClassVars
@@ -49,8 +51,6 @@ class MarkdownGenerator(Generator):
     valid_formats = ["md"]
     visit_all_class_slots = False
     uses_schemaloader = True
-    deprecated = True
-    deprecation_name = "gen-markdown"
 
     # ObjectVars
     directory: Optional[str] = None
@@ -815,6 +815,8 @@ def cli(yamlfile, map_fields, dir, img, index_file, notypesdir, warnonexist, **k
     .. warning::
         `gen-markdown` is deprecated. Please use `gen-doc` instead.
     """
+    deprecation_warning("gen-markdown")
+
     gen = MarkdownGenerator(yamlfile, no_types_dir=notypesdir, warn_on_exist=warnonexist, **kwargs)
     if map_fields is not None:
         gen.metamodel_name_map = {}

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -18,7 +18,6 @@ from linkml_runtime.utils.formatutils import be, camelcase, underscore
 
 from linkml._version import __version__
 from linkml.generators.yumlgen import YumlGenerator
-from linkml.utils.deprecation import deprecation_warning
 from linkml.utils.generator import Generator, shared_arguments
 from linkml.utils.typereferences import References
 
@@ -75,7 +74,6 @@ class MarkdownGenerator(Generator):
         noimages: bool = False,
         **_,
     ) -> str:
-        deprecation_warning("gen-markdown")
         self.gen_classes = classes if classes else []
         for cls in self.gen_classes:
             if cls not in self.schema.classes:
@@ -149,7 +147,6 @@ class MarkdownGenerator(Generator):
         return out
 
     def visit_class(self, cls: ClassDefinition) -> str:
-        deprecation_warning("gen-markdown")
         # allow client to relabel metamodel
         mixin_local_name = self.get_metamodel_slot_name("Mixin")
         class_local_name = self.get_metamodel_slot_name("Class")
@@ -254,7 +251,6 @@ class MarkdownGenerator(Generator):
         return out
 
     def visit_type(self, typ: TypeDefinition) -> str:
-        deprecation_warning("gen-markdown")
         with open(self.exist_warning(self.dir_path(typ)), "w", encoding="UTF-8") as typefile:
             type_uri = typ.definition_uri
             type_curie = self.namespaces.curie_for(type_uri)
@@ -274,7 +270,6 @@ class MarkdownGenerator(Generator):
         return out
 
     def visit_slot(self, aliased_slot_name: str, slot: SlotDefinition) -> str:
-        deprecation_warning("gen-markdown")
         with open(self.exist_warning(self.dir_path(slot)), "w", encoding="UTF-8") as slotfile:
             items = []
             slot_curie = self.namespaces.uri_or_curie_for(str(self.namespaces._base), underscore(slot.name))
@@ -315,7 +310,6 @@ class MarkdownGenerator(Generator):
         return out
 
     def visit_enum(self, enum: EnumDefinition) -> str:
-        deprecation_warning("gen-markdown")
         with open(self.exist_warning(self.dir_path(enum)), "w", encoding="UTF-8") as enumfile:
             items = []
             enum_curie = self.namespaces.uri_or_curie_for(str(self.namespaces._base), underscore(enum.name))
@@ -328,7 +322,6 @@ class MarkdownGenerator(Generator):
         return out
 
     def visit_subset(self, subset: SubsetDefinition) -> str:
-        deprecation_warning("gen-markdown")
         with open(self.exist_warning(self.dir_path(subset)), "w", encoding="UTF-8") as subsetfile:
             items = []
             curie = self.namespaces.uri_or_curie_for(str(self.namespaces._base), underscore(subset.name))
@@ -822,7 +815,6 @@ def cli(yamlfile, map_fields, dir, img, index_file, notypesdir, warnonexist, **k
     .. warning::
         `gen-markdown` is deprecated. Please use `gen-doc` instead.
     """
-    deprecation_warning("gen-markdown")
     gen = MarkdownGenerator(yamlfile, no_types_dir=notypesdir, warn_on_exist=warnonexist, **kwargs)
     if map_fields is not None:
         gen.metamodel_name_map = {}

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -33,11 +33,17 @@ class MarkdownGenerator(Generator):
 
     The markdown is suitable for deployment as a MkDocs or Sphinx site
 
-    .. warning::
-        The MarkdownGenerator class is being deprecated in favor of DocGenerator which can
-        be found at the following path – `linkml/generators/docgen.py`. Going forward, DocGenerator
-        which can be invoked using the `gen-doc` command will be the preferred way to generate
-        Markdown documentation files for LinkML schemas.
+    .. admonition:: Deprecated
+        :class: warning
+
+            The MarkdownGenerator class is being deprecated in favor of DocGenerator which can
+            be found at the following path – `linkml/generators/docgen.py`. Going forward, DocGenerator
+            which can be invoked using the `gen-doc` command will be the preferred way to generate
+            Markdown documentation files for LinkML schemas.
+
+            .. deprecated:: v1.9.1
+
+            Recommendation: Update to use `gen-doc`
     """
 
     def __post_init__(self) -> None:

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -514,9 +514,7 @@ class MarkdownGenerator(Generator):
             else (
                 underscore(obj.name)
                 if isinstance(obj, SlotDefinition)
-                else underscore(obj.name)
-                if isinstance(obj, EnumDefinition)
-                else camelcase(obj.name)
+                else underscore(obj.name) if isinstance(obj, EnumDefinition) else camelcase(obj.name)
             )
         )
         subdir = "/types" if isinstance(obj, TypeDefinition) and not self.no_types_dir else ""

--- a/linkml/utils/deprecation.py
+++ b/linkml/utils/deprecation.py
@@ -243,7 +243,7 @@ DEPRECATIONS = (
             "de-facto generator for generating markdown documentation files (with "
             "embedded mermaid class diagrams) from a LinkML schema"
         ),
-        recommendation="Update to use gen-doc",
+        recommendation="Update to use `gen-doc`",
     ),
 )  # type: tuple[Deprecation, ...]
 

--- a/linkml/utils/deprecation.py
+++ b/linkml/utils/deprecation.py
@@ -232,6 +232,19 @@ DEPRECATIONS = (
         ),
         recommendation="Update to use linkml.validator",
     ),
+    Deprecation(
+        name="gen-markdown",
+        # the last update to any code in markdowngen.py was in v1.9.1
+        # we can start considering it as deprecated from this version
+        deprecated_in=SemVer.from_str("1.9.1"),
+        removed_in=SemVer.from_str("1.10.0"),
+        message=(
+            "gen-markdown has been deprecated in favor of gen-doc, which is the new "
+            "de-facto generator for generating markdown documentation files (with "
+            "embedded mermaid class diagrams) from a LinkML schema"
+        ),
+        recommendation="Update to use gen-doc",
+    ),
 )  # type: tuple[Deprecation, ...]
 
 EMITTED = set()  # type: set[str]

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -190,7 +190,6 @@ class Generator(metaclass=abc.ABCMeta):
             self.format = self.valid_formats[0]
         if self.format not in self.valid_formats:
             raise ValueError(f"Unrecognized format: {format}; known={self.valid_formats}")
-
         # legacy: all generators should use "mergeimports"
         # self.merge_imports = self.mergeimports
         if not self.metadata:

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -166,6 +166,13 @@ class Generator(metaclass=abc.ABCMeta):
     metamodel_name_map: dict[str, str] = None
     """Allows mapping of names of metamodel elements such as slot, etc"""
 
+    deprecated: ClassVar[bool] = False
+    """True means this generator is deprecated"""
+
+    deprecation_name: ClassVar[Optional[str]] = None
+    """If set, this is the value of the name attribute of a Deprecation specified 
+    in the global DEPRECATIONS list."""
+
     importmap: Optional[Union[str, Optional[Mapping[str, str]]]] = None
     """File name of import mapping file -- maps import name/uri to target"""
 
@@ -190,6 +197,13 @@ class Generator(metaclass=abc.ABCMeta):
             self.format = self.valid_formats[0]
         if self.format not in self.valid_formats:
             raise ValueError(f"Unrecognized format: {format}; known={self.valid_formats}")
+        # a generator can be considered "deprecated" if:
+        # (a) the `deprecated` boolean flag has been set to True, and
+        # (b) the `deprecation_name` attribute has been set to a non-None value
+        if self.deprecated and self.deprecation_name:
+            from linkml.utils.deprecation import deprecation_warning
+
+            deprecation_warning(self.deprecation_name)
         # legacy: all generators should use "mergeimports"
         # self.merge_imports = self.mergeimports
         if not self.metadata:

--- a/linkml/utils/generator.py
+++ b/linkml/utils/generator.py
@@ -166,13 +166,6 @@ class Generator(metaclass=abc.ABCMeta):
     metamodel_name_map: dict[str, str] = None
     """Allows mapping of names of metamodel elements such as slot, etc"""
 
-    deprecated: ClassVar[bool] = False
-    """True means this generator is deprecated"""
-
-    deprecation_name: ClassVar[Optional[str]] = None
-    """If set, this is the value of the name attribute of a Deprecation specified 
-    in the global DEPRECATIONS list."""
-
     importmap: Optional[Union[str, Optional[Mapping[str, str]]]] = None
     """File name of import mapping file -- maps import name/uri to target"""
 
@@ -197,27 +190,6 @@ class Generator(metaclass=abc.ABCMeta):
             self.format = self.valid_formats[0]
         if self.format not in self.valid_formats:
             raise ValueError(f"Unrecognized format: {format}; known={self.valid_formats}")
-
-        # check if `deprecation_name` is in the global DEPRECATIONS list
-        # defined in linkml/utils/deprecation.py
-        if self.deprecation_name:
-            from linkml.utils.deprecation import DEPRECATIONS, deprecation_warning
-
-            # check if `deprecation_name` is in DEPRECATIONS
-            # log a warning message if we are using a `deprecation_name` other than
-            # anything defined in the global DEPRECATIONS list
-            if not any(d.name == self.deprecation_name for d in DEPRECATIONS):
-                self.logger.warning(f"Deprecation name '{self.deprecation_name}' not found in DEPRECATIONS list")
-
-            # ensure the `deprecated` flag is set if `deprecation_name` is provided
-            if not self.deprecated:
-                self.logger.warning(
-                    f"Setting deprecated=True for generator with deprecation_name='{self.deprecation_name}'"
-                )
-                self.deprecated = True
-
-            # issue the deprecation warning
-            deprecation_warning(self.deprecation_name)
 
         # legacy: all generators should use "mergeimports"
         # self.merge_imports = self.mergeimports

--- a/tests/test_generators/test_markdowngen.py
+++ b/tests/test_generators/test_markdowngen.py
@@ -1,3 +1,4 @@
+import pytest
 from linkml.generators.markdowngen import MarkdownGenerator
 
 
@@ -59,3 +60,19 @@ def test_slot_name_mapping(kitchen_sink_path, tmp_path):
     gen.serialize(directory=tmp_path)
     assert_mdfile_contains(tmp_path / "index.md", "Address", after="Records")
     assert_mdfile_contains(tmp_path / "index.md", "HasAliases", after="Traits")
+
+
+def test_markdowngen_deprecation(kitchen_sink_path):
+    """Test that MarkdownGenerator emits a deprecation warning since
+    it has been marked for deprecation."""
+    from linkml.utils.deprecation import EMITTED
+
+    # clear any previously emitted warnings for this test
+    if "gen-markdown" in EMITTED:
+        EMITTED.remove("gen-markdown")
+
+    with pytest.warns(DeprecationWarning) as record:
+        MarkdownGenerator(kitchen_sink_path)
+
+    assert len(record) == 1
+    assert "gen-markdown" in str(record[0].message)

--- a/tests/test_generators/test_markdowngen.py
+++ b/tests/test_generators/test_markdowngen.py
@@ -1,4 +1,5 @@
 import pytest
+
 from linkml.generators.markdowngen import MarkdownGenerator
 
 


### PR DESCRIPTION
This PR seeks to deprecate `gen-markdown` by following the deprecation protocol described here: https://linkml.io/linkml/developers/deprecation.html and announce/recommend via warnings, that the defacto markdown documentation generator is now `gen-doc`.

- [x] update linkml documentation pages to "announce" this as well.