### PR TITLE
Don't try to upload coverage data for dependabot PRs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,12 +91,12 @@ jobs:
           poetry run coverage report -m
         shell: bash
       - name: Upload coverage report
-        if: github.repository == 'linkml/linkml'
-        uses: codecov/codecov-action@v4
+        if: github.repository == 'linkml/linkml' && github.actor != 'dependabot[bot]'
+        uses: codecov/codecov-action@v5.4.2
         with:
           name: codecov-results-${{ matrix.os }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.xml
+          files: coverage.xml
           fail_ci_if_error: true
 
   test_slow:
@@ -135,7 +135,7 @@ jobs:
           poetry run coverage xml
           poetry run coverage report -m
       - name: Upload coverage report
-        if: github.repository == 'linkml/linkml'
+        if: github.repository == 'linkml/linkml' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5.4.2
         with:
           name: codecov-results-slow-${{ matrix.os }}-${{ matrix.python-version }}


### PR DESCRIPTION
This will hopefully prevent the failures for dependabot created PRs (e.g in #2657, #2658) which are caused by insufficient permissions for uploading to Codecov. Since coverage data for dependabot changes are not very useful, [selectively skipping](https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows) the coverage data upload should be OK.

Closes #2663