### PR TITLE
test(convert): fix and improve test

### DIFF
--- a/tests/test_utils/test_converter.py
+++ b/tests/test_utils/test_converter.py
@@ -18,7 +18,47 @@ def test_help(cli_runner):
     assert "INPUT" in out
 
 
-def test_infer_and_convert(input_path, cli_runner, tmp_path):
+P1_EXPECTED = {
+    "full_name": "first1 last1",
+    "is_juvenile": True,
+    "age_in_years": 10,
+    "age_in_months": 120,
+    "age_category": "juvenile",
+}
+
+P2_EXPECTED = {
+    "full_name": "first2 last2",
+    "age_in_years": 20,
+    "age_in_months": 240,
+    "age_category": "adult",
+}
+
+
+def check_output(json_out):
+    with open(json_out) as file:
+        obj = json.load(file)
+        persons = obj["persons"]
+        for p, exptc in [(persons["P:1"], P1_EXPECTED), (persons["P:2"], P2_EXPECTED)]:
+            for attr in exptc.keys():
+                assert p[attr] == exptc[attr]
+
+        assert "is_juvenile" not in persons["P:2"]
+
+
+def test_infer(input_path, cli_runner, tmp_path):
+    """
+    Tests using the --infer option to add missing values
+    """
+    schema = input_path("schema_with_inference.yaml")
+    data_in = input_path("data_example.yaml")
+    json_out = tmp_path / "data_example.out.json"
+    result = cli_runner.invoke(cli, ["--infer", "-s", schema, data_in, "-o", json_out])
+    assert result.exit_code == 0
+    check_output(json_out)
+
+
+@pytest.mark.xfail(reason="Bug 2723: missing intermediate checks")
+def test_convert(input_path, cli_runner, tmp_path):
     """
     Tests using the --infer option to add missing values, and also roundtripping
     through yaml->json->yaml->rdf->json
@@ -28,25 +68,15 @@ def test_infer_and_convert(input_path, cli_runner, tmp_path):
     json_out = tmp_path / "data_example.out.json"
     yaml_out = tmp_path / "data_example.out.yaml"
     rdf_out = tmp_path / "data_example.out.ttl"
-    cli_runner.invoke(cli, ["--infer", "-s", schema, data_in, "-o", json_out])
-    cli_runner.invoke(cli, ["-s", schema, json_out, "-t", "yaml", "-o", yaml_out])
-    cli_runner.invoke(cli, ["-s", schema, yaml_out, "-t", "rdf", "-o", rdf_out])
-    cli_runner.invoke(cli, ["-s", schema, rdf_out, "-t", "json", "-o", json_out])
-    with open(json_out) as file:
-        obj = json.load(file)
-        persons = obj["persons"]
-        p1 = persons["P:1"]
-        p2 = persons["P:2"]
-        assert p1["is_juvenile"]
-        assert "is_juvenile" not in p2
-        assert p1["age_in_years"] == 10
-        assert p1["age_in_months"] == 120
-        assert p1["age_category"] == "juvenile"
-        assert p1["full_name"] == "first1 last1"
-        assert p2["age_in_years"] == 20
-        assert p2["age_in_months"] == 240
-        assert p2["age_category"] == "adult"
-        assert p2["full_name"] == "first2 last2"
+    result = cli_runner.invoke(cli, ["--infer", "-s", schema, data_in, "-o", json_out])
+    assert result.exit_code == 0
+    result = cli_runner.invoke(cli, ["-s", schema, json_out, "-t", "yaml", "-o", yaml_out])
+    assert result.exit_code == 0
+    result = cli_runner.invoke(cli, ["-s", schema, yaml_out, "-t", "rdf", "-o", rdf_out])
+    assert result.exit_code == 0
+    result = cli_runner.invoke(cli, ["-s", schema, rdf_out, "-t", "json", "-o", json_out])
+    assert result.exit_code == 0
+    check_output(json_out)
 
 
 def test_prefix_file(input_path, cli_runner, tmp_path):


### PR DESCRIPTION
Calling multiple conversions in a row without checking intermediate results does not provide enough information to know what has failed (if so). This patch improves it.

Additionally missing intermediate checks where missing an error in the test execution. Therefore the test has been split in two:
- one with the correct part (which was correctly succeeding)
- another with the erroneous part (which was erroneously succeeding)

Fixes: #2723