### PR TITLE
Finish pydantic v1 deprecation for 1.9.0 release

### DIFF
--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -22,7 +22,6 @@ from linkml_runtime.linkml_model.meta import (
 from linkml_runtime.utils.compile_python import compile_python
 from linkml_runtime.utils.formatutils import camelcase, remove_empty_items, underscore
 from linkml_runtime.utils.schemaview import SchemaView
-from pydantic.version import VERSION as PYDANTIC_VERSION
 
 from linkml._version import __version__
 from linkml.generators.common.lifecycle import LifecycleMixin
@@ -46,10 +45,6 @@ from linkml.utils import deprecation_warning
 from linkml.utils.generator import shared_arguments
 
 logger = logging.getLogger(__name__)
-
-
-if int(PYDANTIC_VERSION[0]) == 1:
-    deprecation_warning("pydantic-v1")
 
 
 def _get_pyrange(t: TypeDefinition, sv: SchemaView) -> str:

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -5,10 +5,9 @@ from typing import Any, ClassVar, Literal, Optional, Union, get_args
 
 from jinja2 import Environment, PackageLoader
 from pydantic import BaseModel, Field, field_validator
-from pydantic.version import VERSION as PYDANTIC_VERSION
+from pydantic import computed_field
 
 from linkml.generators.common.template import TemplateModel
-from linkml.utils.deprecation import deprecation_warning
 
 try:
     if find_spec("black") is not None:
@@ -19,15 +18,6 @@ try:
 except ImportError:
     # we can also get an import error from find_spec during testing because that's how we mock not having it installed
     format_black = None
-
-if int(PYDANTIC_VERSION[0]) >= 2:
-    from pydantic import computed_field
-else:
-    deprecation_warning("pydantic-v1")
-
-    def computed_field(f):
-        """No-op decorator to allow this module to not break imports until 1.9.0"""
-        return f
 
 
 IMPORT_GROUPS = Literal["future", "stdlib", "thirdparty", "local", "conditional"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [  # Specifier syntax: https://peps.python.org/pep-0631/
     "parse",
     "prefixcommons >= 0.1.7",
     "prefixmaps >= 0.2.2",
-    "pydantic >= 1.0.0, < 3.0.0",
+    "pydantic >= 2.0.0, < 3.0.0",
     "pyjsg >= 0.11.6",
     "pyshex >= 0.7.20",
     "pyshexc >= 0.8.3",


### PR DESCRIPTION
I wasn't 100% confident about what needed to happen here. I removed the PYDANTICVERSION checks and compatibility tweaks and bumped up to 2.0.0 as the minimum in pyproject.toml 