### PR TITLE
Add understand to the git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ tests/test_config.ini
 # Don't lock
 Pipfile.lock
 
+# Understand databases
+*.und
+
 # User defined
 .vscode/*
 


### PR DESCRIPTION
Understand is a great tool that lets you analyze and understand large unfamiliar codebases.

https://scitools.com/

It's free to use for open source and academic projects.

Unfortunately it creates a bunch of local database files in the working directory,  so it will be great if we ignore them in the .gitignore file.