### PR TITLE
Bug fix: remove duplicate `-d` option in `click` options

### DIFF
--- a/linkml/generators/docgen.py
+++ b/linkml/generators/docgen.py
@@ -1031,7 +1031,6 @@ class DocGenerator(Generator):
     help="Folder in which example files are found. These are used to make inline examples",
 )
 @click.option(
-    "-d",
     "--include",
     help="""
 Include LinkML Schema outside of imports mechanism.  Helpful in including deprecated classes and slots in a separate


### PR DESCRIPTION
An extra `-d` had crept into the click options for the docgen, which conflicts with the existing `-d` for the directory. This PR removes it.