### PR TITLE
fix(tests): unreleased linkml-runtime may fail

### DIFF
--- a/.github/workflows/test-with-unreleased-runtime.yaml
+++ b/.github/workflows/test-with-unreleased-runtime.yaml
@@ -148,5 +148,6 @@ jobs:
         run: poetry run python -c 'from importlib.metadata import version; print(version("linkml-runtime"))'
 
       - name: run tests
+        continue-on-error: true
         working-directory: linkml
         run: poetry run python -m pytest --with-slow

--- a/tests/test_generators/test_plantuml.py
+++ b/tests/test_generators/test_plantuml.py
@@ -170,8 +170,8 @@ def test_generate_svg(tmp_path, kitchen_sink_path, kroki_url):
     groups = svg_dom.getElementsByTagName("g")
     for group in groups:
         id = group.getAttribute("id")
-        if id.startswith("elem_"):
-            class_name = id[len("elem_") :]
+        if id.startswith("entity_"):
+            class_name = id[len("entity_") :]
             classes_list.append(class_name)
         if id.startswith("link_"):
             link_name = id[len("link_") :]


### PR DESCRIPTION
Workflow with unreleased (`main` branch) of `linkml-runtime` may fail without blocking the whole test-suite.

Fixes: #2729 