### PR TITLE
fix: reproducible rdf

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4045,14 +4045,14 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "rdflib"
-version = "7.1.1"
+version = "7.1.4"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
 optional = false
 python-versions = "<4.0.0,>=3.8.1"
 groups = ["main"]
 files = [
-    {file = "rdflib-7.1.1-py3-none-any.whl", hash = "sha256:e590fa9a2c34ba33a667818b5a84be3fb8a4d85868f8038f17912ec84f912a25"},
-    {file = "rdflib-7.1.1.tar.gz", hash = "sha256:164de86bd3564558802ca983d84f6616a4a1a420c7a17a8152f5016076b2913e"},
+    {file = "rdflib-7.1.4-py3-none-any.whl", hash = "sha256:72f4adb1990fa5241abd22ddaf36d7cafa5d91d9ff2ba13f3086d339b213d997"},
+    {file = "rdflib-7.1.4.tar.gz", hash = "sha256:fed46e24f26a788e2ab8e445f7077f00edcf95abb73bcef4b86cefa8b62dd174"},
 ]
 
 [package.dependencies]
@@ -5443,4 +5443,4 @@ tests = ["black", "numpydantic", "pyshacl"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "5d6090d1d8793c20907095f3339b7710380fa3d470857ee0e475a27a43b9e4d9"
+content-hash = "37f59586b973ca281fc3fcdadc75d589545e0ce8f794ff0373c59aa9e644a5a0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [  # Specifier syntax: https://peps.python.org/pep-0631/
     "pyshexc >= 0.8.3",
     "python-dateutil",
     "pyyaml",
-    "rdflib >=6.0.0",
+    "rdflib >=7.1.3",
     "requests >= 2.22",
     "sqlalchemy >= 1.4.31",
     "watchdog >= 0.9.0",


### PR DESCRIPTION
Upgrade rdflib to be at least v7.1.3. [That version](https://github.com/RDFLib/rdflib/releases/tag/7.1.3) provides sorted RDF generation, what we need for our tests with snapshots to be stable.

Fixes: #1943
Fixes: #2706