### PR TITLE
Bug fix: ensure that pydantic pattern field validators work correctly on multivalued entries

### DIFF
--- a/linkml/generators/pydanticgen/templates/validator.py.jinja
+++ b/linkml/generators/pydanticgen/templates/validator.py.jinja
@@ -1,11 +1,12 @@
 @field_validator('{{name}}')
     def pattern_{{name}}(cls, v):
         pattern=re.compile(r"{{pattern}}")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid {{name}} format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid {{name}} format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid {{name}} format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid {{name}} format: {v}"
+            raise ValueError(err_msg)
         return v

--- a/tests/test_generators/input/pattern-example.yaml
+++ b/tests/test_generators/input/pattern-example.yaml
@@ -32,7 +32,6 @@ settings:
   unit.length: "(centimeter|meter|inch)"
   unit.weight: "(kg|g|lbs|stone)"
   email: "\\S+@\\S+{\\.\\w}+"
-  
 #==================================
 # Classes                         #
 #==================================
@@ -44,6 +43,7 @@ classes:
       - name
       - height
       - email
+      - nicknames
 
 #==================================
 # Slots                           #
@@ -56,6 +56,11 @@ slots:
     pattern: "^P\\d{7}"    ## simple pattern. Note {}s are NOT interpolated
   name:
     range: string
+    pattern: "^[A-Z0-9]\\w+.*$"
+  nicknames:
+    range: string
+    pattern: "^[A-Z0-9]\\w+.*$"
+    multivalued: true
   email:
     range: EmailString
   height:
@@ -82,5 +87,3 @@ types:
       syntax: "{email}"
       interpolated: true
       partial_match: false  ## implicit ^...$
-    
-      

--- a/tests/test_generators/test_linkmlgen.py
+++ b/tests/test_generators/test_linkmlgen.py
@@ -75,6 +75,8 @@ def test_structured_pattern(input_path):
     pattern_gen.serialize()
     # log yaml_filename so developers can look at its contents
     assert pattern_gen.schemaview.get_slot("id").pattern == r"^P\d{7}"
+    assert pattern_gen.schemaview.get_slot("name").pattern == r"^[A-Z0-9]\w+.*$"
+    assert pattern_gen.schemaview.get_slot("nicknames").pattern == r"^[A-Z0-9]\w+.*$"
     assert pattern_gen.schemaview.get_slot("height").pattern == "\\d+[\\.\\d+] (centimeter|meter|inch)"
     assert pattern_gen.schemaview.get_slot("weight").pattern == "\\d+[\\.\\d+] (kg|g|lbs|stone)"
 


### PR DESCRIPTION
Fixes a bug where the field validator would not be called on list entries. See inline comments for details.