### PR TITLE
Remove py38 from action for testing unreleased linkml-runtime

### DIFF
--- a/.github/workflows/test-with-unreleased-runtime.yaml
+++ b/.github/workflows/test-with-unreleased-runtime.yaml
@@ -1,4 +1,4 @@
-name: Run tests with unreleased linkml-runtime
+name: Test with unreleased linkml-runtime
 on:
   pull_request:
     branches:
@@ -15,19 +15,12 @@ on:
         default: "main"
 
 jobs:
-  test_with_unreleased_runtime:
+  test:
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        exclude:
-          - os: windows-latest
-            python-version: "3.9"
-          - os: windows-latest
-            python-version: "3.10"
-          - os: windows-latest
-            python-version: "3.11"
+        python-version: [ "3.9", "3.13" ]
     runs-on: ${{ matrix.os }}
     env:
       POETRY_VIRTUALENVS_IN_PROJECT: true


### PR DESCRIPTION
Other changes:
- reduced test matrix with just the oldest and newest supported Python version.
- shorter job name.
