### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# Check https://editorconfig.org for more information
+# This is the main config file for this project:
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.md]
+# Trailing whitespace may be used to trigger line breaks in markdown.
+trim_trailing_whitespace = false


### PR DESCRIPTION
This proposes to add a configuration for [editorconfig](https://editorconfig.org) to keep files more consistent regarding trailing whitespace etc. - Many editors understand the file directly, some require a plugin. While this is not required it is another line of defence (besides pre-commit and running a linter) to prevent this #2757 happening again.

I have used the committed file since ~2 years in my local linkml-* repositories. So it should be a good start (if you want this at all).