### PR TITLE
Adding linter rule to find undeclared slots

### DIFF
--- a/linkml/linter/config/datamodel/config.py
+++ b/linkml/linter/config/datamodel/config.py
@@ -1,5 +1,5 @@
 # Auto generated from config.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-04-07T17:57:08
+# Generation date: 2025-06-05T06:54:12
 # Schema: linter-config
 #
 # id: https://w3id.org/linkml/linter/config
@@ -17,7 +17,8 @@ from datetime import (
 from typing import (
     Any,
     ClassVar,
-
+    Dict,
+    List,
     Optional,
     Union
 )
@@ -61,7 +62,6 @@ from linkml_runtime.utils.metamodelcore import Bool
 metamodel_version = "1.7.0"
 version = None
 
-
 # Namespaces
 LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
 LINTCFG = CurieNamespace('lintcfg', 'https://w3id.org/linkml/linter/config')
@@ -80,7 +80,6 @@ class Config(YAMLRoot):
     This is the top-level representation of a LinkML linter configuration file. It allows defining a set of rules
     while also optionally extending a predefined set of rules.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["Config"]
@@ -91,7 +90,7 @@ class Config(YAMLRoot):
     extends: Optional[Union[str, "ExtendableConfigs"]] = None
     rules: Optional[Union[dict, "Rules"]] = None
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if self.extends is not None and not isinstance(self.extends, ExtendableConfigs):
             self.extends = ExtendableConfigs(self.extends)
 
@@ -104,8 +103,7 @@ class Config(YAMLRoot):
 @dataclass(repr=False)
 class Rules(YAMLRoot):
     """
-    Each attribute of this class represents a rule that can be enabled and possibly configured by a configuration
-    file.
+    Each attribute of this class represents a rule that can be enabled and possibly configured by a configuration file.
     """
     _inherited_slots: ClassVar[list[str]] = []
 
@@ -120,10 +118,11 @@ class Rules(YAMLRoot):
     recommended: Optional[Union[dict, "RecommendedRuleConfig"]] = None
     no_xsd_int_type: Optional[Union[dict, "RuleConfig"]] = None
     no_invalid_slot_usage: Optional[Union[dict, "RuleConfig"]] = None
+    no_undeclared_slots: Optional[Union[dict, "RuleConfig"]] = None
     standard_naming: Optional[Union[dict, "StandardNamingConfig"]] = None
     canonical_prefixes: Optional[Union[dict, "CanonicalPrefixesConfig"]] = None
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if self.no_empty_title is not None and not isinstance(self.no_empty_title, NoEmptyTitleConfig):
             self.no_empty_title = NoEmptyTitleConfig(**as_dict(self.no_empty_title))
 
@@ -142,6 +141,9 @@ class Rules(YAMLRoot):
         if self.no_invalid_slot_usage is not None and not isinstance(self.no_invalid_slot_usage, RuleConfig):
             self.no_invalid_slot_usage = RuleConfig(**as_dict(self.no_invalid_slot_usage))
 
+        if self.no_undeclared_slots is not None and not isinstance(self.no_undeclared_slots, RuleConfig):
+            self.no_undeclared_slots = RuleConfig(**as_dict(self.no_undeclared_slots))
+
         if self.standard_naming is not None and not isinstance(self.standard_naming, StandardNamingConfig):
             self.standard_naming = StandardNamingConfig(**as_dict(self.standard_naming))
 
@@ -154,9 +156,8 @@ class Rules(YAMLRoot):
 @dataclass(repr=False)
 class RuleConfig(YAMLRoot):
     """
-    This is the base class for linter rules. It contains configuration options that are  common to all rules.
+    This is the base class for linter rules. It contains configuration options that are common to all rules.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["RuleConfig"]
@@ -166,7 +167,7 @@ class RuleConfig(YAMLRoot):
 
     level: Union[str, "RuleLevel"] = None
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.level):
             self.MissingRequiredField("level")
         if not isinstance(self.level, RuleLevel):
@@ -180,7 +181,6 @@ class PermissibleValuesFormatRuleConfig(RuleConfig):
     """
     Additional configuration options for the `permissible_values_format` rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["PermissibleValuesFormatRuleConfig"]
@@ -191,7 +191,7 @@ class PermissibleValuesFormatRuleConfig(RuleConfig):
     level: Union[str, "RuleLevel"] = None
     format: Optional[str] = None
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if self.format is not None and not isinstance(self.format, str):
             self.format = str(self.format)
 
@@ -203,7 +203,6 @@ class TreeRootClassRuleConfig(RuleConfig):
     """
     Additional configuration options for the `tree_root_class` rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["TreeRootClassRuleConfig"]
@@ -215,7 +214,7 @@ class TreeRootClassRuleConfig(RuleConfig):
     root_class_name: Optional[str] = None
     validate_existing_class_name: Optional[Union[bool, Bool]] = None
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if self.root_class_name is not None and not isinstance(self.root_class_name, str):
             self.root_class_name = str(self.root_class_name)
 
@@ -230,7 +229,6 @@ class RecommendedRuleConfig(RuleConfig):
     """
     Additional configuration options for the `recommended` rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["RecommendedRuleConfig"]
@@ -243,7 +241,7 @@ class RecommendedRuleConfig(RuleConfig):
     exclude: Optional[Union[str, list[str]]] = empty_list()
     exclude_type: Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]] = empty_list()
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if not isinstance(self.include, list):
             self.include = [self.include] if self.include is not None else []
         self.include = [v if isinstance(v, str) else str(v) for v in self.include]
@@ -264,7 +262,6 @@ class StandardNamingConfig(RuleConfig):
     """
     Additional configuration options for the `standard_naming` rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["StandardNamingConfig"]
@@ -278,7 +275,7 @@ class StandardNamingConfig(RuleConfig):
     class_pattern: Optional[str] = None
     slot_pattern: Optional[str] = None
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if self.permissible_values_upper_case is not None and not isinstance(self.permissible_values_upper_case, Bool):
             self.permissible_values_upper_case = Bool(self.permissible_values_upper_case)
 
@@ -300,7 +297,6 @@ class CanonicalPrefixesConfig(RuleConfig):
     """
     Additional configuration options for the canonical_prefixes rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["CanonicalPrefixesConfig"]
@@ -311,7 +307,7 @@ class CanonicalPrefixesConfig(RuleConfig):
     level: Union[str, "RuleLevel"] = None
     prefixmaps_contexts: Optional[Union[str, list[str]]] = empty_list()
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if not isinstance(self.prefixmaps_contexts, list):
             self.prefixmaps_contexts = [self.prefixmaps_contexts] if self.prefixmaps_contexts is not None else []
         self.prefixmaps_contexts = [v if isinstance(v, str) else str(v) for v in self.prefixmaps_contexts]
@@ -334,7 +330,7 @@ class NoEmptyTitleConfig(RuleConfig):
     level: Union[str, "RuleLevel"] = None
     exclude_type: Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]] = empty_list()
 
-    def __post_init__(self, *_: list[str], **kwargs: dict[str, Any]):
+    def __post_init__(self, *_: str, **kwargs: Any):
         if not isinstance(self.exclude_type, list):
             self.exclude_type = [self.exclude_type] if self.exclude_type is not None else []
         self.exclude_type = [v if isinstance(v, MetamodelElementTypeEnum) else MetamodelElementTypeEnum(v) for v in self.exclude_type]
@@ -388,7 +384,9 @@ class MetamodelElementTypeEnum(EnumDefinitionImpl):
     permissible_value = PermissibleValue(
         text="permissible_value",
         meaning=LINKML["PermissibleValue"])
-    slot_definition = PermissibleValue(text="slot_definition")
+    slot_definition = PermissibleValue(
+        text="slot_definition",
+        meaning=LINKML["SlotDefinition"])
 
     _defn = EnumDefinition(
         name="MetamodelElementTypeEnum",
@@ -422,6 +420,9 @@ slots.rules__no_xsd_int_type = Slot(uri=LINTCFG.no_xsd_int_type, name="rules__no
 
 slots.rules__no_invalid_slot_usage = Slot(uri=LINTCFG.no_invalid_slot_usage, name="rules__no_invalid_slot_usage", curie=LINTCFG.curie('no_invalid_slot_usage'),
                    model_uri=LINTCFG.rules__no_invalid_slot_usage, domain=None, range=Optional[Union[dict, RuleConfig]])
+
+slots.rules__no_undeclared_slots = Slot(uri=LINTCFG.no_undeclared_slots, name="rules__no_undeclared_slots", curie=LINTCFG.curie('no_undeclared_slots'),
+                   model_uri=LINTCFG.rules__no_undeclared_slots, domain=None, range=Optional[Union[dict, RuleConfig]])
 
 slots.rules__standard_naming = Slot(uri=LINTCFG.standard_naming, name="rules__standard_naming", curie=LINTCFG.curie('standard_naming'),
                    model_uri=LINTCFG.rules__standard_naming, domain=None, range=Optional[Union[dict, StandardNamingConfig]])

--- a/linkml/linter/config/datamodel/config.yaml
+++ b/linkml/linter/config/datamodel/config.yaml
@@ -20,7 +20,7 @@ classes:
   Config:
     tree_root: true
     description: >-
-      This is the top-level representation of a LinkML linter configuration file. It allows 
+      This is the top-level representation of a LinkML linter configuration file. It allows
       defining a set of rules while also optionally extending a predefined set of rules.
     attributes:
       extends:
@@ -31,11 +31,11 @@ classes:
         range: Rules
         description: >-
           This is where a configuration defines its rules and the configuration of those rules.
-  
+
   Rules:
     description: >-
-      Each attribute of this class represents a rule that can be enabled and possibly 
-      configured by a configuration file. 
+      Each attribute of this class represents a rule that can be enabled and possibly
+      configured by a configuration file.
     attributes:
       no_empty_title:
         range: NoEmptyTitleConfig
@@ -50,7 +50,7 @@ classes:
       tree_root_class:
         range: TreeRootClassRuleConfig
         description: >-
-          Require a single class with `tree_root: true` and optionally verify that class's 
+          Require a single class with `tree_root: true` and optionally verify that class's
           name. Autofix will create a new class with `tree_root: true`, a name based on
           the rule configuration, and slots for existing classes.
       recommended:
@@ -61,18 +61,23 @@ classes:
       no_xsd_int_type:
         range: RuleConfig
         description: >-
-          Disallow use of `uri: xsd:int` in type definitions. Autofix will change the 
+          Disallow use of `uri: xsd:int` in type definitions. Autofix will change the
           uri to xsd:integer.
       no_invalid_slot_usage:
         range: RuleConfig
         description: >-
           Disallow slot_usage definitions where the name of the slot does not refer
           to an existing slot. Not auto-fixable.
+      no_undeclared_slots:
+        range: RuleConfig
+        description: >-
+          Disallow the use of slots in class specifications if the name of the slot
+          does not refer to an existing slot. Not auto-fixable.
       standard_naming:
         range: StandardNamingConfig
         description: >-
           Enforce standard naming conventions: CamelCase for classes, snake_case for slots,
-          CamelCase for enums, snake_case (default) or UPPER_SNAKE for permissible_values 
+          CamelCase for enums, snake_case (default) or UPPER_SNAKE for permissible_values
           (see permissible_values_upper_case option). This rule may conflict with the
           permissible_values_format rule. Not auto-fixable.
       canonical_prefixes:
@@ -84,7 +89,7 @@ classes:
 
   RuleConfig:
     description: >-
-      This is the base class for linter rules. It contains configuration options that are 
+      This is the base class for linter rules. It contains configuration options that are
       common to all rules.
     attributes:
       level:
@@ -188,8 +193,8 @@ classes:
         multivalued: true
         description: >-
           Default: [merged]
-          The list of context names which will be loaded by the `prefixmaps` library to do the 
-          validation. The order of names is meaningful and will be preserved. See:  
+          The list of context names which will be loaded by the `prefixmaps` library to do the
+          validation. The order of names is meaningful and will be preserved. See:
           https://github.com/linkml/prefixmaps#usage
 
   NoEmptyTitleConfig:
@@ -202,7 +207,7 @@ classes:
         multivalued: true
         description: >-
           Default: []
-          Elements of all types (ClassDefinition, SlotDefinition, EnumDefinition, PermissibleValue, etc.) except the types specified in this list will be checked 
+          Elements of all types (ClassDefinition, SlotDefinition, EnumDefinition, PermissibleValue, etc.) except the types specified in this list will be checked
 
 enums:
   ExtendableConfigs:

--- a/linkml/linter/config/default.yaml
+++ b/linkml/linter/config/default.yaml
@@ -18,6 +18,8 @@ rules:
     level: disabled
   no_invalid_slot_usage:
     level: disabled
+  no_undeclared_slots:
+    level: disabled
   standard_naming:
     level: disabled
     permissible_values_upper_case: false

--- a/linkml/linter/config/recommended.yaml
+++ b/linkml/linter/config/recommended.yaml
@@ -5,6 +5,8 @@ rules:
     level: error
   no_invalid_slot_usage:
     level: error
+  no_undeclared_slots:
+    level: error
   standard_naming:
     level: warning
   canonical_prefixes:

--- a/tests/test_linter/test_rule_no_undeclared_slots.py
+++ b/tests/test_linter/test_rule_no_undeclared_slots.py
@@ -1,0 +1,66 @@
+"""Tests of the linter's missing slots rules."""
+
+from linkml_runtime.utils.schemaview import SchemaView
+
+from linkml.linter.config.datamodel.config import RuleConfig, RuleLevel
+from linkml.linter.rules import NoUndeclaredSlotsRule
+
+
+def test_undeclared_slots() -> None:
+    """Test that slots that appear under a class but not in the main `slots` declaration throw an error."""
+    test_schema = """id: http://example.org/test_undeclared_slots
+name: slot_test
+default_range: string
+slots:
+  name:
+
+classes:
+  class_1:
+    slots:
+      - name
+      - id
+
+  class_2:
+    attributes:
+      name:
+      description:
+"""
+    schema_view = SchemaView(test_schema)
+    config = RuleConfig(level=RuleLevel.error.text)
+
+    rule = NoUndeclaredSlotsRule(config)
+    problems = list(rule.check(schema_view, fix=False))
+
+    # `id` from class_1 is not declared in `slots`
+    # `description` from class_2 is an attribute so it doesn't need to be in `slots`
+    assert len(problems) == 1
+    assert problems[0].message == "Slot 'id' from class 'class_1' not found in schema 'slots' declaration."
+
+
+def test_valid_slot_usage() -> None:
+    """Test that a valid schema does not throw an error."""
+    test_schema = """id: http://example.org/test_undeclared_slots
+name: slot_test
+default_range: string
+slots:
+  name:
+  id:
+
+classes:
+  class_1:
+    slots:
+      - name
+      - id
+
+  class_2:
+    attributes:
+      name:
+      description:
+"""
+    schema_view = SchemaView(test_schema)
+    config = RuleConfig(level=RuleLevel.error.text)
+
+    rule = NoUndeclaredSlotsRule(config)
+    problems = list(rule.check(schema_view, fix=False))
+
+    assert not problems


### PR DESCRIPTION
Adding a rule that will find slots that appear in classes but have not been declared in the main `slots` section.