### PR TITLE
Add GraphQL validity tests

### DIFF
--- a/linkml/generators/graphqlgen.py
+++ b/linkml/generators/graphqlgen.py
@@ -24,6 +24,7 @@ class GraphqlGenerator(Generator):
 
     strict_naming: bool = False
     _permissible_value_valid_characters = re.compile("^[_A-Za-z][_0-9A-Za-z]*?$")
+    _types_any = []
 
     def __post_init__(self):
         self.name_compatiblity = NameCompatibility(profile=NamingProfiles.graphql, do_not_fix=self.strict_naming)
@@ -39,6 +40,10 @@ class GraphqlGenerator(Generator):
         return out
 
     def visit_class(self, cls: ClassDefinition) -> str:
+        # no type can be declared for subtypes of "Any"
+        if cls.class_uri == "linkml:Any":
+            self._types_any.append(cls.name)
+            return f"scalar {cls.name}"
         etype = "interface" if (cls.abstract or cls.mixin) and not cls.mixins else "type"
         mixins = ", ".join([camelcase(mixin) for mixin in cls.mixins])
         out = f"{etype} {camelcase(cls.name)}" + (f" implements {mixins}" if mixins else "")
@@ -46,14 +51,35 @@ class GraphqlGenerator(Generator):
         return out
 
     def end_class(self, cls: ClassDefinition) -> str:
-        return "\n  }\n\n"
+        if cls.name in self._types_any:
+            return "\n\n"
+        else:
+            return "\n  }\n\n"
 
     def visit_class_slot(self, cls: ClassDefinition, aliased_slot_name: str, slot: SlotDefinition) -> str:
-        slotrange = (
-            camelcase(slot.range)
-            if slot.range in self.schema.classes or slot.range in self.schema.types or slot.range in self.schema.enums
-            else "String"
-        )
+        if slot.range in self.schema.classes or slot.range in self.schema.slots or slot.range in self.schema.enums:
+            slotrange = camelcase(slot.range)
+        elif slot.range in self.schema.types:
+            if self.schema.types[slot.range].from_schema != "https://w3id.org/linkml/types":
+                slotrange = camelcase(slot.range)
+            else:
+                graphql_scalars = ["Int", "Float", "String", "Boolean", "ID"]
+                if slot.range == "integer":
+                    slotrange = "Int"
+                elif slot.range == "decimal":
+                    slotrange = "Float"
+                elif camelcase(slot.range) in graphql_scalars:
+                    slotrange = camelcase(slot.range)
+                else:
+                    if self.schema.types[slot.range].repr:
+                        python_type = self.schema.types[slot.range].repr
+                    elif self.schema.types[slot.range].base:
+                        python_type = self.schema.types[slot.range].base
+                    if str(python_type) == "float":
+                        slotrange = "Float"
+                    elif str(python_type) == "str":
+                        slotrange = "String"
+
         if slot.multivalued:
             slotrange = f"[{slotrange}]"
         if slot.required:

--- a/poetry.lock
+++ b/poetry.lock
@@ -229,6 +229,18 @@ files = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["dev"]
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 description = "Screen-scraping library"
@@ -1145,6 +1157,47 @@ beautifulsoup4 = "*"
 pygments = ">=2.7"
 sphinx = ">=6.0,<8.0"
 sphinx-basic-ng = "*"
+
+[[package]]
+name = "gql"
+version = "3.5.2"
+description = "GraphQL client for Python"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "gql-3.5.2-py2.py3-none-any.whl", hash = "sha256:c830ffc38b3997b2a146317b27758305ab3d0da3bde607b49f34e32affb23ba2"},
+    {file = "gql-3.5.2.tar.gz", hash = "sha256:07e1325b820c8ba9478e95de27ce9f23250486e7e79113dbb7659a442dc13e74"},
+]
+
+[package.dependencies]
+anyio = ">=3.0,<5"
+backoff = ">=1.11.1,<3.0"
+graphql-core = ">=3.2,<3.2.5"
+yarl = ">=1.6,<2.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.8.0,<4) ; python_version <= \"3.11\"", "aiohttp (>=3.9.0b0,<4) ; python_version > \"3.11\""]
+all = ["aiohttp (>=3.8.0,<4) ; python_version <= \"3.11\"", "aiohttp (>=3.9.0b0,<4) ; python_version > \"3.11\"", "botocore (>=1.21,<2)", "httpx (>=0.23.1,<1)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "websockets (>=10,<12)"]
+botocore = ["botocore (>=1.21,<2)"]
+dev = ["aiofiles", "aiohttp (>=3.8.0,<4) ; python_version <= \"3.11\"", "aiohttp (>=3.9.0b0,<4) ; python_version > \"3.11\"", "black (==22.3.0)", "botocore (>=1.21,<2)", "check-manifest (>=0.42,<1)", "flake8 (==3.8.1)", "httpx (>=0.23.1,<1)", "isort (==4.3.21)", "mock (==4.0.2)", "mypy (==0.910)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "sphinx (>=5.3.0,<6)", "sphinx-argparse (==0.2.5)", "sphinx-rtd-theme (>=0.4,<1)", "types-aiofiles", "types-mock", "types-requests", "vcrpy (==4.4.0) ; python_version <= \"3.8\"", "vcrpy (==7.0.0) ; python_version > \"3.8\"", "websockets (>=10,<12)"]
+httpx = ["httpx (>=0.23.1,<1)"]
+requests = ["requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)"]
+test = ["aiofiles", "aiohttp (>=3.8.0,<4) ; python_version <= \"3.11\"", "aiohttp (>=3.9.0b0,<4) ; python_version > \"3.11\"", "botocore (>=1.21,<2)", "httpx (>=0.23.1,<1)", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "vcrpy (==4.4.0) ; python_version <= \"3.8\"", "vcrpy (==7.0.0) ; python_version > \"3.8\"", "websockets (>=10,<12)"]
+test-no-transport = ["aiofiles", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "vcrpy (==4.4.0) ; python_version <= \"3.8\"", "vcrpy (==7.0.0) ; python_version > \"3.8\""]
+websockets = ["websockets (>=10,<12)"]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.4"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+optional = false
+python-versions = "<4,>=3.6"
+groups = ["dev"]
+files = [
+    {file = "graphql-core-3.2.4.tar.gz", hash = "sha256:acbe2e800980d0e39b4685dd058c2f4042660b89ebca38af83020fd872ff1264"},
+    {file = "graphql_core-3.2.4-py3-none-any.whl", hash = "sha256:1604f2042edc5f3114f49cac9d77e25863be51b23a54a61a23245cf32f6476f0"},
+]
 
 [[package]]
 name = "graphviz"
@@ -2456,6 +2509,123 @@ docs = ["sphinx"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "multidict"
+version = "6.4.3"
+description = "multidict implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "multidict-6.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32a998bd8a64ca48616eac5a8c1cc4fa38fb244a3facf2eeb14abe186e0f6cc5"},
+    {file = "multidict-6.4.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a54ec568f1fc7f3c313c2f3b16e5db346bf3660e1309746e7fccbbfded856188"},
+    {file = "multidict-6.4.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a7be07e5df178430621c716a63151165684d3e9958f2bbfcb644246162007ab7"},
+    {file = "multidict-6.4.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b128dbf1c939674a50dd0b28f12c244d90e5015e751a4f339a96c54f7275e291"},
+    {file = "multidict-6.4.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b9cb19dfd83d35b6ff24a4022376ea6e45a2beba8ef3f0836b8a4b288b6ad685"},
+    {file = "multidict-6.4.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3cf62f8e447ea2c1395afa289b332e49e13d07435369b6f4e41f887db65b40bf"},
+    {file = "multidict-6.4.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:909f7d43ff8f13d1adccb6a397094adc369d4da794407f8dd592c51cf0eae4b1"},
+    {file = "multidict-6.4.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0bb8f8302fbc7122033df959e25777b0b7659b1fd6bcb9cb6bed76b5de67afef"},
+    {file = "multidict-6.4.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:224b79471b4f21169ea25ebc37ed6f058040c578e50ade532e2066562597b8a9"},
+    {file = "multidict-6.4.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a7bd27f7ab3204f16967a6f899b3e8e9eb3362c0ab91f2ee659e0345445e0078"},
+    {file = "multidict-6.4.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:99592bd3162e9c664671fd14e578a33bfdba487ea64bcb41d281286d3c870ad7"},
+    {file = "multidict-6.4.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a62d78a1c9072949018cdb05d3c533924ef8ac9bcb06cbf96f6d14772c5cd451"},
+    {file = "multidict-6.4.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:3ccdde001578347e877ca4f629450973c510e88e8865d5aefbcb89b852ccc666"},
+    {file = "multidict-6.4.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:eccb67b0e78aa2e38a04c5ecc13bab325a43e5159a181a9d1a6723db913cbb3c"},
+    {file = "multidict-6.4.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8b6fcf6054fc4114a27aa865f8840ef3d675f9316e81868e0ad5866184a6cba5"},
+    {file = "multidict-6.4.3-cp310-cp310-win32.whl", hash = "sha256:f92c7f62d59373cd93bc9969d2da9b4b21f78283b1379ba012f7ee8127b3152e"},
+    {file = "multidict-6.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:b57e28dbc031d13916b946719f213c494a517b442d7b48b29443e79610acd887"},
+    {file = "multidict-6.4.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f6f19170197cc29baccd33ccc5b5d6a331058796485857cf34f7635aa25fb0cd"},
+    {file = "multidict-6.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f2882bf27037eb687e49591690e5d491e677272964f9ec7bc2abbe09108bdfb8"},
+    {file = "multidict-6.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fbf226ac85f7d6b6b9ba77db4ec0704fde88463dc17717aec78ec3c8546c70ad"},
+    {file = "multidict-6.4.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e329114f82ad4b9dd291bef614ea8971ec119ecd0f54795109976de75c9a852"},
+    {file = "multidict-6.4.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1f4e0334d7a555c63f5c8952c57ab6f1c7b4f8c7f3442df689fc9f03df315c08"},
+    {file = "multidict-6.4.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:740915eb776617b57142ce0bb13b7596933496e2f798d3d15a20614adf30d229"},
+    {file = "multidict-6.4.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:255dac25134d2b141c944b59a0d2f7211ca12a6d4779f7586a98b4b03ea80508"},
+    {file = "multidict-6.4.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4e8535bd4d741039b5aad4285ecd9b902ef9e224711f0b6afda6e38d7ac02c7"},
+    {file = "multidict-6.4.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30c433a33be000dd968f5750722eaa0991037be0be4a9d453eba121774985bc8"},
+    {file = "multidict-6.4.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4eb33b0bdc50acd538f45041f5f19945a1f32b909b76d7b117c0c25d8063df56"},
+    {file = "multidict-6.4.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:75482f43465edefd8a5d72724887ccdcd0c83778ded8f0cb1e0594bf71736cc0"},
+    {file = "multidict-6.4.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ce5b3082e86aee80b3925ab4928198450d8e5b6466e11501fe03ad2191c6d777"},
+    {file = "multidict-6.4.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e413152e3212c4d39f82cf83c6f91be44bec9ddea950ce17af87fbf4e32ca6b2"},
+    {file = "multidict-6.4.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:8aac2eeff69b71f229a405c0a4b61b54bade8e10163bc7b44fcd257949620618"},
+    {file = "multidict-6.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ab583ac203af1d09034be41458feeab7863c0635c650a16f15771e1386abf2d7"},
+    {file = "multidict-6.4.3-cp311-cp311-win32.whl", hash = "sha256:1b2019317726f41e81154df636a897de1bfe9228c3724a433894e44cd2512378"},
+    {file = "multidict-6.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:43173924fa93c7486402217fab99b60baf78d33806af299c56133a3755f69589"},
+    {file = "multidict-6.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1f1c2f58f08b36f8475f3ec6f5aeb95270921d418bf18f90dffd6be5c7b0e676"},
+    {file = "multidict-6.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:26ae9ad364fc61b936fb7bf4c9d8bd53f3a5b4417142cd0be5c509d6f767e2f1"},
+    {file = "multidict-6.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:659318c6c8a85f6ecfc06b4e57529e5a78dfdd697260cc81f683492ad7e9435a"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1eb72c741fd24d5a28242ce72bb61bc91f8451877131fa3fe930edb195f7054"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3cd06d88cb7398252284ee75c8db8e680aa0d321451132d0dba12bc995f0adcc"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4543d8dc6470a82fde92b035a92529317191ce993533c3c0c68f56811164ed07"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30a3ebdc068c27e9d6081fca0e2c33fdf132ecea703a72ea216b81a66860adde"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b038f10e23f277153f86f95c777ba1958bcd5993194fda26a1d06fae98b2f00c"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c605a2b2dc14282b580454b9b5d14ebe0668381a3a26d0ac39daa0ca115eb2ae"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8bd2b875f4ca2bb527fe23e318ddd509b7df163407b0fb717df229041c6df5d3"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c2e98c840c9c8e65c0e04b40c6c5066c8632678cd50c8721fdbcd2e09f21a507"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66eb80dd0ab36dbd559635e62fba3083a48a252633164857a1d1684f14326427"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c23831bdee0a2a3cf21be057b5e5326292f60472fb6c6f86392bbf0de70ba731"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1535cec6443bfd80d028052e9d17ba6ff8a5a3534c51d285ba56c18af97e9713"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b73e7227681f85d19dec46e5b881827cd354aabe46049e1a61d2f9aaa4e285a"},
+    {file = "multidict-6.4.3-cp312-cp312-win32.whl", hash = "sha256:8eac0c49df91b88bf91f818e0a24c1c46f3622978e2c27035bfdca98e0e18124"},
+    {file = "multidict-6.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:11990b5c757d956cd1db7cb140be50a63216af32cd6506329c2c59d732d802db"},
+    {file = "multidict-6.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7a76534263d03ae0cfa721fea40fd2b5b9d17a6f85e98025931d41dc49504474"},
+    {file = "multidict-6.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:805031c2f599eee62ac579843555ed1ce389ae00c7e9f74c2a1b45e0564a88dd"},
+    {file = "multidict-6.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c56c179839d5dcf51d565132185409d1d5dd8e614ba501eb79023a6cab25576b"},
+    {file = "multidict-6.4.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c64f4ddb3886dd8ab71b68a7431ad4aa01a8fa5be5b11543b29674f29ca0ba3"},
+    {file = "multidict-6.4.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3002a856367c0b41cad6784f5b8d3ab008eda194ed7864aaa58f65312e2abcac"},
+    {file = "multidict-6.4.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3d75e621e7d887d539d6e1d789f0c64271c250276c333480a9e1de089611f790"},
+    {file = "multidict-6.4.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:995015cf4a3c0d72cbf453b10a999b92c5629eaf3a0c3e1efb4b5c1f602253bb"},
+    {file = "multidict-6.4.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2b0fabae7939d09d7d16a711468c385272fa1b9b7fb0d37e51143585d8e72e0"},
+    {file = "multidict-6.4.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:61ed4d82f8a1e67eb9eb04f8587970d78fe7cddb4e4d6230b77eda23d27938f9"},
+    {file = "multidict-6.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:062428944a8dc69df9fdc5d5fc6279421e5f9c75a9ee3f586f274ba7b05ab3c8"},
+    {file = "multidict-6.4.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b90e27b4674e6c405ad6c64e515a505c6d113b832df52fdacb6b1ffd1fa9a1d1"},
+    {file = "multidict-6.4.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7d50d4abf6729921e9613d98344b74241572b751c6b37feed75fb0c37bd5a817"},
+    {file = "multidict-6.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:43fe10524fb0a0514be3954be53258e61d87341008ce4914f8e8b92bee6f875d"},
+    {file = "multidict-6.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:236966ca6c472ea4e2d3f02f6673ebfd36ba3f23159c323f5a496869bc8e47c9"},
+    {file = "multidict-6.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:422a5ec315018e606473ba1f5431e064cf8b2a7468019233dcf8082fabad64c8"},
+    {file = "multidict-6.4.3-cp313-cp313-win32.whl", hash = "sha256:f901a5aace8e8c25d78960dcc24c870c8d356660d3b49b93a78bf38eb682aac3"},
+    {file = "multidict-6.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:1c152c49e42277bc9a2f7b78bd5fa10b13e88d1b0328221e7aef89d5c60a99a5"},
+    {file = "multidict-6.4.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:be8751869e28b9c0d368d94f5afcb4234db66fe8496144547b4b6d6a0645cfc6"},
+    {file = "multidict-6.4.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0d4b31f8a68dccbcd2c0ea04f0e014f1defc6b78f0eb8b35f2265e8716a6df0c"},
+    {file = "multidict-6.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756"},
+    {file = "multidict-6.4.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e78006af1a7c8a8007e4f56629d7252668344442f66982368ac06522445e375"},
+    {file = "multidict-6.4.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:daeac9dd30cda8703c417e4fddccd7c4dc0c73421a0b54a7da2713be125846be"},
+    {file = "multidict-6.4.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f6f90700881438953eae443a9c6f8a509808bc3b185246992c4233ccee37fea"},
+    {file = "multidict-6.4.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f84627997008390dd15762128dcf73c3365f4ec0106739cde6c20a07ed198ec8"},
+    {file = "multidict-6.4.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3307b48cd156153b117c0ea54890a3bdbf858a5b296ddd40dc3852e5f16e9b02"},
+    {file = "multidict-6.4.3-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ead46b0fa1dcf5af503a46e9f1c2e80b5d95c6011526352fa5f42ea201526124"},
+    {file = "multidict-6.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1748cb2743bedc339d63eb1bca314061568793acd603a6e37b09a326334c9f44"},
+    {file = "multidict-6.4.3-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:acc9fa606f76fc111b4569348cc23a771cb52c61516dcc6bcef46d612edb483b"},
+    {file = "multidict-6.4.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:31469d5832b5885adeb70982e531ce86f8c992334edd2f2254a10fa3182ac504"},
+    {file = "multidict-6.4.3-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:ba46b51b6e51b4ef7bfb84b82f5db0dc5e300fb222a8a13b8cd4111898a869cf"},
+    {file = "multidict-6.4.3-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:389cfefb599edf3fcfd5f64c0410da686f90f5f5e2c4d84e14f6797a5a337af4"},
+    {file = "multidict-6.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:64bc2bbc5fba7b9db5c2c8d750824f41c6994e3882e6d73c903c2afa78d091e4"},
+    {file = "multidict-6.4.3-cp313-cp313t-win32.whl", hash = "sha256:0ecdc12ea44bab2807d6b4a7e5eef25109ab1c82a8240d86d3c1fc9f3b72efd5"},
+    {file = "multidict-6.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:7146a8742ea71b5d7d955bffcef58a9e6e04efba704b52a460134fefd10a8208"},
+    {file = "multidict-6.4.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5427a2679e95a642b7f8b0f761e660c845c8e6fe3141cddd6b62005bd133fc21"},
+    {file = "multidict-6.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:24a8caa26521b9ad09732972927d7b45b66453e6ebd91a3c6a46d811eeb7349b"},
+    {file = "multidict-6.4.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6b5a272bc7c36a2cd1b56ddc6bff02e9ce499f9f14ee4a45c45434ef083f2459"},
+    {file = "multidict-6.4.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edf74dc5e212b8c75165b435c43eb0d5e81b6b300a938a4eb82827119115e840"},
+    {file = "multidict-6.4.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9f35de41aec4b323c71f54b0ca461ebf694fb48bec62f65221f52e0017955b39"},
+    {file = "multidict-6.4.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae93e0ff43b6f6892999af64097b18561691ffd835e21a8348a441e256592e1f"},
+    {file = "multidict-6.4.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5e3929269e9d7eff905d6971d8b8c85e7dbc72c18fb99c8eae6fe0a152f2e343"},
+    {file = "multidict-6.4.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb6214fe1750adc2a1b801a199d64b5a67671bf76ebf24c730b157846d0e90d2"},
+    {file = "multidict-6.4.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d79cf5c0c6284e90f72123f4a3e4add52d6c6ebb4a9054e88df15b8d08444c6"},
+    {file = "multidict-6.4.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2427370f4a255262928cd14533a70d9738dfacadb7563bc3b7f704cc2360fc4e"},
+    {file = "multidict-6.4.3-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:fbd8d737867912b6c5f99f56782b8cb81f978a97b4437a1c476de90a3e41c9a1"},
+    {file = "multidict-6.4.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:0ee1bf613c448997f73fc4efb4ecebebb1c02268028dd4f11f011f02300cf1e8"},
+    {file = "multidict-6.4.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:578568c4ba5f2b8abd956baf8b23790dbfdc953e87d5b110bce343b4a54fc9e7"},
+    {file = "multidict-6.4.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:a059ad6b80de5b84b9fa02a39400319e62edd39d210b4e4f8c4f1243bdac4752"},
+    {file = "multidict-6.4.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:dd53893675b729a965088aaadd6a1f326a72b83742b056c1065bdd2e2a42b4df"},
+    {file = "multidict-6.4.3-cp39-cp39-win32.whl", hash = "sha256:abcfed2c4c139f25c2355e180bcc077a7cae91eefbb8b3927bb3f836c9586f1f"},
+    {file = "multidict-6.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:b1b389ae17296dd739015d5ddb222ee99fd66adeae910de21ac950e00979d897"},
+    {file = "multidict-6.4.3-py3-none-any.whl", hash = "sha256:59fe01ee8e2a1e8ceb3f6dbb216b09c8d9f4ef1c22c4fc825d045a147fa2ebc9"},
+    {file = "multidict-6.4.3.tar.gz", hash = "sha256:3ada0b058c9f213c5f95ba301f922d402ac234f1111a7d8fd70f1b99f3c281ec"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -3330,6 +3500,114 @@ files = [
 
 [package.dependencies]
 wcwidth = "*"
+
+[[package]]
+name = "propcache"
+version = "0.3.1"
+description = "Accelerated property cache"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "propcache-0.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f27785888d2fdd918bc36de8b8739f2d6c791399552333721b58193f68ea3e98"},
+    {file = "propcache-0.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4e89cde74154c7b5957f87a355bb9c8ec929c167b59c83d90654ea36aeb6180"},
+    {file = "propcache-0.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:730178f476ef03d3d4d255f0c9fa186cb1d13fd33ffe89d39f2cda4da90ceb71"},
+    {file = "propcache-0.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:967a8eec513dbe08330f10137eacb427b2ca52118769e82ebcfcab0fba92a649"},
+    {file = "propcache-0.3.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b9145c35cc87313b5fd480144f8078716007656093d23059e8993d3a8fa730f"},
+    {file = "propcache-0.3.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e64e948ab41411958670f1093c0a57acfdc3bee5cf5b935671bbd5313bcf229"},
+    {file = "propcache-0.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:319fa8765bfd6a265e5fa661547556da381e53274bc05094fc9ea50da51bfd46"},
+    {file = "propcache-0.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c66d8ccbc902ad548312b96ed8d5d266d0d2c6d006fd0f66323e9d8f2dd49be7"},
+    {file = "propcache-0.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2d219b0dbabe75e15e581fc1ae796109b07c8ba7d25b9ae8d650da582bed01b0"},
+    {file = "propcache-0.3.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd6a55f65241c551eb53f8cf4d2f4af33512c39da5d9777694e9d9c60872f519"},
+    {file = "propcache-0.3.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9979643ffc69b799d50d3a7b72b5164a2e97e117009d7af6dfdd2ab906cb72cd"},
+    {file = "propcache-0.3.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4cf9e93a81979f1424f1a3d155213dc928f1069d697e4353edb8a5eba67c6259"},
+    {file = "propcache-0.3.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2fce1df66915909ff6c824bbb5eb403d2d15f98f1518e583074671a30fe0c21e"},
+    {file = "propcache-0.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4d0dfdd9a2ebc77b869a0b04423591ea8823f791293b527dc1bb896c1d6f1136"},
+    {file = "propcache-0.3.1-cp310-cp310-win32.whl", hash = "sha256:1f6cc0ad7b4560e5637eb2c994e97b4fa41ba8226069c9277eb5ea7101845b42"},
+    {file = "propcache-0.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:47ef24aa6511e388e9894ec16f0fbf3313a53ee68402bc428744a367ec55b833"},
+    {file = "propcache-0.3.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7f30241577d2fef2602113b70ef7231bf4c69a97e04693bde08ddab913ba0ce5"},
+    {file = "propcache-0.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:43593c6772aa12abc3af7784bff4a41ffa921608dd38b77cf1dfd7f5c4e71371"},
+    {file = "propcache-0.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a75801768bbe65499495660b777e018cbe90c7980f07f8aa57d6be79ea6f71da"},
+    {file = "propcache-0.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6f1324db48f001c2ca26a25fa25af60711e09b9aaf4b28488602776f4f9a744"},
+    {file = "propcache-0.3.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cdb0f3e1eb6dfc9965d19734d8f9c481b294b5274337a8cb5cb01b462dcb7e0"},
+    {file = "propcache-0.3.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1eb34d90aac9bfbced9a58b266f8946cb5935869ff01b164573a7634d39fbcb5"},
+    {file = "propcache-0.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f35c7070eeec2cdaac6fd3fe245226ed2a6292d3ee8c938e5bb645b434c5f256"},
+    {file = "propcache-0.3.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b23c11c2c9e6d4e7300c92e022046ad09b91fd00e36e83c44483df4afa990073"},
+    {file = "propcache-0.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3e19ea4ea0bf46179f8a3652ac1426e6dcbaf577ce4b4f65be581e237340420d"},
+    {file = "propcache-0.3.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:bd39c92e4c8f6cbf5f08257d6360123af72af9f4da75a690bef50da77362d25f"},
+    {file = "propcache-0.3.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:b0313e8b923b3814d1c4a524c93dfecea5f39fa95601f6a9b1ac96cd66f89ea0"},
+    {file = "propcache-0.3.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e861ad82892408487be144906a368ddbe2dc6297074ade2d892341b35c59844a"},
+    {file = "propcache-0.3.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:61014615c1274df8da5991a1e5da85a3ccb00c2d4701ac6f3383afd3ca47ab0a"},
+    {file = "propcache-0.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:71ebe3fe42656a2328ab08933d420df5f3ab121772eef78f2dc63624157f0ed9"},
+    {file = "propcache-0.3.1-cp311-cp311-win32.whl", hash = "sha256:58aa11f4ca8b60113d4b8e32d37e7e78bd8af4d1a5b5cb4979ed856a45e62005"},
+    {file = "propcache-0.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:9532ea0b26a401264b1365146c440a6d78269ed41f83f23818d4b79497aeabe7"},
+    {file = "propcache-0.3.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f78eb8422acc93d7b69964012ad7048764bb45a54ba7a39bb9e146c72ea29723"},
+    {file = "propcache-0.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:89498dd49c2f9a026ee057965cdf8192e5ae070ce7d7a7bd4b66a8e257d0c976"},
+    {file = "propcache-0.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:09400e98545c998d57d10035ff623266927cb784d13dd2b31fd33b8a5316b85b"},
+    {file = "propcache-0.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa8efd8c5adc5a2c9d3b952815ff8f7710cefdcaf5f2c36d26aff51aeca2f12f"},
+    {file = "propcache-0.3.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c2fe5c910f6007e716a06d269608d307b4f36e7babee5f36533722660e8c4a70"},
+    {file = "propcache-0.3.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a0ab8cf8cdd2194f8ff979a43ab43049b1df0b37aa64ab7eca04ac14429baeb7"},
+    {file = "propcache-0.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:563f9d8c03ad645597b8d010ef4e9eab359faeb11a0a2ac9f7b4bc8c28ebef25"},
+    {file = "propcache-0.3.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb6e0faf8cb6b4beea5d6ed7b5a578254c6d7df54c36ccd3d8b3eb00d6770277"},
+    {file = "propcache-0.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1c5c7ab7f2bb3f573d1cb921993006ba2d39e8621019dffb1c5bc94cdbae81e8"},
+    {file = "propcache-0.3.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:050b571b2e96ec942898f8eb46ea4bfbb19bd5502424747e83badc2d4a99a44e"},
+    {file = "propcache-0.3.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e1c4d24b804b3a87e9350f79e2371a705a188d292fd310e663483af6ee6718ee"},
+    {file = "propcache-0.3.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e4fe2a6d5ce975c117a6bb1e8ccda772d1e7029c1cca1acd209f91d30fa72815"},
+    {file = "propcache-0.3.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:feccd282de1f6322f56f6845bf1207a537227812f0a9bf5571df52bb418d79d5"},
+    {file = "propcache-0.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ec314cde7314d2dd0510c6787326bbffcbdc317ecee6b7401ce218b3099075a7"},
+    {file = "propcache-0.3.1-cp312-cp312-win32.whl", hash = "sha256:7d2d5a0028d920738372630870e7d9644ce437142197f8c827194fca404bf03b"},
+    {file = "propcache-0.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:88c423efef9d7a59dae0614eaed718449c09a5ac79a5f224a8b9664d603f04a3"},
+    {file = "propcache-0.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f1528ec4374617a7a753f90f20e2f551121bb558fcb35926f99e3c42367164b8"},
+    {file = "propcache-0.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dc1915ec523b3b494933b5424980831b636fe483d7d543f7afb7b3bf00f0c10f"},
+    {file = "propcache-0.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a110205022d077da24e60b3df8bcee73971be9575dec5573dd17ae5d81751111"},
+    {file = "propcache-0.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d249609e547c04d190e820d0d4c8ca03ed4582bcf8e4e160a6969ddfb57b62e5"},
+    {file = "propcache-0.3.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5ced33d827625d0a589e831126ccb4f5c29dfdf6766cac441d23995a65825dcb"},
+    {file = "propcache-0.3.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4114c4ada8f3181af20808bedb250da6bae56660e4b8dfd9cd95d4549c0962f7"},
+    {file = "propcache-0.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:975af16f406ce48f1333ec5e912fe11064605d5c5b3f6746969077cc3adeb120"},
+    {file = "propcache-0.3.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a34aa3a1abc50740be6ac0ab9d594e274f59960d3ad253cd318af76b996dd654"},
+    {file = "propcache-0.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9cec3239c85ed15bfaded997773fdad9fb5662b0a7cbc854a43f291eb183179e"},
+    {file = "propcache-0.3.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:05543250deac8e61084234d5fc54f8ebd254e8f2b39a16b1dce48904f45b744b"},
+    {file = "propcache-0.3.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5cb5918253912e088edbf023788de539219718d3b10aef334476b62d2b53de53"},
+    {file = "propcache-0.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f3bbecd2f34d0e6d3c543fdb3b15d6b60dd69970c2b4c822379e5ec8f6f621d5"},
+    {file = "propcache-0.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:aca63103895c7d960a5b9b044a83f544b233c95e0dcff114389d64d762017af7"},
+    {file = "propcache-0.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5a0a9898fdb99bf11786265468571e628ba60af80dc3f6eb89a3545540c6b0ef"},
+    {file = "propcache-0.3.1-cp313-cp313-win32.whl", hash = "sha256:3a02a28095b5e63128bcae98eb59025924f121f048a62393db682f049bf4ac24"},
+    {file = "propcache-0.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:813fbb8b6aea2fc9659815e585e548fe706d6f663fa73dff59a1677d4595a037"},
+    {file = "propcache-0.3.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a444192f20f5ce8a5e52761a031b90f5ea6288b1eef42ad4c7e64fef33540b8f"},
+    {file = "propcache-0.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fbe94666e62ebe36cd652f5fc012abfbc2342de99b523f8267a678e4dfdee3c"},
+    {file = "propcache-0.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f011f104db880f4e2166bcdcf7f58250f7a465bc6b068dc84c824a3d4a5c94dc"},
+    {file = "propcache-0.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e584b6d388aeb0001d6d5c2bd86b26304adde6d9bb9bfa9c4889805021b96de"},
+    {file = "propcache-0.3.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a17583515a04358b034e241f952f1715243482fc2c2945fd99a1b03a0bd77d6"},
+    {file = "propcache-0.3.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5aed8d8308215089c0734a2af4f2e95eeb360660184ad3912686c181e500b2e7"},
+    {file = "propcache-0.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d8e309ff9a0503ef70dc9a0ebd3e69cf7b3894c9ae2ae81fc10943c37762458"},
+    {file = "propcache-0.3.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b655032b202028a582d27aeedc2e813299f82cb232f969f87a4fde491a233f11"},
+    {file = "propcache-0.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f64d91b751df77931336b5ff7bafbe8845c5770b06630e27acd5dbb71e1931c"},
+    {file = "propcache-0.3.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:19a06db789a4bd896ee91ebc50d059e23b3639c25d58eb35be3ca1cbe967c3bf"},
+    {file = "propcache-0.3.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:bef100c88d8692864651b5f98e871fb090bd65c8a41a1cb0ff2322db39c96c27"},
+    {file = "propcache-0.3.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:87380fb1f3089d2a0b8b00f006ed12bd41bd858fabfa7330c954c70f50ed8757"},
+    {file = "propcache-0.3.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e474fc718e73ba5ec5180358aa07f6aded0ff5f2abe700e3115c37d75c947e18"},
+    {file = "propcache-0.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:17d1c688a443355234f3c031349da69444be052613483f3e4158eef751abcd8a"},
+    {file = "propcache-0.3.1-cp313-cp313t-win32.whl", hash = "sha256:359e81a949a7619802eb601d66d37072b79b79c2505e6d3fd8b945538411400d"},
+    {file = "propcache-0.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e7fb9a84c9abbf2b2683fa3e7b0d7da4d8ecf139a1c635732a8bda29c5214b0e"},
+    {file = "propcache-0.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:ed5f6d2edbf349bd8d630e81f474d33d6ae5d07760c44d33cd808e2f5c8f4ae6"},
+    {file = "propcache-0.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:668ddddc9f3075af019f784456267eb504cb77c2c4bd46cc8402d723b4d200bf"},
+    {file = "propcache-0.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0c86e7ceea56376216eba345aa1fc6a8a6b27ac236181f840d1d7e6a1ea9ba5c"},
+    {file = "propcache-0.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83be47aa4e35b87c106fc0c84c0fc069d3f9b9b06d3c494cd404ec6747544894"},
+    {file = "propcache-0.3.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:27c6ac6aa9fc7bc662f594ef380707494cb42c22786a558d95fcdedb9aa5d035"},
+    {file = "propcache-0.3.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:64a956dff37080b352c1c40b2966b09defb014347043e740d420ca1eb7c9b908"},
+    {file = "propcache-0.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82de5da8c8893056603ac2d6a89eb8b4df49abf1a7c19d536984c8dd63f481d5"},
+    {file = "propcache-0.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c3c3a203c375b08fd06a20da3cf7aac293b834b6f4f4db71190e8422750cca5"},
+    {file = "propcache-0.3.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b303b194c2e6f171cfddf8b8ba30baefccf03d36a4d9cab7fd0bb68ba476a3d7"},
+    {file = "propcache-0.3.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:916cd229b0150129d645ec51614d38129ee74c03293a9f3f17537be0029a9641"},
+    {file = "propcache-0.3.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a461959ead5b38e2581998700b26346b78cd98540b5524796c175722f18b0294"},
+    {file = "propcache-0.3.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:069e7212890b0bcf9b2be0a03afb0c2d5161d91e1bf51569a64f629acc7defbf"},
+    {file = "propcache-0.3.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:ef2e4e91fb3945769e14ce82ed53007195e616a63aa43b40fb7ebaaf907c8d4c"},
+    {file = "propcache-0.3.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8638f99dca15b9dff328fb6273e09f03d1c50d9b6512f3b65a4154588a7595fe"},
+    {file = "propcache-0.3.1-cp39-cp39-win32.whl", hash = "sha256:6f173bbfe976105aaa890b712d1759de339d8a7cef2fc0a1714cc1a1e1c47f64"},
+    {file = "propcache-0.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:603f1fe4144420374f1a69b907494c3acbc867a581c2d49d4175b0de7cc64566"},
+    {file = "propcache-0.3.1-py3-none-any.whl", hash = "sha256:9a8ecf38de50a7f518c21568c80f985e776397b902f1ce0b01f799aba1608b40"},
+    {file = "propcache-0.3.1.tar.gz", hash = "sha256:40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf"},
+]
 
 [[package]]
 name = "psutil"
@@ -5412,6 +5690,125 @@ files = [
 ]
 
 [[package]]
+name = "yarl"
+version = "1.20.0"
+description = "Yet another URL library"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "yarl-1.20.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f1f6670b9ae3daedb325fa55fbe31c22c8228f6e0b513772c2e1c623caa6ab22"},
+    {file = "yarl-1.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:85a231fa250dfa3308f3c7896cc007a47bc76e9e8e8595c20b7426cac4884c62"},
+    {file = "yarl-1.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1a06701b647c9939d7019acdfa7ebbfbb78ba6aa05985bb195ad716ea759a569"},
+    {file = "yarl-1.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7595498d085becc8fb9203aa314b136ab0516c7abd97e7d74f7bb4eb95042abe"},
+    {file = "yarl-1.20.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af5607159085dcdb055d5678fc2d34949bd75ae6ea6b4381e784bbab1c3aa195"},
+    {file = "yarl-1.20.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:95b50910e496567434cb77a577493c26bce0f31c8a305135f3bda6a2483b8e10"},
+    {file = "yarl-1.20.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b594113a301ad537766b4e16a5a6750fcbb1497dcc1bc8a4daae889e6402a634"},
+    {file = "yarl-1.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:083ce0393ea173cd37834eb84df15b6853b555d20c52703e21fbababa8c129d2"},
+    {file = "yarl-1.20.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f1a350a652bbbe12f666109fbddfdf049b3ff43696d18c9ab1531fbba1c977a"},
+    {file = "yarl-1.20.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:fb0caeac4a164aadce342f1597297ec0ce261ec4532bbc5a9ca8da5622f53867"},
+    {file = "yarl-1.20.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:d88cc43e923f324203f6ec14434fa33b85c06d18d59c167a0637164863b8e995"},
+    {file = "yarl-1.20.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e52d6ed9ea8fd3abf4031325dc714aed5afcbfa19ee4a89898d663c9976eb487"},
+    {file = "yarl-1.20.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ce360ae48a5e9961d0c730cf891d40698a82804e85f6e74658fb175207a77cb2"},
+    {file = "yarl-1.20.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:06d06c9d5b5bc3eb56542ceeba6658d31f54cf401e8468512447834856fb0e61"},
+    {file = "yarl-1.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c27d98f4e5c4060582f44e58309c1e55134880558f1add7a87c1bc36ecfade19"},
+    {file = "yarl-1.20.0-cp310-cp310-win32.whl", hash = "sha256:f4d3fa9b9f013f7050326e165c3279e22850d02ae544ace285674cb6174b5d6d"},
+    {file = "yarl-1.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:bc906b636239631d42eb8a07df8359905da02704a868983265603887ed68c076"},
+    {file = "yarl-1.20.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fdb5204d17cb32b2de2d1e21c7461cabfacf17f3645e4b9039f210c5d3378bf3"},
+    {file = "yarl-1.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eaddd7804d8e77d67c28d154ae5fab203163bd0998769569861258e525039d2a"},
+    {file = "yarl-1.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:634b7ba6b4a85cf67e9df7c13a7fb2e44fa37b5d34501038d174a63eaac25ee2"},
+    {file = "yarl-1.20.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d409e321e4addf7d97ee84162538c7258e53792eb7c6defd0c33647d754172e"},
+    {file = "yarl-1.20.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ea52f7328a36960ba3231c6677380fa67811b414798a6e071c7085c57b6d20a9"},
+    {file = "yarl-1.20.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c8703517b924463994c344dcdf99a2d5ce9eca2b6882bb640aa555fb5efc706a"},
+    {file = "yarl-1.20.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:077989b09ffd2f48fb2d8f6a86c5fef02f63ffe6b1dd4824c76de7bb01e4f2e2"},
+    {file = "yarl-1.20.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0acfaf1da020253f3533526e8b7dd212838fdc4109959a2c53cafc6db611bff2"},
+    {file = "yarl-1.20.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4230ac0b97ec5eeb91d96b324d66060a43fd0d2a9b603e3327ed65f084e41f8"},
+    {file = "yarl-1.20.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a6a1e6ae21cdd84011c24c78d7a126425148b24d437b5702328e4ba640a8902"},
+    {file = "yarl-1.20.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:86de313371ec04dd2531f30bc41a5a1a96f25a02823558ee0f2af0beaa7ca791"},
+    {file = "yarl-1.20.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dd59c9dd58ae16eaa0f48c3d0cbe6be8ab4dc7247c3ff7db678edecbaf59327f"},
+    {file = "yarl-1.20.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a0bc5e05f457b7c1994cc29e83b58f540b76234ba6b9648a4971ddc7f6aa52da"},
+    {file = "yarl-1.20.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c9471ca18e6aeb0e03276b5e9b27b14a54c052d370a9c0c04a68cefbd1455eb4"},
+    {file = "yarl-1.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:40ed574b4df723583a26c04b298b283ff171bcc387bc34c2683235e2487a65a5"},
+    {file = "yarl-1.20.0-cp311-cp311-win32.whl", hash = "sha256:db243357c6c2bf3cd7e17080034ade668d54ce304d820c2a58514a4e51d0cfd6"},
+    {file = "yarl-1.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:8c12cd754d9dbd14204c328915e23b0c361b88f3cffd124129955e60a4fbfcfb"},
+    {file = "yarl-1.20.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e06b9f6cdd772f9b665e5ba8161968e11e403774114420737f7884b5bd7bdf6f"},
+    {file = "yarl-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b9ae2fbe54d859b3ade40290f60fe40e7f969d83d482e84d2c31b9bff03e359e"},
+    {file = "yarl-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d12b8945250d80c67688602c891237994d203d42427cb14e36d1a732eda480e"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:087e9731884621b162a3e06dc0d2d626e1542a617f65ba7cc7aeab279d55ad33"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:69df35468b66c1a6e6556248e6443ef0ec5f11a7a4428cf1f6281f1879220f58"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b2992fe29002fd0d4cbaea9428b09af9b8686a9024c840b8a2b8f4ea4abc16f"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c903e0b42aab48abfbac668b5a9d7b6938e721a6341751331bcd7553de2dcae"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf099e2432131093cc611623e0b0bcc399b8cddd9a91eded8bfb50402ec35018"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a7f62f5dc70a6c763bec9ebf922be52aa22863d9496a9a30124d65b489ea672"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:54ac15a8b60382b2bcefd9a289ee26dc0920cf59b05368c9b2b72450751c6eb8"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:25b3bc0763a7aca16a0f1b5e8ef0f23829df11fb539a1b70476dcab28bd83da7"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b2586e36dc070fc8fad6270f93242124df68b379c3a251af534030a4a33ef594"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:866349da9d8c5290cfefb7fcc47721e94de3f315433613e01b435473be63daa6"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:33bb660b390a0554d41f8ebec5cd4475502d84104b27e9b42f5321c5192bfcd1"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:737e9f171e5a07031cbee5e9180f6ce21a6c599b9d4b2c24d35df20a52fabf4b"},
+    {file = "yarl-1.20.0-cp312-cp312-win32.whl", hash = "sha256:839de4c574169b6598d47ad61534e6981979ca2c820ccb77bf70f4311dd2cc64"},
+    {file = "yarl-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:3d7dbbe44b443b0c4aa0971cb07dcb2c2060e4a9bf8d1301140a33a93c98e18c"},
+    {file = "yarl-1.20.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2137810a20b933b1b1b7e5cf06a64c3ed3b4747b0e5d79c9447c00db0e2f752f"},
+    {file = "yarl-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:447c5eadd750db8389804030d15f43d30435ed47af1313303ed82a62388176d3"},
+    {file = "yarl-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42fbe577272c203528d402eec8bf4b2d14fd49ecfec92272334270b850e9cd7d"},
+    {file = "yarl-1.20.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18e321617de4ab170226cd15006a565d0fa0d908f11f724a2c9142d6b2812ab0"},
+    {file = "yarl-1.20.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4345f58719825bba29895011e8e3b545e6e00257abb984f9f27fe923afca2501"},
+    {file = "yarl-1.20.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5d9b980d7234614bc4674468ab173ed77d678349c860c3af83b1fffb6a837ddc"},
+    {file = "yarl-1.20.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af4baa8a445977831cbaa91a9a84cc09debb10bc8391f128da2f7bd070fc351d"},
+    {file = "yarl-1.20.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:123393db7420e71d6ce40d24885a9e65eb1edefc7a5228db2d62bcab3386a5c0"},
+    {file = "yarl-1.20.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ab47acc9332f3de1b39e9b702d9c916af7f02656b2a86a474d9db4e53ef8fd7a"},
+    {file = "yarl-1.20.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4a34c52ed158f89876cba9c600b2c964dfc1ca52ba7b3ab6deb722d1d8be6df2"},
+    {file = "yarl-1.20.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:04d8cfb12714158abf2618f792c77bc5c3d8c5f37353e79509608be4f18705c9"},
+    {file = "yarl-1.20.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7dc63ad0d541c38b6ae2255aaa794434293964677d5c1ec5d0116b0e308031f5"},
+    {file = "yarl-1.20.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f9d02b591a64e4e6ca18c5e3d925f11b559c763b950184a64cf47d74d7e41877"},
+    {file = "yarl-1.20.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:95fc9876f917cac7f757df80a5dda9de59d423568460fe75d128c813b9af558e"},
+    {file = "yarl-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bb769ae5760cd1c6a712135ee7915f9d43f11d9ef769cb3f75a23e398a92d384"},
+    {file = "yarl-1.20.0-cp313-cp313-win32.whl", hash = "sha256:70e0c580a0292c7414a1cead1e076c9786f685c1fc4757573d2967689b370e62"},
+    {file = "yarl-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:4c43030e4b0af775a85be1fa0433119b1565673266a70bf87ef68a9d5ba3174c"},
+    {file = "yarl-1.20.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b6c4c3d0d6a0ae9b281e492b1465c72de433b782e6b5001c8e7249e085b69051"},
+    {file = "yarl-1.20.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8681700f4e4df891eafa4f69a439a6e7d480d64e52bf460918f58e443bd3da7d"},
+    {file = "yarl-1.20.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:84aeb556cb06c00652dbf87c17838eb6d92cfd317799a8092cee0e570ee11229"},
+    {file = "yarl-1.20.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f166eafa78810ddb383e930d62e623d288fb04ec566d1b4790099ae0f31485f1"},
+    {file = "yarl-1.20.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5d3d6d14754aefc7a458261027a562f024d4f6b8a798adb472277f675857b1eb"},
+    {file = "yarl-1.20.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2a8f64df8ed5d04c51260dbae3cc82e5649834eebea9eadfd829837b8093eb00"},
+    {file = "yarl-1.20.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d9949eaf05b4d30e93e4034a7790634bbb41b8be2d07edd26754f2e38e491de"},
+    {file = "yarl-1.20.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c366b254082d21cc4f08f522ac201d0d83a8b8447ab562732931d31d80eb2a5"},
+    {file = "yarl-1.20.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91bc450c80a2e9685b10e34e41aef3d44ddf99b3a498717938926d05ca493f6a"},
+    {file = "yarl-1.20.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9c2aa4387de4bc3a5fe158080757748d16567119bef215bec643716b4fbf53f9"},
+    {file = "yarl-1.20.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:d2cbca6760a541189cf87ee54ff891e1d9ea6406079c66341008f7ef6ab61145"},
+    {file = "yarl-1.20.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:798a5074e656f06b9fad1a162be5a32da45237ce19d07884d0b67a0aa9d5fdda"},
+    {file = "yarl-1.20.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f106e75c454288472dbe615accef8248c686958c2e7dd3b8d8ee2669770d020f"},
+    {file = "yarl-1.20.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:3b60a86551669c23dc5445010534d2c5d8a4e012163218fc9114e857c0586fdd"},
+    {file = "yarl-1.20.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e429857e341d5e8e15806118e0294f8073ba9c4580637e59ab7b238afca836f"},
+    {file = "yarl-1.20.0-cp313-cp313t-win32.whl", hash = "sha256:65a4053580fe88a63e8e4056b427224cd01edfb5f951498bfefca4052f0ce0ac"},
+    {file = "yarl-1.20.0-cp313-cp313t-win_amd64.whl", hash = "sha256:53b2da3a6ca0a541c1ae799c349788d480e5144cac47dba0266c7cb6c76151fe"},
+    {file = "yarl-1.20.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:119bca25e63a7725b0c9d20ac67ca6d98fa40e5a894bd5d4686010ff73397914"},
+    {file = "yarl-1.20.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:35d20fb919546995f1d8c9e41f485febd266f60e55383090010f272aca93edcc"},
+    {file = "yarl-1.20.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:484e7a08f72683c0f160270566b4395ea5412b4359772b98659921411d32ad26"},
+    {file = "yarl-1.20.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d8a3d54a090e0fff5837cd3cc305dd8a07d3435a088ddb1f65e33b322f66a94"},
+    {file = "yarl-1.20.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f0cf05ae2d3d87a8c9022f3885ac6dea2b751aefd66a4f200e408a61ae9b7f0d"},
+    {file = "yarl-1.20.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a884b8974729e3899d9287df46f015ce53f7282d8d3340fa0ed57536b440621c"},
+    {file = "yarl-1.20.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8d8aa8dd89ffb9a831fedbcb27d00ffd9f4842107d52dc9d57e64cb34073d5c"},
+    {file = "yarl-1.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b4e88d6c3c8672f45a30867817e4537df1bbc6f882a91581faf1f6d9f0f1b5a"},
+    {file = "yarl-1.20.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdb77efde644d6f1ad27be8a5d67c10b7f769804fff7a966ccb1da5a4de4b656"},
+    {file = "yarl-1.20.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4ba5e59f14bfe8d261a654278a0f6364feef64a794bd456a8c9e823071e5061c"},
+    {file = "yarl-1.20.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:d0bf955b96ea44ad914bc792c26a0edcd71b4668b93cbcd60f5b0aeaaed06c64"},
+    {file = "yarl-1.20.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:27359776bc359ee6eaefe40cb19060238f31228799e43ebd3884e9c589e63b20"},
+    {file = "yarl-1.20.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:04d9c7a1dc0a26efb33e1acb56c8849bd57a693b85f44774356c92d610369efa"},
+    {file = "yarl-1.20.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:faa709b66ae0e24c8e5134033187a972d849d87ed0a12a0366bedcc6b5dc14a5"},
+    {file = "yarl-1.20.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:44869ee8538208fe5d9342ed62c11cc6a7a1af1b3d0bb79bb795101b6e77f6e0"},
+    {file = "yarl-1.20.0-cp39-cp39-win32.whl", hash = "sha256:b7fa0cb9fd27ffb1211cde944b41f5c67ab1c13a13ebafe470b1e206b8459da8"},
+    {file = "yarl-1.20.0-cp39-cp39-win_amd64.whl", hash = "sha256:d4fad6e5189c847820288286732075f213eabf81be4d08d6cc309912e62be5b7"},
+    {file = "yarl-1.20.0-py3-none-any.whl", hash = "sha256:5d0fe6af927a47a230f31e6004621fd0959eaa915fc62acfafa67ff7229a3124"},
+    {file = "yarl-1.20.0.tar.gz", hash = "sha256:686d51e51ee5dfe62dec86e4866ee0e9ed66df700d55c828a615640adc885307"},
+]
+
+[package.dependencies]
+idna = ">=2.0"
+multidict = ">=4.0"
+propcache = ">=0.2.1"
+
+[[package]]
 name = "zipp"
 version = "3.20.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -5443,4 +5840,4 @@ tests = ["black", "numpydantic", "pyshacl"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "5d6090d1d8793c20907095f3339b7710380fa3d470857ee0e475a27a43b9e4d9"
+content-hash = "8c508d4477aa098e8d5055fbf0ffc3b379b631bbee48b1f912aaaa6fce03dcd9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ requests-cache = "^1.2.0"
 myst-nb = {version=">=1.0.0", python=">=3.9"}
 sphinx-design = "^0.5.0"
 rich = "^13.7.1"
+gql = "^3.5.2"
 
 [tool.poetry.group.tests.dependencies]
 pytest = "^7.4.0"

--- a/tests/test_biolink_model/__snapshots__/biolink.graphql
+++ b/tests/test_biolink_model/__snapshots__/biolink.graphql
@@ -209,7 +209,7 @@ type Activity implements ActivityAndBehavior
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -226,7 +226,7 @@ interface AdministrativeEntity
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -237,9 +237,9 @@ type Agent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
-    affiliation: [Uriorcurie]
+    affiliation: [String]
     address: String
     id: String!
     name: LabelType
@@ -253,7 +253,7 @@ type AnatomicalEntity implements PhysicalEssence
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -276,7 +276,7 @@ interface AnatomicalEntityToAnatomicalEntityAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -300,7 +300,7 @@ type AnatomicalEntityToAnatomicalEntityOntogenicAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -325,7 +325,7 @@ type AnatomicalEntityToAnatomicalEntityPartOfAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -348,17 +348,17 @@ type Article
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
     authors: [String]
     pages: [String]
     summary: String
     keywords: [String]
-    meshTerms: [Uriorcurie]
-    xref: [Uriorcurie]
+    meshTerms: [String]
+    xref: [String]
     id: String!
     name: LabelType
     type: String!
-    publishedIn: Uriorcurie!
+    publishedIn: String!
     isoAbbreviation: String
     volume: String
     issue: String
@@ -383,7 +383,7 @@ type Association
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -396,7 +396,7 @@ type Attribute implements OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -414,7 +414,7 @@ type Behavior implements OntologyClass, ActivityAndBehavior
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasInput: [Occurrent]
@@ -439,7 +439,7 @@ type BehaviorToBehavioralFeatureAssociation implements EntityToPhenotypicFeature
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -449,10 +449,10 @@ type BehaviorToBehavioralFeatureAssociation implements EntityToPhenotypicFeature
     severityQualifier: SeverityValue
     onsetQualifier: Onset
     sexQualifier: BiologicalSex
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type BehavioralExposure implements ExposureEvent
@@ -462,7 +462,7 @@ type BehavioralExposure implements ExposureEvent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -481,7 +481,7 @@ type BehavioralFeature
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -499,7 +499,7 @@ type BiologicalEntity implements ThingWithTaxon
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -513,7 +513,7 @@ type BiologicalProcess implements Occurrent, OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasInput: [Occurrent]
@@ -530,7 +530,7 @@ type BiologicalProcessOrActivity implements Occurrent, OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasInput: [Occurrent]
@@ -545,7 +545,7 @@ type BiologicalSex
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -561,7 +561,7 @@ type BioticExposure implements ExposureEvent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -581,13 +581,13 @@ type Book
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
     authors: [String]
     pages: [String]
     summary: String
     keywords: [String]
-    meshTerms: [Uriorcurie]
-    xref: [Uriorcurie]
+    meshTerms: [String]
+    xref: [String]
     name: LabelType
     id: String!
     type: String!
@@ -603,17 +603,17 @@ type BookChapter
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
     authors: [String]
     pages: [String]
     summary: String
     keywords: [String]
-    meshTerms: [Uriorcurie]
-    xref: [Uriorcurie]
+    meshTerms: [String]
+    xref: [String]
     id: String!
     name: LabelType
     type: String!
-    publishedIn: Uriorcurie!
+    publishedIn: String!
     volume: String
     chapter: String
   }
@@ -626,7 +626,7 @@ type Case implements SubjectOfInvestigation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -656,7 +656,7 @@ type CaseToPhenotypicFeatureAssociation implements EntityToPhenotypicFeatureAsso
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -664,10 +664,10 @@ type CaseToPhenotypicFeatureAssociation implements EntityToPhenotypicFeatureAsso
     severityQualifier: SeverityValue
     onsetQualifier: Onset
     sexQualifier: BiologicalSex
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type Cell
@@ -678,7 +678,7 @@ type Cell
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -692,7 +692,7 @@ type CellLine implements SubjectOfInvestigation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -716,7 +716,7 @@ type CellLineAsAModelOfDiseaseAssociation implements ModelToDiseaseAssociationMi
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -744,7 +744,7 @@ type CellLineToDiseaseOrPhenotypicFeatureAssociation implements CellLineToEntity
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -764,7 +764,7 @@ type CellularComponent
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -778,7 +778,7 @@ type CellularOrganism implements SubjectOfInvestigation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -800,7 +800,7 @@ type ChemicalAffectsGeneAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -833,7 +833,7 @@ type ChemicalEntity implements PhysicalEssence, ChemicalOrDrugOrTreatment, Chemi
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -858,7 +858,7 @@ type ChemicalEntityAssessesNamedThingAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -887,7 +887,7 @@ type ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -913,7 +913,7 @@ type ChemicalExposure implements ExposureEvent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -939,7 +939,7 @@ type ChemicalGeneInteractionAssociation implements ChemicalToEntityAssociationMi
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -965,7 +965,7 @@ type ChemicalMixture
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -1000,7 +1000,7 @@ type ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation im
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1026,7 +1026,7 @@ type ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation implements
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1041,7 +1041,7 @@ type ChemicalRole
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1068,7 +1068,7 @@ type ChemicalToChemicalAssociation implements ChemicalToEntityAssociationMixin
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1091,7 +1091,7 @@ type ChemicalToChemicalDerivationAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1119,7 +1119,7 @@ type ChemicalToDiseaseOrPhenotypicFeatureAssociation implements ChemicalToEntity
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1148,7 +1148,7 @@ type ChemicalToPathwayAssociation implements ChemicalToEntityAssociationMixin
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1165,12 +1165,12 @@ type ChiSquaredAnalysisResult
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type ClinicalAttribute
@@ -1180,7 +1180,7 @@ type ClinicalAttribute
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1196,7 +1196,7 @@ type ClinicalCourse
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1214,7 +1214,7 @@ type ClinicalEntity
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -1226,7 +1226,7 @@ type ClinicalFinding
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [ClinicalAttribute]
@@ -1241,7 +1241,7 @@ type ClinicalIntervention
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -1252,7 +1252,7 @@ type ClinicalMeasurement
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasQuantitativeValue: [QuantityValue]
@@ -1268,7 +1268,7 @@ type ClinicalModifier
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1286,7 +1286,7 @@ type ClinicalTrial
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -1299,7 +1299,7 @@ type CodingSequence
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -1319,7 +1319,7 @@ type Cohort implements SubjectOfInvestigation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -1334,12 +1334,12 @@ type CommonDataElement
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type ComplexChemicalExposure
@@ -1349,7 +1349,7 @@ type ComplexChemicalExposure
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1367,7 +1367,7 @@ type ComplexMolecularMixture
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -1389,12 +1389,12 @@ type ConceptCountAnalysisResult
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type ConfidenceLevel
@@ -1406,12 +1406,12 @@ type ConfidenceLevel
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type ContributorAssociation
@@ -1429,7 +1429,7 @@ type ContributorAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1448,12 +1448,12 @@ type Dataset
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type DatasetDistribution
@@ -1465,12 +1465,12 @@ type DatasetDistribution
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
     distributionDownloadUrl: String
   }
 
@@ -1483,12 +1483,12 @@ type DatasetSummary
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
     sourceWebPage: String
     sourceLogo: String
   }
@@ -1502,12 +1502,12 @@ type DatasetVersion
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
     hasDataset: Dataset
     ingestDate: String
     hasDistribution: DatasetDistribution
@@ -1522,7 +1522,7 @@ type Device
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -1535,7 +1535,7 @@ type Disease
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -1549,7 +1549,7 @@ type DiseaseOrPhenotypicFeature
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -1561,7 +1561,7 @@ type DiseaseOrPhenotypicFeatureExposure implements ExposureEvent, PathologicalEn
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1597,7 +1597,7 @@ type DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation implements Diseas
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1623,7 +1623,7 @@ type DiseaseOrPhenotypicFeatureToLocationAssociation implements DiseaseOrPhenoty
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1654,7 +1654,7 @@ type DiseaseToExposureEventAssociation implements DiseaseToEntityAssociationMixi
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1677,7 +1677,7 @@ type DiseaseToPhenotypicFeatureAssociation implements EntityToPhenotypicFeatureA
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1687,10 +1687,10 @@ type DiseaseToPhenotypicFeatureAssociation implements EntityToPhenotypicFeatureA
     severityQualifier: SeverityValue
     onsetQualifier: Onset
     sexQualifier: BiologicalSex
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type Drug implements ChemicalOrDrugOrTreatment, OntologyClass
@@ -1702,7 +1702,7 @@ type Drug implements ChemicalOrDrugOrTreatment, OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -1722,7 +1722,7 @@ type DrugExposure implements ExposureEvent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1755,7 +1755,7 @@ type DrugToGeneAssociation implements DrugToEntityAssociationMixin
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1769,7 +1769,7 @@ type DrugToGeneInteractionExposure implements GeneGroupingMixin
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1795,7 +1795,7 @@ type DruggableGeneToDiseaseAssociation implements EntityToDiseaseAssociationMixi
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1838,7 +1838,7 @@ type EntityToDiseaseAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1894,7 +1894,7 @@ type EntityToPhenotypicFeatureAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -1908,10 +1908,10 @@ type EntityToPhenotypicFeatureAssociationMixin implements FrequencyQuantifier
     onsetQualifier: Onset
     sexQualifier: BiologicalSex
     object: PhenotypicFeature!
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type EnvironmentalExposure implements ExposureEvent
@@ -1921,7 +1921,7 @@ type EnvironmentalExposure implements ExposureEvent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -1940,7 +1940,7 @@ type EnvironmentalFeature
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -1953,7 +1953,7 @@ type EnvironmentalFoodContaminant
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -1971,7 +1971,7 @@ type EnvironmentalProcess implements Occurrent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -1993,7 +1993,7 @@ type Event
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -2006,12 +2006,12 @@ type EvidenceType
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type Exon
@@ -2023,7 +2023,7 @@ type Exon
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -2052,7 +2052,7 @@ type ExonToTranscriptRelationship
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2085,7 +2085,7 @@ type ExposureEventToOutcomeAssociation implements EntityToOutcomeAssociationMixi
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2111,7 +2111,7 @@ type ExposureEventToPhenotypicFeatureAssociation implements EntityToPhenotypicFe
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2120,10 +2120,10 @@ type ExposureEventToPhenotypicFeatureAssociation implements EntityToPhenotypicFe
     severityQualifier: SeverityValue
     onsetQualifier: Onset
     sexQualifier: BiologicalSex
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type Food
@@ -2135,7 +2135,7 @@ type Food
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -2157,7 +2157,7 @@ type FoodAdditive
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -2173,10 +2173,10 @@ interface FrequencyQualifierMixin
 
 interface FrequencyQuantifier
   {
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type FunctionalAssociation
@@ -2196,7 +2196,7 @@ type FunctionalAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2217,7 +2217,7 @@ type Gene implements GeneOrGeneProduct, GenomicEntity, ChemicalEntityOrGeneOrGen
     inTaxon: [OrganismTaxon]
     symbol: String
     synonym: [LabelType]
-    xref: [Uriorcurie]
+    xref: [String]
     hasBiologicalSequence: BiologicalSequence
   }
 
@@ -2238,7 +2238,7 @@ type GeneAsAModelOfDiseaseAssociation implements ModelToDiseaseAssociationMixin,
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2266,7 +2266,7 @@ type GeneFamily implements GeneGroupingMixin, ChemicalEntityOrGeneOrGeneProduct
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasGeneOrGeneProduct: [Gene]
@@ -2293,7 +2293,7 @@ type GeneHasVariantThatContributesToDiseaseAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2315,14 +2315,14 @@ interface GeneProductIsoformMixin
   {
     name: SymbolType
     synonym: [LabelType]
-    xref: [Uriorcurie]
+    xref: [String]
   }
 
 interface GeneProductMixin
   {
     name: SymbolType
     synonym: [LabelType]
-    xref: [Uriorcurie]
+    xref: [String]
   }
 
 type GeneToDiseaseAssociation implements EntityToDiseaseAssociationMixin, GeneToEntityAssociationMixin
@@ -2342,7 +2342,7 @@ type GeneToDiseaseAssociation implements EntityToDiseaseAssociationMixin, GeneTo
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2374,7 +2374,7 @@ type GeneToExpressionSiteAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2402,7 +2402,7 @@ interface GeneToGeneAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2426,7 +2426,7 @@ type GeneToGeneCoexpressionAssociation implements GeneExpressionMixin
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2455,7 +2455,7 @@ type GeneToGeneFamilyAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2480,7 +2480,7 @@ type GeneToGeneHomologyAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2505,7 +2505,7 @@ type GeneToGeneProductRelationship
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2531,7 +2531,7 @@ type GeneToGoTermAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2556,7 +2556,7 @@ type GeneToPathwayAssociation implements GeneToEntityAssociationMixin
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2581,7 +2581,7 @@ type GeneToPhenotypicFeatureAssociation implements EntityToPhenotypicFeatureAsso
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2591,10 +2591,10 @@ type GeneToPhenotypicFeatureAssociation implements EntityToPhenotypicFeatureAsso
     severityQualifier: SeverityValue
     onsetQualifier: Onset
     sexQualifier: BiologicalSex
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type GeneticInheritance
@@ -2606,7 +2606,7 @@ type GeneticInheritance
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -2620,7 +2620,7 @@ type Genome implements GenomicEntity, PhysicalEssence, OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasBiologicalSequence: BiologicalSequence
@@ -2633,7 +2633,7 @@ type GenomicBackgroundExposure implements ExposureEvent, GeneGroupingMixin, Phys
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -2667,12 +2667,12 @@ type GenomicSequenceLocalization
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
-    startInterbaseCoordinate: Integer
-    endInterbaseCoordinate: Integer
+    startInterbaseCoordinate: Int
+    endInterbaseCoordinate: Int
     genomeBuild: StrandEnum
     strand: StrandEnum
     phase: PhaseEnum
@@ -2690,7 +2690,7 @@ type Genotype implements PhysicalEssence, GenomicEntity, OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasZygosity: Zygosity
@@ -2713,7 +2713,7 @@ type GenotypeAsAModelOfDiseaseAssociation implements ModelToDiseaseAssociationMi
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2741,7 +2741,7 @@ type GenotypeToDiseaseAssociation implements GenotypeToEntityAssociationMixin, E
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2774,7 +2774,7 @@ type GenotypeToGeneAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2799,7 +2799,7 @@ type GenotypeToGenotypePartAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2825,7 +2825,7 @@ type GenotypeToPhenotypicFeatureAssociation implements EntityToPhenotypicFeature
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2835,10 +2835,10 @@ type GenotypeToPhenotypicFeatureAssociation implements EntityToPhenotypicFeature
     severityQualifier: SeverityValue
     onsetQualifier: Onset
     sexQualifier: BiologicalSex
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type GenotypeToVariantAssociation
@@ -2857,7 +2857,7 @@ type GenotypeToVariantAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -2873,7 +2873,7 @@ type GenotypicSex
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -2889,7 +2889,7 @@ type GeographicExposure implements ExposureEvent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -2908,7 +2908,7 @@ type GeographicLocation
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     latitude: Float
     longitude: Float
@@ -2923,7 +2923,7 @@ type GeographicLocationAtTime
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     latitude: Float
     longitude: Float
@@ -2938,7 +2938,7 @@ type GrossAnatomicalStructure
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -2953,7 +2953,7 @@ type Haplotype implements GenomicEntity, PhysicalEssence, OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasBiologicalSequence: BiologicalSequence
@@ -2968,7 +2968,7 @@ type Hospitalization
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -2984,7 +2984,7 @@ type IndividualOrganism implements SubjectOfInvestigation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -2999,12 +2999,12 @@ interface InformationContentEntity
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type InformationContentEntityToNamedThingAssociation
@@ -3023,7 +3023,7 @@ type InformationContentEntityToNamedThingAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3041,12 +3041,12 @@ type InformationResource
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type LifeStage
@@ -3057,7 +3057,7 @@ type LifeStage
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -3072,7 +3072,7 @@ type MacromolecularComplex implements MacromolecularMachineMixin
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -3099,7 +3099,7 @@ type MacromolecularMachineToBiologicalProcessAssociation implements Macromolecul
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3124,7 +3124,7 @@ type MacromolecularMachineToCellularComponentAssociation implements Macromolecul
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3154,7 +3154,7 @@ type MacromolecularMachineToMolecularActivityAssociation implements Macromolecul
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3176,7 +3176,7 @@ type MaterialSample implements SubjectOfInvestigation
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -3196,7 +3196,7 @@ type MaterialSampleDerivationAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3224,7 +3224,7 @@ type MaterialSampleToDiseaseOrPhenotypicFeatureAssociation implements MaterialSa
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3244,7 +3244,7 @@ type MicroRNA
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -3272,7 +3272,7 @@ type MolecularActivity implements Occurrent, OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasInput: [MolecularEntity]
@@ -3297,7 +3297,7 @@ type MolecularActivityToChemicalEntityAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3322,7 +3322,7 @@ type MolecularActivityToMolecularActivityAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3346,7 +3346,7 @@ type MolecularActivityToPathwayAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3364,7 +3364,7 @@ type MolecularEntity
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -3383,7 +3383,7 @@ type MolecularMixture
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -3409,7 +3409,7 @@ type NamedThing
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -3431,7 +3431,7 @@ type NamedThingAssociatedWithLikelihoodOfNamedThingAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3451,7 +3451,7 @@ type NoncodingRNAProduct
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -3473,7 +3473,7 @@ type NucleicAcidEntity implements GenomicEntity, ThingWithTaxon, PhysicalEssence
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -3494,7 +3494,7 @@ type NucleicAcidSequenceMotif
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -3508,7 +3508,7 @@ type NucleosomeModification implements GeneProductIsoformMixin, GenomicEntity, E
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     synonym: [LabelType]
@@ -3524,12 +3524,12 @@ type ObservedExpectedFrequencyAnalysisResult
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 interface Occurrent
@@ -3543,7 +3543,7 @@ type Onset
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -3564,7 +3564,7 @@ type OrganismAttribute
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -3582,7 +3582,7 @@ type OrganismTaxon
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     hasTaxonomicRank: TaxonomicRank
   }
@@ -3608,7 +3608,7 @@ type OrganismTaxonToEnvironmentAssociation implements OrganismTaxonToEntityAssoc
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3634,7 +3634,7 @@ type OrganismTaxonToOrganismTaxonAssociation implements OrganismTaxonToEntityAss
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3658,7 +3658,7 @@ type OrganismTaxonToOrganismTaxonInteraction
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3684,7 +3684,7 @@ type OrganismTaxonToOrganismTaxonSpecialization
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3710,7 +3710,7 @@ type OrganismToOrganismAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3726,7 +3726,7 @@ type OrganismalEntity implements SubjectOfInvestigation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -3750,7 +3750,7 @@ type OrganismalEntityAsAModelOfDiseaseAssociation implements ModelToDiseaseAssoc
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3780,7 +3780,7 @@ type PairwiseGeneToGeneInteraction
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3804,7 +3804,7 @@ type PairwiseMolecularInteraction
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -3826,7 +3826,7 @@ type PathologicalAnatomicalExposure implements ExposureEvent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -3848,7 +3848,7 @@ type PathologicalAnatomicalStructure implements PathologicalEntityMixin
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -3867,7 +3867,7 @@ type PathologicalProcess implements PathologicalEntityMixin
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasInput: [Occurrent]
@@ -3882,7 +3882,7 @@ type PathologicalProcessExposure implements ExposureEvent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -3905,7 +3905,7 @@ type Pathway implements OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasInput: [Occurrent]
@@ -3922,7 +3922,7 @@ type Phenomenon implements Occurrent
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -3935,7 +3935,7 @@ type PhenotypicFeature
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -3947,7 +3947,7 @@ type PhenotypicQuality
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -3963,7 +3963,7 @@ type PhenotypicSex
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -3981,7 +3981,7 @@ type PhysicalEntity implements PhysicalEssence
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -4002,7 +4002,7 @@ type PhysiologicalProcess implements OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasInput: [Occurrent]
@@ -4019,7 +4019,7 @@ type PlanetaryEntity
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -4032,7 +4032,7 @@ type Polypeptide implements ChemicalEntityOrGeneOrGeneProduct, ChemicalEntityOrP
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
   }
@@ -4045,7 +4045,7 @@ type PopulationOfIndividualOrganisms implements SubjectOfInvestigation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -4067,7 +4067,7 @@ type PopulationToPopulationAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4085,7 +4085,7 @@ type PosttranslationalModification implements GeneProductIsoformMixin
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     synonym: [LabelType]
@@ -4125,7 +4125,7 @@ type Procedure implements ActivityAndBehavior
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
   }
 
@@ -4138,7 +4138,7 @@ type ProcessedMaterial
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -4160,7 +4160,7 @@ type Protein implements GeneProductMixin
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     synonym: [LabelType]
@@ -4175,7 +4175,7 @@ type ProteinDomain implements GeneGroupingMixin, ChemicalEntityOrGeneOrGeneProdu
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasGeneOrGeneProduct: [Gene]
@@ -4190,7 +4190,7 @@ type ProteinFamily implements GeneGroupingMixin, ChemicalEntityOrGeneOrGeneProdu
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasGeneOrGeneProduct: [Gene]
@@ -4205,7 +4205,7 @@ type ProteinIsoform implements GeneProductIsoformMixin
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     synonym: [LabelType]
@@ -4221,13 +4221,13 @@ type Publication
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
     authors: [String]
     pages: [String]
     summary: String
     keywords: [String]
-    meshTerms: [Uriorcurie]
-    xref: [Uriorcurie]
+    meshTerms: [String]
+    xref: [String]
     id: String!
     name: LabelType
     type: String!
@@ -4236,7 +4236,7 @@ type Publication
 type QuantityValue
   {
     hasUnit: Unit
-    hasNumericValue: Double
+    hasNumericValue: Float
   }
 
 type ReactionToCatalystAssociation
@@ -4256,11 +4256,11 @@ type ReactionToCatalystAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
-    stoichiometry: Integer
+    stoichiometry: Int
     reactionDirection: ReactionDirectionEnum
     reactionSide: ReactionSideEnum
     subject: MolecularEntity!
@@ -4284,12 +4284,12 @@ type ReactionToParticipantAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
     object: ChemicalEntity!
-    stoichiometry: Integer
+    stoichiometry: Int
     reactionDirection: ReactionDirectionEnum
     reactionSide: ReactionSideEnum
     subject: MolecularEntity!
@@ -4304,7 +4304,7 @@ type ReagentTargetedGene implements GenomicEntity, PhysicalEssence, OntologyClas
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasBiologicalSequence: BiologicalSequence
@@ -4328,12 +4328,12 @@ type RelativeFrequencyAnalysisResult
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type RNAProduct implements GeneProductMixin
@@ -4345,7 +4345,7 @@ type RNAProduct implements GeneProductMixin
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -4367,7 +4367,7 @@ type RNAProductIsoform implements GeneProductIsoformMixin
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -4403,7 +4403,7 @@ type SequenceAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4426,7 +4426,7 @@ type SequenceFeatureRelationship
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4442,7 +4442,7 @@ type SequenceVariant implements GenomicEntity, PhysicalEssence, OntologyClass
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasGene: [Gene]
@@ -4467,7 +4467,7 @@ interface SequenceVariantModulatesTreatmentAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4485,13 +4485,13 @@ type Serial
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
     authors: [String]
     pages: [String]
     summary: String
     keywords: [String]
-    meshTerms: [Uriorcurie]
-    xref: [Uriorcurie]
+    meshTerms: [String]
+    xref: [String]
     name: LabelType
     isoAbbreviation: String
     volume: String
@@ -4507,7 +4507,7 @@ type SeverityValue
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -4525,7 +4525,7 @@ type SiRNA
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -4546,7 +4546,7 @@ type SmallMolecule
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -4565,7 +4565,7 @@ type Snv
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasGene: [Gene]
@@ -4580,7 +4580,7 @@ type SocioeconomicAttribute
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -4595,7 +4595,7 @@ type SocioeconomicExposure implements ExposureEvent
     type: String
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!
@@ -4623,12 +4623,12 @@ type Study
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type StudyPopulation
@@ -4639,7 +4639,7 @@ type StudyPopulation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -4654,12 +4654,12 @@ interface StudyResult
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 type StudyVariable
@@ -4671,12 +4671,12 @@ type StudyVariable
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 interface SubjectOfInvestigation
@@ -4700,7 +4700,7 @@ type TaxonToTaxonAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4722,12 +4722,12 @@ type TextMiningResult
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     license: String
     rights: String
     format: String
-    creationDate: Date
+    creationDate: String
   }
 
 interface ThingWithTaxon
@@ -4744,7 +4744,7 @@ type Transcript
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     tradeName: ChemicalEntity
     availableFrom: [DrugAvailabilityEnum]
@@ -4773,7 +4773,7 @@ type TranscriptToGeneRelationship
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4790,7 +4790,7 @@ type Treatment implements ExposureEvent, ChemicalOrDrugOrTreatment
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     hasDrug: [Drug]
     hasDevice: [Device]
@@ -4814,7 +4814,7 @@ type VariantAsAModelOfDiseaseAssociation implements ModelToDiseaseAssociationMix
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4842,7 +4842,7 @@ type VariantToDiseaseAssociation implements VariantToEntityAssociationMixin, Ent
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4876,7 +4876,7 @@ type VariantToGeneAssociation implements VariantToEntityAssociationMixin
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4901,7 +4901,7 @@ type VariantToGeneExpressionAssociation implements GeneExpressionMixin
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4931,7 +4931,7 @@ type VariantToPhenotypicFeatureAssociation implements VariantToEntityAssociation
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
@@ -4940,10 +4940,10 @@ type VariantToPhenotypicFeatureAssociation implements VariantToEntityAssociation
     severityQualifier: SeverityValue
     onsetQualifier: Onset
     sexQualifier: BiologicalSex
-    hasCount: Integer
-    hasTotal: Integer
-    hasQuotient: Double
-    hasPercentage: Double
+    hasCount: Int
+    hasTotal: Int
+    hasQuotient: Float
+    hasPercentage: Float
   }
 
 type VariantToPopulationAssociation implements VariantToEntityAssociationMixin, FrequencyQuantifier, FrequencyQualifierMixin
@@ -4963,16 +4963,16 @@ type VariantToPopulationAssociation implements VariantToEntityAssociationMixin, 
     aggregatorKnowledgeSource: [InformationResource]
     timepoint: TimeType
     originalSubject: String
-    originalPredicate: Uriorcurie
+    originalPredicate: String
     originalObject: String
     type: String
     category: [CategoryType]
     subject: SequenceVariant!
     object: PopulationOfIndividualOrganisms!
-    hasQuotient: Double
-    hasCount: Integer
-    hasTotal: Integer
-    hasPercentage: Double
+    hasQuotient: Float
+    hasCount: Int
+    hasTotal: Int
+    hasPercentage: Float
     frequencyQualifier: FrequencyValue
   }
 
@@ -4984,7 +4984,7 @@ type Virus implements SubjectOfInvestigation
     name: LabelType
     description: NarrativeText
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     inTaxon: [OrganismTaxon]
     hasAttribute: [Attribute]
@@ -4997,7 +4997,7 @@ type Zygosity
     description: NarrativeText
     hasAttribute: [Attribute]
     providedBy: [String]
-    xref: [Uriorcurie]
+    xref: [String]
     category: [CategoryType]!
     name: LabelType
     hasAttributeType: OntologyClass!

--- a/tests/test_generators/__snapshots__/kitchen_sink.graphql
+++ b/tests/test_generators/__snapshots__/kitchen_sink.graphql
@@ -47,8 +47,8 @@ enum OtherCodes
 type Activity
   {
     id: String!
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     wasInformedBy: Activity
     wasAssociatedWith: Agent
     used: String
@@ -59,7 +59,7 @@ type Address
   {
     street: String
     city: String
-    altitude: Decimal
+    altitude: Float
   }
 
 type Agent
@@ -69,9 +69,7 @@ type Agent
     wasInformedBy: Activity
   }
 
-type AnyObject
-  {
-  }
+scalar AnyObject
 
 type AnyOfClasses
   {
@@ -95,8 +93,8 @@ type AnyOfSimpleType
 
 type BirthEvent
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     inLocation: Place
@@ -146,8 +144,8 @@ type DiagnosisConcept
 
 type EmploymentEvent
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     employedAt: Company
@@ -166,8 +164,8 @@ type EqualsStringIn
 
 type Event
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
   }
@@ -179,8 +177,8 @@ type FakeClass
 
 type FamilialRelationship
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     cordialness: String
     type: FamilialRelationshipType!
     relatedTo: Person!
@@ -198,8 +196,8 @@ interface HasAliases
 
 type MarriageEvent implements WithLocation
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     marriedTo: Person
@@ -208,8 +206,8 @@ type MarriageEvent implements WithLocation
 
 type MedicalEvent
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     inLocation: Place
@@ -231,11 +229,11 @@ type Person implements HasAliases
     hasEmploymentHistory: [EmploymentEvent]
     hasFamilialRelationships: [FamilialRelationship]
     hasMedicalHistory: [MedicalEvent]
-    ageInYears: Integer
+    ageInYears: Int
     addresses: [Address]
     hasBirthEvent: BirthEvent
     speciesName: String
-    stomachCount: Integer
+    stomachCount: Int
     isLiving: LifeStatusEnum
     aliases: [String]
   }
@@ -256,8 +254,8 @@ type ProcedureConcept
 
 type Relationship
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     relatedTo: String
     type: String
     cordialness: CordialnessEnum

--- a/tests/test_generators/test_graphql.py
+++ b/tests/test_generators/test_graphql.py
@@ -11,11 +11,11 @@ type Person implements HasAliases
     hasEmploymentHistory: [EmploymentEvent]
     hasFamilialRelationships: [FamilialRelationship]
     hasMedicalHistory: [MedicalEvent]
-    ageInYears: Integer
+    ageInYears: Int
     addresses: [Address]
     hasBirthEvent: BirthEvent
     speciesName: String
-    stomachCount: Integer
+    stomachCount: Int
     isLiving: LifeStatusEnum
     aliases: [String]
   }
@@ -24,8 +24,8 @@ type Person implements HasAliases
 MEDICALEVENT = """
 type MedicalEvent
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     inLocation: Place
@@ -37,8 +37,8 @@ type MedicalEvent
 FAMILIALRELATIONSHIP = """
 type FamilialRelationship
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     cordialness: String
     type: FamilialRelationshipType!
     relatedTo: Person!
@@ -65,24 +65,16 @@ enum FamilialRelationshipType
   }
 """
 
-OTHERCODES = """
-enum OtherCodes
-  {
-    a_b
-  }
-"""
-
 
 @pytest.mark.parametrize(
     "input_class,expected",
     [
         # check that expected GraphQL schema blocks are present
-        ("Person", PERSON),
+        pytest.param("Person", PERSON, marks=pytest.mark.xfail(reason="Bug 2302: invalid GraphQL code")),
         ("Dataset", DATASET),
-        ("MedicalEvent", MEDICALEVENT),
-        ("FamilialRelationship", FAMILIALRELATIONSHIP),
+        pytest.param("MedicalEvent", MEDICALEVENT, marks=pytest.mark.xfail(reason="Bug 2302: invalid GraphQL code")),
+        pytest.param("FamilialRelationship", FAMILIALRELATIONSHIP, marks=pytest.mark.xfail(reason="Bug 2302: invalid GraphQL code")),
         ("FamilialRelationshipType", FAMILIALRELATIONSHIPTYPE),
-        ("OtherCodes", OTHERCODES),
     ],
 )
 def test_serialize_selected(input_class, expected, kitchen_sink_path):

--- a/tests/test_generators/test_graphql.py
+++ b/tests/test_generators/test_graphql.py
@@ -1,4 +1,5 @@
 import pytest
+from graphql import parse
 
 from linkml.generators.graphqlgen import GraphqlGenerator
 
@@ -97,3 +98,18 @@ def test_snapshot(kitchen_sink_path, snapshot):
     generator = GraphqlGenerator(kitchen_sink_path)
     generated = generator.serialize()
     assert generated == snapshot("kitchen_sink.graphql")
+
+
+@pytest.mark.xfail(reason="Bug 2302: invalid GraphQL code")
+def test_graphql_validity(kitchen_sink_path):
+    generator = GraphqlGenerator(kitchen_sink_path)
+    generated = generator.serialize()
+    print("\nGenerated GraphQL schema:")
+    print("vvvvvv Start GraphQL vvvvvv")
+    print(generated)
+    print("^^^^^^^ End GraphQL ^^^^^^^")
+    try:
+        parse(generated)
+    except Exception as ex:
+        print(f"\nvvvvvv Start Error Message vvvvvv\n{str(ex)}\n^^^^^^^ End Error Message ^^^^^^^")
+        pytest.fail("Generated GraphQL appears to be wrong, it cannot be parsed!")

--- a/tests/test_generators/test_graphql.py
+++ b/tests/test_generators/test_graphql.py
@@ -70,10 +70,10 @@ enum FamilialRelationshipType
     "input_class,expected",
     [
         # check that expected GraphQL schema blocks are present
-        pytest.param("Person", PERSON, marks=pytest.mark.xfail(reason="Bug 2302: invalid GraphQL code")),
+        ("Person", PERSON),
         ("Dataset", DATASET),
-        pytest.param("MedicalEvent", MEDICALEVENT, marks=pytest.mark.xfail(reason="Bug 2302: invalid GraphQL code")),
-        pytest.param("FamilialRelationship", FAMILIALRELATIONSHIP, marks=pytest.mark.xfail(reason="Bug 2302: invalid GraphQL code")),
+        ("MedicalEvent", MEDICALEVENT),
+        ("FamilialRelationship", FAMILIALRELATIONSHIP),
         ("FamilialRelationshipType", FAMILIALRELATIONSHIPTYPE),
     ],
 )
@@ -92,7 +92,6 @@ def test_snapshot(kitchen_sink_path, snapshot):
     assert generated == snapshot("kitchen_sink.graphql")
 
 
-@pytest.mark.xfail(reason="Bug 2302: invalid GraphQL code")
 def test_graphql_validity(kitchen_sink_path):
     generator = GraphqlGenerator(kitchen_sink_path)
     generated = generator.serialize()

--- a/tests/test_scripts/__snapshots__/gengraphql/meta.graphql
+++ b/tests/test_scripts/__snapshots__/gengraphql/meta.graphql
@@ -47,8 +47,8 @@ enum OtherCodes
 type Activity
   {
     id: String!
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     wasInformedBy: Activity
     wasAssociatedWith: Agent
     used: String
@@ -59,7 +59,7 @@ type Address
   {
     street: String
     city: String
-    altitude: Decimal
+    altitude: Float
   }
 
 type Agent
@@ -69,9 +69,7 @@ type Agent
     wasInformedBy: Activity
   }
 
-type AnyObject
-  {
-  }
+scalar AnyObject
 
 type AnyOfClasses
   {
@@ -95,8 +93,8 @@ type AnyOfSimpleType
 
 type BirthEvent
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     inLocation: Place
@@ -146,8 +144,8 @@ type DiagnosisConcept
 
 type EmploymentEvent
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     employedAt: Company
@@ -166,8 +164,8 @@ type EqualsStringIn
 
 type Event
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
   }
@@ -179,8 +177,8 @@ type FakeClass
 
 type FamilialRelationship
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     cordialness: String
     type: FamilialRelationshipType!
     relatedTo: Person!
@@ -198,8 +196,8 @@ interface HasAliases
 
 type MarriageEvent implements WithLocation
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     marriedTo: Person
@@ -208,8 +206,8 @@ type MarriageEvent implements WithLocation
 
 type MedicalEvent
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     isCurrent: Boolean
     metadata: AnyObject
     inLocation: Place
@@ -231,11 +229,11 @@ type Person implements HasAliases
     hasEmploymentHistory: [EmploymentEvent]
     hasFamilialRelationships: [FamilialRelationship]
     hasMedicalHistory: [MedicalEvent]
-    ageInYears: Integer
+    ageInYears: Int
     addresses: [Address]
     hasBirthEvent: BirthEvent
     speciesName: String
-    stomachCount: Integer
+    stomachCount: Int
     isLiving: LifeStatusEnum
     aliases: [String]
   }
@@ -256,8 +254,8 @@ type ProcedureConcept
 
 type Relationship
   {
-    startedAtTime: Date
-    endedAtTime: Date
+    startedAtTime: String
+    endedAtTime: String
     relatedTo: String
     type: String
     cordialness: CordialnessEnum


### PR DESCRIPTION
Add tests for the generation of GraphQL scalar types.

It also adds validation of the GraphQL code using [GQL](https://gql.readthedocs.io/en/stable/).

Please review the proposed [type](https://linkml.io/linkml-model/latest/docs/#types) equivalence based on [GraphQL native scalar types](https://graphql.org/learn/schema/#scalar-types):
- To GraphQL `Boolean`: `Boolean`
- To GraphQL `Int`: `Integer`
- To GraphQL `Float`: `Float`, `Double`, `Decimal`
- To GraphQL `String`: `String`, `Time`,  `Date`, `Datetime`, `DateOrDatetime`, `Uriorcurie`, `Curie`, `Uri`, `Ncname`, `Objectidentifier`, `Nodeidentifier`, `Jsonpointer`, `Jsonpath`, `Sparqlpath`

Closes #2302

This PR replaces outdated PR #2304 