### PR TITLE
fix(gen-plantuml): fix changes in svg code

### DIFF
--- a/.github/workflows/scripts/report_unreleased_linkml_runtime.py
+++ b/.github/workflows/scripts/report_unreleased_linkml_runtime.py
@@ -5,35 +5,114 @@ import os
 import subprocess
 import sys
 
+summary_header = "Tests with 'unreleased linkml-runtime'"
+
+
+def format_results_message(total_tests, passed_count, failed_tests):
+    """Format the results message for the PR comment"""
+
+    server_url = os.environ.get("GITHUB_SERVER_URL", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+
+    # Construct the job URL
+    job_url = f"{server_url}/{repository}/actions/runs/{run_id}"
+
+    if not failed_tests:
+        lines = [
+            f"## ✨ 🧪 {summary_header} ([View Details]({job_url})) ✨\n",
+            f"- Total Tests: {total_tests}",
+            f"- ✅ Passed: {passed_count}",
+            "\n✨ All tests passed!",
+        ]
+    else:
+        lines = [
+            f"## ⚠️ 🧪 {summary_header} ([View Details]({job_url})) ⚠️\n",
+            f"- Total Tests: {total_tests}",
+            f"- ✅ Passed: {passed_count}",
+        ]
+        failed_count = len(failed_tests)
+        lines.extend(
+            [
+                f"- ❌ Failed: {failed_count}\n",
+                "### Failed Tests",
+                "| File | Test Name |",
+                "|------|-----------|",
+            ]
+        )
+        for (
+            filename,
+            test_name,
+        ) in failed_tests:
+            lines.append(f"| {filename} | {test_name} |")
+
+    return "\n".join(lines)
+
+
+def write_job_summary(total_tests, passed_count, failed_tests):
+    """Write a markdown summary to the GitHub Actions job summary"""
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as f:
+            f.write(f"## 🧪 {summary_header}\n\n")
+            f.write(f"- Total Tests: {total_tests}\n")
+            f.write(f"- ✅ Passed: {passed_count}\n")
+            if failed_tests:
+                f.write(f"- ❌ Failed: {len(failed_tests)}\n\n")
+                f.write("### Failed Tests\n\n")
+                for filename, test_name in failed_tests:
+                    f.write(f"- {filename} - {test_name}\n")
+
 
 def run_tests_and_report():
-    # Get all command line arguments except the script name
+    # Get user provided arguments first
     test_cli = sys.argv[1:]
 
     # Always ensure we have the JSON report arguments
     json_report_args = ["--json-report", "--json-report-file=report.json"]
 
-    # Combine base arguments with user provided arguments
+    # Combine arguments (user args first, then JSON report args)
     full_command = test_cli + json_report_args
 
-    # Run pytest with all arguments
-    subprocess.run(full_command)
+    # Run pytest and stream output
+    subprocess.run(full_command, stdout=sys.stdout, stderr=sys.stderr)
 
-    # Read the JSON report
+    # Process the results
     with open("report.json") as f:
         report = json.load(f)
 
-    # Process failed tests
+    print(f"::group::{summary_header}", file=sys.stderr)
+
+    failed_tests = []
     for test in report["tests"]:
         if test["outcome"] == "failed":
             filename = test["nodeid"].split("::")[0]
             test_name = test["nodeid"].split("::")[1] if "::" in test["nodeid"] else test["nodeid"]
-            line = test.get("call", {}).get("crash_line", "1")
-            print(f"::warning file={filename},line={line},col=1::Failing Test: {test_name}")
+            failed_tests.append((filename, test_name))
+            print(f"::warning file={filename}::Failing Test: {filename} - {test_name}", file=sys.stderr)
 
-    # Cleanup
+    total_tests = len(report["tests"])
+    failed_count = len(failed_tests)
+    passed_count = total_tests - failed_count
+
+    print(f"Total Tests: {total_tests}", file=sys.stderr)
+    print(f"✅ Passed: {passed_count}", file=sys.stderr)
+    if failed_count > 0:
+        print(f"❌ Failed: {failed_count}", file=sys.stderr)
+        print(f"::notice::Test Summary: {failed_count} test{'s' if failed_count > 1 else ''} failed", file=sys.stderr)
+
+    print("::endgroup::", file=sys.stderr)
+
+    # Write job summary
+    write_job_summary(total_tests, passed_count, failed_tests)
+
+    # Write the results to test-results_unreleased-linkml-runtime.md
+    with open("test-results_unreleased-linkml-runtime.md", "w", encoding="utf-8") as f:
+        f.write(format_results_message(total_tests, passed_count, failed_tests))
+
     os.remove("report.json")
+    return 0
 
 
 if __name__ == "__main__":
-    run_tests_and_report()
+    sys.exit(run_tests_and_report())

--- a/.github/workflows/scripts/report_unreleased_linkml_runtime.py
+++ b/.github/workflows/scripts/report_unreleased_linkml_runtime.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import json
+import os
+import subprocess
+import sys
+
+
+def run_tests_and_report():
+    # Get all command line arguments except the script name
+    test_cli = sys.argv[1:]
+
+    # Always ensure we have the JSON report arguments
+    json_report_args = ["--json-report", "--json-report-file=report.json"]
+
+    # Combine base arguments with user provided arguments
+    full_command = test_cli + json_report_args
+
+    # Run pytest with all arguments
+    subprocess.run(full_command)
+
+    # Read the JSON report
+    with open("report.json") as f:
+        report = json.load(f)
+
+    # Process failed tests
+    for test in report["tests"]:
+        if test["outcome"] == "failed":
+            filename = test["nodeid"].split("::")[0]
+            test_name = test["nodeid"].split("::")[1] if "::" in test["nodeid"] else test["nodeid"]
+            line = test.get("call", {}).get("crash_line", "1")
+            print(f"::warning file={filename},line={line},col=1::Failing Test: {test_name}")
+
+    # Cleanup
+    os.remove("report.json")
+
+
+if __name__ == "__main__":
+    run_tests_and_report()

--- a/.github/workflows/test-with-unreleased-runtime.yaml
+++ b/.github/workflows/test-with-unreleased-runtime.yaml
@@ -148,5 +148,6 @@ jobs:
         run: poetry run python -c 'from importlib.metadata import version; print(version("linkml-runtime"))'
 
       - name: run tests
+        continue-on-error: true
         working-directory: linkml
-        run: poetry run python -m pytest --with-slow
+        run: python .github/workflows/scripts/report_unreleased_linkml_runtime.py poetry run python -m pytest --with-slow

--- a/.github/workflows/test-with-unreleased-runtime.yaml
+++ b/.github/workflows/test-with-unreleased-runtime.yaml
@@ -147,7 +147,27 @@ jobs:
         working-directory: linkml
         run: poetry run python -c 'from importlib.metadata import version; print(version("linkml-runtime"))'
 
-      - name: run tests
+      - name: Run tests and report failures
         continue-on-error: true
+        id: test_with_unreleased_linkml_runtime
+        shell: bash
+        env:
+          PYTHONIOENCODING: utf-8
         working-directory: linkml
-        run: python .github/workflows/scripts/report_unreleased_linkml_runtime.py poetry run python -m pytest --with-slow
+        # "sed -e '$a\' ..." needed to ensure that 'EOF' is preceeded by a newline
+        run: |
+          python .github/workflows/scripts/report_unreleased_linkml_runtime.py poetry run python -m pytest --with-slow
+          cat ./test-results_unreleased-linkml-runtime.md
+          {
+            echo 'test_results_unreleased_linkml_runtime<<EOF'
+            echo '# OS: ${{ matrix.os }} - Python version: ${{ matrix.python-version }}'
+            sed -e '$a\' ./test-results_unreleased-linkml-runtime.md
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add or update PR comment
+        uses: phulsechinmay/rewritable-pr-comment@v0.3.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_IDENTIFIER: test-results_unreleased-linkml-runtime-${{ matrix.os }}-${{ matrix.python-version }}
+          message: ${{ steps.test_with_unreleased_linkml_runtime.outputs.test_results_unreleased_linkml_runtime }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -3700,6 +3700,22 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-json-report"
+version = "1.5.0"
+description = "A pytest plugin to report test results as JSON files"
+optional = false
+python-versions = "*"
+groups = ["tests"]
+files = [
+    {file = "pytest-json-report-1.5.0.tar.gz", hash = "sha256:2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de"},
+    {file = "pytest_json_report-1.5.0-py3-none-any.whl", hash = "sha256:9897b68c910b12a2e48dd849f9a284b2c79a732a8a9cb398452ddd23d3c8c325"},
+]
+
+[package.dependencies]
+pytest = ">=3.8.0"
+pytest-metadata = "*"
+
+[[package]]
 name = "pytest-logging"
 version = "2015.11.4"
 description = "Configures logging and allows tweaking the log level with a py.test flag"
@@ -3712,6 +3728,24 @@ files = [
 
 [package.dependencies]
 pytest = ">=2.8.1"
+
+[[package]]
+name = "pytest-metadata"
+version = "3.1.1"
+description = "pytest plugin for test session metadata"
+optional = false
+python-versions = ">=3.8"
+groups = ["tests"]
+files = [
+    {file = "pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b"},
+    {file = "pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "tox (>=3.24.5)"]
 
 [[package]]
 name = "pytest-subtests"
@@ -5443,4 +5477,4 @@ tests = ["black", "numpydantic", "pyshacl"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "5d6090d1d8793c20907095f3339b7710380fa3d470857ee0e475a27a43b9e4d9"
+content-hash = "7b7748b28634ac0c893f054a0105e599a7ea212e1d96b6ecaf8a5cfe745b98ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ requests-cache = "^1.2.0"
 mock = "^5.1.0"
 testcontainers = "3.7.1"
 jsonpatch = "^1.33"
+pytest-json-report = "^1.5.0"
 
 [tool.poetry.group.docs]
 optional = true

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -170,8 +170,8 @@ def test_generate_svg(tmp_path, kitchen_sink_path, kroki_url):
     groups = svg_dom.getElementsByTagName("g")
     for group in groups:
         id = group.getAttribute("id")
-        if id.startswith("elem_"):
-            class_name = id[len("elem_") :]
+        if id.startswith("entity_"):
+            class_name = id[len("entity_") :]
             classes_list.append(class_name)
         if id.startswith("link_"):
             link_name = id[len("link_") :]


### PR DESCRIPTION
Kroki has slightly changed the names of the groups being used in the generated SVG code (XML dialect). This patch updates it.

It also makes tests on *unreleased `linkml-runtime`* non-blocking. The results should have enough visibility though, because their results are visible at PR-level. Simply scroll down to see them on this PR.

Current status is very verbose because it reports both failing and succeeding tests, but is the best I can do as of now. My proposal is to merge it to stop blocking all other PRs and improve it (e.g. creating comments only for failing jobs or having a single consolidated comment) later.

Fixes: #2728 (first commit)
Fixes: #2729 (2nd commit)