### PR TITLE
Issue2708 gen doc template fixes

### DIFF
--- a/linkml/generators/docgen/class.md.jinja2
+++ b/linkml/generators/docgen/class.md.jinja2
@@ -21,12 +21,11 @@
     {%- endif -%}
 {% endmacro %}
 
-# Class: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
+# Class: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong></span> {% endif %}
 
 {%- if header -%}
-{{header}}
+{{ header }}
 {%- endif -%}
-
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}
@@ -40,7 +39,6 @@ _{{ element_description_line }}_
 {% endif %}
 
 URI: {{ gen.uri_link(element) }}
-
 
 {% if diagram_type == "er_diagram" %}
 ```{{ gen.mermaid_directive() }}
@@ -93,7 +91,7 @@ URI: {{ gen.uri_link(element) }}
 | used by | used in | type | used |
 | ---  | --- | --- | --- |
 {% for usage in schemaview.usage_index().get(element.name) -%}
-| {{gen.link(usage.used_by)}} | {{gen.link(usage.slot)}} | {{usage.metaslot}} | {{ gen.link(usage.used) }} |
+| {{ gen.link(usage.used_by) }} | {{ gen.link(usage.slot) }} | {{ usage.metaslot }} | {{ gen.link(usage.used) }} |
 {% endfor %}
 {% endif %}
 
@@ -102,14 +100,13 @@ URI: {{ gen.uri_link(element) }}
 {% if gen.example_object_blobs(element.name) -%}
 ## Examples
 {% for name, blob in gen.example_object_blobs(element.name) -%}
-### Example: {{name}}
+### Example: {{ name }}
 
 ```yaml
 {{ blob }}
 ```
 {% endfor %}
 {% endif %}
-
 
 ## LinkML Source
 
@@ -119,7 +116,7 @@ URI: {{ gen.uri_link(element) }}
 
 <details>
 ```yaml
-{{gen.yaml(element)}}
+{{ gen.yaml(element) }}
 ```
 </details>
 
@@ -127,10 +124,10 @@ URI: {{ gen.uri_link(element) }}
 
 <details>
 ```yaml
-{{gen.yaml(element, inferred=True)}}
+{{ gen.yaml(element, inferred=True) }}
 ```
 </details>
 
 {%- if footer -%}
-{{footer}}
+{{ footer }}
 {%- endif -%}

--- a/linkml/generators/docgen/class_diagram.md.jinja2
+++ b/linkml/generators/docgen/class_diagram.md.jinja2
@@ -11,19 +11,19 @@
 ```{{ gen.mermaid_directive() }}
  classDiagram
     class {{ gen.name(element) }}
-    click {{ gen.name(element) }} href "../{{gen.name(element)}}"
+    click {{ gen.name(element) }} href "../{{ gen.name(element) }}"
       {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
         {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
-        click {{ gen.name(schemaview.get_element(s)) }} href "../{{gen.name(schemaview.get_element(s))}}"
+        click {{ gen.name(schemaview.get_element(s)) }} href "../{{ gen.name(schemaview.get_element(s)) }}"
       {% endfor %}
 
       {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
-        click {{ gen.name(schemaview.get_element(s)) }} href "../{{gen.name(schemaview.get_element(s))}}"
+        click {{ gen.name(schemaview.get_element(s)) }} href "../{{ gen.name(schemaview.get_element(s)) }}"
       {% endfor %}
       
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
-        {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} : {{ gen.name(s) }}
         {% if s.range is not none and s.range not in gen.all_type_object_names() %}
           {{ slot_relationship(element, s) }}
         {% endif %}
@@ -33,13 +33,13 @@
 ```{{ gen.mermaid_directive() }}
  classDiagram
     class {{ gen.name(element) }}
-    click {{ gen.name(element) }} href "../{{gen.name(element)}}"
+    click {{ gen.name(element) }} href "../{{ gen.name(element) }}"
       {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
         {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
-        click {{ gen.name(schemaview.get_element(s)) }} href "../{{gen.name(schemaview.get_element(s))}}"
+        click {{ gen.name(schemaview.get_element(s)) }} href "../{{ gen.name(schemaview.get_element(s)) }}"
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
-        {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} : {{ gen.name(s) }}
         {% if s.range is not none and s.range not in gen.all_type_object_names() %}
           {{ slot_relationship(element, s) }}
         {% endif %}
@@ -49,13 +49,13 @@
 ```{{ gen.mermaid_directive() }}
  classDiagram
     class {{ gen.name(element) }}
-    click {{ gen.name(element) }} href "../{{gen.name(element)}}"
+    click {{ gen.name(element) }} href "../{{ gen.name(element) }}"
       {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
-        click {{ gen.name(schemaview.get_element(s)) }} href "../{{gen.name(schemaview.get_element(s))}}"
+        click {{ gen.name(schemaview.get_element(s)) }} href "../{{ gen.name(schemaview.get_element(s)) }}"
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
-        {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} : {{ gen.name(s) }}
         {% if s.range is not none and s.range not in gen.all_type_object_names() %}
           {{ slot_relationship(element, s) }}
         {% endif %}
@@ -65,9 +65,9 @@
 ```{{ gen.mermaid_directive() }}
  classDiagram
     class {{ gen.name(element) }}
-    click {{ gen.name(element) }} href "../{{gen.name(element)}}"
+    click {{ gen.name(element) }} href "../{{ gen.name(element) }}"
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
-        {{ gen.name(element) }} : {{gen.name(s)}}
+        {{ gen.name(element) }} : {{ gen.name(s) }}
         {% if s.range is not none and s.range not in gen.all_type_object_names() %}
           {{ slot_relationship(element, s) }}
         {% endif %}

--- a/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/linkml/generators/docgen/common_metadata.md.jinja2
@@ -6,7 +6,6 @@
 {%- endfor %}
 {% endif %}
 
-
 {% if element.examples %}
 ## Examples
 
@@ -21,7 +20,7 @@
 ## Comments
 
 {% for x in element.comments -%}
-* {{x}}
+* {{ x }}
 {% endfor %}
 {% endif -%}
 
@@ -29,7 +28,7 @@
 ## TODOs
 
 {% for x in element.todos -%}
-* {{x}}
+* {{ x }}
 {% endfor %}
 {% endif -%}
 
@@ -48,11 +47,10 @@
 
 Instances of this class *should* have identifiers with one of the following prefixes:
 {% for p in element.id_prefixes %}
-* {{p}}
+* {{ p }}
 {% endfor %}
 
 {% endif %}
-
 
 {% if element.annotations %}
 ### Annotations

--- a/linkml/generators/docgen/enum.md.jinja2
+++ b/linkml/generators/docgen/enum.md.jinja2
@@ -1,4 +1,4 @@
-# Enum: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
+# Enum: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong></span> {% endif %}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}
@@ -15,7 +15,7 @@ URI: {{ gen.link(element) }}
 | Value | Meaning | Description |
 | --- | --- | --- |
 {% for pv in element.permissible_values.values() -%}
-| {{pv.text}} | {{pv.meaning}} | {{pv.description|enshorten}} |
+| {{ pv.text }} | {{ pv.meaning }} | {{ pv.description|enshorten }} |
 {% endfor %}
 {% else %}
 _This is a dynamic enum_
@@ -28,7 +28,7 @@ _This is a dynamic enum_
 | Name | Description |
 | ---  | --- |
 {% for s in schemaview.get_slots_by_enum(element.name) -%}
-| {{gen.link(s)}} | {{s.description|enshorten}} |
+| {{ gen.link(s) }} | {{ s.description|enshorten }} |
 {% endfor %}
 {% endif %}
 
@@ -38,7 +38,7 @@ _This is a dynamic enum_
 
 <details>
 ```yaml
-{{gen.yaml(element)}}
+{{ gen.yaml(element) }}
 ```
 </details>
 

--- a/linkml/generators/docgen/index.md.jinja2
+++ b/linkml/generators/docgen/index.md.jinja2
@@ -25,7 +25,7 @@ Name: {{ schema.name }}
 {% endfor %}
 {% else -%}
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(c, True)}} | {{c.description|enshorten}} |
+| {{ gen.link(c, True) }} | {{ c.description|enshorten }} |
 {% endfor %}
 {% endif %}
 
@@ -34,7 +34,7 @@ Name: {{ schema.name }}
 | Slot | Description |
 | --- | --- |
 {% for s in gen.all_slot_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(s, True)}} | {{s.description|enshorten}} |
+| {{ gen.link(s, True) }} | {{ s.description|enshorten }} |
 {% endfor %}
 
 ## Enumerations
@@ -42,7 +42,7 @@ Name: {{ schema.name }}
 | Enumeration | Description |
 | --- | --- |
 {% for e in gen.all_enum_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(e, True)}} | {{e.description|enshorten}} |
+| {{ gen.link(e, True) }} | {{ e.description|enshorten }} |
 {% endfor %}
 
 ## Types
@@ -50,7 +50,7 @@ Name: {{ schema.name }}
 | Type | Description |
 | --- | --- |
 {% for t in gen.all_type_objects()|sort(attribute=sort_by) -%}
-| {{gen.link(t, True)}} | {{t.description|enshorten}} |
+| {{ gen.link(t, True) }} | {{ t.description|enshorten }} |
 {% endfor %}
 
 ## Subsets
@@ -58,5 +58,5 @@ Name: {{ schema.name }}
 | Subset | Description |
 | --- | --- |
 {% for ss in schemaview.all_subsets().values()|sort(attribute='name') -%}
-| {{gen.link(ss, True)}} | {{ss.description|enshorten}} |
+| {{ gen.link(ss, True) }} | {{ ss.description|enshorten }} |
 {% endfor %}

--- a/linkml/generators/docgen/index.tex.jinja2
+++ b/linkml/generators/docgen/index.tex.jinja2
@@ -1,7 +1,7 @@
 \documentclass{article}
 \usepackage[utf8]{inputenc}
 
-\title{ {{gen.latex(gen.schema_title())}} }
+\title{ {{ gen.latex(gen.schema_title()) }} }
 
 \begin{document}
 

--- a/linkml/generators/docgen/schema.md.jinja2
+++ b/linkml/generators/docgen/schema.md.jinja2
@@ -1,7 +1,5 @@
-# {{ schema.name }} {% if schema.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
+# {{ schema.name }} {% if schema.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong></span> {% endif %}
 
 {{ schema.description }}
 
 URI: {{ schema.id }}
-
-

--- a/linkml/generators/docgen/slot.md.jinja2
+++ b/linkml/generators/docgen/slot.md.jinja2
@@ -21,10 +21,10 @@
     {%- endif -%}
 {% endmacro %}
 
-# Slot: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
+# Slot: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong></span> {% endif %}
 
 {%- if header -%}
-{{header}}
+{{ header }}
 {%- endif -%}
 
 {% if element.description %}
@@ -66,7 +66,6 @@ Alias: {{ element.alias }}
 
 {% endif %}
 
-
 {% if schemaview.is_mixin(element.name) %}
 ## Mixin Usage
 
@@ -95,12 +94,11 @@ Alias: {{ element.alias }}
 * Maximum Value: {{ element.maximum_value|int }}
 {% endif -%}
 {% if element.pattern %}
-* Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}
+* Regex pattern: {{ '`' }}{{ element.pattern }}{{ '`' }}
 {% endif -%}
 {% if schemaview.is_mixin(element.name) %}
 * Mixin: {{ element.mixin }}
 {% endif -%}
-
 
 {% if schemaview.usage_index().get(element.name) %}
 ## Usages
@@ -108,7 +106,7 @@ Alias: {{ element.alias }}
 | used by | used in | type | used |
 | ---  | --- | --- | --- |
 {% for usage in schemaview.usage_index().get(element.name) -%}
-| {{gen.link(usage.used_by)}} | {{gen.link(usage.slot)}} | {{usage.metaslot}} | {{ gen.link(usage.used) }} |
+| {{ gen.link(usage.used_by) }} | {{ gen.link(usage.slot) }} | {{ usage.metaslot }} | {{ gen.link(usage.used) }} |
 {% endfor %}
 {% endif %}
 
@@ -123,5 +121,5 @@ Alias: {{ element.alias }}
 </details>
 
 {%- if footer -%}
-{{footer}}
+{{ footer }}
 {%- endif -%}

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -1,4 +1,4 @@
-# Subset: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
+# Subset: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong></span> {% endif %}
 
 {%- if header -%}
 {{ header }}
@@ -45,7 +45,7 @@ URI: {{ gen.link(element) }}
 | --- | --- |
 {% for c in classes_in_subset -%}
 {%- if element.name in c.in_subset -%}
-| {{gen.link(c)}} | {{c.description|enshorten}} |
+| {{ gen.link(c) }} | {{ c.description|enshorten }} |
 {% endif -%}
 {% endfor %}
 
@@ -67,16 +67,14 @@ URI: {{ gen.link(element) }}
 | Name | Cardinality and Range | Description |
 | ---  | ---  | --- |
 {% for s in filtered_slots -%}
-| {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{gen.link(s.range)}} | {{s.description|enshorten}} {% if s.identifier %}**identifier**{% endif %} |
+| {{ gen.link(s) }} | {{ gen.cardinality(s) }} <br/> {{ gen.link(s.range) }} | {{ s.description|enshorten }} {% if s.identifier %}**identifier**{% endif %} |
 {% endfor %}
 {%- endif %}
 
-
 {%- endif %}
 {% endfor %}
 
 {%- endif %}
-
 
 {% if slots_in_subset %}
 ## Slots in subset
@@ -90,7 +88,6 @@ URI: {{ gen.link(element) }}
 {% endfor %}
 
 {%- endif %}
-
 
 {% if enums_in_subset %}
 ## Enumerations in subset

--- a/linkml/generators/docgen/subset.md.jinja2
+++ b/linkml/generators/docgen/subset.md.jinja2
@@ -98,7 +98,7 @@ URI: {{ gen.link(element) }}
 | Enumeration | Description |
 | --- | --- |
 {% for e in enums_in_subset|sort(attribute='name') -%}
-{%- if element.name in e.in_subset %}
+{% if element.name in e.in_subset -%}
 | {{ gen.link(e) }} | {{ e.description|enshorten }} |
 {%- endif %}
 {% endfor %}

--- a/linkml/generators/docgen/type.md.jinja2
+++ b/linkml/generators/docgen/type.md.jinja2
@@ -1,4 +1,4 @@
-# Type: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong></span> (DEPRECATED) </strong> {% endif %}
+# Type: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong></span> {% endif %}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}

--- a/linkml/generators/docgen/type.md.jinja2
+++ b/linkml/generators/docgen/type.md.jinja2
@@ -1,4 +1,4 @@
-# Type: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
+# Type: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong></span> (DEPRECATED) </strong> {% endif %}
 
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}
@@ -15,8 +15,7 @@ URI: {{ gen.uri_link(element) }}
 {{ gen.bullet(element, "typeof") }}
 {{ gen.bullet(element, "pattern", backquote=True) }}
 {% if gen.number_value_range(element) %}
-* Numeric Value Range: {{gen.number_value_range(element)}}
+* Numeric Value Range: {{ gen.number_value_range(element) }}
 {% endif %}
 
 {% include "common_metadata.md.jinja2" %}
-


### PR DESCRIPTION
The first commit fixes the template for enums in subsets. Then the linter pointed out other problems in the template files:
- a missing closing tag for the span-tags for marking deprecated elements (fixed in 2nd commit)
- some (purely cosmetic) white space issues (fixed in 3rd commit)

Closes #2708