### PR TITLE
Deprecate `gen-yuml` generator

### DIFF
--- a/docs/generators/yuml.rst
+++ b/docs/generators/yuml.rst
@@ -1,5 +1,17 @@
 YUML
-========
+====
+
+.. admonition:: Deprecated
+    :class: warning
+
+    The `yuml` generator is **deprecated** and is no longer supported.
+
+    Please use one of the following alternatives, which offer enhanced visualization options:
+
+    - ``gen-doc`` – Generates documentation with **embedded Mermaid class diagrams**.
+    - ``gen-plantuml`` – Produces **PlantUML diagrams**.
+    - ``gen-mermaid-class-diagram`` – Creates **standalone Mermaid class diagrams**.
+    - ``gen-erdiagram`` – For **Entity-Relationship (ER) diagrams**.
 
 .. automodule:: linkml.generators.yumlgen
     :members:

--- a/linkml/generators/yumlgen.py
+++ b/linkml/generators/yumlgen.py
@@ -15,9 +15,8 @@ from linkml_runtime.utils.formatutils import camelcase, underscore
 from rdflib import Namespace
 
 from linkml import REQUESTS_TIMEOUT
-from linkml.utils.generator import Generator, shared_arguments
-
 from linkml.utils.deprecation import deprecation_warning
+from linkml.utils.generator import Generator, shared_arguments
 
 yuml_is_a = "^-"
 yuml_uses = "uses -.->"
@@ -42,7 +41,8 @@ class YumlGenerator(Generator):
 
             The `yuml` generator is being deprecated and is no longer supported.
 
-            Going forward, we recommend using one of the following alternatives that offer improved visualization capabilities:
+            Going forward, we recommend using one of the following alternatives that offer improved visualization
+            capabilities:
 
             - `gen-doc` – Generates documentation with **embedded Mermaid class diagrams**.
             - `gen-plantuml` – Produces **PlantUML diagrams**.
@@ -111,6 +111,7 @@ class YumlGenerator(Generator):
 
         file_suffix = ".svg" if self.format == "yuml" else "." + self.format
         file_name = diagram_name or camelcase(sorted(classes)[0] if classes else self.schema.name)
+
         if directory:
             self.output_file_name = os.path.join(
                 directory,

--- a/linkml/generators/yumlgen.py
+++ b/linkml/generators/yumlgen.py
@@ -54,6 +54,7 @@ class YumlGenerator(Generator):
             Recommendation: Migrate to one of the supported generators listed above.
 
     """
+
     def __post_init__(self) -> None:
         deprecation_warning("gen-yuml")
         super().__post_init__()

--- a/linkml/generators/yumlgen.py
+++ b/linkml/generators/yumlgen.py
@@ -17,6 +17,8 @@ from rdflib import Namespace
 from linkml import REQUESTS_TIMEOUT
 from linkml.utils.generator import Generator, shared_arguments
 
+from linkml.utils.deprecation import deprecation_warning
+
 yuml_is_a = "^-"
 yuml_uses = "uses -.->"
 yuml_injected = "< -.- inject"
@@ -34,6 +36,28 @@ YUML = Namespace(yuml_base + yuml_scale + yuml_dir + yuml_class)
 
 @dataclass
 class YumlGenerator(Generator):
+    """
+    .. admonition:: Deprecated
+        :class: warning
+
+            The `yuml` generator is being deprecated and is no longer supported.
+
+            Going forward, we recommend using one of the following alternatives that offer improved visualization capabilities:
+
+            - `gen-doc` – Generates documentation with **embedded Mermaid class diagrams**.
+            - `gen-plantuml` – Produces **PlantUML diagrams**.
+            - `gen-mermaid-class-diagram` – Creates **standalone Mermaid class diagrams**.
+            - `gen-erdiagram` – For **Entity-Relationship (ER) diagrams**.
+
+            .. deprecated:: v1.8.7
+
+            Recommendation: Migrate to one of the supported generators listed above.
+
+    """
+    def __post_init__(self) -> None:
+        deprecation_warning("gen-yuml")
+        super().__post_init__()
+
     generatorname = os.path.basename(__file__)
     generatorversion = "0.1.1"
     valid_formats = ["yuml", "png", "pdf", "jpg", "json", "svg"]
@@ -274,7 +298,13 @@ class YumlGenerator(Generator):
     help="Name of the diagram in the output directory (without suffix!)",
 )
 def cli(yamlfile, **args):
-    """Generate a UML representation of a LinkML model"""
+    """Generate a UML representation of a LinkML model
+
+    .. warning::
+        `gen-yuml` is deprecated. Please use `gen-doc`, `gen-plantuml`, `gen-mermaid-class-diagram`, or `gen-erdiagram` instead.
+    """
+    deprecation_warning("gen-yuml")
+
     print(YumlGenerator(yamlfile, **args).serialize(**args), end="")
 
 

--- a/linkml/generators/yumlgen.py
+++ b/linkml/generators/yumlgen.py
@@ -301,7 +301,7 @@ def cli(yamlfile, **args):
     """Generate a yUML representation of a LinkML model
 
     .. warning::
-        `gen-yuml` is deprecated. Please use `gen-doc`, `gen-plantuml`, `gen-mermaid-class-diagram`, or `gen-erdiagram` instead.
+        `gen-yuml` is deprecated. Please use `gen-doc`, `gen-plantuml` or `gen-mermaid-class-diagram`.
     """
     deprecation_warning("gen-yuml")
 

--- a/linkml/generators/yumlgen.py
+++ b/linkml/generators/yumlgen.py
@@ -298,7 +298,7 @@ class YumlGenerator(Generator):
     help="Name of the diagram in the output directory (without suffix!)",
 )
 def cli(yamlfile, **args):
-    """Generate a UML representation of a LinkML model
+    """Generate a yUML representation of a LinkML model
 
     .. warning::
         `gen-yuml` is deprecated. Please use `gen-doc`, `gen-plantuml`, `gen-mermaid-class-diagram`, or `gen-erdiagram` instead.

--- a/linkml/utils/deprecation.py
+++ b/linkml/utils/deprecation.py
@@ -245,6 +245,19 @@ DEPRECATIONS = (
         ),
         recommendation="Update to use `gen-doc`",
     ),
+    Deprecation(
+        name="gen-yuml",
+        # the last update to any code in yumlgen.py was in v1.8.7
+        # we can start considering it as deprecated from this version
+        deprecated_in=SemVer.from_str("1.8.7"),
+        removed_in=SemVer.from_str("1.10.0"),
+        message=(
+            "gen-yuml has been deprecated and is no longer supported. "
+            "It has been replaced by more feature-rich diagram generators such as "
+            "gen-doc (embedded mermaid diagrams), gen-plantuml, gen-mermaid-class-diagram, and gen-erdiagram."
+        ),
+        recommendation="Update to use `gen-doc`, `gen-plantuml`, `gen-mermaid-class-diagram`, or `gen-erdiagram`",
+    ),
 )  # type: tuple[Deprecation, ...]
 
 EMITTED = set()  # type: set[str]

--- a/tests/test_scripts/test_gen_yuml.py
+++ b/tests/test_scripts/test_gen_yuml.py
@@ -65,11 +65,13 @@ def test_specified_diagram_name(tmp_path, snapshot):
     assert result.exit_code == 0
     assert tmp_path == snapshot("genyuml/specified_name_dir")
 
+
 def test_yumlgen_deprecation():
     """Test that YumlGenerator emits a deprecation warning since
     it has been marked for deprecation."""
     from linkml.generators.yumlgen import YumlGenerator
     from linkml.utils.deprecation import EMITTED
+
     print(KITCHEN_SINK_PATH)
 
     # clear any previously emitted warnings for this test

--- a/tests/test_scripts/test_gen_yuml.py
+++ b/tests/test_scripts/test_gen_yuml.py
@@ -68,8 +68,8 @@ def test_specified_diagram_name(tmp_path, snapshot):
 def test_yumlgen_deprecation():
     """Test that YumlGenerator emits a deprecation warning since
     it has been marked for deprecation."""
-    from linkml.utils.deprecation import EMITTED
     from linkml.generators.yumlgen import YumlGenerator
+    from linkml.utils.deprecation import EMITTED
     print(KITCHEN_SINK_PATH)
 
     # clear any previously emitted warnings for this test

--- a/tests/test_scripts/test_gen_yuml.py
+++ b/tests/test_scripts/test_gen_yuml.py
@@ -9,7 +9,7 @@ from ..conftest import KITCHEN_SINK_PATH
 def test_help():
     runner = CliRunner()
     result = runner.invoke(cli, "--help")
-    assert "Generate a UML representation of a LinkML model" in result.output
+    assert "Generate a yUML representation of a LinkML model" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scripts/test_gen_yuml.py
+++ b/tests/test_scripts/test_gen_yuml.py
@@ -64,3 +64,20 @@ def test_specified_diagram_name(tmp_path, snapshot):
     result = runner.invoke(cli, ["--diagram-name", "specified_name", "-d", str(tmp_path), KITCHEN_SINK_PATH])
     assert result.exit_code == 0
     assert tmp_path == snapshot("genyuml/specified_name_dir")
+
+def test_yumlgen_deprecation():
+    """Test that YumlGenerator emits a deprecation warning since
+    it has been marked for deprecation."""
+    from linkml.utils.deprecation import EMITTED
+    from linkml.generators.yumlgen import YumlGenerator
+    print(KITCHEN_SINK_PATH)
+
+    # clear any previously emitted warnings for this test
+    if "gen-yuml" in EMITTED:
+        EMITTED.remove("gen-yuml")
+
+    with pytest.warns(DeprecationWarning) as record:
+        YumlGenerator(KITCHEN_SINK_PATH)
+
+    assert len(record) == 1
+    assert "gen-yuml" in str(record[0].message)


### PR DESCRIPTION
This PR deprecates the `gen-yuml` generator in accordance with the [LinkML deprecation protocol](https://linkml.io/linkml/developers/deprecation.html). The changes are aligned with the approach demonstrated in [linkml/linkml#2637](https://github.com/linkml/linkml/pull/2637).

Users are encouraged to migrate to supported alternatives, depending on their use case:

- `gen-doc` — generates documentation with embedded Mermaid class diagrams
- `gen-plantuml` — generates PlantUML diagrams
- `gen-mermaid-class-diagram` — generates standalone Mermaid class diagrams
- `gen-erdiagram` — generates entity-relationship (ER) diagrams

The `gen-yuml` generator is now marked as deprecated and will be removed in a future release. 

- [x] update linkml documentation pages to "announce" this as well.

Closes #2644 