### PR TITLE
Switch to using ruff for code formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,16 +11,15 @@ repos:
   - id: check-toml
   - id: trailing-whitespace
     exclude: __snapshots__
-- repo: https://github.com/psf/black
-  rev: 24.10.0
-  hooks:
-  - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ensure this version stays in sync with tox.ini
-  rev: v0.4.8
+  rev: v0.11.13
   hooks:
-  - id: ruff
+  # Run the linter.
+  - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix]
+  # Run the formatter.
+  - id: ruff-format
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6
   hooks:

--- a/linkml/generators/dbmlgen.py
+++ b/linkml/generators/dbmlgen.py
@@ -113,7 +113,6 @@ class DBMLGenerator(Generator):
 
                 # Check if the slot references another class
                 if slot.range in self.schemaview.all_classes():
-
                     # Find the identifier slot of the referenced class
                     identifier_slot_name = next(
                         (

--- a/linkml/generators/erdiagramgen.py
+++ b/linkml/generators/erdiagramgen.py
@@ -23,7 +23,7 @@ class Attribute(pydantic.BaseModel):
 
     def __str__(self):
         cmt = f'"{self.comment}"' if self.comment else ""
-        return f'    {self.datatype} {self.name} {self.key if self.key else ""} {cmt}'
+        return f"    {self.datatype} {self.name} {self.key if self.key else ''} {cmt}"
 
 
 class IdentifyingType(str, Enum):

--- a/linkml/generators/graphqlgen.py
+++ b/linkml/generators/graphqlgen.py
@@ -66,7 +66,7 @@ class GraphqlGenerator(Generator):
             for value in enum.permissible_values:
                 permissible_values.append(self.name_compatiblity.compatible(value))
             values = "\n    ".join(permissible_values)
-            return f"enum {camelcase(enum.name).replace(' ','')}\n  {{\n    {values}\n  }}\n\n"
+            return f"enum {camelcase(enum.name).replace(' ', '')}\n  {{\n    {values}\n  }}\n\n"
         else:
             logging.warning(
                 f"Enumeration {enum.name} using `reachable_from` instead of `permissible_values` "

--- a/linkml/generators/jsonldcontextgen.py
+++ b/linkml/generators/jsonldcontextgen.py
@@ -197,7 +197,6 @@ class ContextGenerator(Generator):
         elif not uri_prefix or is_default_namespace:
             definition["@id"] = uri_suffix
         else:
-
             definition["@id"] = (uri_prefix + ":" + uri_suffix) if uri_prefix else uri
 
         if uri_prefix and not is_default_namespace:

--- a/linkml/generators/jsonldgen.py
+++ b/linkml/generators/jsonldgen.py
@@ -106,7 +106,9 @@ class JSONLDGenerator(Generator):
                     else (
                         SubsetDefinitionName(camelcase(node))
                         if node in self.schema.subsets
-                        else TypeDefinitionName(underscore(node)) if node in self.schema.types else None
+                        else TypeDefinitionName(underscore(node))
+                        if node in self.schema.types
+                        else None
                     )
                 )
             )

--- a/linkml/generators/linkmlgen.py
+++ b/linkml/generators/linkmlgen.py
@@ -73,7 +73,7 @@ class LinkmlGenerator(Generator):
             return yaml_str
         else:
             raise ValueError(
-                f"{self.format} is an invalid format. Use one of the following " f"formats: {self.valid_formats}"
+                f"{self.format} is an invalid format. Use one of the following formats: {self.valid_formats}"
             )
 
 

--- a/linkml/generators/markdowngen.py
+++ b/linkml/generators/markdowngen.py
@@ -204,7 +204,7 @@ class MarkdownGenerator(Generator):
             if cls.name in self.synopsis.mixinrefs:
                 items.append(self.header(2, f"{mixin_local_name} for"))
                 for mixin in sorted(self.synopsis.mixinrefs[cls.name].classrefs):
-                    items.append(self.bullet(f'{self.class_link(mixin, use_desc=True, after_link="(mixin)")}'))
+                    items.append(self.bullet(f"{self.class_link(mixin, use_desc=True, after_link='(mixin)')}"))
 
             if cls.name in self.synopsis.classrefs:
                 items.append(self.header(2, f"Referenced by {class_local_name}"))
@@ -513,7 +513,9 @@ class MarkdownGenerator(Generator):
             else (
                 underscore(obj.name)
                 if isinstance(obj, SlotDefinition)
-                else underscore(obj.name) if isinstance(obj, EnumDefinition) else camelcase(obj.name)
+                else underscore(obj.name)
+                if isinstance(obj, EnumDefinition)
+                else camelcase(obj.name)
             )
         )
         subdir = "/types" if isinstance(obj, TypeDefinition) and not self.no_types_dir else ""
@@ -548,7 +550,7 @@ class MarkdownGenerator(Generator):
         for example in slot.examples:
             items.append(
                 self.bullet(
-                    f'Example: {getattr(example, "value", " ")} {getattr(example, "description", " ")}',
+                    f"Example: {getattr(example, 'value', ' ')} {getattr(example, 'description', ' ')}",
                     level=1,
                 )
             )
@@ -599,7 +601,7 @@ class MarkdownGenerator(Generator):
 
     def header(self, level: int, txt: str) -> str:
         txt = self.get_metamodel_slot_name(txt)
-        out = f'\n{"#" * level} {txt}\n'
+        out = f"\n{'#' * level} {txt}\n"
         return out
 
     @staticmethod
@@ -608,7 +610,7 @@ class MarkdownGenerator(Generator):
 
     @staticmethod
     def bullet(txt: str, level=0) -> str:
-        return f'{"    " * level} * {txt}'
+        return f"{'    ' * level} * {txt}"
 
     def frontmatter(self, thingtype: str, layout="default") -> str:
         return self.header(1, thingtype)
@@ -674,8 +676,11 @@ class MarkdownGenerator(Generator):
             link_name = obj.name
             link_ref = link_name
         desc = self.desc_for(obj, use_desc)
-        return f"[{link_name}]" f"({link_ref}.{self.format})" + (f" {after_link} " if after_link else "") + (
-            f" - {desc.split(nl)[0]}" if desc else ""
+        return (
+            f"[{link_name}]"
+            f"({link_ref}.{self.format})"
+            + (f" {after_link} " if after_link else "")
+            + (f" - {desc.split(nl)[0]}" if desc else "")
         )
 
     def type_link(

--- a/linkml/generators/pydanticgen/pydanticgen.py
+++ b/linkml/generators/pydanticgen/pydanticgen.py
@@ -832,8 +832,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
             meta = remove_empty_items(source)
         else:
             raise ValueError(
-                f"Unknown metadata mode '{self.metadata_mode}', needs to be one of "
-                f"{[mode for mode in MetadataMode]}"
+                f"Unknown metadata mode '{self.metadata_mode}', needs to be one of {[mode for mode in MetadataMode]}"
             )
 
         model.meta = meta

--- a/linkml/generators/pydanticgen/template.py
+++ b/linkml/generators/pydanticgen/template.py
@@ -596,7 +596,7 @@ class Imports(PydanticTemplateModel):
             else:
                 return all([obj in an_import.objects for obj in item.objects])
         else:
-            raise TypeError("Imports only contains single Import objects or other Imports\n" f"Got: {type(item)}")
+            raise TypeError(f"Imports only contains single Import objects or other Imports\nGot: {type(item)}")
 
     @field_validator("imports", mode="after")
     @classmethod

--- a/linkml/generators/python/python_ifabsent_processor.py
+++ b/linkml/generators/python/python_ifabsent_processor.py
@@ -57,7 +57,7 @@ class PythonIfAbsentProcessor(IfAbsentProcessor):
         slot: SlotDefinition,
         cls: ClassDefinition,
     ):
-        return f"datetime({int(year)}, {int(month)}, {int(day)}, " f"{int(hour)}, {int(minutes)}, {int(seconds)})"
+        return f"datetime({int(year)}, {int(month)}, {int(day)}, {int(hour)}, {int(minutes)}, {int(seconds)})"
 
     def map_uri_or_curie_default_value(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition):
         return self._uri_for(default_value)

--- a/linkml/generators/pythongen.py
+++ b/linkml/generators/pythongen.py
@@ -474,7 +474,7 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
     def gen_classdef(self, cls: ClassDefinition) -> str:
         """Generate python definition for class cls"""
 
-        parentref = f'({self.formatted_element_name(cls.is_a, True) if cls.is_a else "YAMLRoot"})'
+        parentref = f"({self.formatted_element_name(cls.is_a, True) if cls.is_a else 'YAMLRoot'})"
         slotdefs = self.gen_class_variables(cls)
         postinits = self.gen_postinits(cls)
         constructor = self.gen_constructor(cls)
@@ -833,8 +833,7 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
                 elif slot_range == "uri":
                     lookup_by_props = ["class_class_uri", "class_model_uri"]
                     td_val_expression = (
-                        f"URIRef({td_val_expression}) if "
-                        f"isinstance({td_val_expression}, str) else {td_val_expression}"
+                        f"URIRef({td_val_expression}) if isinstance({td_val_expression}, str) else {td_val_expression}"
                     )
                 elif slot_range == "uriorcurie":
                     lookup_by_props = ["class_class_curie", "class_class_uri", "class_model_uri"]
@@ -917,8 +916,7 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
                 rlines.append(f"self.{aliased_slot_name} = str(self.{td_value_classvar})")
             elif (
                 # A really weird case -- a class that has no properties
-                slot.range in self.schema.classes
-                and not self.schema.classes[slot.range].slots
+                slot.range in self.schema.classes and not self.schema.classes[slot.range].slots
             ):
                 rlines.append(f"\tself.{aliased_slot_name} = {base_type_name}()")
             else:
@@ -985,7 +983,7 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
             sn = f"self.{aliased_slot_name}"
             rlines.append(f"if not isinstance({sn}, list):")
             rlines.append(f"\t{sn} = [{sn}] if {sn} is not None else []")
-            rlines.append(f"{sn} = [v if isinstance(v, {base_type_name}) " f"else {base_type_name}(v) for v in {sn}]")
+            rlines.append(f"{sn} = [v if isinstance(v, {base_type_name}) else {base_type_name}(v) for v in {sn}]")
         while rlines and copy(rlines[-1]).strip() == "":
             rlines.pop()
         rlines.append("")
@@ -1229,7 +1227,7 @@ class {enum_name}(EnumDefinitionImpl):
         indent_str = (4 + indent) * " "
         pv_attrs = [f'{indent_str}text="{pv_text}"']
         if pv.description:
-            pv_attrs.append(f'{self.process_multiline_string(pv.description, f"{indent_str}description=")}')
+            pv_attrs.append(f"{self.process_multiline_string(pv.description, f'{indent_str}description=')}")
         if pv.meaning:
             pv_meaning = self.namespaces.curie_for(
                 self.namespaces.uri_for(pv.meaning), default_ok=False, pythonform=True

--- a/linkml/generators/shacl/shacl_ifabsent_processor.py
+++ b/linkml/generators/shacl/shacl_ifabsent_processor.py
@@ -6,7 +6,6 @@ from linkml.generators.shacl.shacl_data_type import ShaclDataType
 
 
 class ShaclIfAbsentProcessor(IfAbsentProcessor):
-
     def map_custom_default_values(self, default_value: str, slot: SlotDefinition, cls: ClassDefinition) -> (bool, str):
         if default_value == "class_curie":
             class_uri = self.schema_view.get_uri(cls, expand=True)

--- a/linkml/generators/shaclgen.py
+++ b/linkml/generators/shaclgen.py
@@ -141,7 +141,7 @@ class ShaclGenerator(Generator):
                     # slot definition, as both are mapped to sh:in in SHACL
                     if s.equals_string or s.equals_string_in:
                         error = "'equals_string'/'equals_string_in' and 'any_of' are mutually exclusive"
-                        raise ValueError(f'{TypedNode.yaml_loc(str(s), suffix="")} {error}')
+                        raise ValueError(f"{TypedNode.yaml_loc(str(s), suffix='')} {error}")
 
                     or_node = BNode()
                     prop_pv(SH["or"], or_node)

--- a/linkml/generators/sparqlgen.py
+++ b/linkml/generators/sparqlgen.py
@@ -151,7 +151,7 @@ class SparqlGenerator(Generator):
         template_obj = Template(template)
         extra = ""
         if named_graphs is not None:
-            extra += f'FILTER( ?graph in ( {",".join(named_graphs)} ))'
+            extra += f"FILTER( ?graph in ( {','.join(named_graphs)} ))"
         logger.info(f"Named Graphs = {named_graphs} // extra={extra}")
         if limit is not None and isinstance(limit, int):
             limit = f"LIMIT {limit}"

--- a/linkml/generators/terminusdbgen.py
+++ b/linkml/generators/terminusdbgen.py
@@ -114,8 +114,7 @@ class TerminusdbGenerator(Generator):
 
         if rng not in XSD_Ok and slot.range not in self.schema.classes:
             raise Exception(
-                f"slot range for {name} must be schema class or supported xsd type. "
-                f"Range {rng} is of type {type(rng)}."
+                f"slot range for {name} must be schema class or supported xsd type. Range {rng} is of type {type(rng)}."
             )
 
         self.clswq.property(underscore(name), rng, label=name, description=slot.description)

--- a/linkml/utils/logictools.py
+++ b/linkml/utils/logictools.py
@@ -125,11 +125,11 @@ class And(Expression):
         self.operands: list[Expression] = list(operands)
 
     def __str__(self):
-        return f'({" & ".join(str(operand) for operand in self.operands)})'
+        return f"({' & '.join(str(operand) for operand in self.operands)})"
 
     def _ordered_str(self, **kwargs):
         sorted_operands = sorted([op._ordered_str(**kwargs) for op in self.operands], key=str)
-        return f'({" & ".join(sorted_operands)})'
+        return f"({' & '.join(sorted_operands)})"
 
 
 class Or(Expression):
@@ -137,13 +137,13 @@ class Or(Expression):
         self.operands = list(operands)
 
     def __str__(self):
-        return f'({" | ".join(str(operand) for operand in self.operands)})'
+        return f"({' | '.join(str(operand) for operand in self.operands)})"
 
     def _ordered_str(self, pairwise=False):
         if pairwise and len(self.operands) > 2:
             return Or(Or(*self.operands[0:2]), Or(*self.operands[2:]))._ordered_str(pairwise=True)
         sorted_operands = sorted([op._ordered_str(pairwise=True) for op in self.operands], key=str)
-        return f'({" | ".join(sorted_operands)})'
+        return f"({' | '.join(sorted_operands)})"
 
 
 class Eq(Expression):
@@ -167,7 +167,7 @@ class Term(Expression):
         if self.predicate in OPS:
             return f"{str(self.operands[0])} {OPS[self.predicate]} {str(self.operands[1])}"
         else:
-            return f'{self.predicate}({", ".join(str(operand) for operand in self.operands)})'
+            return f"{self.predicate}({', '.join(str(operand) for operand in self.operands)})"
 
     def _ordered_str(self, **kwargs):
         return str(self)

--- a/linkml/utils/schemaloader.py
+++ b/linkml/utils/schemaloader.py
@@ -737,7 +737,7 @@ class SchemaLoader:
                 for slot_usage in values(cls.slot_usage):
                     if slot_usage.alias:
                         self.raise_value_error(
-                            f'Class: "{cls.name}" - alias not permitted in slot_usage slot:' f" {slot_usage.alias}"
+                            f'Class: "{cls.name}" - alias not permitted in slot_usage slot: {slot_usage.alias}'
                         )
                     if not located_aliased_parent_slot(cls, slot_usage):
                         if slot_usage.name not in self.schema.slots:
@@ -765,7 +765,7 @@ class SchemaLoader:
         for slotname, slot_usage in cls.slot_usage.items():
             if slot_usage.alias:
                 self.raise_value_error(
-                    f'Class: "{cls.name}" - alias not permitted in slot_usage slot:' f" {slot_usage.alias}"
+                    f'Class: "{cls.name}" - alias not permitted in slot_usage slot: {slot_usage.alias}'
                 )
             # Construct a new slot
             # If we've already assigned a parent, use it
@@ -947,7 +947,7 @@ class SchemaLoader:
             locs = "\n".join(TypedNode.yaml_loc(e, suffix="") for e in loc_str)
             raise ValueError(f"{locs} {error}")
         else:
-            raise ValueError(f'{TypedNode.yaml_loc(loc_str, suffix="")} {error}')
+            raise ValueError(f"{TypedNode.yaml_loc(loc_str, suffix='')} {error}")
 
     def logger_warning(
         self,
@@ -958,7 +958,7 @@ class SchemaLoader:
             locs = "\n\t".join(TypedNode.yaml_loc(e, suffix="") for e in loc_str)
             self.logger.warning(f"{warning}\n\t{locs}")
         else:
-            self.logger.warning(f'{warning}\n\t{TypedNode.yaml_loc(loc_str, suffix="")}')
+            self.logger.warning(f"{warning}\n\t{TypedNode.yaml_loc(loc_str, suffix='')}")
 
     def _get_base_dir(self, stated_base: str) -> Optional[str]:
         if stated_base:

--- a/linkml/utils/schemasynopsis.py
+++ b/linkml/utils/schemasynopsis.py
@@ -115,7 +115,11 @@ class SchemaSynopsis:
             (
                 ClassType
                 if v.range in self.schema.classes
-                else EnumType if v.range in self.schema.enums else TypeType if v.range in self.schema.types else None
+                else EnumType
+                if v.range in self.schema.enums
+                else TypeType
+                if v.range in self.schema.types
+                else None
             ),
             v.range,
         )
@@ -244,19 +248,19 @@ class SchemaSynopsis:
         rval = []
         undefined_classes = set(self.classrefs.keys()) - set(self.schema.classes.keys())
         if undefined_classes:
-            rval += [f"\tUndefined class references: " f"{', '.join(format_undefineds(undefined_classes))}"]
+            rval += [f"\tUndefined class references: {', '.join(format_undefineds(undefined_classes))}"]
         undefined_slots = set(self.slotrefs.keys()) - set(self.schema.slots.keys())
         if undefined_slots:
-            rval += [f"\tUndefined slot references: " f"{', '.join(format_undefineds(undefined_slots))}"]
+            rval += [f"\tUndefined slot references: {', '.join(format_undefineds(undefined_slots))}"]
         undefined_types = set(self.typerefs.keys()) - set(self.schema.types.keys())
         if undefined_types:
-            rval += [f"\tUndefined type references: " f"{', '.join(format_undefineds(undefined_types))}"]
+            rval += [f"\tUndefined type references: {', '.join(format_undefineds(undefined_types))}"]
         undefined_subsets = set(self.subsetrefs.keys()) - set(self.schema.subsets.keys())
         if undefined_subsets:
-            rval += [f"\tUndefined subset references: " f"{', '.join(format_undefineds(undefined_subsets))}"]
+            rval += [f"\tUndefined subset references: {', '.join(format_undefineds(undefined_subsets))}"]
         undefined_enums = set(self.enumrefs.keys()) - set(self.schema.enums.keys())
         if undefined_enums:
-            rval += [f"\tUndefined enun references: " f"{', '.join(format_undefineds(undefined_enums))}"]
+            rval += [f"\tUndefined enun references: {', '.join(format_undefineds(undefined_enums))}"]
 
         # Inlined slots must be multivalued (not a inviolable rule, but we make assumptions about this elsewhere in
         # the python generator
@@ -373,7 +377,7 @@ class SchemaSynopsis:
             for slotname in sorted(domain_mismatches):
                 rval.append(
                     f'\t\t\tSlot: "{slotname}" declared domain: "{self.schema.slots[slotname].domain}" '
-                    f'actual domain(s): {", ".join(self.slotclasses[slotname])}'
+                    f"actual domain(s): {', '.join(self.slotclasses[slotname])}"
                 )
         if unkdomains:
             rval += [f"\t* Unknown domain: {', '.join(sorted(unkdomains))}"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 include = ["linkml"]
 requires-python = ">=3.9"
 dynamic = ["version"]
-dependencies = [  # Specifier syntax: https://peps.python.org/pep-0631/
+dependencies = [ # Specifier syntax: https://peps.python.org/pep-0631/
     "antlr4-python3-runtime >= 4.9.0, < 4.10",
     "click >= 7.0",
     "graphviz >= 0.10.1",
@@ -326,10 +326,10 @@ commands = [
 ]
 
 [tool.tox.env.lint]
-description = "Run code linter (no fixes)."
+description = "Run code linter and formatter (no fixes)."
 skip_install = true
-deps = ["black", "ruff==0.4.8"]
+deps = ["ruff==0.11.13"]
 commands = [
   ["ruff", "check", "{posargs:.}"],
-  ["black", "--check", "--diff", "{posargs:.}"],
+  ["ruff", "format", "{posargs:.}"],
 ]

--- a/tests/test_compliance/helper.py
+++ b/tests/test_compliance/helper.py
@@ -320,7 +320,6 @@ def _generate_framework_output(
 
         cached_generator_output[pair] = (gen, output, out_path)
         for context, impdict in mappings:
-
             if framework in impdict:
                 expected = impdict[framework]
                 if expected is None:
@@ -559,7 +558,7 @@ def _make_schema(
 
     if imported_schemas:
         for imp in imported_schemas:
-            imp_path = f'{out_dir / imp["name"]}.yaml'
+            imp_path = f"{out_dir / imp['name']}.yaml"
             with open(imp_path, "w", encoding="utf-8") as imp_stream:
                 yaml.safe_dump(imp, imp_stream, sort_keys=False)
 
@@ -788,9 +787,9 @@ def check_data(
                         assert True, f"could not coerce invalid object; exception: {e}"
                     if py_inst:
                         if coerced:
-                            assert _as_compact_yaml(py_inst) == _as_compact_yaml(
-                                coerced
-                            ), f"coerced {py_inst} != {coerced}"
+                            assert _as_compact_yaml(py_inst) == _as_compact_yaml(coerced), (
+                                f"coerced {py_inst} != {coerced}"
+                            )
                         else:
                             logger.warning(f"INCOMPLETE TEST: did not check coerced: {py_inst}")
                 else:

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -583,7 +583,7 @@ def test_cardinality(framework, multivalued, required, data_name, value):
     )
     sql_nullable = "NOT NULL" if required else ""
     if not multivalued:
-        sqlite = 'CREATE TABLE "C" (' f"  id INTEGER NOT NULL," f"  s1 TEXT {sql_nullable}," "  PRIMARY KEY (id)" ");"
+        sqlite = f'CREATE TABLE "C" (  id INTEGER NOT NULL,  s1 TEXT {sql_nullable},  PRIMARY KEY (id));'
     else:
         sqlite = (
             'CREATE TABLE "C_s1" ('

--- a/tests/test_enhancements/test_enumeration.py
+++ b/tests/test_enhancements/test_enumeration.py
@@ -60,7 +60,6 @@ def test_enum_errors(file, error, input_path):
     ],
 )
 def test_enum_warns(file, warnings, input_path, caplog):
-
     generator = YAMLGenerator(
         (Path(input_path("enumeration")) / file).with_suffix(".yaml"),
         mergeimports=False,

--- a/tests/test_generators/shacl/test_shacl_ifabsent_processor.py
+++ b/tests/test_generators/shacl/test_shacl_ifabsent_processor.py
@@ -366,7 +366,7 @@ def test_process_impossible_range_ifabsent_attribute():
         )
 
     assert str(e.value) == (
-        "The ifabsent value `ImpossibleEnum(DivideByZero)` of the `impossibleRange` slot could not " "be processed"
+        "The ifabsent value `ImpossibleEnum(DivideByZero)` of the `impossibleRange` slot could not be processed"
     )
 
 

--- a/tests/test_generators/test_panderagen.py
+++ b/tests/test_generators/test_panderagen.py
@@ -294,7 +294,6 @@ def test_synthetic_dataframe_wrong_datatype(
 def test_synthetic_dataframe_boolean_error(
     pl, pandera, compiled_synthetic_schema_module, big_synthetic_dataframe, drop_column
 ):
-
     # fmt: off
     error_dataframe = (
         big_synthetic_dataframe

--- a/tests/test_generators/test_pydanticgen.py
+++ b/tests/test_generators/test_pydanticgen.py
@@ -402,9 +402,9 @@ def test_pydantic_inlining(range, multivalued, inlined, inlined_as_list, B_has_i
     assert f"a2b: {expected}" in code, f"did not find expected {expected} in {code}"
     if expected not in expected_default_factories:
         raise ValueError(f"unexpected default factory for {expected}")
-    assert (
-        expected_default_factories[expected] in code
-    ), f"did not find expected default factory {expected_default_factories[expected]}"
+    assert expected_default_factories[expected] in code, (
+        f"did not find expected default factory {expected_default_factories[expected]}"
+    )
 
 
 def test_ifabsent():
@@ -2563,9 +2563,9 @@ def test_generate_split_pattern(input_path):
     for an_import in should_have:
         assert an_import in imports, "Missed a necessary import when generating from a pattern"
     for an_import in shouldnt_have:
-        assert (
-            an_import not in imports
-        ), "Got one of the imports with the default template instead of the supplied pattern"
+        assert an_import not in imports, (
+            "Got one of the imports with the default template instead of the supplied pattern"
+        )
 
 
 @pytest.mark.pydanticgen_split
@@ -2700,9 +2700,9 @@ def test_crappy_stdlib_set_removed():
 
         linkml_meta = metadata("linkml")
         req_python = SpecifierSet(linkml_meta.json["requires_python"])
-        assert req_python.contains(
-            Version("3.9")
-        ), "REMOVE _some_stdlib_module_names from the bottom of pydanticgen/template.py, "
+        assert req_python.contains(Version("3.9")), (
+            "REMOVE _some_stdlib_module_names from the bottom of pydanticgen/template.py, "
+        )
         "and then REMOVE THIS TEST!"
     except Exception:
         pass

--- a/tests/test_generators/test_pythongen.py
+++ b/tests/test_generators/test_pythongen.py
@@ -99,9 +99,7 @@ types:
         source_file_date="August 10, 2020",
         source_file_size=173,
     ).serialize()
-    assert output.startswith(
-        f"# Auto generated from None by pythongen.py version: " f"{PythonGenerator.generatorversion}"
-    )
+    assert output.startswith(f"# Auto generated from None by pythongen.py version: {PythonGenerator.generatorversion}")
 
     output = PythonGenerator(yaml, format="py", metadata=False).serialize()
     assert output.startswith("\n# id: https://w3id.org/biolink/metamodel")

--- a/tests/test_generators/test_typescriptgen.py
+++ b/tests/test_generators/test_typescriptgen.py
@@ -95,7 +95,6 @@ enums:
 
 
 def test_output_option(kitchen_sink_path, tmp_path):
-
     tss = TypescriptGenerator(kitchen_sink_path, mergeimports=True)
 
     tss.serialize(output=tmp_path / "kitchen_sink.ts")

--- a/tests/test_issues/test_linkml_issue_384.py
+++ b/tests/test_issues/test_linkml_issue_384.py
@@ -89,9 +89,9 @@ def test_issue_owl_properties(input_path, snapshot):
             assert (p, RDF.type, OWL.ObjectProperty) in g
         assert _contains_restriction(g, Person, parent, OWL.allValuesFrom, Person)
         assert _contains_restriction(g, Organization, parent, OWL.allValuesFrom, Organization)
-        assert _contains_restriction(
-            g, Person, aliases, OWL.allValuesFrom, string_rep
-        ), f"expected {string_rep} for {conf}"
+        assert _contains_restriction(g, Person, aliases, OWL.allValuesFrom, string_rep), (
+            f"expected {string_rep} for {conf}"
+        )
         # TODO: also validate cardinality restrictions
         # assert self._contains_restriction(g, Thing, full_name, OWL.allValuesFrom, string_rep)
 

--- a/tests/test_issues/test_linkml_issue_711.py
+++ b/tests/test_issues/test_linkml_issue_711.py
@@ -105,6 +105,6 @@ def _test_subject_annotations(subject, graph):
     # err:non_existing must not be present in the result
     predicates = list(graph.predicates(subject=subject, object=None))
     for pred in predicates:
-        assert (
-            "non_existing" not in pred
-        ), f"Annotation err:non_existing for {subject} should be skipped, but is present in the result."
+        assert "non_existing" not in pred, (
+            f"Annotation err:non_existing for {subject} should be skipped, but is present in the result."
+        )

--- a/tests/utils/compare_jsonld_context.py
+++ b/tests/utils/compare_jsonld_context.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 
 class CompareJsonldContext:
-
     @staticmethod
     def compare_with_snapshot(jsonld_context: str, snapshot: Path):
         with open(snapshot) as snapshot:


### PR DESCRIPTION
Switch to using ruff for code formatting and linting, instead of using black for formatting.

Running `ruff format` over the repo results in a few minor changes, mostly in `'` and `"` use and display of long lines.