### PR TITLE
updating shaclgen.py to accept custom shape_uris via annotations and use linkml native names to fix issue #2084

### DIFF
--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -71,10 +71,22 @@ class ShaclGenerator(Generator):
                 if v is not None:
                     g.add((class_uri_with_suffix, p, v))
 
+            # first, get the base class URI
             class_uri = URIRef(sv.get_uri(c, expand=True))
-            class_uri_with_suffix = class_uri
-            if self.suffix is not None:
-                class_uri_with_suffix += self.suffix
+
+            # check for an annotation
+            shape_uri = None
+            if c.annotations and c.annotations['shape_uri'].value :
+                shape_uri = c.annotations['shape_uri'].value
+
+            if shape_uri:
+                class_uri_with_suffix = URIRef(shape_uri)
+            elif URIRef(sv.get_uri(c, expand=True, native=True)) is not None:
+                 class_uri_with_suffix = URIRef(sv.get_uri(c, native=True)) #.replace("/:","#"))
+            else:
+                class_uri_with_suffix = class_uri
+                if self.suffix is not None:
+                    class_uri_with_suffix += self.suffix
             shape_pv(RDF.type, SH.NodeShape)
             shape_pv(SH.targetClass, class_uri)  # TODO
 

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -76,13 +76,13 @@ class ShaclGenerator(Generator):
 
             # check for an annotation
             shape_uri = None
-            if c.annotations and c.annotations['shape_uri'].value :
-                shape_uri = c.annotations['shape_uri'].value
+            if c.annotations and c.annotations["shape_uri"].value:
+                shape_uri = c.annotations["shape_uri"].value
 
             if shape_uri:
                 class_uri_with_suffix = URIRef(shape_uri)
             elif URIRef(sv.get_uri(c, expand=True, native=True)) is not None:
-                 class_uri_with_suffix = URIRef(sv.get_uri(c, native=True)) #.replace("/:","#"))
+                class_uri_with_suffix = URIRef(sv.get_uri(c, native=True))  # .replace("/:","#"))
             else:
                 class_uri_with_suffix = class_uri
                 if self.suffix is not None:


### PR DESCRIPTION
This PR is intended as a fix for issue https://github.com/linkml/linkml/issues/2084, in that it allows to have freely defined shacl_shape_uri's cia annotations['shacl_uri'] and by switching from the previously implemented shacl shape naming schema with class_uri+suffix, to reusing the native linkML class name as the name for the SHACL shape. This should be more aligned to the ideas behind SHACL, where a shape is its own rdf instance and thus the linkML class with its name should directly represent the shape, while the class uri is used for the traget class.

Since i am neither an expert in good pull request nor have i ever used poetry before, feel free to leave a comment which may help me with the next PR. I have tried to use poetry to the best of my knowledge (e.g. poetry tox and poetry run pytest).