### PR TITLE
Pass permissible_value title to constructor in generated code

### DIFF
--- a/linkml/generators/pythongen.py
+++ b/linkml/generators/pythongen.py
@@ -1211,6 +1211,7 @@ class {enum_name}(EnumDefinitionImpl):
         PermissibleValue(text="NAME_ONLY")
         PermissibleValue(
             text="CODE",
+            title="...",
             description="...",
             meaning="...")
 
@@ -1221,11 +1222,13 @@ class {enum_name}(EnumDefinitionImpl):
         constructor = "PermissibleValue"
         pv_text = pv.text.replace('"', '\\"')
 
-        if not pv.description and not pv.meaning:
+        if not pv.description and not pv.meaning and not pv.title:
             return f'{constructor}(text="{pv_text}")'
 
         indent_str = (4 + indent) * " "
         pv_attrs = [f'{indent_str}text="{pv_text}"']
+        if pv.title:
+            pv_attrs.append(f'{indent_str}title="{pv.title}"')
         if pv.description:
             pv_attrs.append(f"{self.process_multiline_string(pv.description, f'{indent_str}description=')}")
         if pv.meaning:

--- a/tests/test_generators/test_pythongen.py
+++ b/tests/test_generators/test_pythongen.py
@@ -134,3 +134,33 @@ class ParentClass:
     kitchen_module = compile_python(pstr)
     friend = kitchen_module.Friend(name="bestie")
     assert repr(friend) != "overridden"
+
+
+def test_permissible_values():
+    """
+    Test that permissible values are generated correctly
+    """
+    yaml = """id: http://example.org/test
+description: Test schema for permissible values
+prefixes:
+  example: http://example.org/
+enums:
+  TestEnum:
+    permissible_values:
+      - BASIC:
+      - ADVANCED:
+          description: This is an advanced option
+          title: Advanced Option
+          meaning: "example:advanced"
+"""
+
+    py_module = make_python(yaml)
+    assert py_module.TestEnum.BASIC.text == "BASIC"
+    assert py_module.TestEnum.BASIC.description is None
+    assert py_module.TestEnum.BASIC.title is None
+    assert py_module.TestEnum.BASIC.meaning is None
+
+    assert py_module.TestEnum.ADVANCED.text == "ADVANCED"
+    assert py_module.TestEnum.ADVANCED.description == "This is an advanced option"
+    assert py_module.TestEnum.ADVANCED.title == "Advanced Option"
+    assert py_module.TestEnum.ADVANCED.meaning == "http://example.org/advanced"


### PR DESCRIPTION
Fixes #2837 

These changes add `title` as one of the metamodel slots passed to the `PermissibleValue` constructor in generated Python code.