### PR TITLE
Incorrect syntax in docs page for markdown/documentation generator

### DIFF
--- a/docs/generators/docgen.rst
+++ b/docs/generators/docgen.rst
@@ -1,6 +1,17 @@
-Docs
-========
+Documentation
+=============
 
-.. automodule:: linkml.generators.docgen
-    :members:
-    :undoc-members:
+Command Line
+^^^^^^^^^^^^
+
+.. currentmodule:: linkml.generators.docgen
+
+.. click:: linkml.generators.docgen:cli
+    :prog: gen-doc
+    :nested: short
+
+Code
+^^^^
+
+.. autoclass:: DocGenerator
+    :members: serialize

--- a/docs/generators/markdown.rst
+++ b/docs/generators/markdown.rst
@@ -65,22 +65,6 @@ Docs
 Command Line
 ^^^^^^^^^^^^
 
-.. currentmodule:: linkml.generators.docgen
-
-.. click:: linkml.generators.docgen:cli
-    :prog: gen-doc
-    :nested: short
-
-Code
-^^^^
-
-.. autoclass:: DocGenerator
-    :members: serialize
-
-
-Command Line
-^^^^^^^^^^^^
-
 .. currentmodule:: linkml.generators.markdowngen
 
 .. click:: linkml.generators.markdowngen:cli

--- a/docs/generators/markdown.rst
+++ b/docs/generators/markdown.rst
@@ -77,5 +77,18 @@ Code
 .. autoclass:: DocGenerator
     :members: serialize
 
+
+Command Line
+^^^^^^^^^^^^
+
+.. currentmodule:: linkml.generators.markdowngen
+
+.. click:: linkml.generators.markdowngen:cli
+    :prog: gen-markdown
+    :nested: short
+
+Code
+^^^^
+
 .. autoclass:: MarkdownGenerator
     :members: serialize


### PR DESCRIPTION
See error in this Action: https://github.com/linkml/linkml/actions/runs/14715922190

Fixes below:

```
/Users/sujaypatil/Desktop/linkml/linkml/generators/docgen.py:docstring of linkml.generators.docgen.DocGenerator:1: WARNING: duplicate object description of linkml.generators.docgen.DocGenerator, other instance in generators/docgen, use :noindex: for one of them
/Users/sujaypatil/Desktop/linkml/linkml/generators/docgen.py:docstring of linkml.generators.docgen.DocGenerator.serialize:1: WARNING: duplicate object description of linkml.generators.docgen.DocGenerator.serialize, other instance in generators/docgen, use :noindex: for one of them
WARNING: autodoc: failed to import class 'MarkdownGenerator' from module 'linkml.generators.docgen'; the following exception was raised:
Traceback (most recent call last):
  File "/Users/sujaypatil/Desktop/linkml/.venv/lib/python3.10/site-packages/sphinx/util/inspect.py", line 341, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'linkml.generators.docgen' has no attribute 'MarkdownGenerator'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/sujaypatil/Desktop/linkml/.venv/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 106, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/Users/sujaypatil/Desktop/linkml/.venv/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 325, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/Users/sujaypatil/Desktop/linkml/.venv/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 2770, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/Users/sujaypatil/Desktop/linkml/.venv/lib/python3.10/site-packages/sphinx/util/inspect.py", line 357, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: MarkdownGenerator
```