### PR TITLE
permissible values: more compliance tests, fixing owlgen to properly encode all PVs

### DIFF
--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -1251,7 +1251,8 @@ class OwlSchemaGenerator(Generator):
             return URIRef(self.schemaview.expand_curie(pv.meaning))
         else:
             from urllib.parse import quote
-            encoded_text = quote(pv.text.strip(), safe='', encoding='utf-8')
+
+            encoded_text = quote(pv.text.strip(), safe="", encoding="utf-8")
             return URIRef(enum_uri + self.enum_iri_separator + encoded_text)
 
     def slot_owl_type(self, slot: SlotDefinition) -> URIRef:

--- a/linkml/generators/owlgen.py
+++ b/linkml/generators/owlgen.py
@@ -1250,7 +1250,9 @@ class OwlSchemaGenerator(Generator):
         if pv.meaning:
             return URIRef(self.schemaview.expand_curie(pv.meaning))
         else:
-            return URIRef(enum_uri + self.enum_iri_separator + pv.text.replace(" ", "+"))
+            from urllib.parse import quote
+            encoded_text = quote(pv.text.strip(), safe='', encoding='utf-8')
+            return URIRef(enum_uri + self.enum_iri_separator + encoded_text)
 
     def slot_owl_type(self, slot: SlotDefinition) -> URIRef:
         sv = self.schemaview

--- a/tests/test_biolink_model/__snapshots__/biolink.owl.ttl
+++ b/tests/test_biolink_model/__snapshots__/biolink.owl.ttl
@@ -1736,32 +1736,32 @@ biolink:CaseToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "case to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Case ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ] ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ] ;
     skos:definition "An abstract association for use where the case is the subject" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -1769,32 +1769,32 @@ biolink:CellLineToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "cell line to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:CellLine ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ] ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ] ;
     skos:definition "An relationship between a cell line and another entity" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -1807,7 +1807,7 @@ biolink:DrugToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "drug to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -1817,22 +1817,22 @@ biolink:DrugToEntityAssociationMixin a owl:Class,
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Drug ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
         biolink:ChemicalEntityToEntityAssociationMixin ;
     skos:definition "An interaction between a drug and another entity" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -1841,31 +1841,31 @@ biolink:EntityToExposureEventAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to exposure event association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ExposureEvent ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ] ;
     skos:definition "An association between some entity and an exposure event." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -1874,32 +1874,32 @@ biolink:EntityToOutcomeAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to outcome association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Outcome ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Outcome ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ] ;
+            owl:onProperty biolink:predicate ] ;
     skos:definition "An association between some entity and an outcome" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -1907,13 +1907,13 @@ biolink:EpigenomicEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "epigenomic entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:biological_sequence ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_biological_sequence ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -1921,50 +1921,50 @@ biolink:FeatureOrDiseaseQualifiersToEntityMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "feature or disease qualifiers to entity mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
+            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_direction_qualifier ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_direction_qualifier ],
         biolink:FrequencyQualifierMixin ;
     skos:definition "Qualifiers for disease or phenotype to entity associations." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -1976,29 +1976,29 @@ biolink:MaterialSampleToEntityAssociationMixin a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MaterialSample ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ] ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ] ;
     skos:definition "An association between a material sample and something." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -3168,32 +3168,32 @@ biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "anatomical entity to anatomical entity ontogenic association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
     skos:definition "A relationship between two anatomical entities where the relationship is ontogenic, i.e. the two entities are related by development. A number of different relationship types can be used to specify the precise nature of the relationship." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3202,32 +3202,32 @@ biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "anatomical entity to anatomical entity part of association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
     skos:definition "A relationship between two anatomical entities where the relationship is mereological, i.e the two entities are related by parthood. This includes relationships between cellular components and cells, between cells and tissues, tissues and whole organisms" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3320,23 +3320,23 @@ biolink:BehaviorToBehavioralFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "behavior to behavioral feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Behavior ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:BehavioralFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:Behavior ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin ;
     skos:definition "An association between an mixture behavior and a behavioral feature manifested by the individual exhibited or has exhibited the behavior." ;
@@ -3364,20 +3364,20 @@ biolink:Book a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "book" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
+            owl:onProperty biolink:type ],
         biolink:Publication ;
     skos:definition "This class may rarely be instantiated except if use cases of a given knowledge graph support its utility." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3395,20 +3395,20 @@ biolink:CausalGeneToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "causal gene to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
@@ -3521,13 +3521,13 @@ biolink:CellLineAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "cell line as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:CellLine ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation,
         biolink:EntityToDiseaseAssociationMixin,
@@ -3538,167 +3538,167 @@ biolink:ChemicalAffectsGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical affects gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
+            owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
+            owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
             owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:qualified_predicate ],
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
+            owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
             owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:species_context_qualifier ],
+            owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
         biolink:Association ;
     skos:definition "Describes an effect that a chemical has on a gene or gene product (e.g. an impact of on its abundance, activity,localization, processing, expression, etc.)" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3713,26 +3713,26 @@ biolink:ChemicalEntityAssessesNamedThingAssociation a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -3740,40 +3740,40 @@ biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical entity or gene or gene product regulates gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "A regulatory relationship between two genes" ;
@@ -3789,29 +3789,29 @@ biolink:ChemicalEntityToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical entity to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
             owl:onProperty biolink:subject ] ;
@@ -3823,76 +3823,10 @@ biolink:ChemicalGeneInteractionAssociation a owl:Class,
     rdfs:label "chemical gene interaction association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
+            owl:onProperty biolink:subject_part_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:anatomical_context_qualifier ],
@@ -3903,20 +3837,86 @@ biolink:ChemicalGeneInteractionAssociation a owl:Class,
             owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_part_qualifier ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
@@ -3930,10 +3930,10 @@ biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation
         linkml:ClassDefinition ;
     rdfs:label "chemical or drug or treatment side effect disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -3972,17 +3972,23 @@ biolink:ChemicalToChemicalDerivationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to chemical derivation association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:catalyst_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
@@ -3990,19 +3996,13 @@ biolink:ChemicalToChemicalDerivationAssociation a owl:Class,
             owl:allValuesFrom biolink:MacromolecularMachineMixin ;
             owl:onProperty biolink:catalyst_qualifier ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:catalyst_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:subject ],
         biolink:ChemicalToChemicalAssociation ;
     skos:definition "A causal relationship between two chemical entities, where the subject represents the upstream entity and the object represents the downstream. For any such association there is an implicit reaction: IF R has-input C1 AND R has-output C2 AND R enabled-by P AND R type Reaction THEN C1 derives-into C2 catalyst qualifier P" ;
@@ -4012,13 +4012,13 @@ biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin,
@@ -4031,23 +4031,23 @@ biolink:ChemicalToPathwayAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to pathway association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Pathway ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Pathway ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin ;
     skos:definition "An interaction between a chemical entity and a biological process or pathway." ;
@@ -4182,32 +4182,32 @@ biolink:ContributorAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:qualifiers ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:InformationContentEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:qualifiers ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Agent ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:qualifiers ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:InformationContentEntity ;
-            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "Any association between an entity (such as a publication) and various agents that contribute to its realisation" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4216,23 +4216,23 @@ biolink:CorrelatedGeneToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "correlated gene to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:GeneToDiseaseAssociation,
         biolink:GeneToEntityAssociationMixin ;
@@ -4267,27 +4267,27 @@ biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin a owl:Class,
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
+            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4295,22 +4295,22 @@ biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease or phenotypic feature to genetic inheritance association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:GeneticInheritance ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneticInheritance ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin ;
@@ -4321,13 +4321,13 @@ biolink:DiseaseOrPhenotypicFeatureToLocationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease or phenotypic feature to location association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:Association,
         biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin ;
@@ -4338,32 +4338,32 @@ biolink:DiseaseToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Disease ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Disease ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ] ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
 biolink:DiseaseToExposureEventAssociation a owl:Class,
@@ -4379,29 +4379,29 @@ biolink:DiseaseToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "disease to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PhenotypicFeature ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:allValuesFrom biolink:Onset ;
+            owl:onProperty biolink:onset_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:onset_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Onset ;
-            owl:onProperty biolink:onset_qualifier ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:PhenotypicFeature ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:onset_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:onset_qualifier ],
@@ -4501,29 +4501,29 @@ biolink:DruggableGeneToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "druggable gene to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:DruggableGeneCategoryEnum ;
+            owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DruggableGeneCategoryEnum ;
-            owl:onProperty biolink:has_evidence ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:GeneToDiseaseAssociation,
         biolink:GeneToEntityAssociationMixin ;
@@ -4533,6 +4533,15 @@ biolink:EntityToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:max_research_phase ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:clinical_approval_status ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ResearchPhaseEnum ;
+            owl:onProperty biolink:max_research_phase ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:ClinicalApprovalStatusEnum ;
             owl:onProperty biolink:clinical_approval_status ],
         [ a owl:Restriction ;
@@ -4541,15 +4550,6 @@ biolink:EntityToDiseaseAssociation a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:max_research_phase ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:max_research_phase ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ResearchPhaseEnum ;
-            owl:onProperty biolink:max_research_phase ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:clinical_approval_status ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4557,23 +4557,23 @@ biolink:EntityToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ClinicalApprovalStatusEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:clinical_approval_status ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:max_research_phase ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:clinical_approval_status ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:clinical_approval_status ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ResearchPhaseEnum ;
             owl:onProperty biolink:max_research_phase ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:max_research_phase ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:clinical_approval_status ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ClinicalApprovalStatusEnum ;
+            owl:onProperty biolink:clinical_approval_status ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4612,13 +4612,16 @@ biolink:ExonToTranscriptRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exon to transcript relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Transcript ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Transcript ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Exon ;
@@ -4626,9 +4629,6 @@ biolink:ExonToTranscriptRelationship a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A transcript is formed from multiple exons" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4637,11 +4637,8 @@ biolink:ExposureEventToOutcomeAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "exposure event to outcome association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:temporal_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
-            owl:onProperty biolink:population_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:population_context_qualifier ],
@@ -4649,11 +4646,14 @@ biolink:ExposureEventToOutcomeAssociation a owl:Class,
             owl:allValuesFrom biolink:time_type ;
             owl:onProperty biolink:temporal_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:population_context_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:temporal_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:population_context_qualifier ],
         biolink:Association,
         biolink:EntityToOutcomeAssociationMixin ;
     skos:definition "An association between an exposure event and an outcome." ;
@@ -4726,146 +4726,116 @@ biolink:GeneAffectsChemicalAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene affects chemical association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
-            owl:onProperty biolink:object_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+            owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_part_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
@@ -4874,28 +4844,58 @@ biolink:GeneAffectsChemicalAssociation a owl:Class,
             owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
             owl:onProperty biolink:object_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_derivative_qualifier ],
         biolink:Association ;
     skos:definition "Describes an effect that a gene or gene product has on a chemical entity (e.g. an impact of on its abundance, activity, localization, processing, transport, etc.)" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -4904,13 +4904,13 @@ biolink:GeneAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:GeneToDiseaseAssociation,
@@ -4921,41 +4921,41 @@ biolink:GeneExpressionMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene expression mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:stage_qualifier ],
+            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:onProperty biolink:phenotypic_state ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:expression_site ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:phenotypic_state ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:phenotypic_state ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:expression_site ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:expression_site ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:quantifier_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:phenotypic_state ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:expression_site ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:phenotypic_state ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:LifeStage ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:expression_site ],
+            owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:quantifier_qualifier ] ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
+            owl:onProperty biolink:expression_site ] ;
     skos:definition "Observed gene expression intensity, context (site, stage) and associated phenotypic status within which the expression occurs." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -4963,40 +4963,40 @@ biolink:GeneHasVariantThatContributesToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene has variant that contributes to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         biolink:GeneToDiseaseAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5323,68 +5323,68 @@ biolink:GeneRegulatesGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene regulates gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
             owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "Describes a regulatory relationship between two genes or gene products." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5394,50 +5394,50 @@ biolink:GeneToExpressionSiteAssociation a owl:Class,
     rdfs:label "gene to expression site association" ;
     rdfs:seeAlso <https://github.com/monarch-initiative/ingest-artifacts/tree/master/sources/BGee> ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:stage_qualifier ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:LifeStage ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:quantifier_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:stage_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:quantifier_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "An association between a gene and a gene expression site, possibly qualified by stage/timing info." ;
     skos:editorialNote "TBD: introduce subclasses for distinction between wild-type and experimental conditions?" ;
@@ -5447,13 +5447,13 @@ biolink:GeneToGeneCoexpressionAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene coexpression association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         biolink:GeneExpressionMixin,
         biolink:GeneToGeneAssociation ;
@@ -5464,32 +5464,32 @@ biolink:GeneToGeneFamilyAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene family association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneFamily ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
         biolink:Association ;
     skos:definition "Set membership of a gene in a family of genes related by common evolutionary ancestry usually inferred by sequence comparisons. The genes in a given family generally share common sequence motifs which generally map onto shared gene product structure-function relationships." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5504,25 +5504,25 @@ biolink:GeneToGeneHomologyAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:GeneToGeneAssociation ;
     skos:definition "A homology association between two genes. May be orthology (in which case the species of subject and object should differ) or paralogy (in which case the species may be the same)" ;
@@ -5532,32 +5532,32 @@ biolink:GeneToGeneProductRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene product relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Gene ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneProductMixin ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Gene ;
-            owl:onProperty biolink:subject ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A gene is transcribed and potentially translated to a gene product" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5566,19 +5566,19 @@ biolink:GeneToGoTermAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to go term association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -5592,23 +5592,23 @@ biolink:GeneToPathwayAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to pathway association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Pathway ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:Pathway ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:GeneToEntityAssociationMixin ;
     skos:definition "An interaction between a gene or gene product and a biological process or pathway." ;
@@ -5624,7 +5624,7 @@ biolink:GeneToPhenotypicFeatureAssociation a owl:Class,
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhenotypicFeature ;
@@ -5633,7 +5633,7 @@ biolink:GeneToPhenotypicFeatureAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:EntityToPhenotypicFeatureAssociationMixin,
         biolink:GeneToDiseaseOrPhenotypicFeatureAssociation,
@@ -5689,32 +5689,32 @@ biolink:GenotypeToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Genotype ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Genotype ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ] ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
 biolink:GenotypeToGeneAssociation a owl:Class,
@@ -5724,29 +5724,29 @@ biolink:GenotypeToGeneAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Gene ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Gene ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Genotype ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Genotype ;
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "Any association between a genotype and a gene. The genotype have have multiple variants in that gene or a single one. There is no assumption of cardinality" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5756,31 +5756,31 @@ biolink:GenotypeToGenotypePartAssociation a owl:Class,
     rdfs:label "genotype to genotype part association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "Any association between one genotype and a genotypic entity that is a sub-component of it" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5789,12 +5789,6 @@ biolink:GenotypeToPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
@@ -5804,8 +5798,14 @@ biolink:GenotypeToPhenotypicFeatureAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
         biolink:GenotypeToEntityAssociationMixin ;
@@ -5819,26 +5819,26 @@ biolink:GenotypeToVariantAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Genotype ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:SequenceVariant ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
@@ -5881,13 +5881,13 @@ biolink:GeographicLocationAtTime a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "geographic location at time" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:timepoint ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:time_type ;
+            owl:onProperty biolink:timepoint ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:timepoint ],
         biolink:GeographicLocation ;
     skos:definition "a location that can be described in lat/long coordinates, for a particular time" ;
@@ -5944,31 +5944,31 @@ biolink:InformationContentEntityToNamedThingAssociation a owl:Class,
     rdfs:label "information content entity to named thing association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "association between a named thing and a information content entity where the specific context of the relationship between that named thing and the publication is unknown. For example, model organisms databases often capture the knowledge that a gene is found in a journal article, but not specifically the context in which that gene was documented in the article. In these cases, this association with the accompanying predicate 'mentions' could be used. Conversely, for more specific associations (like 'gene to disease association', the publication should be captured as an edge property)." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6050,10 +6050,10 @@ biolink:MacromolecularMachineToBiologicalProcessAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine to biological process association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:BiologicalProcess ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:BiologicalProcess ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -6070,10 +6070,10 @@ biolink:MacromolecularMachineToCellularComponentAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:CellularComponent ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:CellularComponent ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:FunctionalAssociation,
         biolink:MacromolecularMachineToEntityAssociationMixin ;
@@ -6087,10 +6087,10 @@ biolink:MacromolecularMachineToMolecularActivityAssociation a owl:Class,
             owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:FunctionalAssociation,
         biolink:MacromolecularMachineToEntityAssociationMixin ;
@@ -6101,32 +6101,32 @@ biolink:MaterialSampleDerivationAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "material sample derivation association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MaterialSample ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MaterialSample ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "An association between a material sample and the material entity from which it is derived." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6159,17 +6159,17 @@ biolink:MolecularActivityToChemicalEntityAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ChemicalEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularActivity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularActivity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:ChemicalEntity ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6181,20 +6181,20 @@ biolink:MolecularActivityToMolecularActivityAssociation a owl:Class,
             owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6203,11 +6203,11 @@ biolink:MolecularActivityToPathwayAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular activity to pathway association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -6215,20 +6215,20 @@ biolink:MolecularActivityToPathwayAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MolecularActivity ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Pathway ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:Pathway ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Association that holds the relationship between a reaction and the pathway it participates in." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6237,77 +6237,77 @@ biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "named thing associated with likelihood of named thing association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:subject_context_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
+            owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:population_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_context_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_context_qualifier ],
+            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:population_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:population_context_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:population_context_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_aspect_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_context_qualifier ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -6340,6 +6340,12 @@ biolink:OrganismTaxonToEntityAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to entity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
@@ -6353,19 +6359,13 @@ biolink:OrganismTaxonToEntityAssociation a owl:Class,
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ] ;
+            owl:onProperty biolink:object ] ;
     skos:definition "An association between an organism taxon and another entity" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -6373,32 +6373,32 @@ biolink:OrganismTaxonToEnvironmentAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to environment association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:OrganismTaxonToEntityAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6407,33 +6407,6 @@ biolink:OrganismTaxonToOrganismTaxonInteraction a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to organism taxon interaction" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:associated_environmental_context ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:associated_environmental_context ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
@@ -6442,6 +6415,33 @@ biolink:OrganismTaxonToOrganismTaxonInteraction a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:associated_environmental_context ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:associated_environmental_context ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:OrganismTaxonToOrganismTaxonAssociation ;
     skos:definition "An interaction relationship between two taxa. This may be a symbiotic relationship (encompassing mutualism and parasitism), or it may be non-symbiotic. Example: plague transmitted_by flea; cattle domesticated_by Homo sapiens; plague infects Homo sapiens" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6450,31 +6450,31 @@ biolink:OrganismTaxonToOrganismTaxonSpecialization a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to organism taxon specialization" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:OrganismTaxonToOrganismTaxonAssociation ;
     skos:definition "A child-parent relationship between two taxa. For example: Homo sapiens subclass_of Homo" ;
@@ -6485,18 +6485,18 @@ biolink:OrganismToOrganismAssociation a owl:Class,
     rdfs:label "organism to organism association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom biolink:IndividualOrganism ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:IndividualOrganism ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:IndividualOrganism ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -6508,13 +6508,13 @@ biolink:OrganismalEntityAsAModelOfDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organismal entity as a model of disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismalEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
@@ -6529,22 +6529,28 @@ biolink:PairwiseMolecularInteraction a owl:Class,
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:interacting_molecules_category ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
+            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:interacting_molecules_category ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:interacting_molecules_category ],
@@ -6552,23 +6558,17 @@ biolink:PairwiseMolecularInteraction a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:interacting_molecules_category ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:object ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:PairwiseGeneToGeneInteraction ;
     skos:definition "An interaction at the molecular level between two physical entities" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -6657,13 +6657,13 @@ biolink:PhenotypicFeatureToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "phenotypic feature to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
@@ -6674,22 +6674,22 @@ biolink:PhenotypicFeatureToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "phenotypic feature to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:PhenotypicFeature ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:sex_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PhenotypicFeature ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:BiologicalSex ;
             owl:onProperty biolink:sex_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:sex_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:sex_qualifier ],
         biolink:FeatureOrDiseaseQualifiersToEntityMixin,
         biolink:FrequencyQuantifier ;
@@ -6752,28 +6752,28 @@ biolink:PopulationToPopulationAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "An association between a two populations" ;
@@ -6791,194 +6791,194 @@ biolink:PredicateMapping a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "predicate mapping" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
             owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:object_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:mapped_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:mapped_predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:exact_match ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_derivative_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:mapped_predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:exact_match ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:narrow_match ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_part_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:causal_mechanism_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:exact_match ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:broad_match ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:broad_match ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:narrow_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_form_or_variant_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
+            owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:causal_mechanism_qualifier ],
+            owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:broad_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:narrow_match ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:exact_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:species_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:broad_match ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_part_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_form_or_variant_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:narrow_match ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_derivative_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:mapped_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty biolink:exact_match ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_derivative_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:exact_match ],
+            owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_derivative_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:broad_match ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_context_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:qualified_predicate ] ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_form_or_variant_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:broad_match ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_derivative_qualifier ] ;
     skos:definition "A deprecated predicate mapping object contains the deprecated predicate and an example of the rewiring that should be done to use a qualified statement in its place." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -6995,32 +6995,32 @@ biolink:ProcessRegulatesProcessAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "process regulates process association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:BiologicalProcess ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:BiologicalProcess ;
-            owl:onProperty biolink:object ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:BiologicalProcess ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:definition "Describes a regulatory relationship between two genes or gene products." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -7203,19 +7203,19 @@ biolink:SequenceVariantModulatesTreatmentAssociation a owl:Class,
     rdfs:label "sequence variant modulates treatment association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Treatment ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
@@ -7228,46 +7228,46 @@ biolink:Serial a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "serial" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:issue ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:iso_abbreviation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:iso_abbreviation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:iso_abbreviation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:issue ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:issue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:issue ],
         biolink:Publication ;
     skos:altLabel "journal" ;
@@ -7331,9 +7331,14 @@ biolink:SocioeconomicExposure a owl:Class,
     skos:definition "A socioeconomic exposure is a factor relating to social and financial status of an affected individual (e.g. poverty)." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
-<https://w3id.org/biolink/vocab/StrandEnum#+> a owl:Class,
+<https://w3id.org/biolink/vocab/StrandEnum#%2B> a owl:Class,
         biolink:StrandEnum ;
     rdfs:label "+" ;
+    rdfs:subClassOf biolink:StrandEnum .
+
+<https://w3id.org/biolink/vocab/StrandEnum#%3F> a owl:Class,
+        biolink:StrandEnum ;
+    rdfs:label "?" ;
     rdfs:subClassOf biolink:StrandEnum .
 
 <https://w3id.org/biolink/vocab/StrandEnum#-> a owl:Class,
@@ -7344,11 +7349,6 @@ biolink:SocioeconomicExposure a owl:Class,
 <https://w3id.org/biolink/vocab/StrandEnum#.> a owl:Class,
         biolink:StrandEnum ;
     rdfs:label "." ;
-    rdfs:subClassOf biolink:StrandEnum .
-
-<https://w3id.org/biolink/vocab/StrandEnum#?> a owl:Class,
-        biolink:StrandEnum ;
-    rdfs:label "?" ;
     rdfs:subClassOf biolink:StrandEnum .
 
 biolink:StudyVariable a owl:Class,
@@ -7365,16 +7365,16 @@ biolink:TaxonToTaxonAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "taxon to taxon association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
@@ -7407,19 +7407,19 @@ biolink:TranscriptToGeneRelationship a owl:Class,
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Transcript ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:SequenceFeatureRelationship ;
     skos:definition "A gene is a collection of transcripts" ;
@@ -7446,10 +7446,10 @@ biolink:VariantAsAModelOfDiseaseAssociation a owl:Class,
             owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:ModelToDiseaseAssociationMixin,
@@ -7480,10 +7480,10 @@ biolink:VariantToPhenotypicFeatureAssociation a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:SequenceVariant ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
@@ -7495,49 +7495,49 @@ biolink:VariantToPopulationAssociation a owl:Class,
     rdfs:label "variant to population association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_total ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_count ],
+            owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_quotient ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:has_quotient ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_quotient ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:has_total ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
         biolink:Association,
         biolink:FrequencyQualifierMixin,
         biolink:FrequencyQuantifier,
@@ -8186,11 +8186,14 @@ biolink:Article a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "article" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:volume ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:issue ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:published_in ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:iso_abbreviation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:iso_abbreviation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:published_in ],
@@ -8201,26 +8204,23 @@ biolink:Article a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:issue ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:iso_abbreviation ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:issue ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:iso_abbreviation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:issue ],
+            owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:issue ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:published_in ],
         biolink:Publication ;
     skos:definition "a piece of writing on a particular topic presented as a stand-alone section of a larger publication" ;
     skos:exactMatch fabio:article,
@@ -8252,23 +8252,23 @@ biolink:BookChapter a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "book chapter" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:published_in ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:chapter ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:volume ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:chapter ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:volume ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:chapter ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:chapter ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:volume ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:volume ],
@@ -8276,8 +8276,8 @@ biolink:BookChapter a owl:Class,
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:published_in ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:published_in ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:chapter ],
         biolink:Publication ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8295,13 +8295,13 @@ biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "cell line to disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:CellLineToEntityAssociationMixin,
@@ -8329,13 +8329,16 @@ biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation a owl:C
         linkml:ClassDefinition ;
     rdfs:label "chemical or drug or treatment to disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:FDA_adverse_event_level ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:FDAIDAAdverseEventEnum ;
             owl:onProperty biolink:FDA_adverse_event_level ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -8343,9 +8346,6 @@ biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation a owl:C
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:FDAIDAAdverseEventEnum ;
-            owl:onProperty biolink:FDA_adverse_event_level ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin,
         biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
@@ -8421,14 +8421,14 @@ biolink:EntityToFeatureOrDiseaseQualifiersMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to feature or disease qualifiers mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualified_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_direction_qualifier ],
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:disease_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:object_direction_qualifier ],
@@ -8436,44 +8436,44 @@ biolink:EntityToFeatureOrDiseaseQualifiersMixin a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_aspect_qualifier ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualified_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:disease_context_qualifier ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:disease_context_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_aspect_qualifier ],
+            owl:onProperty biolink:object_aspect_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:qualified_predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DirectionQualifierEnum ;
             owl:onProperty biolink:subject_direction_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:qualified_predicate ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:disease_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_aspect_qualifier ],
+            owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:disease_context_qualifier ],
+            owl:onProperty biolink:subject_direction_qualifier ],
         biolink:FrequencyQualifierMixin ;
     skos:definition "Qualifiers for entity to disease or phenotype associations." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -8507,41 +8507,41 @@ biolink:FrequencyQualifierMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "frequency qualifier mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:frequency_value ;
             owl:onProperty biolink:frequency_qualifier ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:frequency_qualifier ],
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:subject ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:frequency_qualifier ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:frequency_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ] ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ] ;
     skos:definition "Qualifier for frequency type associations" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8565,77 +8565,77 @@ biolink:GenomicSequenceLocalization a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genomic sequence localization" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:start_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NucleicAcidEntity ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:strand ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:end_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:strand ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:end_interbase_coordinate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NucleicAcidEntity ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:genome_build ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:StrandEnum ;
-            owl:onProperty biolink:genome_build ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhaseEnum ;
             owl:onProperty biolink:phase ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:start_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NucleicAcidEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:phase ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NucleicAcidEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:genome_build ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:phase ],
+            owl:onProperty biolink:start_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:end_interbase_coordinate ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:phase ],
+            owl:onProperty biolink:strand ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:start_interbase_coordinate ],
+            owl:onProperty biolink:end_interbase_coordinate ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:end_interbase_coordinate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:StrandEnum ;
+            owl:onProperty biolink:genome_build ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:genome_build ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:start_interbase_coordinate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:StrandEnum ;
             owl:onProperty biolink:strand ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:strand ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:phase ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
         biolink:SequenceAssociation ;
     skos:broadMatch dcid:Chromosome ;
     skos:definition "A relationship between a sequence feature and a nucleic acid entity it is localized to. The reference entity may be a chromosome, chromosome region or information entity such as a contig." ;
@@ -8646,31 +8646,31 @@ biolink:GenotypeToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
@@ -8683,22 +8683,22 @@ biolink:GeographicLocation a owl:Class,
     rdfs:label "geographic location" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:latitude ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:latitude ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty biolink:latitude ],
+            owl:onProperty biolink:longitude ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:longitude ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:latitude ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Float ;
             owl:onProperty biolink:longitude ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:longitude ],
+            owl:onProperty biolink:latitude ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty biolink:latitude ],
         biolink:PlanetaryEntity ;
     skos:definition "a location that can be described in lat/long coordinates" ;
     skos:exactMatch STY:T083,
@@ -8709,41 +8709,41 @@ biolink:MacromolecularMachineToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:species_context_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:species_context_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:species_context_qualifier ] ;
+            owl:onProperty biolink:object ] ;
     skos:definition "an association which has a macromolecular machine mixin as a subject" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8778,13 +8778,13 @@ biolink:PairwiseGeneToGeneInteraction a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "pairwise gene to gene interaction" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:GeneToGeneAssociation ;
     skos:definition "An interaction between two genes or two gene products. May be physical (e.g. protein binding) or genetic (between genes). May be symmetric (e.g. protein interaction) or directed (e.g. phosphorylation)" ;
@@ -8816,20 +8816,11 @@ biolink:ReactionToParticipantAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "reaction to participant association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:reaction_side ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:stoichiometry ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:ReactionDirectionEnum ;
             owl:onProperty biolink:reaction_direction ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:subject ],
+            owl:allValuesFrom biolink:ReactionSideEnum ;
+            owl:onProperty biolink:reaction_side ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:stoichiometry ],
@@ -8840,17 +8831,26 @@ biolink:ReactionToParticipantAssociation a owl:Class,
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ReactionDirectionEnum ;
+            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty biolink:stoichiometry ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:reaction_direction ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:ReactionSideEnum ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:stoichiometry ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:reaction_side ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:reaction_direction ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty biolink:stoichiometry ],
         biolink:ChemicalToChemicalAssociation ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -8895,19 +8895,19 @@ biolink:Treatment a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_drug ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_procedure ],
+            owl:allValuesFrom biolink:Drug ;
+            owl:onProperty biolink:has_drug ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_device ],
+            owl:onProperty biolink:has_procedure ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Procedure ;
             owl:onProperty biolink:has_procedure ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Drug ;
-            owl:onProperty biolink:has_drug ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Device ;
+            owl:onProperty biolink:has_device ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_device ],
         biolink:ChemicalOrDrugOrTreatment,
         biolink:ExposureEvent,
@@ -8924,31 +8924,31 @@ biolink:VariantToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
             owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToDiseaseAssociationMixin,
@@ -8960,22 +8960,22 @@ biolink:VariantToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "variant to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:VariantToEntityAssociationMixin ;
@@ -9735,21 +9735,21 @@ biolink:AnatomicalEntityToAnatomicalEntityAssociation a owl:Class,
     rdfs:label "anatomical entity to anatomical entity association" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AnatomicalEntity ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AnatomicalEntity ;
             owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -9779,31 +9779,31 @@ biolink:ChemicalToChemicalAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical to chemical association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntity ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         biolink:Association,
         biolink:ChemicalToEntityAssociationMixin ;
@@ -9856,40 +9856,40 @@ biolink:FrequencyQuantifier a owl:Class,
     rdfs:label "frequency quantifier" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_total ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_quotient ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:has_percentage ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Double ;
             owl:onProperty biolink:has_percentage ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_percentage ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_quotient ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_total ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty biolink:has_count ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Double ;
             owl:onProperty biolink:has_quotient ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_percentage ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Integer ;
             owl:onProperty biolink:has_total ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_quotient ],
+            owl:onProperty biolink:has_count ],
         biolink:RelationshipQuantifier ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -9925,50 +9925,50 @@ biolink:GeneToDiseaseOrPhenotypicFeatureAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to disease or phenotypic feature association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:allValuesFrom biolink:DirectionQualifierEnum ;
+            owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_aspect_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_direction_qualifier ],
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
             owl:onProperty biolink:subject_aspect_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DirectionQualifierEnum ;
-            owl:onProperty biolink:object_direction_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_direction_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_direction_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_direction_qualifier ],
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
         biolink:Association,
         biolink:EntityToPhenotypicFeatureAssociationMixin,
         biolink:GeneToEntityAssociationMixin ;
@@ -10015,19 +10015,19 @@ biolink:OrganismTaxonToOrganismTaxonAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon to organism taxon association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -10097,31 +10097,31 @@ biolink:VariantToEntityAssociationMixin a owl:Class,
     rdfs:label "variant to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:SequenceVariant ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ] ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
 biolink:Zygosity a owl:Class,
@@ -10492,21 +10492,21 @@ biolink:DatasetSummary a owl:Class,
     rdfs:label "dataset summary" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:source_logo ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:source_web_page ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:source_logo ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:source_logo ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:source_web_page ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:source_logo ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:source_web_page ],
         biolink:InformationContentEntity ;
     skos:definition "an item that holds summary level information about a dataset." ;
@@ -10516,32 +10516,32 @@ biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to disease or phenotypic feature association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ] ;
+            owl:onProperty biolink:object ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
 biolink:GeneGroupingMixin a owl:Class,
@@ -10560,16 +10560,10 @@ biolink:GeneToGeneAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to gene association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -10577,6 +10571,12 @@ biolink:GeneToGeneAssociation a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:object ],
         biolink:Association ;
     skos:altLabel "molecular or genetic interaction" ;
     skos:definition "abstract parent class for different kinds of gene-gene or gene product to gene product relationships. Includes homology and interaction." ;
@@ -10620,32 +10620,32 @@ biolink:ModelToDiseaseAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "model to disease association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ] ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ] ;
     skos:definition "This mixin is used for any association class for which the subject (source node) plays the role of a 'model', in that it recapitulates some features of the disease in a way that is useful for studying the disease outside a patient carrying the disease" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -10685,23 +10685,23 @@ biolink:QuantityValue a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "quantity value" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_numeric_value ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Double ;
             owl:onProperty biolink:has_numeric_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_unit ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:unit ;
             owl:onProperty biolink:has_unit ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_numeric_value ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_numeric_value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_unit ],
         biolink:Annotation ;
     skos:definition "A value of an attribute that is quantitative and measurable, expressed as a combination of a unit and a numeric value" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -10710,23 +10710,23 @@ biolink:SequenceFeatureRelationship a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "sequence feature relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NucleicAcidEntity ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NucleicAcidEntity ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NucleicAcidEntity ;
-            owl:onProperty biolink:subject ],
         biolink:Association ;
     skos:definition "For example, a particular exon is part of a particular transcript or gene" ;
     skos:exactMatch CHADO:feature_relationship ;
@@ -10841,29 +10841,29 @@ biolink:ChemicalToEntityAssociationMixin a owl:Class,
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
         biolink:ChemicalEntityToEntityAssociationMixin ;
     skos:definition "An interaction between a chemical entity and another entity" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -10880,29 +10880,29 @@ biolink:DatasetVersion a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "dataset version" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:ingest_date ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_dataset ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:has_distribution ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:ingest_date ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_distribution ],
+            owl:onProperty biolink:ingest_date ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_dataset ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:DatasetDistribution ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_distribution ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:ingest_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:ingest_date ],
+            owl:allValuesFrom biolink:DatasetDistribution ;
+            owl:onProperty biolink:has_distribution ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Dataset ;
             owl:onProperty biolink:has_dataset ],
@@ -10920,20 +10920,20 @@ biolink:FunctionalAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "functional association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:MacromolecularMachineMixin ;
             owl:onProperty biolink:subject ],
@@ -10945,16 +10945,16 @@ biolink:GeneProductMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene product mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:label_type ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:synonym ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:xref ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:label_type ;
             owl:onProperty biolink:synonym ],
         biolink:GeneOrGeneProduct ;
     skos:definition "The functional molecular product of a single gene locus. Gene products are either proteins or functional RNA molecules." ;
@@ -10967,13 +10967,13 @@ biolink:MacromolecularMachineMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "macromolecular machine mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:symbol_type ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:name ] ;
     skos:definition "A union of gene locus, gene product, and macromolecular complex. These are the basic units of function in a cell. They either carry out individual biological activities, or they encode molecules which do this." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -11010,22 +11010,22 @@ biolink:ThingWithTaxon a owl:Class,
     rdfs:label "thing with taxon" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:in_taxon ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty biolink:in_taxon_label ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:in_taxon ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OrganismTaxon ;
-            owl:onProperty biolink:in_taxon ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:in_taxon_label ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:label_type ;
             owl:onProperty biolink:in_taxon_label ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OrganismTaxon ;
+            owl:onProperty biolink:in_taxon ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:in_taxon_label ] ;
+            owl:onProperty biolink:in_taxon ] ;
     skos:definition "A mixin that can be used on any entity that can be taxonomically classified. This includes individual organisms; genes, their products and other molecular entities; body parts; biological processes" ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -11423,22 +11423,22 @@ biolink:ChemicalMixture a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical mixture" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:is_supplement ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:DrugDeliveryEnum ;
             owl:onProperty biolink:routes_of_delivery ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:drug_regulatory_status_world_wide ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:drug_regulatory_status_world_wide ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ApprovalStatusEnum ;
-            owl:onProperty biolink:drug_regulatory_status_world_wide ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:drug_regulatory_status_world_wide ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:highest_FDA_approval_status ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:is_supplement ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -11447,14 +11447,14 @@ biolink:ChemicalMixture a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty biolink:routes_of_delivery ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:is_supplement ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:ApprovalStatusEnum ;
-            owl:onProperty biolink:highest_FDA_approval_status ],
+            owl:onProperty biolink:drug_regulatory_status_world_wide ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:is_supplement ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:is_supplement ],
+            owl:onProperty biolink:highest_FDA_approval_status ],
         biolink:ChemicalEntity ;
     skos:closeMatch dcid:ChemicalCompound ;
     skos:definition "A chemical mixture is a chemical entity composed of two or more molecular entities." ;
@@ -11466,22 +11466,22 @@ biolink:GeneToDiseaseAssociation a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to disease association" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Disease ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Disease ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:GeneOrGeneProduct ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         biolink:EntityToDiseaseAssociationMixin,
         biolink:GeneToDiseaseOrPhenotypicFeatureAssociation,
@@ -11495,32 +11495,32 @@ biolink:GeneToEntityAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene to entity association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:predicate_type ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ] ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:GeneOrGeneProduct ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:object ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
 biolink:LogicalInterpretationEnum a owl:Class,
@@ -11534,32 +11534,32 @@ biolink:MolecularActivity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:enabled_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:enabled_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:MolecularEntity ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
             owl:allValuesFrom biolink:MacromolecularMachineMixin ;
             owl:onProperty biolink:enabled_by ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:MolecularEntity ;
+            owl:onProperty biolink:has_output ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_output ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:enabled_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_output ],
         biolink:BiologicalProcessOrActivity,
         biolink:Occurrent,
         biolink:OntologyClass ;
@@ -11576,25 +11576,28 @@ biolink:RetrievalSource a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "retrieval source" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:resource_id ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:upstream_resource_ids ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:resource_role ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:upstream_resource_ids ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:upstream_resource_ids ],
+            owl:onProperty biolink:resource_role ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ResourceRoleEnum ;
             owl:onProperty biolink:resource_role ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:upstream_resource_ids ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:resource_id ],
+            owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:upstream_resource_ids ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -11604,10 +11607,7 @@ biolink:RetrievalSource a owl:Class,
             owl:onProperty biolink:resource_id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:resource_role ],
+            owl:onProperty biolink:upstream_resource_ids ],
         biolink:InformationContentEntity ;
     skos:definition "Provides information about how a particular InformationResource served as a source from which knowledge expressed in an Edge, or data used to generate this knowledge, was retrieved." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -11953,77 +11953,77 @@ biolink:EntityToPhenotypicFeatureAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to phenotypic feature association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:subject_specialization_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:disease_context_qualifier ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:subject_specialization_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:object_specialization_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_specialization_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:PhenotypicFeature ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:object_specialization_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_specialization_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:subject_specialization_qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:sex_qualifier ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:PhenotypicFeature ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
             owl:onProperty biolink:disease_context_qualifier ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:sex_qualifier ],
+            owl:onProperty biolink:subject_specialization_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:disease_context_qualifier ],
         [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:anatomical_context_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_specialization_qualifier ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty biolink:object_specialization_qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:sex_qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:BiologicalSex ;
+            owl:onProperty biolink:sex_qualifier ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:anatomical_context_qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:BiologicalSex ;
-            owl:onProperty biolink:sex_qualifier ],
         biolink:EntityToFeatureOrDiseaseQualifiersMixin,
         biolink:FrequencyQuantifier ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -12032,13 +12032,13 @@ biolink:Genotype a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genotype" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Zygosity ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_zygosity ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_zygosity ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom biolink:Zygosity ;
             owl:onProperty biolink:has_zygosity ],
         biolink:BiologicalEntity,
         biolink:GenomicEntity,
@@ -12145,68 +12145,68 @@ biolink:Entity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:narrative_text ;
-            owl:onProperty biolink:description ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:deprecated ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:deprecated ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:category ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Attribute ;
-            owl:onProperty biolink:has_attribute ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:label_type ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:iri_type ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_attribute ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty biolink:deprecated ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
+            owl:allValuesFrom biolink:Attribute ;
+            owl:onProperty biolink:has_attribute ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:category ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:description ] ;
+            owl:onProperty biolink:deprecated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:iri_type ;
+            owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:category ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_attribute ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:narrative_text ;
+            owl:onProperty biolink:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:iri ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ] ;
     skos:definition "Root Biolink Model class for all things and informational relationships, real or imagined." ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> .
 
@@ -12305,13 +12305,13 @@ biolink:EntityToDiseaseAssociationMixin a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "entity to disease association mixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Disease ;
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:object ],
         biolink:EntityToFeatureOrDiseaseQualifiersMixin ;
     skos:definition "mixin class for any association whose object (target node) is a disease" ;
@@ -12337,11 +12337,11 @@ biolink:OrganismalEntity a owl:Class,
 
 biolink:StrandEnum a owl:Class,
         linkml:EnumDefinition ;
-    owl:unionOf ( <https://w3id.org/biolink/vocab/StrandEnum#+> <https://w3id.org/biolink/vocab/StrandEnum#-> <https://w3id.org/biolink/vocab/StrandEnum#.> <https://w3id.org/biolink/vocab/StrandEnum#?> ) ;
-    linkml:permissible_values <https://w3id.org/biolink/vocab/StrandEnum#+>,
+    owl:unionOf ( <https://w3id.org/biolink/vocab/StrandEnum#%2B> <https://w3id.org/biolink/vocab/StrandEnum#-> <https://w3id.org/biolink/vocab/StrandEnum#.> <https://w3id.org/biolink/vocab/StrandEnum#%3F> ) ;
+    linkml:permissible_values <https://w3id.org/biolink/vocab/StrandEnum#%2B>,
+        <https://w3id.org/biolink/vocab/StrandEnum#%3F>,
         <https://w3id.org/biolink/vocab/StrandEnum#->,
-        <https://w3id.org/biolink/vocab/StrandEnum#.>,
-        <https://w3id.org/biolink/vocab/StrandEnum#?> .
+        <https://w3id.org/biolink/vocab/StrandEnum#.> .
 
 biolink:object_form_or_variant_qualifier a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -12375,32 +12375,32 @@ biolink:BiologicalProcessOrActivity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "biological process or activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:has_output ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:has_input ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_input ],
+            owl:onProperty biolink:enabled_by ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:enabled_by ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:has_output ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_input ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:enabled_by ],
+            owl:onProperty biolink:has_output ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:PhysicalEntity ;
             owl:onProperty biolink:enabled_by ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_output ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_input ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:has_input ],
         biolink:BiologicalEntity,
         biolink:Occurrent,
         biolink:OntologyClass ;
@@ -12428,37 +12428,37 @@ biolink:Agent a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:affiliation ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:address ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:address ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:address ],
+            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:address ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:affiliation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:affiliation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:address ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:address ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:name ],
         biolink:AdministrativeEntity ;
     skos:altLabel "group" ;
@@ -12581,10 +12581,10 @@ biolink:ExposureEvent a owl:Class,
             owl:allValuesFrom biolink:time_type ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:timepoint ],
         biolink:OntologyClass ;
     skos:altLabel "experimental condition",
@@ -12635,13 +12635,13 @@ biolink:MolecularEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "molecular entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:is_metabolite ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:is_metabolite ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty biolink:is_metabolite ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:is_metabolite ],
         biolink:ChemicalEntity ;
     skos:definition "A molecular entity is a chemical entity composed of individual or covalently bonded atoms." ;
@@ -12691,40 +12691,40 @@ biolink:InformationContentEntity a owl:Class,
     rdfs:label "information content entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:creation_date ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:format ],
+            owl:onProperty biolink:license ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:license ],
+            owl:onProperty biolink:creation_date ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:rights ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:format ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:format ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:license ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:creation_date ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:rights ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:rights ],
+            owl:onProperty biolink:creation_date ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Date ;
             owl:onProperty biolink:creation_date ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:format ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:format ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:rights ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty biolink:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:format ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:rights ],
         biolink:NamedThing ;
     skos:altLabel "information",
         "information artefact",
@@ -12749,13 +12749,13 @@ biolink:OrganismTaxon a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "organism taxon" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_taxonomic_rank ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_taxonomic_rank ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:TaxonomicRank ;
+            owl:onProperty biolink:has_taxonomic_rank ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_taxonomic_rank ],
         biolink:NamedThing ;
     skos:altLabel "taxon",
@@ -12794,10 +12794,10 @@ biolink:Attribute a owl:Class,
     rdfs:label "attribute" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:name ],
+            owl:onProperty biolink:iri ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:has_attribute_type ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:has_qualitative_value ],
@@ -12806,16 +12806,7 @@ biolink:Attribute a owl:Class,
             owl:onProperty biolink:has_quantitative_value ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:iri_type ;
-            owl:onProperty biolink:iri ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_quantitative_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_qualitative_value ],
+            owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:NamedThing ;
             owl:onProperty biolink:has_qualitative_value ],
@@ -12824,16 +12815,25 @@ biolink:Attribute a owl:Class,
             owl:onProperty biolink:has_attribute_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:has_qualitative_value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:label_type ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:has_attribute_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_quantitative_value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:iri_type ;
             owl:onProperty biolink:iri ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty biolink:has_attribute_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:label_type ;
-            owl:onProperty biolink:name ],
+            owl:onProperty biolink:iri ],
         biolink:NamedThing,
         biolink:OntologyClass ;
     skos:definition "A property or characteristic of an entity. For example, an apple may have properties such as color, shape, age, crispiness. An environmental sample may have attributes such as depth, lat, long, material." ;
@@ -12866,20 +12866,20 @@ biolink:Gene a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "gene" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty biolink:symbol ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:symbol ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:symbol ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:symbol ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:symbol ],
+            owl:onProperty biolink:xref ],
         biolink:BiologicalEntity,
         biolink:ChemicalEntityOrGeneOrGeneProduct,
         biolink:GeneOrGeneProduct,
@@ -12902,26 +12902,26 @@ biolink:SequenceVariant a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_gene ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:id ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:has_biological_sequence ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Gene ;
             owl:onProperty biolink:has_gene ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_biological_sequence ],
+            owl:onProperty biolink:has_gene ],
         biolink:BiologicalEntity,
         biolink:GenomicEntity,
         biolink:OntologyClass,
@@ -12968,41 +12968,26 @@ biolink:Publication a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "publication" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:keywords ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:summary ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:summary ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:authors ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:id ],
+            owl:onProperty biolink:publication_type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:xref ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:Agent ;
             owl:onProperty biolink:authors ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:keywords ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:publication_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:mesh_terms ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:mesh_terms ],
@@ -13013,23 +12998,38 @@ biolink:Publication a owl:Class,
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:authors ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:pages ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:publication_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:summary ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:mesh_terms ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:summary ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:summary ],
+            owl:onProperty biolink:keywords ],
         biolink:InformationContentEntity ;
     skos:definition "Any ‘published’ piece of information. Publications are considered broadly to include any document or document part made available in print or on the web - which may include scientific journal issues, individual articles, and books - as well as things like pre-prints, white papers, patents, drug labels, web pages, protocol documents,  and even a part of a publication if of significant knowledge scope (e.g. a figure, figure legend, or section highlighted by NLP)." ;
     skos:exactMatch IAO:0000311 ;
@@ -13053,41 +13053,41 @@ biolink:ChemicalEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "chemical entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty biolink:is_toxic ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:is_toxic ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_chemical_role ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:max_tolerated_dose ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:max_tolerated_dose ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:available_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:trade_name ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:ChemicalRole ;
             owl:onProperty biolink:has_chemical_role ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:has_chemical_role ],
+            owl:onProperty biolink:trade_name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:max_tolerated_dose ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:max_tolerated_dose ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:max_tolerated_dose ],
+            owl:onProperty biolink:is_toxic ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:DrugAvailabilityEnum ;
             owl:onProperty biolink:available_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:trade_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:trade_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:is_toxic ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:is_toxic ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty biolink:is_toxic ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty biolink:trade_name ],
@@ -13111,13 +13111,13 @@ biolink:GenomicEntity a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "genomic entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom biolink:biological_sequence ;
+            owl:onProperty biolink:has_biological_sequence ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_biological_sequence ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:has_biological_sequence ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:biological_sequence ;
             owl:onProperty biolink:has_biological_sequence ] ;
     skos:inScheme <https://w3id.org/biolink/biolink-model> ;
     skos:narrowMatch STY:T028,
@@ -13201,10 +13201,10 @@ biolink:OntologyClass a owl:Class,
     rdfs:label "ontology class" ;
     rdfs:seeAlso <https://github.com/biolink/biolink-model/issues/486> ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -13239,260 +13239,260 @@ biolink:Association a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "association" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
+            owl:minCardinality 1 ;
             owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:NamedThing ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:p_value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:primary_knowledge_source ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:original_predicate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_namespace ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject_namespace ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:timepoint ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:adjusted_p_value ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:RetrievalSource ;
             owl:onProperty biolink:retrieval_source_ids ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:adjusted_p_value ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:original_subject ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:original_predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty biolink:original_predicate ],
+            owl:onProperty biolink:subject ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty biolink:agent_type ],
+            owl:onProperty biolink:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:p_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:aggregator_knowledge_source ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:original_subject ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:negated ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:qualifier ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:timepoint ],
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_namespace ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualifiers ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:adjusted_p_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:subject_namespace ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:original_object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_namespace ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:predicate_type ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:has_supporting_studies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_namespace ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty biolink:adjusted_p_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:knowledge_level ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:aggregator_knowledge_source ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:qualifier ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty biolink:p_value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_closure ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:object_label_closure ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:subject_category_closure ],
+            owl:onProperty biolink:object_category ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:EvidenceType ;
+            owl:onProperty biolink:has_evidence ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:subject_label_closure ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:Publication ;
+            owl:onProperty biolink:publications ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:retrieval_source_ids ],
+            owl:onProperty biolink:object_category_closure ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:AgentTypeEnum ;
+            owl:onProperty biolink:agent_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:qualifier ],
+            owl:onProperty biolink:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:KnowledgeLevelEnum ;
             owl:onProperty biolink:knowledge_level ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:predicate ],
+            owl:onProperty biolink:subject_namespace ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:original_object ],
+            owl:onProperty biolink:agent_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_closure ],
+            owl:onProperty biolink:primary_knowledge_source ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:object_category ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:subject_category ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:agent_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:knowledge_source ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:timepoint ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:knowledge_source ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:qualifiers ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_label_closure ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:original_subject ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:p_value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:original_object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:time_type ;
             owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:aggregator_knowledge_source ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:knowledge_source ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_closure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_closure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_label_closure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:qualifier ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_label_closure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:subject_closure ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:qualifier ],
+            owl:onProperty biolink:original_predicate ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:NamedThing ;
+            owl:onProperty biolink:object ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:qualifiers ],
+            owl:onProperty biolink:publications ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:primary_knowledge_source ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty biolink:p_value ],
+            owl:onProperty biolink:negated ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:object_category ],
+            owl:onProperty biolink:subject_category_closure ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:knowledge_source ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_namespace ],
+            owl:onProperty biolink:original_object ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_namespace ],
+            owl:onProperty biolink:primary_knowledge_source ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:object_category_closure ],
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:p_value ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:object_namespace ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:has_evidence ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty biolink:negated ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:predicate_type ;
-            owl:onProperty biolink:predicate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:subject_label_closure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:has_supporting_studies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:subject_category ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty biolink:original_predicate ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
             owl:onProperty biolink:object_category_closure ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:object_namespace ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:OntologyClass ;
-            owl:onProperty biolink:qualifiers ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Publication ;
-            owl:onProperty biolink:publications ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:Study ;
-            owl:onProperty biolink:has_supporting_studies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty biolink:adjusted_p_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:original_object ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:subject_category ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:negated ],
+            owl:onProperty biolink:original_subject ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:knowledge_level ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:retrieval_source_ids ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:knowledge_source ],
+            owl:allValuesFrom biolink:Study ;
+            owl:onProperty biolink:has_supporting_studies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom biolink:time_type ;
+            owl:onProperty biolink:timepoint ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:category ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:knowledge_level ],
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:original_object ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:object_category ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_closure ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:subject_category_closure ],
+            owl:onProperty biolink:object_closure ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:original_subject ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty biolink:negated ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:qualifier ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:original_predicate ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:primary_knowledge_source ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:category ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:subject ],
+            owl:onProperty biolink:negated ],
         [ a owl:Restriction ;
             owl:allValuesFrom biolink:OntologyClass ;
+            owl:onProperty biolink:subject_category_closure ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:knowledge_source ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:subject_category ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty biolink:object_category ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty biolink:object ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty biolink:primary_knowledge_source ],
+            owl:onProperty biolink:knowledge_level ],
         [ a owl:Restriction ;
-            owl:allValuesFrom biolink:EvidenceType ;
-            owl:onProperty biolink:has_evidence ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:agent_type ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty biolink:object_label_closure ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:publications ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:aggregator_knowledge_source ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom biolink:AgentTypeEnum ;
-            owl:onProperty biolink:agent_type ],
+            owl:onProperty biolink:adjusted_p_value ],
         biolink:Entity ;
     skos:definition "A typed association between two entities, supported by evidence" ;
     skos:exactMatch OBAN:association,
@@ -13514,38 +13514,38 @@ biolink:NamedThing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "named thing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom biolink:label_type ;
-            owl:onProperty biolink:synonym ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:category ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty biolink:xref ],
+            owl:onProperty biolink:full_name ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:provided_by ],
+            owl:allValuesFrom biolink:label_type ;
+            owl:onProperty biolink:synonym ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty biolink:provided_by ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty biolink:full_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:provided_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty biolink:category ],
+        [ a owl:Restriction ;
             owl:allValuesFrom biolink:label_type ;
             owl:onProperty biolink:full_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty biolink:xref ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty biolink:synonym ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty biolink:xref ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty biolink:full_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty biolink:full_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty biolink:category ],
         biolink:Entity ;
     skos:definition "a databased entity or concept/class" ;
     skos:exactMatch STY:T071,
@@ -13663,909 +13663,9 @@ biolink:subject a owl:ObjectProperty,
     skos:definition "Entity and association taxonomy and datamodel for life-sciences data" .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleosomeModification ;
+    rdfs:subClassOf biolink:PopulationOfIndividualOrganisms ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleosomeModification .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToGenotypePartAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToGenotypePartAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:JournalArticle ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:JournalArticle .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Treatment ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Treatment .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ObservedExpectedFrequencyAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ObservedExpectedFrequencyAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TranscriptToGeneRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TranscriptToGeneRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneCoexpressionAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneCoexpressionAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellularComponent ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellularComponent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EntityToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EntityToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Protein ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Protein .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularMachineToCellularComponentAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularMachineToCellularComponentAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:WebPage ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:WebPage .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Genotype ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Genotype .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalRole ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalRole .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Event ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Event .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PosttranslationalModification ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PosttranslationalModification .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalProcessOrActivity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalProcessOrActivity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PairwiseMolecularInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PairwiseMolecularInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TranscriptionFactorBindingSite ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TranscriptionFactorBindingSite .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenomicBackgroundExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenomicBackgroundExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGoTermAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGoTermAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Mammal ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Mammal .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalTrial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalTrial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ContributorAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ContributorAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhenotypicQuality ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhenotypicQuality .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Haplotype ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Haplotype .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellularOrganism ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellularOrganism .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CodingSequence ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CodingSequence .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RegulatoryRegion ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RegulatoryRegion .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MaterialSample ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MaterialSample .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToExpressionSiteAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToExpressionSiteAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicLocationAtTime ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicLocationAtTime .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CommonDataElement ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CommonDataElement .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Attribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Attribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntityAssessesNamedThingAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntityAssessesNamedThingAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularMachineToBiologicalProcessAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularMachineToBiologicalProcessAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProteinDomain ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProteinDomain .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Procedure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Procedure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalAnatomicalStructure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalAnatomicalStructure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProteinIsoform ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProteinIsoform .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneProductRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneProductRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:InformationContentEntityToNamedThingAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:InformationContentEntityToNamedThingAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Onset ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Onset .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToPopulationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToPopulationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Activity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Activity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SocioeconomicExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SocioeconomicExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Snv ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Snv .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:LogOddsAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:LogOddsAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Gene ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Gene .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalFoodContaminant ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalFoodContaminant .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalCourse ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalCourse .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SmallMolecule ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SmallMolecule .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CausalGeneToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CausalGeneToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToLocationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToLocationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalAffectsGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalAffectsGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToGeneExpressionAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToGeneExpressionAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToChemicalEntityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToChemicalEntityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Case ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Case .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Cell ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Cell .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExonToTranscriptRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExonToTranscriptRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Plant ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Plant .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Vertebrate ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Vertebrate .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetDistribution ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetDistribution .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Agent ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Agent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TaxonToTaxonAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TaxonToTaxonAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToPathwayAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToPathwayAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:VariantToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:VariantToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalAnatomicalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalAnatomicalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugLabel ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugLabel .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReactionToParticipantAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReactionToParticipantAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProcessedMaterial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProcessedMaterial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalGeneInteractionAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalGeneInteractionAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Exon ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Exon .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceFeatureRelationship ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceFeatureRelationship .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseToExposureEventAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseToExposureEventAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Book ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Book .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneRegulatesGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneRegulatesGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DruggableGeneToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DruggableGeneToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhysiologicalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhysiologicalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Virus ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Virus .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeographicLocation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeographicLocation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToGeneAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToGeneAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneFamilyAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneFamilyAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EvidenceType ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EvidenceType .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:FoodAdditive ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:FoodAdditive .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToEnvironmentAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToEnvironmentAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Food ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Food .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Behavior ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Behavior .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismToOrganismAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismToOrganismAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypicSex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypicSex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalProcess ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalProcess .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:LifeStage ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:LifeStage .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChiSquaredAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChiSquaredAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Study ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Study .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MaterialSampleDerivationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MaterialSampleDerivationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ConfidenceLevel ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ConfidenceLevel .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExposureEventToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExposureEventToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonSpecialization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonSpecialization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MicroRNA ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MicroRNA .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReagentTargetedGene ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReagentTargetedGene .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Drug ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Drug .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehavioralFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehavioralFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SocioeconomicAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SocioeconomicAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ComplexChemicalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ComplexChemicalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLineAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLineAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyVariable ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyVariable .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhenotypicFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhenotypicFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetVersion ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetVersion .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ConceptCountAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ConceptCountAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneticInheritance ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneticInheritance .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PlanetaryEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PlanetaryEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ExposureEventToOutcomeAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ExposureEventToOutcomeAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhysicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhysicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Human ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Human .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Cohort ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Cohort .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RNAProduct ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RNAProduct .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismalEntityAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismalEntityAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MolecularActivityToMolecularActivityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MolecularActivityToMolecularActivityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PopulationToPopulationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PopulationToPopulationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Hospitalization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Hospitalization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToGeneHomologyAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToGeneHomologyAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneHasVariantThatContributesToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneHasVariantThatContributesToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:StudyPopulation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:StudyPopulation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Bacterium ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Bacterium .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RetrievalSource ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RetrievalSource .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneAsAModelOfDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneAsAModelOfDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DatasetSummary ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DatasetSummary .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CorrelatedGeneToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CorrelatedGeneToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Pathway ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Pathway .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhenotypicFeatureToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhenotypicFeatureToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceVariantModulatesTreatmentAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceVariantModulatesTreatmentAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Invertebrate ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Invertebrate .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CellLine ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CellLine .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalIntervention ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalIntervention .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehavioralExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehavioralExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularComplex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularComplex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Dataset ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Dataset .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ReactionToCatalystAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ReactionToCatalystAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Fungus ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Fungus .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToDiseaseAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToDiseaseAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismalEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismalEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BioticExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BioticExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:CaseToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:CaseToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleicAcidSequenceMotif ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleicAcidSequenceMotif .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxon ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxon .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneAffectsChemicalAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneAffectsChemicalAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NoncodingRNAProduct ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NoncodingRNAProduct .
+    owl:someValuesFrom biolink:PopulationOfIndividualOrganisms .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:Association ;
@@ -14573,299 +13673,9 @@ biolink:subject a owl:ObjectProperty,
     owl:someValuesFrom biolink:Association .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugExposure ;
+    rdfs:subClassOf biolink:ChemicalEntity ;
     owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SequenceVariant ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SequenceVariant .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Publication ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Publication .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EnvironmentalFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EnvironmentalFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:IndividualOrganism ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:IndividualOrganism .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiagnosticAid ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiagnosticAid .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenomicSequenceLocalization ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenomicSequenceLocalization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AccessibleDnaRegion ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AccessibleDnaRegion .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MacromolecularMachineToMolecularActivityAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MacromolecularMachineToMolecularActivityAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Zygosity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Zygosity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:InformationContentEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:InformationContentEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BehaviorToBehavioralFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BehaviorToBehavioralFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PathologicalProcessExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PathologicalProcessExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToChemicalDerivationAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToChemicalDerivationAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PairwiseGeneToGeneInteraction .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:FunctionalAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:FunctionalAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BookChapter ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BookChapter .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GrossAnatomicalStructure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GrossAnatomicalStructure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:AdministrativeEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:AdministrativeEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Serial ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Serial .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeature ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeature .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:EntityToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Transcript ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Transcript .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GenotypeToVariantAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GenotypeToVariantAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RNAProductIsoform ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RNAProductIsoform .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PreprintPublication ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PreprintPublication .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:BiologicalSex ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:BiologicalSex .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SeverityValue ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SeverityValue .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NucleicAcidEntity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NucleicAcidEntity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:OrganismAttribute ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:OrganismAttribute .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Article ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Article .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:SiRNA ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:SiRNA .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:NamedThing ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:NamedThing .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneFamily ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneFamily .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalModifier ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalModifier .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:GeneToPathwayAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:GeneToPathwayAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProteinFamily ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProteinFamily .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToPathwayAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToPathwayAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:DrugToGeneInteractionExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:DrugToGeneInteractionExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalExposure ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalExposure .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Polypeptide ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Polypeptide .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalFinding ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalFinding .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Phenomenon ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Phenomenon .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:RelativeFrequencyAnalysisResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:RelativeFrequencyAnalysisResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Entity ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Entity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PopulationOfIndividualOrganisms ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PopulationOfIndividualOrganisms .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ChemicalToChemicalAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ChemicalToChemicalAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ComplexMolecularMixture ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ComplexMolecularMixture .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ClinicalMeasurement ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ClinicalMeasurement .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:PhenotypicFeatureToPhenotypicFeatureAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:PhenotypicFeatureToPhenotypicFeatureAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Device ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Device .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:ProcessRegulatesProcessAssociation ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:ProcessRegulatesProcessAssociation .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:TextMiningResult ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:TextMiningResult .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf biolink:Disease ;
-    owl:onProperty biolink:category ;
-    owl:someValuesFrom biolink:Disease .
+    owl:someValuesFrom biolink:ChemicalEntity .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:PhenotypicSex ;
@@ -14873,9 +13683,789 @@ biolink:subject a owl:ObjectProperty,
     owl:someValuesFrom biolink:PhenotypicSex .
 
 [] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToPopulationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToPopulationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugLabel ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugLabel .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalFinding ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalFinding .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ExonToTranscriptRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ExonToTranscriptRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RelativeFrequencyAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RelativeFrequencyAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TranscriptToGeneRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TranscriptToGeneRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularMachineToCellularComponentAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularMachineToCellularComponentAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReactionToCatalystAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReactionToCatalystAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Entity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Entity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Study ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Study .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ContributorAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ContributorAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DruggableGeneToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DruggableGeneToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NoncodingRNAProduct ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NoncodingRNAProduct .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TranscriptionFactorBindingSite ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TranscriptionFactorBindingSite .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToChemicalDerivationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToChemicalDerivationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenomicSequenceLocalization ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenomicSequenceLocalization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EnvironmentalFoodContaminant ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EnvironmentalFoodContaminant .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Protein ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Protein .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CodingSequence ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CodingSequence .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EntityToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Invertebrate ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Invertebrate .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:WebPage ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:WebPage .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CaseToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CaseToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:InformationContentEntityToNamedThingAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:InformationContentEntityToNamedThingAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToPathwayAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToPathwayAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalModifier ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalModifier .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypicSex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypicSex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MaterialSampleDerivationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MaterialSampleDerivationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RNAProductIsoform ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RNAProductIsoform .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RegulatoryRegion ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RegulatoryRegion .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularComplex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularComplex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProteinFamily ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProteinFamily .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Drug ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Drug .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NucleicAcidSequenceMotif ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NucleicAcidSequenceMotif .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Cell ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Cell .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReagentTargetedGene ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReagentTargetedGene .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalProcessExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalProcessExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneAffectsChemicalAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneAffectsChemicalAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ExposureEventToOutcomeAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ExposureEventToOutcomeAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PreprintPublication ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PreprintPublication .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalAttribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalAttribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneFamily ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneFamily .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhysiologicalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhysiologicalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:StudyResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:StudyResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToMolecularActivityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToMolecularActivityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Device ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Device .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Behavior ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Behavior .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GrossAnatomicalStructure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GrossAnatomicalStructure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MaterialSample ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MaterialSample .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalAnatomicalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalAnatomicalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceFeatureRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceFeatureRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AdministrativeEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AdministrativeEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGoTermAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGoTermAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CommonDataElement ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CommonDataElement .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Human ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Human .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhenotypicFeatureToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhenotypicFeatureToDiseaseAssociation .
+
+[] a owl:Restriction ;
     rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation ;
     owl:onProperty biolink:category ;
     owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SocioeconomicExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SocioeconomicExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ComplexChemicalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ComplexChemicalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Agent ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Agent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PlanetaryEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PlanetaryEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalIntervention ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalIntervention .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TextMiningResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TextMiningResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Fungus ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Fungus .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProcessRegulatesProcessAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProcessRegulatesProcessAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToLocationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToLocationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Treatment ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Treatment .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalEntityAssessesNamedThingAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalEntityAssessesNamedThingAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CausalGeneToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CausalGeneToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularMachineToMolecularActivityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularMachineToMolecularActivityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SocioeconomicAttribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SocioeconomicAttribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Event ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Event .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NucleosomeModification ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NucleosomeModification .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SmallMolecule ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SmallMolecule .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseToExposureEventAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseToExposureEventAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLineAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLineAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChiSquaredAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChiSquaredAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PairwiseMolecularInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PairwiseMolecularInteraction .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Snv ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Snv .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SiRNA ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SiRNA .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalTrial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalTrial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Gene ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Gene .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalSex ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalSex .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetVersion ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetVersion .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToPathwayAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToPathwayAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Attribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Attribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:TaxonToTaxonAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:TaxonToTaxonAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Case ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Case .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NamedThing ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NamedThing .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:LogOddsAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:LogOddsAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:NucleicAcidEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:NucleicAcidEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EvidenceType ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EvidenceType .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CorrelatedGeneToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CorrelatedGeneToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BookChapter ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BookChapter .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:FoodAdditive ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:FoodAdditive .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToGenotypePartAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToGenotypePartAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Cohort ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Cohort .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ConfidenceLevel ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ConfidenceLevel .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:LifeStage ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:LifeStage .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehavioralFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehavioralFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EnvironmentalExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EnvironmentalExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLine ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLine .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalProcessOrActivity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalProcessOrActivity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToEnvironmentAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToEnvironmentAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalRole ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalRole .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneRegulatesGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneRegulatesGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneCoexpressionAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneCoexpressionAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivityToChemicalEntityAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivityToChemicalEntityAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PairwiseGeneToGeneInteraction .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Serial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Serial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Plant ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Plant .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EnvironmentalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EnvironmentalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProteinDomain ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProteinDomain .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EntityToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EntityToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceVariant ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceVariant .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Zygosity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Zygosity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:JournalArticle ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:JournalArticle .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneHomologyAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneHomologyAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Article ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Article .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalAnatomicalStructure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalAnatomicalStructure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToVariantAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToVariantAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Transcript ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Transcript .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugToGeneInteractionExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugToGeneInteractionExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToChemicalAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToChemicalAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:IndividualOrganism ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:IndividualOrganism .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PathologicalProcess ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PathologicalProcess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Disease ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Disease .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ExposureEventToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ExposureEventToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:StudyPopulation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:StudyPopulation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetDistribution ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetDistribution .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneticInheritance ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneticInheritance .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToGeneExpressionAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToGeneExpressionAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalMixture ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Exon ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Exon .
 
 [] a owl:Restriction ;
     rdfs:subClassOf biolink:Genome ;
@@ -14883,7 +14473,417 @@ biolink:subject a owl:ObjectProperty,
     owl:someValuesFrom biolink:Genome .
 
 [] a owl:Restriction ;
+    rdfs:subClassOf biolink:AccessibleDnaRegion ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AccessibleDnaRegion .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Procedure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Procedure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DatasetSummary ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DatasetSummary .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Mammal ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Mammal .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProcessedMaterial ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProcessedMaterial .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:FunctionalAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:FunctionalAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DiagnosticAid ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DiagnosticAid .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToPathwayAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToPathwayAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Virus ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Virus .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalAffectsGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalAffectsGeneAssociation .
+
+[] a owl:Restriction ;
     rdfs:subClassOf biolink:Patent ;
     owl:onProperty biolink:category ;
     owl:someValuesFrom biolink:Patent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceVariantModulatesTreatmentAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceVariantModulatesTreatmentAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Genotype ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Genotype .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalMeasurement ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalMeasurement .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneHasVariantThatContributesToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneHasVariantThatContributesToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:EnvironmentalFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:EnvironmentalFeature .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Onset ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Onset .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonInteraction ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonInteraction .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MicroRNA ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MicroRNA .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PopulationToPopulationAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PopulationToPopulationAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RNAProduct ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RNAProduct .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToExpressionSiteAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToExpressionSiteAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:StudyVariable ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:StudyVariable .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ConceptCountAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ConceptCountAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Vertebrate ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Vertebrate .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Bacterium ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Bacterium .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalCourse ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalCourse .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PosttranslationalModification ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PosttranslationalModification .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantToDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantToDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Book ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Book .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeToGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeToGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenomicBackgroundExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenomicBackgroundExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BioticExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BioticExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonSpecialization ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonSpecialization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismAttribute ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismAttribute .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:DrugExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:DrugExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehaviorToBehavioralFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehaviorToBehavioralFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellularOrganism ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellularOrganism .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ProteinIsoform ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ProteinIsoform .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MacromolecularMachineToBiologicalProcessAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MacromolecularMachineToBiologicalProcessAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Haplotype ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Haplotype .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneFamilyAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneFamilyAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Hospitalization ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Hospitalization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SequenceAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SequenceAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellularComponent ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellularComponent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GenotypeAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GenotypeAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ReactionToParticipantAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ReactionToParticipantAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Dataset ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Dataset .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Food ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Food .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Pathway ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Pathway .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Publication ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Publication .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ComplexMolecularMixture ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ComplexMolecularMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeneToGeneProductRelationship ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeneToGeneProductRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:InformationContentEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:InformationContentEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularMixture ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularMixture .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:RetrievalSource ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:RetrievalSource .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhenotypicQuality ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhenotypicQuality .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismToOrganismAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismToOrganismAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismalEntityAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismalEntityAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:MolecularActivity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:MolecularActivity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ClinicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ClinicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Polypeptide ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Polypeptide .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:VariantAsAModelOfDiseaseAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:VariantAsAModelOfDiseaseAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:OrganismTaxon ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:OrganismTaxon .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicLocationAtTime ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicLocationAtTime .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ChemicalGeneInteractionAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ChemicalGeneInteractionAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhenotypicFeatureToPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhenotypicFeatureToPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:ObservedExpectedFrequencyAnalysisResult ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:ObservedExpectedFrequencyAnalysisResult .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Activity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Activity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:SeverityValue ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:SeverityValue .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BiologicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BiologicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:Phenomenon ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:Phenomenon .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhysicalEntity ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhysicalEntity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:GeographicLocation ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:GeographicLocation .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:BehavioralExposure ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:BehavioralExposure .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf biolink:PhenotypicFeature ;
+    owl:onProperty biolink:category ;
+    owl:someValuesFrom biolink:PhenotypicFeature .
 

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -820,8 +820,12 @@ def test_non_standard_names(framework, class_name, safe_class_name, slot_name, s
         ("E[x]", "[x]"),
         ("E", "[x]"),
         ("E", "a/b"),
+        # ("E", "a\nb"),  # TODO
         ("E", "a.b"),
-        ("E", "♥️"), # Unicode heart symbol
+        ("E", "a:b"),
+        ("E", "a#b"),
+        ("E", "a{b}"),
+        ("E", "♥️"),  # Unicode heart symbol
     ],
 )
 def test_non_standard_enum_names(framework, enum_name, pv_name):

--- a/tests/test_compliance/test_core_compliance.py
+++ b/tests/test_compliance/test_core_compliance.py
@@ -819,9 +819,12 @@ def test_non_standard_names(framework, class_name, safe_class_name, slot_name, s
         ("E", "'"),
         ("E[x]", "[x]"),
         ("E", "[x]"),
+        ("E", "a/b"),
+        ("E", "a.b"),
+        ("E", "♥️"), # Unicode heart symbol
     ],
 )
-def test_non_standard_num_names(framework, enum_name, pv_name):
+def test_non_standard_enum_names(framework, enum_name, pv_name):
     """
     Tests that non-standard enum and permissible value names are handled gracefully.
 
@@ -848,7 +851,7 @@ def test_non_standard_num_names(framework, enum_name, pv_name):
     }
     name = ensafeify(f"EN{enum_name}_PV{pv_name}")
     schema = validated_schema(
-        test_non_standard_num_names,
+        test_non_standard_enum_names,
         name,
         framework,
         classes=classes,

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl.jsonld
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl.jsonld
@@ -1,1217 +1,5 @@
 [
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Event"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N5c57230b358b4da09c174b6c35ed1b29"
-      },
-      {
-        "@id": "_:N2ed244db8d6d444f9c8a9646e30ec8e3"
-      },
-      {
-        "@id": "_:Ne91e9e7a2cce4fc78b42ad093fdb58fc"
-      },
-      {
-        "@id": "_:Nbd787aeeaf3146b6818a876da037f7f7"
-      },
-      {
-        "@id": "_:N3babc643bea941788e6dd26b6e2be2b2"
-      },
-      {
-        "@id": "_:N0287211f059f40d7bd261fa70ce23456"
-      },
-      {
-        "@id": "_:N2b5379fb091a45269ffda218e90c9381"
-      },
-      {
-        "@id": "_:Nf7937bf865e046948820b0cb200cc698"
-      },
-      {
-        "@id": "_:Nbc0254b5b86f43bfb5c4cf58c74c07c8"
-      },
-      {
-        "@id": "_:N8d1040472acb4882a415fc8796024d5c"
-      },
-      {
-        "@id": "_:N19108d326c644c86a2c0a37df048a3ce"
-      },
-      {
-        "@id": "_:Nb16d33fab75748ac9e3a8600e3b56fb2"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5c57230b358b4da09c174b6c35ed1b29",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2ed244db8d6d444f9c8a9646e30ec8e3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne91e9e7a2cce4fc78b42ad093fdb58fc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbd787aeeaf3146b6818a876da037f7f7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3babc643bea941788e6dd26b6e2be2b2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0287211f059f40d7bd261fa70ce23456",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2b5379fb091a45269ffda218e90c9381",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf7937bf865e046948820b0cb200cc698",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbc0254b5b86f43bfb5c4cf58c74c07c8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8d1040472acb4882a415fc8796024d5c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N19108d326c644c86a2c0a37df048a3ce",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb16d33fab75748ac9e3a8600e3b56fb2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/004",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "TRANSFER"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_A"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Friend",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Friend"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N8aa0e1a830704d159b5c93be1fd775f2"
-      },
-      {
-        "@id": "_:N7506477369b04c0f9c55ff56aff539e5"
-      },
-      {
-        "@id": "_:N97e25f65dbeb4ed29dca2c62f9afad55"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8aa0e1a830704d159b5c93be1fd775f2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7506477369b04c0f9c55ff56aff539e5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N97e25f65dbeb4ed29dca2c62f9afad55",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/TubSubClass1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tub sub class 1"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Same depth as Sub sub class 1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/id",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "id"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "heartfelt"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfMix",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfMix"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N53b96a48f0264d7bbc0cf4093c2df2cc"
-      },
-      {
-        "@id": "_:N6140e15915674561951cfaf88eafba7c"
-      },
-      {
-        "@id": "_:N4b863f81d72d4806bc4b416f8e22c844"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N53b96a48f0264d7bbc0cf4093c2df2cc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nd5b5dc66a4d54a6dab3f0727f33af8de"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd5b5dc66a4d54a6dab3f0727f33af8de",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N6140e15915674561951cfaf88eafba7c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4b863f81d72d4806bc4b416f8e22c844",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Address"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N71200494bbc64a1c84259f4acf974b37"
-      },
-      {
-        "@id": "_:N8d134bb617484b34a2f1834ee9f855b8"
-      },
-      {
-        "@id": "_:Nc381775cd3d44c8da6271520e6d56f7a"
-      },
-      {
-        "@id": "_:N6005836c74c44b1cb7d3533fcbcc486a"
-      },
-      {
-        "@id": "_:Ncc344925e109419d9b13141f308b8f8c"
-      },
-      {
-        "@id": "_:Nea1bc9db6e45405ca57e0d004901ccf1"
-      },
-      {
-        "@id": "_:Nedea297ddbf14368bc65a4ca8351274e"
-      },
-      {
-        "@id": "_:Nbefedb86e63745dcb4e74b5d96193009"
-      },
-      {
-        "@id": "_:N7846bd7c3a314c2fa66e1d0ce3becff5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N71200494bbc64a1c84259f4acf974b37",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8d134bb617484b34a2f1834ee9f855b8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc381775cd3d44c8da6271520e6d56f7a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6005836c74c44b1cb7d3533fcbcc486a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncc344925e109419d9b13141f308b8f8c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nea1bc9db6e45405ca57e0d004901ccf1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nedea297ddbf14368bc65a4ca8351274e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbefedb86e63745dcb4e74b5d96193009",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7846bd7c3a314c2fa66e1d0ce3becff5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "employed at"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
-          }
-        ]
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfEnums",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfEnums"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N7dc8d6771d4b4b0aa97b45dfcc16a300"
-      },
-      {
-        "@id": "_:N11e9a38a15b74af4a56c45814d134c0d"
-      },
-      {
-        "@id": "_:N1f5b082bfbba4ae5974d3d0ed628a786"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7dc8d6771d4b4b0aa97b45dfcc16a300",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N22dbada460dd44dea960668cfd0c0017"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "_:N22dbada460dd44dea960668cfd0c0017",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N11e9a38a15b74af4a56c45814d134c0d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1f5b082bfbba4ae5974d3d0ed628a786",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "cordialness"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/description",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "description"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/003",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "PROMOTION"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/life_status",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "life_status"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Dataset",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Dataset"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N92c8aeeb7939423980afa3a724b06656"
-      },
-      {
-        "@id": "_:Nb74921cb455d44ce8b44aa140dd12d25"
-      },
-      {
-        "@id": "_:N31ab03b9ace84349ab83f9d76769233c"
-      },
-      {
-        "@id": "_:N6352dba6a4994cedb8b8ab1e05721829"
-      },
-      {
-        "@id": "_:Nafec9f8566b74e419b5c1b9764fe0c49"
-      },
-      {
-        "@id": "_:N22b69ec79d474028a4377117ae8b14f4"
-      },
-      {
-        "@id": "_:Ncc2093854a5a4d9a9af53e1632600470"
-      },
-      {
-        "@id": "_:N4cd816f1e88043e987c9367ddff33a89"
-      },
-      {
-        "@id": "_:N819b9b2ebaeb48cdb8f329eff9f817f5"
-      },
-      {
-        "@id": "_:Nadcc92d9fb3d4957a830f8dbade82c6d"
-      },
-      {
-        "@id": "_:N280b7a8ce6ba455895fe9994bb6bef3b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "_:N92c8aeeb7939423980afa3a724b06656",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb74921cb455d44ce8b44aa140dd12d25",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
-      }
-    ]
-  },
-  {
-    "@id": "_:N31ab03b9ace84349ab83f9d76769233c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6352dba6a4994cedb8b8ab1e05721829",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nafec9f8566b74e419b5c1b9764fe0c49",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
-      }
-    ]
-  },
-  {
-    "@id": "_:N22b69ec79d474028a4377117ae8b14f4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncc2093854a5a4d9a9af53e1632600470",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4cd816f1e88043e987c9367ddff33a89",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N819b9b2ebaeb48cdb8f329eff9f817f5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nadcc92d9fb3d4957a830f8dbade82c6d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
-      }
-    ]
-  },
-  {
-    "@id": "_:N280b7a8ce6ba455895fe9994bb6bef3b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "code systems"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "hateful"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ]
-  },
-  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
@@ -1219,54 +7,6 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@value": "attribute6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent"
-          }
-        ]
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "persons"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1293,1111 +33,6 @@
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "indifferent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_C",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_C"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship"
-      },
-      {
-        "@id": "_:Naf05b15267ca4c6893e185375083fd62"
-      },
-      {
-        "@id": "_:N2cf60303105a4606ba7793bf23c8a056"
-      },
-      {
-        "@id": "_:N484db5937d174f00bf7f087c2343a8b9"
-      },
-      {
-        "@id": "_:N06cb5313ac6c481c895054292fa309b5"
-      },
-      {
-        "@id": "_:N73ff4ea0fad2486a9721eac3d651ba46"
-      },
-      {
-        "@id": "_:Na4cd1af272d8491c842057347d9315f8"
-      },
-      {
-        "@id": "_:N822918e7f2c34e6b9078824d583ffa0f"
-      },
-      {
-        "@id": "_:N288fe7db4fde41a4b4e538a5e946ab1f"
-      },
-      {
-        "@id": "_:Nc5719f9848114b45897ffad0ce47d0ad"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 5
-      }
-    ]
-  },
-  {
-    "@id": "_:Naf05b15267ca4c6893e185375083fd62",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2cf60303105a4606ba7793bf23c8a056",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N484db5937d174f00bf7f087c2343a8b9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N06cb5313ac6c481c895054292fa309b5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N73ff4ea0fad2486a9721eac3d651ba46",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na4cd1af272d8491c842057347d9315f8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N822918e7f2c34e6b9078824d583ffa0f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N288fe7db4fde41a4b4e538a5e946ab1f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc5719f9848114b45897ffad0ce47d0ad",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nc35d692b747643fcae3c5b8aefe14736"
-      },
-      {
-        "@id": "_:Ndecd14382d1842559e3b55a67b5b8a3b"
-      },
-      {
-        "@id": "_:N8ed345302d8e4a48bb6e2fe823d8dc86"
-      },
-      {
-        "@id": "_:Nd0ef90057e654983a6acf244ec69aa3d"
-      },
-      {
-        "@id": "_:Ndc18f4a6f38c4956a04dd15219f04f04"
-      },
-      {
-        "@id": "_:Nf630fd6793444fce84b8998ca4dfd91b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc35d692b747643fcae3c5b8aefe14736",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndecd14382d1842559e3b55a67b5b8a3b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8ed345302d8e4a48bb6e2fe823d8dc86",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd0ef90057e654983a6acf244ec69aa3d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndc18f4a6f38c4956a04dd15219f04f04",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf630fd6793444fce84b8998ca4dfd91b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "http://www.w3.org/2001/XMLSchema#integer",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "MarriageEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation"
-      },
-      {
-        "@id": "_:Nd88ad90e326945f18d5277ec087485a4"
-      },
-      {
-        "@id": "_:N4d5688892db14c2a844923c1726a001b"
-      },
-      {
-        "@id": "_:Nd8bd46b17d7b46c889a86dc4110ffbf9"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd88ad90e326945f18d5277ec087485a4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4d5688892db14c2a844923c1726a001b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd8bd46b17d7b46c889a86dc4110ffbf9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "HasAliases"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Na3578b0e337f427ca074e9d1ecedb365"
-      },
-      {
-        "@id": "_:Nc33f9af68b9745058e4725841edf6ad7"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na3578b0e337f427ca074e9d1ecedb365",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc33f9af68b9745058e4725841edf6ad7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "species name"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "_:Nabc10ae7aba8498793f2872c8df3ebd7"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nabc10ae7aba8498793f2872c8df3ebd7",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N2d7a542c0c044ad9833e9f20eebca993"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N2d7a542c0c044ad9833e9f20eebca993",
-    "http://www.w3.org/2001/XMLSchema#pattern": [
-      {
-        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "slot with space 1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/Agent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "agent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N9f600f136e3f4b85af1eb9f62f14ecb0"
-      },
-      {
-        "@id": "_:N656df5d1bcf34e6786b9276ef86e186f"
-      },
-      {
-        "@id": "_:Ndb9fc6aeeb1c45b7a08f510c7fc33f2e"
-      },
-      {
-        "@id": "_:N107fd352d45e4df28d69e47be93e65df"
-      },
-      {
-        "@id": "_:N09da1814b45245e58a891b4529eb55e1"
-      },
-      {
-        "@id": "_:Nc5b4250cfc4a42e5876cdad6e40dec1d"
-      },
-      {
-        "@id": "_:N9f5bc9af317846eb86cfa840ef895e4c"
-      },
-      {
-        "@id": "_:N163c309a2cd446088373ae863c594e5e"
-      },
-      {
-        "@id": "_:Ne896016625d34aeb97bf862d0c2d9fcc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "a provence-generating agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#exactMatch": [
-      {
-        "@id": "http://www.w3.org/ns/prov#Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9f600f136e3f4b85af1eb9f62f14ecb0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
-      }
-    ]
-  },
-  {
-    "@id": "_:N656df5d1bcf34e6786b9276ef86e186f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndb9fc6aeeb1c45b7a08f510c7fc33f2e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
-      }
-    ]
-  },
-  {
-    "@id": "_:N107fd352d45e4df28d69e47be93e65df",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N09da1814b45245e58a891b4529eb55e1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc5b4250cfc4a42e5876cdad6e40dec1d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9f5bc9af317846eb86cfa840ef895e4c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:N163c309a2cd446088373ae863c594e5e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne896016625d34aeb97bf862d0c2d9fcc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "subclass test"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
-      },
-      {
-        "@id": "_:N5498b1a3b6404225961388993d2248ab"
-      },
-      {
-        "@id": "_:Nbd4f6c22f1b34b0584c095bef4375965"
-      },
-      {
-        "@id": "_:N8b8512ea3ccb41cc87d2ac53339e9e2c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5498b1a3b6404225961388993d2248ab",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbd4f6c22f1b34b0584c095bef4375965",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8b8512ea3ccb41cc87d2ac53339e9e2c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/started_at_time",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "started at time"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "in code system"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Organization"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
-      },
-      {
-        "@id": "_:Ne08cc344c9004b36984d7db62d619baa"
-      },
-      {
-        "@id": "_:N4ece6bf0512b46ebab841162c643ad71"
-      },
-      {
-        "@id": "_:Ne2a8bd64af2f4dafbb2610f8521af5ed"
-      },
-      {
-        "@id": "_:N76138d4c0eb249879bdf6821dcdcf854"
-      },
-      {
-        "@id": "_:N9325f191734d4975b7f12f82bb72540b"
-      },
-      {
-        "@id": "_:Nfab96563bd3a4d16b8fe297dc3f46a7a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 3
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne08cc344c9004b36984d7db62d619baa",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4ece6bf0512b46ebab841162c643ad71",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne2a8bd64af2f4dafbb2610f8521af5ed",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N76138d4c0eb249879bdf6821dcdcf854",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9325f191734d4975b7f12f82bb72540b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfab96563bd3a4d16b8fe297dc3f46a7a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has familial relationships"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "test_attribute"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -2434,18 +69,436 @@
     ]
   },
   {
-    "@id": "https://example.org/bizcodes/001",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_A"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/name",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "name"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 2
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "HIRE"
+        "@value": "WithLocation"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N83a894a202c348429e0631d04c250562"
+      },
+      {
+        "@id": "_:Nb1883a2b3f2d41d39e3b7a247182c17f"
+      },
+      {
+        "@id": "_:N68d34f92ed134372b2e55d6a86fb8c2b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N83a894a202c348429e0631d04c250562",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb1883a2b3f2d41d39e3b7a247182c17f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N68d34f92ed134372b2e55d6a86fb8c2b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/003",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "PROMOTION"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute3"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF"
+          }
+        ]
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:N4a437a1d8d9a42328ccb02284f9d7966"
+      },
+      {
+        "@id": "_:N3cf11f86eaf540ac8ac41a1676027a3c"
+      },
+      {
+        "@id": "_:N77bb6f878f2446f0953302f122c3c611"
+      },
+      {
+        "@id": "_:Nc40d4e866c914ab48dc70dc421954a93"
+      },
+      {
+        "@id": "_:N4d3a1d7dbcbf4e10b869a20fb1b47ef6"
+      },
+      {
+        "@id": "_:N150052bfe9794cb499f85e7b9285bec8"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 6
+      }
+    ]
+  },
+  {
+    "@id": "_:N4a437a1d8d9a42328ccb02284f9d7966",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3cf11f86eaf540ac8ac41a1676027a3c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:N77bb6f878f2446f0953302f122c3c611",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc40d4e866c914ab48dc70dc421954a93",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N7bffb39600034e3fad5d45618a5738f6"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7bffb39600034e3fad5d45618a5738f6",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N4d3a1d7dbcbf4e10b869a20fb1b47ef6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N150052bfe9794cb499f85e7b9285bec8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has birth event"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "is_living"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CLEAN"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/TubSubClass1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tub sub class 1"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Same depth as Sub sub class 1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -2466,6 +519,38 @@
     ]
   },
   {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#UNKNOWN",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "UNKNOWN"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "heartfelt"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
@@ -2482,45 +567,18 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "related to"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "PARENT_OF"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "slot with space 2"
+        "@value": "has familial relationships"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2556,538 +614,23 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/life_status",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "DiagnosisConcept"
+        "@value": "life_status"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#closeMatch": [
-      {
-        "@id": "https://w3id.org/biolink/Disease"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/was_generated_by",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "was generated by"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "acted on behalf of"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/Activity",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "activity"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N77b98e62089d4048a22cc6464ee37e2d"
-      },
-      {
-        "@id": "_:Nd630f66befd249528866d5201aaded49"
-      },
-      {
-        "@id": "_:N74bef4dd9fa345dda5d5f79620a60797"
-      },
-      {
-        "@id": "_:N0fee0e9acc7a47989ae9f1ea043c6160"
-      },
-      {
-        "@id": "_:Ncc4dd7c4b1214a61b8e8f9ff7bca6fd3"
-      },
-      {
-        "@id": "_:N49cadd3c1ae648b2a1abcd8da9cfde6f"
-      },
-      {
-        "@id": "_:Nd26d0168fdf84054a60e028de6253e45"
-      },
-      {
-        "@id": "_:N377bfdb2141f4fc28208a5ec4faaadf1"
-      },
-      {
-        "@id": "_:N138a76966105473cac59275ca924778f"
-      },
-      {
-        "@id": "_:N84939e7c25ca4f49b15f94fc30d7a44c"
-      },
-      {
-        "@id": "_:N6a255f7a6c924ff3941c861afd4aa5c9"
-      },
-      {
-        "@id": "_:N187146bdc61c4b44936b27db9e3130d1"
-      },
-      {
-        "@id": "_:N2272ca0456004ffd91d79e1acbaec90a"
-      },
-      {
-        "@id": "_:Nea347a6c93f14c42940f571658dd43fd"
-      },
-      {
-        "@id": "_:N7985dcf110764a058496eb4483c09a3b"
-      },
-      {
-        "@id": "_:N44f839fa23b54d34b0fb543ffc65afcf"
-      },
-      {
-        "@id": "_:N530e32a1069c42f08ba5c0d0b1699a9b"
-      },
-      {
-        "@id": "_:N4268e86664744a619fcd1fe5a3eaf029"
-      },
-      {
-        "@id": "_:Ne1e28d3ef8754f9fb6b21a2a58caabbc"
-      },
-      {
-        "@id": "_:N4ff38e462e964c94b25ef74d79b85f1e"
-      },
-      {
-        "@id": "_:Nbd743d19f478457598ca0b7a183373be"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "a provence-generating activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#mappingRelation": [
-      {
-        "@id": "http://www.w3.org/ns/prov#Activity"
-      }
-    ]
-  },
-  {
-    "@id": "_:N77b98e62089d4048a22cc6464ee37e2d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd630f66befd249528866d5201aaded49",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:N74bef4dd9fa345dda5d5f79620a60797",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0fee0e9acc7a47989ae9f1ea043c6160",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncc4dd7c4b1214a61b8e8f9ff7bca6fd3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N49cadd3c1ae648b2a1abcd8da9cfde6f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd26d0168fdf84054a60e028de6253e45",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N377bfdb2141f4fc28208a5ec4faaadf1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N138a76966105473cac59275ca924778f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N84939e7c25ca4f49b15f94fc30d7a44c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6a255f7a6c924ff3941c861afd4aa5c9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N187146bdc61c4b44936b27db9e3130d1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2272ca0456004ffd91d79e1acbaec90a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nea347a6c93f14c42940f571658dd43fd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7985dcf110764a058496eb4483c09a3b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:N44f839fa23b54d34b0fb543ffc65afcf",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N530e32a1069c42f08ba5c0d0b1699a9b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4268e86664744a619fcd1fe5a3eaf029",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne1e28d3ef8754f9fb6b21a2a58caabbc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4ff38e462e964c94b25ef74d79b85f1e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbd743d19f478457598ca0b7a183373be",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "CHILD_OF"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
       }
     ]
   },
@@ -3098,12 +641,12 @@
     ],
     "http://www.w3.org/2002/07/owl#equivalentClass": [
       {
-        "@id": "_:N1a1fde5f88b0461aadb0fe0fe11f7e5b"
+        "@id": "_:Nd5981886c1394322bfaf7761cc0bf87c"
       }
     ]
   },
   {
-    "@id": "_:N1a1fde5f88b0461aadb0fe0fe11f7e5b",
+    "@id": "_:Nd5981886c1394322bfaf7761cc0bf87c",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3116,14 +659,14 @@
       {
         "@list": [
           {
-            "@id": "_:Nb8fdd1a3ded845ad8c3cb975976d6ac6"
+            "@id": "_:N9c64283c25d04dc0a11aec5af233547f"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Nb8fdd1a3ded845ad8c3cb975976d6ac6",
+    "@id": "_:N9c64283c25d04dc0a11aec5af233547f",
     "http://www.w3.org/2001/XMLSchema#pattern": [
       {
         "@value": "^[\\\\+\\\\d+ +][\\\\d\\\\- ]+$"
@@ -3152,6 +695,27 @@
     ]
   },
   {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_B"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -3174,91 +738,91 @@
         "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
       },
       {
-        "@id": "_:N7f7b9a8dbc1f4cd597124f574e95ef87"
+        "@id": "_:N7587cdde44b54dc59d9e00c9bf850d05"
       },
       {
-        "@id": "_:Ne10918a6c81d4982a8b9d1d09a760d40"
+        "@id": "_:Ne05e4ef5b828492a9128ab4e96ebc7d1"
       },
       {
-        "@id": "_:Nd033a786e9a849e3acca01397c90d7bc"
+        "@id": "_:N4342bffcb31447048555881ea81ffef2"
       },
       {
-        "@id": "_:N8fec5521783344d6a8989b1a9d3cb4de"
+        "@id": "_:N3b08cb895a884887854eea7f6fff0a7c"
       },
       {
-        "@id": "_:Nd8e45a14a0b443409e5cbd4c43bb95a0"
+        "@id": "_:Nd82efaa494b84e5fa605ade28afc393c"
       },
       {
-        "@id": "_:N02e8f919df5c47adbcdee0a34c6014e6"
+        "@id": "_:N182da67d7ddf48808163134ba8167435"
       },
       {
-        "@id": "_:Nfea59a828b154fd589bbc2502774b884"
+        "@id": "_:Nf88a3a3c4da24ae68499b06a4c7a9409"
       },
       {
-        "@id": "_:Nb83380fb26cf40c2bad8d2dc00049c3d"
+        "@id": "_:N58eeef07c755477aa95bad45785e7ca9"
       },
       {
-        "@id": "_:Nfce63a89c16943ac924e88dc051318d7"
+        "@id": "_:Nda651484c1a44b708c3f3f9a8c53b424"
       },
       {
-        "@id": "_:Nfd0ebe1971b54d14b035c1108b1deb73"
+        "@id": "_:N6af61674cfbd42569e5b0950f90471de"
       },
       {
-        "@id": "_:Nbe6dad31b0ff481483fbe65c33e1f4ad"
+        "@id": "_:N752ad7ef4a1945e5b62f85243c446d94"
       },
       {
-        "@id": "_:N8b87cce782d64c9c829b286e44683b35"
+        "@id": "_:N55d8e275e65d4ab5bf41adb375cd7fe8"
       },
       {
-        "@id": "_:N6142fd0e8e024c5da3bc2431b1f9eeaf"
+        "@id": "_:Nfa4b090ffb094e53a70160b952e2520b"
       },
       {
-        "@id": "_:N4d527fba3d4947b9859a18f68c2fb5a9"
+        "@id": "_:Naeecaeb6ef77418598fa8f650782431f"
       },
       {
-        "@id": "_:Nda580a6ae8e54d27b73ec4cdb201f22d"
+        "@id": "_:Na3d71aaca58641d6a8fabdf06fb5800e"
       },
       {
-        "@id": "_:Naff8271653684ce0a856aa46dc36ba08"
+        "@id": "_:Nc8848dfa2a494c3baf1503d3da7f9b6c"
       },
       {
-        "@id": "_:Nb418497608a24b6e8e3bcfae27775650"
+        "@id": "_:N5908373f74ac4dd59b0b34766ef5fedb"
       },
       {
-        "@id": "_:N8096b6b08799423f86401e7d7742f818"
+        "@id": "_:Nb432b436a22d4e85851953b3afe897f6"
       },
       {
-        "@id": "_:N864c3e0b4fc24d19b26ea0eb1a68f38c"
+        "@id": "_:N32caf88c558541fa94c1e6a00bf40a2c"
       },
       {
-        "@id": "_:Naafcf46d9f364d88b1b73497f8022f9e"
+        "@id": "_:Nfcbf1e80d5a34b1bb2f83adc7ce01c77"
       },
       {
-        "@id": "_:N620931285ffc400d8ee98c79e0479124"
+        "@id": "_:N7ca99d0c4e944741af3a8e034f9b36cd"
       },
       {
-        "@id": "_:Nc46c8e8817c946a19c1212e040919750"
+        "@id": "_:N1f1d465b83df4058974170909bc067b2"
       },
       {
-        "@id": "_:N9a43da4db5ad4f71827bfe8ba524d6eb"
+        "@id": "_:Nbcf2d67ea14241dc8dad512ef345876b"
       },
       {
-        "@id": "_:N8987f955fb454df3b1e81aea77419d7c"
+        "@id": "_:Ndfd68174dbfa4a1f9a5ba3e3011c6703"
       },
       {
-        "@id": "_:N8017c62464c14c91a13b3fa3c41e3919"
+        "@id": "_:Nb16e486c0b5e49f6aa02395889875c8d"
       },
       {
-        "@id": "_:N3449432be06944ec818a769cde90173d"
+        "@id": "_:N9912e885512e443a9184ff1ac6f543c2"
       },
       {
-        "@id": "_:N473dff8923dc48089fed88cc801366fd"
+        "@id": "_:N787a62f88c114f0f9dc5a659d2776d29"
       },
       {
-        "@id": "_:N97756a6b308e4cbd981f6ebad340bf19"
+        "@id": "_:N6f73929f1a2d4406aa9e35397d03a22d"
       },
       {
-        "@id": "_:N3c5dad7e831049179060950161ac73d1"
+        "@id": "_:N08c4b8dcc49546059efb8810d5b0f27a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -3306,7 +870,7 @@
     ]
   },
   {
-    "@id": "_:N7f7b9a8dbc1f4cd597124f574e95ef87",
+    "@id": "_:N7587cdde44b54dc59d9e00c9bf850d05",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3322,7 +886,7 @@
     ]
   },
   {
-    "@id": "_:Ne10918a6c81d4982a8b9d1d09a760d40",
+    "@id": "_:Ne05e4ef5b828492a9128ab4e96ebc7d1",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3339,13 +903,13 @@
     ]
   },
   {
-    "@id": "_:Nd033a786e9a849e3acca01397c90d7bc",
+    "@id": "_:N4342bffcb31447048555881ea81ffef2",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N3b99c03b55f14e4d82c793337d9f805b"
+        "@id": "_:Na9c0cca7e80b44fb9fb22036c0bbe34e"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -3355,7 +919,7 @@
     ]
   },
   {
-    "@id": "_:N3b99c03b55f14e4d82c793337d9f805b",
+    "@id": "_:Na9c0cca7e80b44fb9fb22036c0bbe34e",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3366,17 +930,17 @@
             "@id": "http://www.w3.org/2001/XMLSchema#integer"
           },
           {
-            "@id": "_:Na906c57ecd164adb952476d04e568a22"
+            "@id": "_:N9b9dbbf54a9d4a23a7f2bbd017a8494c"
           },
           {
-            "@id": "_:N0bc9ec96927c4ae69916c7acf1c95b80"
+            "@id": "_:Nbeab4e43151c482b9e0bc33212cbfb67"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Na906c57ecd164adb952476d04e568a22",
+    "@id": "_:N9b9dbbf54a9d4a23a7f2bbd017a8494c",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3389,14 +953,14 @@
       {
         "@list": [
           {
-            "@id": "_:Ne1a68b1e5d1e482c8c94f526fdb3ed96"
+            "@id": "_:N5e66df467c1d4541a98acb0f9118b916"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Ne1a68b1e5d1e482c8c94f526fdb3ed96",
+    "@id": "_:N5e66df467c1d4541a98acb0f9118b916",
     "http://www.w3.org/2001/XMLSchema#minInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -3405,7 +969,7 @@
     ]
   },
   {
-    "@id": "_:N0bc9ec96927c4ae69916c7acf1c95b80",
+    "@id": "_:Nbeab4e43151c482b9e0bc33212cbfb67",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3418,14 +982,14 @@
       {
         "@list": [
           {
-            "@id": "_:N369be821ed0541de9ebc310ac14c8ae5"
+            "@id": "_:N0391e2a0076543e8ae3bd83480c52665"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N369be821ed0541de9ebc310ac14c8ae5",
+    "@id": "_:N0391e2a0076543e8ae3bd83480c52665",
     "http://www.w3.org/2001/XMLSchema#maxInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -3434,7 +998,7 @@
     ]
   },
   {
-    "@id": "_:N8fec5521783344d6a8989b1a9d3cb4de",
+    "@id": "_:N3b08cb895a884887854eea7f6fff0a7c",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3451,7 +1015,7 @@
     ]
   },
   {
-    "@id": "_:Nd8e45a14a0b443409e5cbd4c43bb95a0",
+    "@id": "_:Nd82efaa494b84e5fa605ade28afc393c",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3468,7 +1032,7 @@
     ]
   },
   {
-    "@id": "_:N02e8f919df5c47adbcdee0a34c6014e6",
+    "@id": "_:N182da67d7ddf48808163134ba8167435",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3484,7 +1048,7 @@
     ]
   },
   {
-    "@id": "_:Nfea59a828b154fd589bbc2502774b884",
+    "@id": "_:Nf88a3a3c4da24ae68499b06a4c7a9409",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3501,7 +1065,7 @@
     ]
   },
   {
-    "@id": "_:Nb83380fb26cf40c2bad8d2dc00049c3d",
+    "@id": "_:N58eeef07c755477aa95bad45785e7ca9",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3518,7 +1082,7 @@
     ]
   },
   {
-    "@id": "_:Nfce63a89c16943ac924e88dc051318d7",
+    "@id": "_:Nda651484c1a44b708c3f3f9a8c53b424",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3534,7 +1098,7 @@
     ]
   },
   {
-    "@id": "_:Nfd0ebe1971b54d14b035c1108b1deb73",
+    "@id": "_:N6af61674cfbd42569e5b0950f90471de",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3551,7 +1115,7 @@
     ]
   },
   {
-    "@id": "_:Nbe6dad31b0ff481483fbe65c33e1f4ad",
+    "@id": "_:N752ad7ef4a1945e5b62f85243c446d94",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3567,7 +1131,7 @@
     ]
   },
   {
-    "@id": "_:N8b87cce782d64c9c829b286e44683b35",
+    "@id": "_:N55d8e275e65d4ab5bf41adb375cd7fe8",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3584,7 +1148,7 @@
     ]
   },
   {
-    "@id": "_:N6142fd0e8e024c5da3bc2431b1f9eeaf",
+    "@id": "_:Nfa4b090ffb094e53a70160b952e2520b",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3600,7 +1164,7 @@
     ]
   },
   {
-    "@id": "_:N4d527fba3d4947b9859a18f68c2fb5a9",
+    "@id": "_:Naeecaeb6ef77418598fa8f650782431f",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3617,7 +1181,7 @@
     ]
   },
   {
-    "@id": "_:Nda580a6ae8e54d27b73ec4cdb201f22d",
+    "@id": "_:Na3d71aaca58641d6a8fabdf06fb5800e",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3633,7 +1197,7 @@
     ]
   },
   {
-    "@id": "_:Naff8271653684ce0a856aa46dc36ba08",
+    "@id": "_:Nc8848dfa2a494c3baf1503d3da7f9b6c",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3650,7 +1214,7 @@
     ]
   },
   {
-    "@id": "_:Nb418497608a24b6e8e3bcfae27775650",
+    "@id": "_:N5908373f74ac4dd59b0b34766ef5fedb",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3667,7 +1231,7 @@
     ]
   },
   {
-    "@id": "_:N8096b6b08799423f86401e7d7742f818",
+    "@id": "_:Nb432b436a22d4e85851953b3afe897f6",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3683,7 +1247,7 @@
     ]
   },
   {
-    "@id": "_:N864c3e0b4fc24d19b26ea0eb1a68f38c",
+    "@id": "_:N32caf88c558541fa94c1e6a00bf40a2c",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3700,7 +1264,7 @@
     ]
   },
   {
-    "@id": "_:Naafcf46d9f364d88b1b73497f8022f9e",
+    "@id": "_:Nfcbf1e80d5a34b1bb2f83adc7ce01c77",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3717,13 +1281,13 @@
     ]
   },
   {
-    "@id": "_:N620931285ffc400d8ee98c79e0479124",
+    "@id": "_:N7ca99d0c4e944741af3a8e034f9b36cd",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N2f5c33622aaa4e8d9afecfe6af3880a0"
+        "@id": "_:N82679f7bb5d844ce8ef8ff857372ca08"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -3733,7 +1297,7 @@
     ]
   },
   {
-    "@id": "_:N2f5c33622aaa4e8d9afecfe6af3880a0",
+    "@id": "_:N82679f7bb5d844ce8ef8ff857372ca08",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3746,14 +1310,14 @@
       {
         "@list": [
           {
-            "@id": "_:N8602b784519a459494353eabf454b67e"
+            "@id": "_:Ndd6269999a854c588e72d2d9a87d1cbe"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N8602b784519a459494353eabf454b67e",
+    "@id": "_:Ndd6269999a854c588e72d2d9a87d1cbe",
     "http://www.w3.org/2001/XMLSchema#pattern": [
       {
         "@value": "^\\S+ \\S+$"
@@ -3761,7 +1325,7 @@
     ]
   },
   {
-    "@id": "_:Nc46c8e8817c946a19c1212e040919750",
+    "@id": "_:N1f1d465b83df4058974170909bc067b2",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3778,7 +1342,7 @@
     ]
   },
   {
-    "@id": "_:N9a43da4db5ad4f71827bfe8ba524d6eb",
+    "@id": "_:Nbcf2d67ea14241dc8dad512ef345876b",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3795,13 +1359,13 @@
     ]
   },
   {
-    "@id": "_:N8987f955fb454df3b1e81aea77419d7c",
+    "@id": "_:Ndfd68174dbfa4a1f9a5ba3e3011c6703",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:Nb04df2a414c94e5a8c5b4ba4d9b14d68"
+        "@id": "_:N65e9ba151aee4f108e6b0457d9822e4d"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -3811,7 +1375,7 @@
     ]
   },
   {
-    "@id": "_:Nb04df2a414c94e5a8c5b4ba4d9b14d68",
+    "@id": "_:N65e9ba151aee4f108e6b0457d9822e4d",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3824,14 +1388,14 @@
       {
         "@list": [
           {
-            "@id": "_:Ne8bacccb6db2499eb5d8c7026b0ba422"
+            "@id": "_:N5bd4b2e45062417096a0d474c6f3fba0"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Ne8bacccb6db2499eb5d8c7026b0ba422",
+    "@id": "_:N5bd4b2e45062417096a0d474c6f3fba0",
     "http://www.w3.org/2001/XMLSchema#pattern": [
       {
         "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
@@ -3839,7 +1403,7 @@
     ]
   },
   {
-    "@id": "_:N8017c62464c14c91a13b3fa3c41e3919",
+    "@id": "_:Nb16e486c0b5e49f6aa02395889875c8d",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3856,7 +1420,7 @@
     ]
   },
   {
-    "@id": "_:N3449432be06944ec818a769cde90173d",
+    "@id": "_:N9912e885512e443a9184ff1ac6f543c2",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3873,13 +1437,13 @@
     ]
   },
   {
-    "@id": "_:N473dff8923dc48089fed88cc801366fd",
+    "@id": "_:N787a62f88c114f0f9dc5a659d2776d29",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N93f20eca5be74f31a34617dae86806c8"
+        "@id": "_:N431b2f17639f415eb1102800cda545b2"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -3889,7 +1453,7 @@
     ]
   },
   {
-    "@id": "_:N93f20eca5be74f31a34617dae86806c8",
+    "@id": "_:N431b2f17639f415eb1102800cda545b2",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3900,17 +1464,17 @@
             "@id": "http://www.w3.org/2001/XMLSchema#integer"
           },
           {
-            "@id": "_:Ne592ac86fc68481e8129242d4adff4d3"
+            "@id": "_:N5372b453cb7d4a00aab471982f39aa22"
           },
           {
-            "@id": "_:N70020dc21e0a43ad826cf6db2071bf70"
+            "@id": "_:Ndf5252b20c9843b9887267de24e2152c"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Ne592ac86fc68481e8129242d4adff4d3",
+    "@id": "_:N5372b453cb7d4a00aab471982f39aa22",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3923,14 +1487,14 @@
       {
         "@list": [
           {
-            "@id": "_:N7668d6b0afa941f7b4c4bd7cc733dadd"
+            "@id": "_:Nf488a3f020ed43aaab2c1955e00f2e07"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N7668d6b0afa941f7b4c4bd7cc733dadd",
+    "@id": "_:Nf488a3f020ed43aaab2c1955e00f2e07",
     "http://www.w3.org/2001/XMLSchema#minInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -3939,7 +1503,7 @@
     ]
   },
   {
-    "@id": "_:N70020dc21e0a43ad826cf6db2071bf70",
+    "@id": "_:Ndf5252b20c9843b9887267de24e2152c",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3952,14 +1516,14 @@
       {
         "@list": [
           {
-            "@id": "_:Ne9fcd03b14514857a5c61cf6658a224f"
+            "@id": "_:Ne601cc9a49b8477ca07ceb76ecc22286"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Ne9fcd03b14514857a5c61cf6658a224f",
+    "@id": "_:Ne601cc9a49b8477ca07ceb76ecc22286",
     "http://www.w3.org/2001/XMLSchema#maxInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -3968,7 +1532,7 @@
     ]
   },
   {
-    "@id": "_:N97756a6b308e4cbd981f6ebad340bf19",
+    "@id": "_:N6f73929f1a2d4406aa9e35397d03a22d",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3985,7 +1549,7 @@
     ]
   },
   {
-    "@id": "_:N3c5dad7e831049179060950161ac73d1",
+    "@id": "_:N08c4b8dcc49546059efb8810d5b0f27a",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -4002,157 +1566,223 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place",
+    "@id": "https://w3id.org/linkml/tests/core/Agent",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Place"
+        "@value": "agent"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+        "@id": "_:N32f1d41c87cc4f9b8870a1712cd845ee"
       },
       {
-        "@id": "_:N5fc959d41e11416881b72b6b9db66774"
+        "@id": "_:N9dd01dd54e504c1fa21c9066bbeab73e"
       },
       {
-        "@id": "_:Nd37057be982d4b98885c83e51f5a0d8d"
+        "@id": "_:N78e8b357cf1344e7873b33ce47db79ab"
       },
       {
-        "@id": "_:N38ae006e88ba46df8240bcd8d51ec4cb"
+        "@id": "_:Ne27e2b80dd3c4464b2373fbf49157b5e"
       },
       {
-        "@id": "_:Ne2ef06fd740c4745ac2ca745e8a9995c"
+        "@id": "_:N0396462a53fd41ecb7562310b6bf87d8"
       },
       {
-        "@id": "_:Nc7cdeae42908419b8c46ff23c786be35"
+        "@id": "_:N4e62be922810426aad9e8ed1d11d0cc8"
       },
       {
-        "@id": "_:Nbee25e3c1fdd47ba99d018f4fb3989cc"
+        "@id": "_:N233964694d28493cb75c67acc568617e"
+      },
+      {
+        "@id": "_:N9f7c3c372e09494990546b2fbe5aa468"
+      },
+      {
+        "@id": "_:N75c7ab2ed55f42638cb6733816a4b93d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "a provence-generating agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#exactMatch": [
+      {
+        "@id": "http://www.w3.org/ns/prov#Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "_:N32f1d41c87cc4f9b8870a1712cd845ee",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9dd01dd54e504c1fa21c9066bbeab73e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:N78e8b357cf1344e7873b33ce47db79ab",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne27e2b80dd3c4464b2373fbf49157b5e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0396462a53fd41ecb7562310b6bf87d8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4e62be922810426aad9e8ed1d11d0cc8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N233964694d28493cb75c67acc568617e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9f7c3c372e09494990546b2fbe5aa468",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:N75c7ab2ed55f42638cb6733816a4b93d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/type",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "type"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5fc959d41e11416881b72b6b9db66774",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd37057be982d4b98885c83e51f5a0d8d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N38ae006e88ba46df8240bcd8d51ec4cb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne2ef06fd740c4745ac2ca745e8a9995c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc7cdeae42908419b8c46ff23c786be35",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbee25e3c1fdd47ba99d018f4fb3989cc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#LIVING",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "LIVING"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
       }
     ]
   },
@@ -4168,7 +1798,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "_:N37a00469f3864d23912633a67fc519ac"
+        "@id": "_:N56dc4dfd7173446db8963ae7380bc19e"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -4183,7 +1813,7 @@
     ]
   },
   {
-    "@id": "_:N37a00469f3864d23912633a67fc519ac",
+    "@id": "_:N56dc4dfd7173446db8963ae7380bc19e",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -4194,17 +1824,17 @@
             "@id": "http://www.w3.org/2001/XMLSchema#integer"
           },
           {
-            "@id": "_:N45a6b54e599b41a19717824f0cfb3a7f"
+            "@id": "_:Nbd07442101854c07b3eb09c6400fd6a4"
           },
           {
-            "@id": "_:Nbecd2c4e203445d294ee4ba9ddfba091"
+            "@id": "_:N0a82d6cca1b34c4996ac33a0ff0edfb3"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N45a6b54e599b41a19717824f0cfb3a7f",
+    "@id": "_:Nbd07442101854c07b3eb09c6400fd6a4",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -4217,14 +1847,14 @@
       {
         "@list": [
           {
-            "@id": "_:N468e705b715e480b97fe98be6b346b21"
+            "@id": "_:N90d3f9820ca0441493e7f09e672e98b0"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N468e705b715e480b97fe98be6b346b21",
+    "@id": "_:N90d3f9820ca0441493e7f09e672e98b0",
     "http://www.w3.org/2001/XMLSchema#minInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -4233,7 +1863,7 @@
     ]
   },
   {
-    "@id": "_:Nbecd2c4e203445d294ee4ba9ddfba091",
+    "@id": "_:N0a82d6cca1b34c4996ac33a0ff0edfb3",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -4246,14 +1876,14 @@
       {
         "@list": [
           {
-            "@id": "_:N7fb3a4a5045141659477b6a6c4c8796e"
+            "@id": "_:N396cb1c76b7b4f15b62af572d735b849"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N7fb3a4a5045141659477b6a6c4c8796e",
+    "@id": "_:N396cb1c76b7b4f15b62af572d735b849",
     "http://www.w3.org/2001/XMLSchema#maxInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -4262,13 +1892,24 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Friend",
     "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "attribute2"
+        "@value": "Friend"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N28b23b81cc974421a71482033e4818f0"
+      },
+      {
+        "@id": "_:Na8e0d289ddd147609dda471e35fa08a1"
+      },
+      {
+        "@id": "_:N530e23f7baf04728a50d55439bfda857"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -4278,29 +1919,328 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
+    "@id": "_:N28b23b81cc974421a71482033e4818f0",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@value": "CLEAN"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+        "@id": "https://w3id.org/linkml/tests/core/name"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/was_associated_with",
+    "@id": "_:Na8e0d289ddd147609dda471e35fa08a1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N530e23f7baf04728a50d55439bfda857",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "was associated with"
+        "@value": "has employment history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 7
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "test_attribute"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "https://w3id.org/biolink/Disease"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_C",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_C"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfEnums",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfEnums"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nd5eab74e9d944e4c9be22bcb68c140f1"
+      },
+      {
+        "@id": "_:Nae965ca170be4d3aa75d966585af65b8"
+      },
+      {
+        "@id": "_:Nf3f119bdcde148f1ba3623ccb5915c17"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd5eab74e9d944e4c9be22bcb68c140f1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N5113370b6dc04b68add48937cc297659"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5113370b6dc04b68add48937cc297659",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nae965ca170be4d3aa75d966585af65b8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf3f119bdcde148f1ba3623ccb5915c17",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Company"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
+      },
+      {
+        "@id": "_:N6bf163c2268f48f887a317d56b3fb2dc"
+      },
+      {
+        "@id": "_:N9bb0df9d4d1b4933a5111edf78e3fbab"
+      },
+      {
+        "@id": "_:N354b57357dc044ccbd33de19e1c5d5ae"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6bf163c2268f48f887a317d56b3fb2dc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9bb0df9d4d1b4933a5111edf78e3fbab",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "_:N354b57357dc044ccbd33de19e1c5d5ae",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/agent_set",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "agent set"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
@@ -4315,379 +2255,333 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#UNKNOWN",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "https://w3id.org/linkml/permissible_values": [
       {
-        "@value": "UNKNOWN"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "stomach count"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Relationship"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nf6848d20096e4766b437738ca923f082"
-      },
-      {
-        "@id": "_:N59689fc92db04db2b792306d849db350"
-      },
-      {
-        "@id": "_:N205ef97a5c3d412c80283043309a3802"
-      },
-      {
-        "@id": "_:Nf42f2bf4fdd643d4a0ece6ec95c95e06"
-      },
-      {
-        "@id": "_:N8663bf24d02947e3b9c0db7c23f5ba5c"
-      },
-      {
-        "@id": "_:N070d34916b8e4b4b8c276db3bd4e4a11"
-      },
-      {
-        "@id": "_:N25aee538800b4123869e02d9e1a25b9a"
-      },
-      {
-        "@id": "_:Ne87bd120c12441848857ba31776d4ca3"
-      },
-      {
-        "@id": "_:N3c0c729092444e73a9e1e9edf9361941"
-      },
-      {
-        "@id": "_:N2a556924ed324f99873c3c2a84872840"
-      },
-      {
-        "@id": "_:N33a7db7d6f19447ea26cd37d61291d41"
-      },
-      {
-        "@id": "_:N3752e0e54dfc4bf4b5e24abf65c6b56f"
-      },
-      {
-        "@id": "_:Ne0292f34982a49e4b671063b27fae281"
-      },
-      {
-        "@id": "_:Na40e1d1e48b54797911e82e22659bcae"
-      },
-      {
-        "@id": "_:Nd7b223f6e7224cf9a0249541cb724eaf"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf6848d20096e4766b437738ca923f082",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N59689fc92db04db2b792306d849db350",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N205ef97a5c3d412c80283043309a3802",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf42f2bf4fdd643d4a0ece6ec95c95e06",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8663bf24d02947e3b9c0db7c23f5ba5c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N070d34916b8e4b4b8c276db3bd4e4a11",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N25aee538800b4123869e02d9e1a25b9a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne87bd120c12441848857ba31776d4ca3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3c0c729092444e73a9e1e9edf9361941",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2a556924ed324f99873c3c2a84872840",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N33a7db7d6f19447ea26cd37d61291d41",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3752e0e54dfc4bf4b5e24abf65c6b56f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne0292f34982a49e4b671063b27fae281",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na40e1d1e48b54797911e82e22659bcae",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd7b223f6e7224cf9a0249541cb724eaf",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "has medical history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
+        "@value": "code systems"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/ns/shacl#order": [
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Address"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N5a107ed9a3f24cfdb94a0b3eb1a75352"
+      },
+      {
+        "@id": "_:Neda596440a6245bebcdb091db71e2bf9"
+      },
+      {
+        "@id": "_:Nf0af2cfb1f12496190d6df1a1f8b4edc"
+      },
+      {
+        "@id": "_:Nddc4c9cbf08e4e67a31994489bb17612"
+      },
+      {
+        "@id": "_:N421e50dd66eb42b1a4213218cee6ec2c"
+      },
+      {
+        "@id": "_:N78163e380e2a4bb6959a699e3fd2f4c8"
+      },
+      {
+        "@id": "_:N9cf8153e45e14214bc19174c0d398f75"
+      },
+      {
+        "@id": "_:N5dcf9aa05e3f431e9176169306b8b3e4"
+      },
+      {
+        "@id": "_:N6f3d963715ac4b5a84f08da7258c1efa"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5a107ed9a3f24cfdb94a0b3eb1a75352",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Neda596440a6245bebcdb091db71e2bf9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 5
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf0af2cfb1f12496190d6df1a1f8b4edc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nddc4c9cbf08e4e67a31994489bb17612",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:N421e50dd66eb42b1a4213218cee6ec2c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:N78163e380e2a4bb6959a699e3fd2f4c8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9cf8153e45e14214bc19174c0d398f75",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5dcf9aa05e3f431e9176169306b8b3e4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6f3d963715ac4b5a84f08da7258c1efa",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FakeClass",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FakeClass"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nb574240598ef4018a5ed7d690dc4b56c"
+      },
+      {
+        "@id": "_:N650c324cda63496ea183cb876f3263b9"
+      },
+      {
+        "@id": "_:Nb7f0343fcc364ec1845c3d251b0fee7c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb574240598ef4018a5ed7d690dc4b56c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
+      }
+    ]
+  },
+  {
+    "@id": "_:N650c324cda63496ea183cb876f3263b9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb7f0343fcc364ec1845c3d251b0fee7c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "procedure"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -4730,1093 +2624,6 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DIRTY"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "BirthEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:N7c9dc40c0222445e9ca28bedec27545e"
-      },
-      {
-        "@id": "_:N476ec4feaf3d4e8c9bc7695279225911"
-      },
-      {
-        "@id": "_:Ndf8644b5de604c4b90fd6ac8064f0e92"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7c9dc40c0222445e9ca28bedec27545e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N476ec4feaf3d4e8c9bc7695279225911",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndf8644b5de604c4b90fd6ac8064f0e92",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "class with spaces"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Naae3351349524dfdba051651b5bd1e03"
-      },
-      {
-        "@id": "_:N4859a5aea1104b11b31593ca314e39a4"
-      },
-      {
-        "@id": "_:N3ed56900372144ee92186f2dec25984a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Naae3351349524dfdba051651b5bd1e03",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4859a5aea1104b11b31593ca314e39a4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3ed56900372144ee92186f2dec25984a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "is current"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Ontology"
-    ],
-    "http://purl.org/dc/terms/title": [
-      {
-        "@value": "Kitchen Sink Schema"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
-      {
-        "@id": "https://example.org/"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Kitchen Sink Schema\n\nThis schema does not do anything useful. It exists to test all features of linkml.\n\nThis particular text field exists to demonstrate markdown within a text field:\n\nLists:\n\n   * a\n   * b\n   * c\n\nAnd links, e.g to [Person](Person.md)"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyObject"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Example of unconstrained class"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#exactMatch": [
-      {
-        "@id": "https://w3id.org/linkml/Any"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has employment history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 7
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "MedicalEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:Nad8b546f94b24fa698a000768b0ebeb1"
-      },
-      {
-        "@id": "_:Ndf63e66e1ae24fe1be8fb73e1c57c26d"
-      },
-      {
-        "@id": "_:Ne23898eac04d46239e3cfc382a8bd87e"
-      },
-      {
-        "@id": "_:N93168efd57754def9a86bc8bc8ab648a"
-      },
-      {
-        "@id": "_:N5eab12882ce448e49c03a6428c8e91a3"
-      },
-      {
-        "@id": "_:Necf2d5adb662439390a176bdc5f57a04"
-      },
-      {
-        "@id": "_:N0a37ad3a7fae4e4c882a9791858cd399"
-      },
-      {
-        "@id": "_:N4c0a2eb53b0d46a78649de18cfce887e"
-      },
-      {
-        "@id": "_:N2cc93db2c86b47ed99e3cca4c058d0ad"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nad8b546f94b24fa698a000768b0ebeb1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndf63e66e1ae24fe1be8fb73e1c57c26d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne23898eac04d46239e3cfc382a8bd87e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:N93168efd57754def9a86bc8bc8ab648a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5eab12882ce448e49c03a6428c8e91a3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Necf2d5adb662439390a176bdc5f57a04",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0a37ad3a7fae4e4c882a9791858cd399",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4c0a2eb53b0d46a78649de18cfce887e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2cc93db2c86b47ed99e3cca4c058d0ad",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/002",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FIRE"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/name",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "name"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 2
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsString",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EqualsString"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N0a42bc1218d1494f892cc692284de290"
-      },
-      {
-        "@id": "_:N31cde5a7890344918879253beaed801d"
-      },
-      {
-        "@id": "_:N569a83eb3e1f44a6acde04f0f184bfc1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0a42bc1218d1494f892cc692284de290",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "_:N31cde5a7890344918879253beaed801d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "_:N569a83eb3e1f44a6acde04f0f184bfc1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "SIBLING_OF"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsStringIn",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EqualsStringIn"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N2339dce447b048268f831abe4c2b4ec7"
-      },
-      {
-        "@id": "_:Ncac3b4fe5e54487198fce88cf77a47f7"
-      },
-      {
-        "@id": "_:N521251dd8ce14089bbd25cea82ff25cc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2339dce447b048268f831abe4c2b4ec7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N73e14b23dc0c4e26ad58e91dce565775"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "_:N73e14b23dc0c4e26ad58e91dce565775",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#oneOf": [
-      {
-        "@list": [
-          {
-            "@value": "foo"
-          },
-          {
-            "@value": "bar"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncac3b4fe5e54487198fce88cf77a47f7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "_:N521251dd8ce14089bbd25cea82ff25cc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/ended_at_time",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ended at time"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:N80c0444a714a48e2b2fa68ffeb01ace0"
-      },
-      {
-        "@id": "_:N6391114677f6474eb807fd5864b87b22"
-      },
-      {
-        "@id": "_:N37d7432dfb70436c83249387ea9af2d3"
-      },
-      {
-        "@id": "_:Ncf31c8a1f5ee42bfae911ebefabf148d"
-      },
-      {
-        "@id": "_:Nf94456cf60c44b2c9e6087850bf913cb"
-      },
-      {
-        "@id": "_:N247c6decc63945809ed5e302616cee2d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 6
-      }
-    ]
-  },
-  {
-    "@id": "_:N80c0444a714a48e2b2fa68ffeb01ace0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6391114677f6474eb807fd5864b87b22",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:N37d7432dfb70436c83249387ea9af2d3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncf31c8a1f5ee42bfae911ebefabf148d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N91eabd4368c44eba82ec89536c6bbcd9"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N91eabd4368c44eba82ec89536c6bbcd9",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf94456cf60c44b2c9e6087850bf913cb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N247c6decc63945809ed5e302616cee2d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "altitude"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/street",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "street"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "diagnosis"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "addresses"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "WithLocation"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nc9608e8f3c20493584901f9f9728c803"
-      },
-      {
-        "@id": "_:Nbc49b0903b704dd885392dc2fcddbca9"
-      },
-      {
-        "@id": "_:Nd5af1accd03a493799c3b9be5fd2a488"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc9608e8f3c20493584901f9f9728c803",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbc49b0903b704dd885392dc2fcddbca9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd5af1accd03a493799c3b9be5fd2a488",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/city",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
@@ -5833,880 +2640,18 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/was_informed_by",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "was informed by"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_B"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A"
+        "@value": "slot with space 2"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ceo"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "companies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "is_living"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/agent_set",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "agent set"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfClasses",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfClasses"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N3c41c5b95c8e45b8a6280b799e1327f2"
-      },
-      {
-        "@id": "_:N938a0467f7fe4b589ef656f87d998844"
-      },
-      {
-        "@id": "_:Ne3e351b6f56849a6ae93fecfefba9a91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3c41c5b95c8e45b8a6280b799e1327f2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N3eea795052be4eb5ac571c0ca7170f42"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3eea795052be4eb5ac571c0ca7170f42",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N938a0467f7fe4b589ef656f87d998844",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne3e351b6f56849a6ae93fecfefba9a91",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "married to"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Concept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N4d0439c714c9428bbd6713e8f0cd40fa"
-      },
-      {
-        "@id": "_:N2e89b33c9bc04deab78d8ae4fe5f9a76"
-      },
-      {
-        "@id": "_:Nbe5f18c60753447d9a3924891fadb4d0"
-      },
-      {
-        "@id": "_:Nfb21043fb19f4a49b02a9638f5b06563"
-      },
-      {
-        "@id": "_:N8d3d69f0fd5b4b888d7ab9b2ca7a525f"
-      },
-      {
-        "@id": "_:Nea8e8df852024b37b0a03308d25f79ad"
-      },
-      {
-        "@id": "_:N080fdaa4688449a18cc79ac7a8d924d2"
-      },
-      {
-        "@id": "_:Nfdfa4a639d874f7bb2602cdd754760a4"
-      },
-      {
-        "@id": "_:N1bde9f3e4cad43eaa53c4eb737d87fa9"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4d0439c714c9428bbd6713e8f0cd40fa",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2e89b33c9bc04deab78d8ae4fe5f9a76",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbe5f18c60753447d9a3924891fadb4d0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfb21043fb19f4a49b02a9638f5b06563",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8d3d69f0fd5b4b888d7ab9b2ca7a525f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nea8e8df852024b37b0a03308d25f79ad",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N080fdaa4688449a18cc79ac7a8d924d2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfdfa4a639d874f7bb2602cdd754760a4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1bde9f3e4cad43eaa53c4eb737d87fa9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "procedure"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Company"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
-      },
-      {
-        "@id": "_:Nb03022c4f7024fbc8f6895e9687a170c"
-      },
-      {
-        "@id": "_:N5de6e81bde194a878eadb23477885e14"
-      },
-      {
-        "@id": "_:N931fffe4e2304a7fa434819ec53abaf7"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb03022c4f7024fbc8f6895e9687a170c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5de6e81bde194a878eadb23477885e14",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "_:N931fffe4e2304a7fa434819ec53abaf7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FakeClass",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FakeClass"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nf066f49797be41e4be12706c774bf276"
-      },
-      {
-        "@id": "_:Ncae21a1f5b3a46cf9352cc4fdbc71927"
-      },
-      {
-        "@id": "_:N50a349f1f8db4463b3dfb04a7a306357"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf066f49797be41e4be12706c774bf276",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncae21a1f5b3a46cf9352cc4fdbc71927",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "_:N50a349f1f8db4463b3dfb04a7a306357",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubSubClass2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Sub sub class 2"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "a b"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_marriage_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has marriage history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF"
-          }
-        ]
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DEAD"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "aliases"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "mixin_slot_I"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has birth event"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfSimpleType",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfSimpleType"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nb349f5addd29427384b5fbbd4b907a37"
-      },
-      {
-        "@id": "_:N3b8a39b87c6e4e77b17bfa7cc3d17877"
-      },
-      {
-        "@id": "_:N256bf2f60ba740389a09510819bb992b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb349f5addd29427384b5fbbd4b907a37",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nc1d55d3568c4414c8d37aeda51e252d6"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc1d55d3568c4414c8d37aeda51e252d6",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#string"
-          },
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N3b8a39b87c6e4e77b17bfa7cc3d17877",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
-      }
-    ]
-  },
-  {
-    "@id": "_:N256bf2f60ba740389a09510819bb992b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
       }
     ]
   },
@@ -6737,13 +2682,4068 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/type",
+    "@id": "https://w3id.org/linkml/tests/core/was_informed_by",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was informed by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N7a15ff3f3657425a807c0214ff87530b"
+      },
+      {
+        "@id": "_:N342ce1c5043748c09cd01deadcc861a8"
+      },
+      {
+        "@id": "_:N7f9bf6cc1c50409e9ca6a6ad3ce2ed34"
+      },
+      {
+        "@id": "_:Nc2e6728471c44c9f86f7a0a3fff6320b"
+      },
+      {
+        "@id": "_:Nc9de6f91f45647cfab25af3c95ff0b71"
+      },
+      {
+        "@id": "_:N10c101edc5534f25b68aa475a3a1959d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7a15ff3f3657425a807c0214ff87530b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N342ce1c5043748c09cd01deadcc861a8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7f9bf6cc1c50409e9ca6a6ad3ce2ed34",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc2e6728471c44c9f86f7a0a3fff6320b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc9de6f91f45647cfab25af3c95ff0b71",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N10c101edc5534f25b68aa475a3a1959d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "in code system"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfClasses",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfClasses"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N118ce3f2d55f49e6b7fc4979ac8f0c25"
+      },
+      {
+        "@id": "_:N8b1ddc97df18452dac5d8e2005b39aeb"
+      },
+      {
+        "@id": "_:Ne88d6b79550448c39dd2bb3d5082d0d3"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N118ce3f2d55f49e6b7fc4979ac8f0c25",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nbceefea4100f483d8b2f67973c6b4184"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbceefea4100f483d8b2f67973c6b4184",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N8b1ddc97df18452dac5d8e2005b39aeb",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne88d6b79550448c39dd2bb3d5082d0d3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/started_at_time",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "type"
+        "@value": "started at time"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "related to"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "a b"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/was_associated_with",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was associated with"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Place"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:Nce06ed2fb6364020a2ac24cb4f495bb4"
+      },
+      {
+        "@id": "_:N81c79291b4384f3cb63998cf3ded6de8"
+      },
+      {
+        "@id": "_:N62abbc65c49e410bb62c9a1f382aee3c"
+      },
+      {
+        "@id": "_:Ndfd68f79e2014a3286f4f02e17e7d245"
+      },
+      {
+        "@id": "_:N5d2052de02b14070a4e7aaba548ce54c"
+      },
+      {
+        "@id": "_:N8707e9f2c5c0472abc8c721013b57d9d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nce06ed2fb6364020a2ac24cb4f495bb4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N81c79291b4384f3cb63998cf3ded6de8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N62abbc65c49e410bb62c9a1f382aee3c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndfd68f79e2014a3286f4f02e17e7d245",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5d2052de02b14070a4e7aaba548ce54c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8707e9f2c5c0472abc8c721013b57d9d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CHILD_OF"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsStringIn",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EqualsStringIn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nea67029c26dc4db796ba1f672f045771"
+      },
+      {
+        "@id": "_:Na596dd65b7494da79f9213636b4d1671"
+      },
+      {
+        "@id": "_:N25a9e4f877594465aed06145d69ba9b5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nea67029c26dc4db796ba1f672f045771",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nfcd7ac99b3d24ba5b7ccd7cd992d6eb6"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfcd7ac99b3d24ba5b7ccd7cd992d6eb6",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#oneOf": [
+      {
+        "@list": [
+          {
+            "@value": "foo"
+          },
+          {
+            "@value": "bar"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Na596dd65b7494da79f9213636b4d1671",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "_:N25a9e4f877594465aed06145d69ba9b5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfSimpleType",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfSimpleType"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N43b09051d3ac48908ca4625321eb5c34"
+      },
+      {
+        "@id": "_:N1208067d315541ee8d1aeb612ee4be6b"
+      },
+      {
+        "@id": "_:N858dd552dd13411abd5c29cfe69fa86c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N43b09051d3ac48908ca4625321eb5c34",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N4d297ace21d347eda3abe713e0e9601a"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4d297ace21d347eda3abe713e0e9601a",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#string"
+          },
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N1208067d315541ee8d1aeb612ee4be6b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N858dd552dd13411abd5c29cfe69fa86c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/004",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "TRANSFER"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "acted on behalf of"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Dataset",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Dataset"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N8ab89254f2774ae2bf99dc6030fa5363"
+      },
+      {
+        "@id": "_:Nd789da3a031a43efa66ddd9212e07ac5"
+      },
+      {
+        "@id": "_:Nc539598998214c68ae0c93ca31d3df31"
+      },
+      {
+        "@id": "_:N878cda3da727437ebafe35c3d52ba59f"
+      },
+      {
+        "@id": "_:N578965d2b6864cf5b9f8e1ba2fb19675"
+      },
+      {
+        "@id": "_:N65383d8a12c5423190e44f5ef30fdcd2"
+      },
+      {
+        "@id": "_:N3ef852fb2a22448c84618e39e553bf03"
+      },
+      {
+        "@id": "_:Nf3c5c0a972a44725af424b4172920fb2"
+      },
+      {
+        "@id": "_:Naf5e2a5f5272408dbaa65369cad9109b"
+      },
+      {
+        "@id": "_:Nd576ec0eca6845b198db26a62a03f8cd"
+      },
+      {
+        "@id": "_:Na54e880eaec84170a43d33485610b91f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ]
+  },
+  {
+    "@id": "_:N8ab89254f2774ae2bf99dc6030fa5363",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd789da3a031a43efa66ddd9212e07ac5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc539598998214c68ae0c93ca31d3df31",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
+      }
+    ]
+  },
+  {
+    "@id": "_:N878cda3da727437ebafe35c3d52ba59f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
+      }
+    ]
+  },
+  {
+    "@id": "_:N578965d2b6864cf5b9f8e1ba2fb19675",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
+      }
+    ]
+  },
+  {
+    "@id": "_:N65383d8a12c5423190e44f5ef30fdcd2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3ef852fb2a22448c84618e39e553bf03",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf3c5c0a972a44725af424b4172920fb2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Naf5e2a5f5272408dbaa65369cad9109b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd576ec0eca6845b198db26a62a03f8cd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na54e880eaec84170a43d33485610b91f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DIRTY"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubSubClass2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Sub sub class 2"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DEAD"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "species name"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "_:N325c9a0984a9423b9063961ac712b6c2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N325c9a0984a9423b9063961ac712b6c2",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:Nc3b03c3ffb414173aefa7bddd7ab7ef2"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc3b03c3ffb414173aefa7bddd7ab7ef2",
+    "http://www.w3.org/2001/XMLSchema#pattern": [
+      {
+        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Relationship"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N6079c19073674842b3c849fe9c7b9e1c"
+      },
+      {
+        "@id": "_:Nf12ee49340fd4b3abf459969582d58ca"
+      },
+      {
+        "@id": "_:Nca9707720b08403ba022f61e1f57f0a0"
+      },
+      {
+        "@id": "_:N9695723f7f7a4f3785ddd598551e9533"
+      },
+      {
+        "@id": "_:N67751e6b76964ca3bcf9d8debf2c11ff"
+      },
+      {
+        "@id": "_:Nf5970dda13eb4f359b81d9507d4861ff"
+      },
+      {
+        "@id": "_:N61f0e544b033402783422f77dcaf9632"
+      },
+      {
+        "@id": "_:N47373daefabc4c9fac2140b968908eed"
+      },
+      {
+        "@id": "_:N065c1d8c6f6f4ff09a1e52aa5014237e"
+      },
+      {
+        "@id": "_:Ne65e3a1067cc457e886e864aaeec1971"
+      },
+      {
+        "@id": "_:N8b6951ad9f0b4395805ab389dd12bcfe"
+      },
+      {
+        "@id": "_:N4bbfa33feb1d43d892823cbacb05215e"
+      },
+      {
+        "@id": "_:N7aa0159953e247f2a4fc2ce53b3ecc34"
+      },
+      {
+        "@id": "_:N27445bf2f7c6490ab5887bca3585c0c3"
+      },
+      {
+        "@id": "_:N474538149a5648c7896198b43b3ddea5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6079c19073674842b3c849fe9c7b9e1c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf12ee49340fd4b3abf459969582d58ca",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nca9707720b08403ba022f61e1f57f0a0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9695723f7f7a4f3785ddd598551e9533",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N67751e6b76964ca3bcf9d8debf2c11ff",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf5970dda13eb4f359b81d9507d4861ff",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N61f0e544b033402783422f77dcaf9632",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N47373daefabc4c9fac2140b968908eed",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N065c1d8c6f6f4ff09a1e52aa5014237e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne65e3a1067cc457e886e864aaeec1971",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8b6951ad9f0b4395805ab389dd12bcfe",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4bbfa33feb1d43d892823cbacb05215e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7aa0159953e247f2a4fc2ce53b3ecc34",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N27445bf2f7c6490ab5887bca3585c0c3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N474538149a5648c7896198b43b3ddea5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "companies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute4"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/Activity",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "activity"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N898291ebe30445bab9b774f344b84cd6"
+      },
+      {
+        "@id": "_:Ne786b1dfbe3648559d2a88bf81a46733"
+      },
+      {
+        "@id": "_:Nd6cebde4884d490e977b0b004f592119"
+      },
+      {
+        "@id": "_:N1acf50d917ce4c82bd1f956120ab024e"
+      },
+      {
+        "@id": "_:N422ba316551a40d4a80e90f8e9bc2330"
+      },
+      {
+        "@id": "_:N28c77983cd1740e1a770c3627e7c173b"
+      },
+      {
+        "@id": "_:N97cda982dc164b5ebcfa1d621742e191"
+      },
+      {
+        "@id": "_:N9dda1d37f5f842ad9829b6bbdbdea93d"
+      },
+      {
+        "@id": "_:Na68e6388d5db4aaba015576b60421491"
+      },
+      {
+        "@id": "_:Nd5d1573a4663428fab460775a9c12820"
+      },
+      {
+        "@id": "_:N489f713b016c47a38acf93309dc387bd"
+      },
+      {
+        "@id": "_:Nc13f7a135ba6436790882ad90285026f"
+      },
+      {
+        "@id": "_:Nd41d7073c2774e12bf7077b97428b570"
+      },
+      {
+        "@id": "_:N9fdd83ee3da04a219689e70015998c4d"
+      },
+      {
+        "@id": "_:N3510ac923829478385d08a5acb68dc75"
+      },
+      {
+        "@id": "_:Naa40a0eeba6b48bb9f35d571efef6976"
+      },
+      {
+        "@id": "_:N5e0611834c6d419fb8d7901a369eaa4c"
+      },
+      {
+        "@id": "_:Nd5a785d1913a400e90ae123bbd0c47fb"
+      },
+      {
+        "@id": "_:Nfecaf58cd9da46f4b9018073d3ef3ade"
+      },
+      {
+        "@id": "_:N9403c749ba5f4beb9b11171391393182"
+      },
+      {
+        "@id": "_:Neb943177b06d41168e6390aab84066bf"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "a provence-generating activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#mappingRelation": [
+      {
+        "@id": "http://www.w3.org/ns/prov#Activity"
+      }
+    ]
+  },
+  {
+    "@id": "_:N898291ebe30445bab9b774f344b84cd6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne786b1dfbe3648559d2a88bf81a46733",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd6cebde4884d490e977b0b004f592119",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1acf50d917ce4c82bd1f956120ab024e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N422ba316551a40d4a80e90f8e9bc2330",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N28c77983cd1740e1a770c3627e7c173b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N97cda982dc164b5ebcfa1d621742e191",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9dda1d37f5f842ad9829b6bbdbdea93d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na68e6388d5db4aaba015576b60421491",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd5d1573a4663428fab460775a9c12820",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N489f713b016c47a38acf93309dc387bd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc13f7a135ba6436790882ad90285026f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd41d7073c2774e12bf7077b97428b570",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9fdd83ee3da04a219689e70015998c4d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3510ac923829478385d08a5acb68dc75",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:Naa40a0eeba6b48bb9f35d571efef6976",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5e0611834c6d419fb8d7901a369eaa4c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd5a785d1913a400e90ae123bbd0c47fb",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfecaf58cd9da46f4b9018073d3ef3ade",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9403c749ba5f4beb9b11171391393182",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:Neb943177b06d41168e6390aab84066bf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has medical history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 5
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "cordialness"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "employed at"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/002",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FIRE"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "married to"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "PARENT_OF"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Event"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N43cdf6757071490a995d7726ff8cad83"
+      },
+      {
+        "@id": "_:N03b660bbd8774807bdc74e2567e17f10"
+      },
+      {
+        "@id": "_:Ne31fff3ac18e4200884ea6432cdc7aef"
+      },
+      {
+        "@id": "_:N501eec1ceb6848d188fc93986ddc34b9"
+      },
+      {
+        "@id": "_:N1f434ac13f7c4098a01ca8a1cc32500a"
+      },
+      {
+        "@id": "_:Ne918e76da0eb45f38d4cba03fbf7bf48"
+      },
+      {
+        "@id": "_:N949c404956f348ceac89b39171291563"
+      },
+      {
+        "@id": "_:N711d578a13e2440485af3117b512a549"
+      },
+      {
+        "@id": "_:N1fe5fa282b5f4e4881e863c4a2f78abc"
+      },
+      {
+        "@id": "_:N22690e99754848859610d2f583d614ec"
+      },
+      {
+        "@id": "_:N322ea07260894c41bf9dea0493dcfd88"
+      },
+      {
+        "@id": "_:Nfcbe727a08f24ea6a9373694c358c2f4"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N43cdf6757071490a995d7726ff8cad83",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N03b660bbd8774807bdc74e2567e17f10",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne31fff3ac18e4200884ea6432cdc7aef",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N501eec1ceb6848d188fc93986ddc34b9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1f434ac13f7c4098a01ca8a1cc32500a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne918e76da0eb45f38d4cba03fbf7bf48",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
+      }
+    ]
+  },
+  {
+    "@id": "_:N949c404956f348ceac89b39171291563",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:N711d578a13e2440485af3117b512a549",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1fe5fa282b5f4e4881e863c4a2f78abc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:N22690e99754848859610d2f583d614ec",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N322ea07260894c41bf9dea0493dcfd88",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfcbe727a08f24ea6a9373694c358c2f4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/description",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "description"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/was_generated_by",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was generated by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "hateful"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "addresses"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Organization"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:N97a5c25aed0948038c0675e2a049bbf7"
+      },
+      {
+        "@id": "_:N927b925488de496a90f4d589f26f7504"
+      },
+      {
+        "@id": "_:N7b6e0d0389394abab77be49be68ab47c"
+      },
+      {
+        "@id": "_:Nd64f91ad762f4ddc97a67ae99b78278b"
+      },
+      {
+        "@id": "_:Nd1ec96b9ad264adb92bef986693474a2"
+      },
+      {
+        "@id": "_:Nec06a42e3afd4be784e4ea2d169e6fb2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 3
+      }
+    ]
+  },
+  {
+    "@id": "_:N97a5c25aed0948038c0675e2a049bbf7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N927b925488de496a90f4d589f26f7504",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7b6e0d0389394abab77be49be68ab47c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd64f91ad762f4ddc97a67ae99b78278b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd1ec96b9ad264adb92bef986693474a2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nec06a42e3afd4be784e4ea2d169e6fb2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "diagnosis"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Concept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N63131c77d446467a9d9134ab346341fe"
+      },
+      {
+        "@id": "_:Nd9177e6a21ca4125aa3bd6e3b7bf7a74"
+      },
+      {
+        "@id": "_:N4aa28c8dce8543f3aa84025083bbabf3"
+      },
+      {
+        "@id": "_:N496547ab873648a7a9e81c84eabed673"
+      },
+      {
+        "@id": "_:Nb0e9d41007ec4155acbd8b296d6ad732"
+      },
+      {
+        "@id": "_:N3e1d6665470547ce959d073e7394b631"
+      },
+      {
+        "@id": "_:N8e1222ebbdda41e991b4786efaca2a85"
+      },
+      {
+        "@id": "_:Nb2fa2d2b59e74e6fa13752e92c0806d2"
+      },
+      {
+        "@id": "_:N71313d5698404422affd633f0f34ff2f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N63131c77d446467a9d9134ab346341fe",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd9177e6a21ca4125aa3bd6e3b7bf7a74",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4aa28c8dce8543f3aa84025083bbabf3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N496547ab873648a7a9e81c84eabed673",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb0e9d41007ec4155acbd8b296d6ad732",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3e1d6665470547ce959d073e7394b631",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8e1222ebbdda41e991b4786efaca2a85",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb2fa2d2b59e74e6fa13752e92c0806d2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N71313d5698404422affd633f0f34ff2f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyObject"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Example of unconstrained class"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#exactMatch": [
+      {
+        "@id": "https://w3id.org/linkml/Any"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ceo"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/id",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "id"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent"
+          }
+        ]
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "subclass test"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
+      },
+      {
+        "@id": "_:Nf89b1af6d38243ea81395841a8615e8a"
+      },
+      {
+        "@id": "_:Nf6b93756bf2e492f8840d386e30ae5f7"
+      },
+      {
+        "@id": "_:N079c02019ea24e799d73551d7819f71a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf89b1af6d38243ea81395841a8615e8a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf6b93756bf2e492f8840d386e30ae5f7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
+      }
+    ]
+  },
+  {
+    "@id": "_:N079c02019ea24e799d73551d7819f71a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "HasAliases"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N11f20c49ca8e4f4b9ba24067707d86d3"
+      },
+      {
+        "@id": "_:N0064846414984679bd63fda08d66b409"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N11f20c49ca8e4f4b9ba24067707d86d3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0064846414984679bd63fda08d66b409",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Ontology"
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@value": "Kitchen Sink Schema"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+      {
+        "@id": "https://example.org/"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Kitchen Sink Schema\n\nThis schema does not do anything useful. It exists to test all features of linkml.\n\nThis particular text field exists to demonstrate markdown within a text field:\n\nLists:\n\n   * a\n   * b\n   * c\n\nAnd links, e.g to [Person](Person.md)"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "MedicalEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:Nf484f15144a9479c9b736c58cd450398"
+      },
+      {
+        "@id": "_:Nbae8dc78d9fb466e8e3da9a493aa5a89"
+      },
+      {
+        "@id": "_:N4d26f57c988b463f927cecfb9bed0c07"
+      },
+      {
+        "@id": "_:N83ac5cd37fbb47fcb74df1e7fa405eca"
+      },
+      {
+        "@id": "_:N77def8fa96ac4cd08e8f8ba30f2a316c"
+      },
+      {
+        "@id": "_:Nb134720512284ea0a669cd98361cf477"
+      },
+      {
+        "@id": "_:N152a82920fef44a18758eebfd45b7d18"
+      },
+      {
+        "@id": "_:N5b2d9b03d4bd4ce09931facf7e61272c"
+      },
+      {
+        "@id": "_:Ne959145a1b1b4494809a899888b5e14d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf484f15144a9479c9b736c58cd450398",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbae8dc78d9fb466e8e3da9a493aa5a89",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4d26f57c988b463f927cecfb9bed0c07",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:N83ac5cd37fbb47fcb74df1e7fa405eca",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N77def8fa96ac4cd08e8f8ba30f2a316c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb134720512284ea0a669cd98361cf477",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N152a82920fef44a18758eebfd45b7d18",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5b2d9b03d4bd4ce09931facf7e61272c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne959145a1b1b4494809a899888b5e14d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FamilialRelationship"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship"
+      },
+      {
+        "@id": "_:Naa199014400a456cb6ba0e3d986cc16b"
+      },
+      {
+        "@id": "_:Ne2256c5d4295474f8230b96ecba21faf"
+      },
+      {
+        "@id": "_:Neb071c4e32614f5ebde9ce98eebad0f8"
+      },
+      {
+        "@id": "_:Nb5cbe377e4484c3c9a209e8de94a96fd"
+      },
+      {
+        "@id": "_:Nf33956bfa0dd4de7aabf90c9a0ee2abf"
+      },
+      {
+        "@id": "_:Nec511b16aa7b4336913c573b5e52c06a"
+      },
+      {
+        "@id": "_:Nc4b22c7083e14c28adda0e9d901f8cfd"
+      },
+      {
+        "@id": "_:Nb23c348a614742859235b60dbb814ca0"
+      },
+      {
+        "@id": "_:N86937a65978e4ba6ad2d37b0810d526c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 5
+      }
+    ]
+  },
+  {
+    "@id": "_:Naa199014400a456cb6ba0e3d986cc16b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne2256c5d4295474f8230b96ecba21faf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Neb071c4e32614f5ebde9ce98eebad0f8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb5cbe377e4484c3c9a209e8de94a96fd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf33956bfa0dd4de7aabf90c9a0ee2abf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nec511b16aa7b4336913c573b5e52c06a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc4b22c7083e14c28adda0e9d901f8cfd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb23c348a614742859235b60dbb814ca0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N86937a65978e4ba6ad2d37b0810d526c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "class with spaces"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N39a989a52ddf491383856a209c96e1fe"
+      },
+      {
+        "@id": "_:N555447683bf24a8fbd3b2cc2bc21a8e8"
+      },
+      {
+        "@id": "_:N6e82acf633e04435a7c27c12f8492f45"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N39a989a52ddf491383856a209c96e1fe",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N555447683bf24a8fbd3b2cc2bc21a8e8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6e82acf633e04435a7c27c12f8492f45",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "aliases"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "slot with space 1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "BirthEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:N16fa82187e964504928f8cb3bc389623"
+      },
+      {
+        "@id": "_:N53ae0688187b4b9cbd613b092aeba766"
+      },
+      {
+        "@id": "_:N6a435d9acfbe499ab6ddde1ce0eac5c0"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N16fa82187e964504928f8cb3bc389623",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N53ae0688187b4b9cbd613b092aeba766",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6a435d9acfbe499ab6ddde1ce0eac5c0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "stomach count"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/street",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "street"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/ended_at_time",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ended at time"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "altitude"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "mixin_slot_I"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "indifferent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "SIBLING_OF"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfMix",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfMix"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nd20e6a8e61a2403c82aadb0c1f9adcd1"
+      },
+      {
+        "@id": "_:Nba1d28cf7d1d4b1b90897e721bdae689"
+      },
+      {
+        "@id": "_:Na9849cce907b49ffa78a68ceb53a63f5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd20e6a8e61a2403c82aadb0c1f9adcd1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N8e943af9e8f44781b82b409660b38cab"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8e943af9e8f44781b82b409660b38cab",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nba1d28cf7d1d4b1b90897e721bdae689",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na9849cce907b49ffa78a68ceb53a63f5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "MarriageEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation"
+      },
+      {
+        "@id": "_:Nd4362c4fe69a4904b00c4b88fc64f331"
+      },
+      {
+        "@id": "_:N882d2bc199294de1bc79c45fee529414"
+      },
+      {
+        "@id": "_:N199065af1fa14d60bc3aeb837b159b80"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd4362c4fe69a4904b00c4b88fc64f331",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N882d2bc199294de1bc79c45fee529414",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N199065af1fa14d60bc3aeb837b159b80",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+      }
+    ]
+  },
+  {
+    "@id": "http://www.w3.org/2001/XMLSchema#integer",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_marriage_history",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has marriage history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+          }
+        ]
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsString",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EqualsString"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nb1846e6c30184d65bf4cd49e78788c3b"
+      },
+      {
+        "@id": "_:Nd3d0246ccbf047988a16d6485bc9a62e"
+      },
+      {
+        "@id": "_:N9c15953700fd4de69c7168bbf03a43b2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb1846e6c30184d65bf4cd49e78788c3b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd3d0246ccbf047988a16d6485bc9a62e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9c15953700fd4de69c7168bbf03a43b2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#LIVING",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "LIVING"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "persons"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/001",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "HIRE"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "is current"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl.n3
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl.n3
@@ -51,10 +51,10 @@ ks:AnyOfClasses a owl:Class ;
             owl:allValuesFrom [ owl:unionOf ( ks:Person ks:Organization ) ] ;
             owl:onProperty ks:attribute2 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute2 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute2 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -74,48 +74,33 @@ ks:AnyOfEnums a owl:Class ;
 ks:AnyOfMix a owl:Class ;
     rdfs:label "AnyOfMix" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
+            owl:onProperty ks:attribute4 ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:attribute4 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute4 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfSimpleType a owl:Class ;
     rdfs:label "AnyOfSimpleType" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:attribute1 ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute1 ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:unionOf ( xsd:string xsd:integer ) ] ;
+            owl:onProperty ks:attribute1 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty ks:activities ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:AnyObject ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
-            owl:onProperty ks:persons ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:code_systems ],
         [ a owl:Restriction ;
@@ -125,11 +110,26 @@ ks:Dataset a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty ks:activities ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:activities ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:persons ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:AnyObject ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:persons ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:companies ] ;
@@ -139,13 +139,13 @@ ks:Dataset a owl:Class ;
 ks:EqualsString a owl:Class ;
     rdfs:label "EqualsString" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute5 ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:attribute5 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute5 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -156,20 +156,20 @@ ks:EqualsStringIn a owl:Class ;
                     owl:oneOf ( "foo" "bar" ) ] ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute6 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FakeClass a owl:Class ;
     rdfs:label "FakeClass" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
@@ -223,72 +223,72 @@ ks:tree_slot_C a owl:DatatypeProperty ;
 ks:MarriageEvent a owl:Class ;
     rdfs:label "MarriageEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:married_to ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:married_to ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Person ;
-            owl:onProperty ks:married_to ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:married_to ],
         ks:Event,
         ks:WithLocation ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:OtherCodes a owl:Class ;
-    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b> .
+    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b> .
 
-<https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b> a owl:Class ;
+<https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b> a owl:Class ;
     rdfs:label "a b" ;
     rdfs:subClassOf ks:OtherCodes .
 
 ks:Relationship a owl:Class ;
     rdfs:label "Relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CordialnessEnum ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:related_to ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:WithLocation a owl:Class ;
@@ -297,10 +297,10 @@ ks:WithLocation a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -336,32 +336,32 @@ bizcodes:004 a owl:Class ;
 ks:Address a owl:Class ;
     rdfs:label "Address" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:altitude ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:altitude ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:decimal ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:street ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:city ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:street ] ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:city ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:BirthEvent a owl:Class ;
@@ -381,13 +381,13 @@ ks:BirthEvent a owl:Class ;
 ks:ClassWithSpaces a owl:Class ;
     rdfs:label "class with spaces" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:slot_with_space_1 ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:slot_with_space_1 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -398,28 +398,28 @@ ks:Concept a owl:Class ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:in_code_system ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_code_system ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 <https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful> a owl:Class ;
@@ -446,23 +446,23 @@ ks:DiagnosisType a owl:Class ;
 ks:EmploymentEvent a owl:Class ;
     rdfs:label "EmploymentEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:employed_at ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:employed_at ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:employed_at ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
-            owl:onProperty ks:type ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 6 .
@@ -470,13 +470,22 @@ ks:EmploymentEvent a owl:Class ;
 ks:FamilialRelationship a owl:Class ;
     rdfs:label "FamilialRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:type ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:FamilialRelationshipType ;
@@ -485,17 +494,8 @@ ks:FamilialRelationship a owl:Class ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
+            owl:onProperty ks:related_to ],
         ks:Relationship ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 5 .
@@ -540,42 +540,39 @@ ks:KitchenStatus a owl:Class ;
 ks:MedicalEvent a owl:Class ;
     rdfs:label "MedicalEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ks:ProcedureConcept ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:procedure ],
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:diagnosis ],
+            owl:onProperty ks:procedure ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Place ;
+            owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:DiagnosisConcept ;
             owl:onProperty ks:diagnosis ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:procedure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:diagnosis ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -584,11 +581,14 @@ ks:Organization a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:definition """An organization.
 
@@ -611,10 +611,10 @@ ks:ProcedureConcept a owl:Class ;
 ks:SubclassTest a owl:Class ;
     rdfs:label "subclass test" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:ClassWithSpaces ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:ClassWithSpaces ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -692,35 +692,35 @@ ks:AnyObject a owl:Class ;
 ks:CodeSystem a owl:Class ;
     rdfs:label "CodeSystem" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Company a owl:Class ;
     rdfs:label "Company" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
-            owl:onProperty ks:ceo ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:ceo ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:ceo ],
         ks:Organization ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -728,10 +728,10 @@ ks:Company a owl:Class ;
 ks:HasAliases a owl:Class ;
     rdfs:label "HasAliases" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:aliases ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:aliases ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -853,41 +853,41 @@ ks:test_attribute a owl:DatatypeProperty ;
 ks:Event a owl:Class ;
     rdfs:label "Event" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:AnyObject ;
-            owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:boolean ;
             owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ] ;
+            owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:AnyObject ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FamilialRelationshipType a owl:Class ;
@@ -899,52 +899,52 @@ ks:FamilialRelationshipType a owl:Class ;
 ks:Place a owl:Class ;
     rdfs:label "Place" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 <https://w3id.org/linkml/tests/core/Agent> a owl:Class ;
     rdfs:label "agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
@@ -986,68 +986,68 @@ ks:related_to a owl:DatatypeProperty ;
 <https://w3id.org/linkml/tests/core/Activity> a owl:Class ;
     rdfs:label "activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ] ;
     skos:definition "a provence-generating activity" ;
     skos:inScheme <https://w3id.org/linkml/tests/core> ;
     skos:mappingRelation prov:Activity .
@@ -1064,69 +1064,49 @@ ks:Person a owl:Class ;
     rdfs:seeAlso schema1:Person,
         <https://en.wikipedia.org/wiki/Person> ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:MedicalEvent ;
+            owl:onProperty ks:has_medical_history ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:stomach_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationship ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 1 ] ) ] [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:maxInclusive 1 ] ) ] ) ] ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_medical_history ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:EmploymentEvent ;
             owl:onProperty ks:has_employment_history ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1136,34 +1116,54 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
             owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationship ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:has_medical_history ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Address ;
             owl:onProperty ks:addresses ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:BirthEvent ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
             owl:onProperty ks:species_name ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:BirthEvent ;
             owl:onProperty ks:has_birth_event ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:LifeStatusEnum ;
-            owl:onProperty ks:is_living ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_familial_relationships ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Address ;
-            owl:onProperty ks:addresses ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:species_name ],
+            owl:onProperty ks:addresses ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:MedicalEvent ;
-            owl:onProperty ks:has_medical_history ],
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 1 ] ) ] [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:maxInclusive 1 ] ) ] ) ] ;
+            owl:onProperty ks:stomach_count ],
         ks:HasAliases ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl.ttl
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl.ttl
@@ -51,23 +51,23 @@ ks:AnyOfClasses a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute2 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( ks:Person ks:Organization ) ] ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute2 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ owl:unionOf ( ks:Person ks:Organization ) ] ;
             owl:onProperty ks:attribute2 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfEnums a owl:Class ;
     rdfs:label "AnyOfEnums" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:attribute3 ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:DiagnosisType ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:attribute3 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute3 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -77,10 +77,10 @@ ks:AnyOfMix a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute4 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -102,19 +102,10 @@ ks:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:persons ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
-            owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty ks:activities ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:companies ],
@@ -123,16 +114,25 @@ ks:Dataset a owl:Class ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:activities ],
+            owl:onProperty ks:code_systems ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:persons ],
+            owl:allValuesFrom ks:CodeSystem ;
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty ks:activities ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:companies ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:persons ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ] ;
+            owl:onProperty ks:activities ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 1 .
 
@@ -152,40 +152,40 @@ ks:EqualsString a owl:Class ;
 ks:EqualsStringIn a owl:Class ;
     rdfs:label "EqualsStringIn" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:attribute6 ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:oneOf ( "foo" "bar" ) ] ;
-            owl:onProperty ks:attribute6 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute6 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FakeClass a owl:Class ;
     rdfs:label "FakeClass" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:test_attribute ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:test_attribute ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:test_attribute ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Friend a owl:Class ;
     rdfs:label "Friend" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -223,10 +223,10 @@ ks:tree_slot_C a owl:DatatypeProperty ;
 ks:MarriageEvent a owl:Class ;
     rdfs:label "MarriageEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:married_to ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:married_to ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -236,71 +236,71 @@ ks:MarriageEvent a owl:Class ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:OtherCodes a owl:Class ;
-    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b> .
+    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b> .
 
-<https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b> a owl:Class ;
+<https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b> a owl:Class ;
     rdfs:label "a b" ;
     rdfs:subClassOf ks:OtherCodes .
 
 ks:Relationship a owl:Class ;
     rdfs:label "Relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CordialnessEnum ;
-            owl:onProperty ks:cordialness ] ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:WithLocation a owl:Class ;
     rdfs:label "WithLocation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -336,44 +336,44 @@ bizcodes:004 a owl:Class ;
 ks:Address a owl:Class ;
     rdfs:label "Address" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:decimal ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:altitude ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:city ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:city ] ;
+            owl:onProperty ks:street ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:BirthEvent a owl:Class ;
     rdfs:label "BirthEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -381,44 +381,44 @@ ks:BirthEvent a owl:Class ;
 ks:ClassWithSpaces a owl:Class ;
     rdfs:label "class with spaces" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Concept a owl:Class ;
     rdfs:label "Concept" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_code_system ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:in_code_system ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_code_system ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -447,19 +447,19 @@ ks:EmploymentEvent a owl:Class ;
     rdfs:label "EmploymentEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
+            owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
             owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:type ],
@@ -470,32 +470,32 @@ ks:EmploymentEvent a owl:Class ;
 ks:FamilialRelationship a owl:Class ;
     rdfs:label "FamilialRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationshipType ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Person ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:related_to ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationshipType ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty ks:related_to ],
         ks:Relationship ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 5 .
@@ -541,31 +541,31 @@ ks:MedicalEvent a owl:Class ;
     rdfs:label "MedicalEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
-            owl:onProperty ks:in_location ],
+            owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:procedure ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:diagnosis ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:ProcedureConcept ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:DiagnosisConcept ;
             owl:onProperty ks:diagnosis ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:procedure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:procedure ],
+            owl:allValuesFrom ks:Place ;
+            owl:onProperty ks:in_location ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -575,9 +575,6 @@ ks:Organization a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
@@ -585,10 +582,13 @@ ks:Organization a owl:Class ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:definition """An organization.
 
@@ -611,13 +611,13 @@ ks:ProcedureConcept a owl:Class ;
 ks:SubclassTest a owl:Class ;
     rdfs:label "subclass test" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:slot_with_space_2 ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:ClassWithSpaces ;
+            owl:onProperty ks:slot_with_space_2 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_2 ],
         ks:ClassWithSpaces ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -692,20 +692,20 @@ ks:AnyObject a owl:Class ;
 ks:CodeSystem a owl:Class ;
     rdfs:label "CodeSystem" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
@@ -714,10 +714,10 @@ ks:CodeSystem a owl:Class ;
 ks:Company a owl:Class ;
     rdfs:label "Company" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -856,38 +856,38 @@ ks:Event a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:boolean ;
             owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
+            owl:onProperty ks:is_current ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FamilialRelationshipType a owl:Class ;
@@ -899,31 +899,43 @@ ks:FamilialRelationshipType a owl:Class ;
 ks:Place a owl:Class ;
     rdfs:label "Place" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         ks:HasAliases ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 <https://w3id.org/linkml/tests/core/Agent> a owl:Class ;
     rdfs:label "agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
@@ -935,19 +947,7 @@ ks:Place a owl:Class ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:definition "a provence-generating agent" ;
     skos:exactMatch prov:Agent ;
     skos:inScheme <https://w3id.org/linkml/tests/core> .
@@ -986,68 +986,68 @@ ks:related_to a owl:DatatypeProperty ;
 <https://w3id.org/linkml/tests/core/Activity> a owl:Class ;
     rdfs:label "activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
     skos:definition "a provence-generating activity" ;
     skos:inScheme <https://w3id.org/linkml/tests/core> ;
     skos:mappingRelation prov:Activity .
@@ -1064,51 +1064,86 @@ ks:Person a owl:Class ;
     rdfs:seeAlso schema1:Person,
         <https://en.wikipedia.org/wiki/Person> ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:addresses ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationship ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:EmploymentEvent ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:onDatatype xsd:string ;
+                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
             owl:onProperty ks:species_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:is_living ],
+            owl:onProperty ks:species_name ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_familial_relationships ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:has_birth_event ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:BirthEvent ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:MedicalEvent ;
-            owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:stomach_count ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:stomach_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:BirthEvent ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationship ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Address ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:species_name ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
@@ -1120,50 +1155,15 @@ ks:Person a owl:Class ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:age_in_years ],
+            owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:addresses ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:EmploymentEvent ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Address ;
-            owl:onProperty ks:addresses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
-            owl:onProperty ks:age_in_years ],
+            owl:allValuesFrom ks:MedicalEvent ;
+            owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_living ],
         ks:HasAliases ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.jsonld
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.jsonld
@@ -1,1217 +1,5 @@
 [
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Event"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nf4d0db6a7395498a8f98cbbf1ad14cf6"
-      },
-      {
-        "@id": "_:N5fe60ef5722349eab1bfd5396bfd73d0"
-      },
-      {
-        "@id": "_:Nda236dc85909458b95c2d63d75e89204"
-      },
-      {
-        "@id": "_:Nfe48cc168e894668ba2edeec404433d1"
-      },
-      {
-        "@id": "_:N90070438a60c4a40967595e7b106e1ec"
-      },
-      {
-        "@id": "_:N09eb9ff9ea6a4c3ea1322642f2b9ebb6"
-      },
-      {
-        "@id": "_:N46ac0b26e2a44d46a3e7fede5fe93dc8"
-      },
-      {
-        "@id": "_:Ne2de7df6ba824319bf39d631b2a871cc"
-      },
-      {
-        "@id": "_:N929a877f3ac44f00b4fa302aa5385985"
-      },
-      {
-        "@id": "_:N422869f3b20d42cbab32e682595ed6d3"
-      },
-      {
-        "@id": "_:N186dfad18f3c46468adb940c804376f9"
-      },
-      {
-        "@id": "_:N34051af9fe6546dc80fcdc7d57679dca"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf4d0db6a7395498a8f98cbbf1ad14cf6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5fe60ef5722349eab1bfd5396bfd73d0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nda236dc85909458b95c2d63d75e89204",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfe48cc168e894668ba2edeec404433d1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
-      }
-    ]
-  },
-  {
-    "@id": "_:N90070438a60c4a40967595e7b106e1ec",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
-      }
-    ]
-  },
-  {
-    "@id": "_:N09eb9ff9ea6a4c3ea1322642f2b9ebb6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
-      }
-    ]
-  },
-  {
-    "@id": "_:N46ac0b26e2a44d46a3e7fede5fe93dc8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne2de7df6ba824319bf39d631b2a871cc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N929a877f3ac44f00b4fa302aa5385985",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N422869f3b20d42cbab32e682595ed6d3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N186dfad18f3c46468adb940c804376f9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N34051af9fe6546dc80fcdc7d57679dca",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/004",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "TRANSFER"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_A"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Friend",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Friend"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Ne3e600599e3a414aa06c6c8c2521ee21"
-      },
-      {
-        "@id": "_:N42015418f9c74337b373348e170b7195"
-      },
-      {
-        "@id": "_:N91671987740944f6912c1df52afdd54e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne3e600599e3a414aa06c6c8c2521ee21",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N42015418f9c74337b373348e170b7195",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N91671987740944f6912c1df52afdd54e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/TubSubClass1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tub sub class 1"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Same depth as Sub sub class 1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/id",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "id"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "heartfelt"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfMix",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfMix"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N41cf8b1fea1e43dd846c51b6b876bdc6"
-      },
-      {
-        "@id": "_:Nab636b54429c4b98a2a6158785353dcc"
-      },
-      {
-        "@id": "_:N88d0d0e5fb714130a62c548a92cb42d4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N41cf8b1fea1e43dd846c51b6b876bdc6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nba80d44a0efd4b8db38f119099c733a1"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nba80d44a0efd4b8db38f119099c733a1",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nab636b54429c4b98a2a6158785353dcc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "_:N88d0d0e5fb714130a62c548a92cb42d4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Address"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Ne7f14420c6dd489986bdbde5aea441d9"
-      },
-      {
-        "@id": "_:N5bb39be4d7b74ad19ddf4c92f8c4863e"
-      },
-      {
-        "@id": "_:Nc72aa51d0fb54989be9f1a4d8a0eb759"
-      },
-      {
-        "@id": "_:N754fb968db144ed4b16e966c8ef6865d"
-      },
-      {
-        "@id": "_:N21b39ca99dad4857937ec744ba28f2f2"
-      },
-      {
-        "@id": "_:Nf9c6b809261b476ba3943ab0c4f084a6"
-      },
-      {
-        "@id": "_:N48be314124bc4d70a3a8b4b65c49ca05"
-      },
-      {
-        "@id": "_:Ndc8daee5d0fe4933883c1ea1b7ed8f70"
-      },
-      {
-        "@id": "_:Na3d66117172641a89b7b25774ab7c610"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne7f14420c6dd489986bdbde5aea441d9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5bb39be4d7b74ad19ddf4c92f8c4863e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc72aa51d0fb54989be9f1a4d8a0eb759",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N754fb968db144ed4b16e966c8ef6865d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:N21b39ca99dad4857937ec744ba28f2f2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf9c6b809261b476ba3943ab0c4f084a6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:N48be314124bc4d70a3a8b4b65c49ca05",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndc8daee5d0fe4933883c1ea1b7ed8f70",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na3d66117172641a89b7b25774ab7c610",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "employed at"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
-          }
-        ]
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfEnums",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfEnums"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Ndfd79f377fa84dd2ac46ac41a2806c84"
-      },
-      {
-        "@id": "_:Nf234699185194d798504f138d3b58527"
-      },
-      {
-        "@id": "_:N56a3c63fda3e4f5ea445ca4295379df0"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndfd79f377fa84dd2ac46ac41a2806c84",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N985073485bb945449e621cd1ff4ae585"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "_:N985073485bb945449e621cd1ff4ae585",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf234699185194d798504f138d3b58527",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "_:N56a3c63fda3e4f5ea445ca4295379df0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "cordialness"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/description",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "description"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/003",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "PROMOTION"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/life_status",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "life_status"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Dataset",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Dataset"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Ne889228209e84f52a4580e8c0ed2032b"
-      },
-      {
-        "@id": "_:N4375e09678a74148a1432920b54a3c6a"
-      },
-      {
-        "@id": "_:Nf581faee7cb245cb930de1739b0da654"
-      },
-      {
-        "@id": "_:N4d84ddec8304427fb635609880f9e562"
-      },
-      {
-        "@id": "_:N9c10342f358148fbb7a09f4ea915f6ca"
-      },
-      {
-        "@id": "_:N16c11ee02c744326a640d5f6d21fd44d"
-      },
-      {
-        "@id": "_:N9309d67fa44c442b89c11cbcd706eba6"
-      },
-      {
-        "@id": "_:N72a3938044f443e39cfb9343f37d5c20"
-      },
-      {
-        "@id": "_:N0207d97376d84b1e911ec019a452c9e5"
-      },
-      {
-        "@id": "_:N6eb24440e2f74e9c99488c73fe2eed8a"
-      },
-      {
-        "@id": "_:Nd64d55f057a643b397ff9909cc7c766f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne889228209e84f52a4580e8c0ed2032b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4375e09678a74148a1432920b54a3c6a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf581faee7cb245cb930de1739b0da654",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4d84ddec8304427fb635609880f9e562",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9c10342f358148fbb7a09f4ea915f6ca",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
-      }
-    ]
-  },
-  {
-    "@id": "_:N16c11ee02c744326a640d5f6d21fd44d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9309d67fa44c442b89c11cbcd706eba6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N72a3938044f443e39cfb9343f37d5c20",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0207d97376d84b1e911ec019a452c9e5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6eb24440e2f74e9c99488c73fe2eed8a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd64d55f057a643b397ff9909cc7c766f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "code systems"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "hateful"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ]
-  },
-  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
@@ -1219,54 +7,6 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@value": "attribute6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent"
-          }
-        ]
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "persons"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1293,1111 +33,6 @@
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "indifferent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_C",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_C"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship"
-      },
-      {
-        "@id": "_:Na1c1ce3274b54fa18100af2a10398ce8"
-      },
-      {
-        "@id": "_:N78f5d624e36641cd9698e08c78986b91"
-      },
-      {
-        "@id": "_:N3d14fd787ea24c9baaccb4caee6fd209"
-      },
-      {
-        "@id": "_:N811e5414e17e465d9560c8dda57d944c"
-      },
-      {
-        "@id": "_:Nd61df09e97c84efa96da90041e76117e"
-      },
-      {
-        "@id": "_:N245b88ebd1f44ca3ac89277ba7216f64"
-      },
-      {
-        "@id": "_:N2250d022e9c446cd855e11318e5fd009"
-      },
-      {
-        "@id": "_:N5fb4597c40134850b5308a1ee1ca5f2d"
-      },
-      {
-        "@id": "_:Ncb1325d190db45de826ffbc7ed24db18"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 5
-      }
-    ]
-  },
-  {
-    "@id": "_:Na1c1ce3274b54fa18100af2a10398ce8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N78f5d624e36641cd9698e08c78986b91",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3d14fd787ea24c9baaccb4caee6fd209",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N811e5414e17e465d9560c8dda57d944c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd61df09e97c84efa96da90041e76117e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N245b88ebd1f44ca3ac89277ba7216f64",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2250d022e9c446cd855e11318e5fd009",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5fb4597c40134850b5308a1ee1ca5f2d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncb1325d190db45de826ffbc7ed24db18",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Ne20eb4787a114d8eade87dbd296f5c8b"
-      },
-      {
-        "@id": "_:Nd7f6ef8ccd4c4040abaa174c744e5a53"
-      },
-      {
-        "@id": "_:Nf17be17bb1ef4aa3848a1ff960176bda"
-      },
-      {
-        "@id": "_:N95add71cb6c94f80b6dde1471783e671"
-      },
-      {
-        "@id": "_:N7f02ad322ae54455a5a99731e217ff20"
-      },
-      {
-        "@id": "_:N48f6baa6f29a4448ac16fe0abc8796b1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne20eb4787a114d8eade87dbd296f5c8b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd7f6ef8ccd4c4040abaa174c744e5a53",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf17be17bb1ef4aa3848a1ff960176bda",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N95add71cb6c94f80b6dde1471783e671",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7f02ad322ae54455a5a99731e217ff20",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N48f6baa6f29a4448ac16fe0abc8796b1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "http://www.w3.org/2001/XMLSchema#integer",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "MarriageEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation"
-      },
-      {
-        "@id": "_:N4fa03833895c4cf687e7ee87906d2888"
-      },
-      {
-        "@id": "_:Nb6cc4bdb6f4c44fb92e43c15a5012bc6"
-      },
-      {
-        "@id": "_:Nbec06f1035ff460da257f3ce07ef4e24"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4fa03833895c4cf687e7ee87906d2888",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb6cc4bdb6f4c44fb92e43c15a5012bc6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbec06f1035ff460da257f3ce07ef4e24",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "HasAliases"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Ndd11b4f68ef348829dfd2501301f4b3d"
-      },
-      {
-        "@id": "_:N5bf7ad5b5078497882cd752e7601002e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndd11b4f68ef348829dfd2501301f4b3d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5bf7ad5b5078497882cd752e7601002e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "species name"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "_:N08e15dff01a14dfbb1a445416cb542ca"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N08e15dff01a14dfbb1a445416cb542ca",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Ndfaf675a0cb642d280d75fcd1eecbaef"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndfaf675a0cb642d280d75fcd1eecbaef",
-    "http://www.w3.org/2001/XMLSchema#pattern": [
-      {
-        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "slot with space 1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/Agent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "agent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nf75933789818431383d23a1c3d5739f4"
-      },
-      {
-        "@id": "_:N81445ebc6b964b9387d3853277e676eb"
-      },
-      {
-        "@id": "_:N7265d6ac4ade41c8960db321d84805fe"
-      },
-      {
-        "@id": "_:N6a1a18be2ae34fcf9df2f10a0f82a652"
-      },
-      {
-        "@id": "_:N5d759723537b4496ade3ef35cf7ad796"
-      },
-      {
-        "@id": "_:Na4baf6d80e094f96953449290803473a"
-      },
-      {
-        "@id": "_:Nb4b63f7159434caabf98cd2b8821be24"
-      },
-      {
-        "@id": "_:N6696221e368d4d00ab9151da46a7c831"
-      },
-      {
-        "@id": "_:Nacd3583463ca4dc1a584f1a9c2d5f97d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "a provence-generating agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#exactMatch": [
-      {
-        "@id": "http://www.w3.org/ns/prov#Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf75933789818431383d23a1c3d5739f4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
-      }
-    ]
-  },
-  {
-    "@id": "_:N81445ebc6b964b9387d3853277e676eb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7265d6ac4ade41c8960db321d84805fe",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6a1a18be2ae34fcf9df2f10a0f82a652",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5d759723537b4496ade3ef35cf7ad796",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na4baf6d80e094f96953449290803473a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb4b63f7159434caabf98cd2b8821be24",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6696221e368d4d00ab9151da46a7c831",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nacd3583463ca4dc1a584f1a9c2d5f97d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "subclass test"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
-      },
-      {
-        "@id": "_:Ne0d0030c75f6439d8f06a07de5e05b1f"
-      },
-      {
-        "@id": "_:N5cc9f45463a241ab8097fb87fa058b26"
-      },
-      {
-        "@id": "_:N38857c83b79f4dd987f2f87dbb75af52"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne0d0030c75f6439d8f06a07de5e05b1f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5cc9f45463a241ab8097fb87fa058b26",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "_:N38857c83b79f4dd987f2f87dbb75af52",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/started_at_time",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "started at time"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "in code system"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Organization"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
-      },
-      {
-        "@id": "_:N2d7bca8f9fa54338a2ec436e2cabf728"
-      },
-      {
-        "@id": "_:N66393293522846eaaa6678046848090c"
-      },
-      {
-        "@id": "_:N85a063f1457242599c85f9758f6251f2"
-      },
-      {
-        "@id": "_:Nbedf7b036d0c40ceb3e54c2634a4e578"
-      },
-      {
-        "@id": "_:Nf61fa9468a2b43babfbd22dd346bd157"
-      },
-      {
-        "@id": "_:N99f475bb1e4d4133964381578e2ce68f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 3
-      }
-    ]
-  },
-  {
-    "@id": "_:N2d7bca8f9fa54338a2ec436e2cabf728",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N66393293522846eaaa6678046848090c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N85a063f1457242599c85f9758f6251f2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbedf7b036d0c40ceb3e54c2634a4e578",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf61fa9468a2b43babfbd22dd346bd157",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N99f475bb1e4d4133964381578e2ce68f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has familial relationships"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "test_attribute"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -2434,18 +69,436 @@
     ]
   },
   {
-    "@id": "https://example.org/bizcodes/001",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_A"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/name",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "name"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 2
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "HIRE"
+        "@value": "WithLocation"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nb9b6deebd6624a4cbd35264fda95c92a"
+      },
+      {
+        "@id": "_:Ne65890b8c6e249409eb704fd5a8a25cc"
+      },
+      {
+        "@id": "_:Nc27c5fe5f621486cab66747588770fa0"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb9b6deebd6624a4cbd35264fda95c92a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne65890b8c6e249409eb704fd5a8a25cc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc27c5fe5f621486cab66747588770fa0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/003",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "PROMOTION"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute3"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF"
+          }
+        ]
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:Nc27d9e2de7f64c8cb28067ad6f8a6370"
+      },
+      {
+        "@id": "_:Nbc43f0b835f54d8c96a056baa97639d6"
+      },
+      {
+        "@id": "_:Nd5a332ccdb3347af8e3293e7219cbd37"
+      },
+      {
+        "@id": "_:N6120895b5f7b42dc86ce457d771ff9f6"
+      },
+      {
+        "@id": "_:N74c35e8ad4724c549ef281b6973cac12"
+      },
+      {
+        "@id": "_:N2e9aa71be05a44679a1de5a602667bc3"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 6
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc27d9e2de7f64c8cb28067ad6f8a6370",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbc43f0b835f54d8c96a056baa97639d6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd5a332ccdb3347af8e3293e7219cbd37",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6120895b5f7b42dc86ce457d771ff9f6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Ne38f91272906468499de7a3dbdb05cdc"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne38f91272906468499de7a3dbdb05cdc",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N74c35e8ad4724c549ef281b6973cac12",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2e9aa71be05a44679a1de5a602667bc3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has birth event"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "is_living"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CLEAN"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/TubSubClass1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tub sub class 1"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Same depth as Sub sub class 1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -2466,6 +519,38 @@
     ]
   },
   {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#UNKNOWN",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "UNKNOWN"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "heartfelt"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
@@ -2482,45 +567,18 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "related to"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "PARENT_OF"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "slot with space 2"
+        "@value": "has familial relationships"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2556,538 +614,23 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/life_status",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "DiagnosisConcept"
+        "@value": "life_status"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#closeMatch": [
-      {
-        "@id": "https://w3id.org/biolink/Disease"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/was_generated_by",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "was generated by"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "acted on behalf of"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/Activity",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "activity"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N4fcdeb54c5c14563b4bb94156560c909"
-      },
-      {
-        "@id": "_:N25be88efff284c11b7c8db51e1e66857"
-      },
-      {
-        "@id": "_:N6ab298d6fc174fd985da062f1d2d5196"
-      },
-      {
-        "@id": "_:N608db1b824154f1b8f5050ef40b8221e"
-      },
-      {
-        "@id": "_:N4d437c70cf9a4ff08932aa40099f8600"
-      },
-      {
-        "@id": "_:N14ea0516594b4d1ca9c1d86d20a86288"
-      },
-      {
-        "@id": "_:N8c09ad02c0234c1cab6c22ed1d0c0059"
-      },
-      {
-        "@id": "_:N7815628a6a354a17a434197475bc7ea2"
-      },
-      {
-        "@id": "_:N7a15bd32105b46769e340a400996820f"
-      },
-      {
-        "@id": "_:Nb46a6510c8694927afd8c1ce8ae8e709"
-      },
-      {
-        "@id": "_:N0b71bdfebb83489db76ee712583ffa43"
-      },
-      {
-        "@id": "_:Na12ba4c275374006999f4b6be917c531"
-      },
-      {
-        "@id": "_:N7a58e84e1e4446d3af0cd9c41618cb29"
-      },
-      {
-        "@id": "_:N1edcf61918e544bbad1c85707a77c056"
-      },
-      {
-        "@id": "_:Nc4947a1a2a5b41a0a142f665fb7c9731"
-      },
-      {
-        "@id": "_:Na2f8dc4564734f2599c6e7a2cb471109"
-      },
-      {
-        "@id": "_:N99368d160db04955bd7bbd260ce55867"
-      },
-      {
-        "@id": "_:Ne87f48fa895e46ee96f22e51a7da1d9f"
-      },
-      {
-        "@id": "_:N224ea6b2e3f340cf8ca8d5eddd7ce0e0"
-      },
-      {
-        "@id": "_:N052e682a9c6043b78d5ea7fb1e51b330"
-      },
-      {
-        "@id": "_:Nbd4117fe187d4a33a49b32de3afeb2e1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "a provence-generating activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#mappingRelation": [
-      {
-        "@id": "http://www.w3.org/ns/prov#Activity"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4fcdeb54c5c14563b4bb94156560c909",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:N25be88efff284c11b7c8db51e1e66857",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6ab298d6fc174fd985da062f1d2d5196",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:N608db1b824154f1b8f5050ef40b8221e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4d437c70cf9a4ff08932aa40099f8600",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N14ea0516594b4d1ca9c1d86d20a86288",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8c09ad02c0234c1cab6c22ed1d0c0059",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7815628a6a354a17a434197475bc7ea2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7a15bd32105b46769e340a400996820f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb46a6510c8694927afd8c1ce8ae8e709",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0b71bdfebb83489db76ee712583ffa43",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na12ba4c275374006999f4b6be917c531",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7a58e84e1e4446d3af0cd9c41618cb29",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1edcf61918e544bbad1c85707a77c056",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc4947a1a2a5b41a0a142f665fb7c9731",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na2f8dc4564734f2599c6e7a2cb471109",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N99368d160db04955bd7bbd260ce55867",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne87f48fa895e46ee96f22e51a7da1d9f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N224ea6b2e3f340cf8ca8d5eddd7ce0e0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:N052e682a9c6043b78d5ea7fb1e51b330",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbd4117fe187d4a33a49b32de3afeb2e1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "CHILD_OF"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
       }
     ]
   },
@@ -3098,12 +641,12 @@
     ],
     "http://www.w3.org/2002/07/owl#equivalentClass": [
       {
-        "@id": "_:N75eee72100be40e5b98fecf12d32cf5b"
+        "@id": "_:N9ccd36a0f7dc45e9a78451716b331a8f"
       }
     ]
   },
   {
-    "@id": "_:N75eee72100be40e5b98fecf12d32cf5b",
+    "@id": "_:N9ccd36a0f7dc45e9a78451716b331a8f",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3116,14 +659,14 @@
       {
         "@list": [
           {
-            "@id": "_:N91d6a41ae25c4db8a50b213d4c092d83"
+            "@id": "_:Nb04d7f3ef56c4513bd590b7c6d02ef7e"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N91d6a41ae25c4db8a50b213d4c092d83",
+    "@id": "_:Nb04d7f3ef56c4513bd590b7c6d02ef7e",
     "http://www.w3.org/2001/XMLSchema#pattern": [
       {
         "@value": "^[\\\\+\\\\d+ +][\\\\d\\\\- ]+$"
@@ -3152,6 +695,27 @@
     ]
   },
   {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_B"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -3174,91 +738,91 @@
         "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
       },
       {
-        "@id": "_:Nec9a579ea6ce48d39d1830fbea63c73f"
+        "@id": "_:N87fac4e68c7e45c6b8bebe9acac0ca23"
       },
       {
-        "@id": "_:N3baae1d14ef542aab50e0da22ec1a62b"
+        "@id": "_:N71218184e1ca4556a39c88e85f31360a"
       },
       {
-        "@id": "_:N9034478d7059410e95d2d8c179ac88dd"
+        "@id": "_:N7c46fa471b39424c881e718e0cfe27d6"
       },
       {
-        "@id": "_:N38deb3644d3b4356a989efc116b6b987"
+        "@id": "_:N817dcb2abf204d8593e77099a5a420e2"
       },
       {
-        "@id": "_:N2b6dd06293f948fb8d5482bc922c017d"
+        "@id": "_:N2ab1989a04264f88a1e84c73942d82e2"
       },
       {
-        "@id": "_:N8facb47c2e2a4738a2b1b18fb514f465"
+        "@id": "_:N8f74ea72ec104a85acd125ee9b09942f"
       },
       {
-        "@id": "_:N625d5fa2b54749138a92224e3a0bcd7c"
+        "@id": "_:Nf1127e5b19114f4e99855f13b7d5ed93"
       },
       {
-        "@id": "_:Nd96afbffa77147f49d0e31caceb5d6a0"
+        "@id": "_:Nc1087fcc1d464d98894e5121de94eed7"
       },
       {
-        "@id": "_:Nac73eb21fa88477b8fceff7f53a38521"
+        "@id": "_:Nf2aa561daca244a3aeb0d0eff86b4e3b"
       },
       {
-        "@id": "_:Ne6c47b4d69004bb28121817841fb8299"
+        "@id": "_:Ncf50bbc81cd24fc2b4fb03e487b15373"
       },
       {
-        "@id": "_:N3e452e60da174f359349dfbc16590aa5"
+        "@id": "_:N0d5e270e16fe4e9e86dce864deacae15"
       },
       {
-        "@id": "_:Nadd85f4544d4432894e22255372a6d69"
+        "@id": "_:N1812fbab23ba41e39b3213351b158d0f"
       },
       {
-        "@id": "_:N2b264b9bb0584b4b8e7d393f58c3404d"
+        "@id": "_:Nb49e527ec64946f4beb95e510e8657cd"
       },
       {
-        "@id": "_:N8564abd4caa04365af6625b7aad2eb46"
+        "@id": "_:Ne12a4c1e95b3450ba4c7aa6d9de3b611"
       },
       {
-        "@id": "_:N0c0123e4a3774977b71481db8a07d270"
+        "@id": "_:N3df1788a7e4b4f6ab5db209381b01fe9"
       },
       {
-        "@id": "_:Na03b79a62c594564ad7108c2e8b77f89"
+        "@id": "_:N8a4934fea51a4d418cb20ecfda23820e"
       },
       {
-        "@id": "_:N05ce0025eaa543ed8df3bb7aa76e33a2"
+        "@id": "_:Ne8425292369b4c3c88c7a9b5c134aef9"
       },
       {
-        "@id": "_:Ncd84fc71af244308b56a6e0b91cc80d2"
+        "@id": "_:N384bc0f3195d4f60abaf0ed0f526e5ae"
       },
       {
-        "@id": "_:N96d0ea967d5e4f3ca0b1306f02e412ed"
+        "@id": "_:Nf731a3b8e48d433d81b6d50522f9045d"
       },
       {
-        "@id": "_:N407d603beb9b475bac3d6e12b1c2c7cf"
+        "@id": "_:N6e1b0087a84548a2859a54fcb4ddcd74"
       },
       {
-        "@id": "_:N62d4fea68eb84812810bf44362d99d25"
+        "@id": "_:Na37b0b94fec84d3eaa48f13bda731239"
       },
       {
-        "@id": "_:N5072b25be4cc4f8ead32cbd7e28c8f89"
+        "@id": "_:N3da66f975f5848fa833bc9ce558ba249"
       },
       {
-        "@id": "_:N9552de244b39498c82e31d4416b73e73"
+        "@id": "_:Nccc09b03eb604cd3af2ec4aaaaabd77d"
       },
       {
-        "@id": "_:Nf811450e54984d7789968f74589a2d8d"
+        "@id": "_:Nf493e7142a6e4c5d8251be3fdc3f1649"
       },
       {
-        "@id": "_:Nfbec8fe4939c4c83856fcda9989d091d"
+        "@id": "_:N7d2baaaf8718446481fa3681e85a3855"
       },
       {
-        "@id": "_:N8ce7630ad9854ab38cae69a364177825"
+        "@id": "_:N92ddf9f970604c9aa3fd9a70075b6d98"
       },
       {
-        "@id": "_:Nc79fcd3ac492462ca7f58488f9e89372"
+        "@id": "_:Nf33a0b4553f34a8f9052a5a0afe5376a"
       },
       {
-        "@id": "_:Nb816593414344204ac870d657f6d9b9a"
+        "@id": "_:N5f16c940eec847218ce32853ad4475d6"
       },
       {
-        "@id": "_:N6048331a52de46a98f00fb48e63a8ec8"
+        "@id": "_:N295cbda8cc284409828bcbe8eaf6df2f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -3306,7 +870,7 @@
     ]
   },
   {
-    "@id": "_:Nec9a579ea6ce48d39d1830fbea63c73f",
+    "@id": "_:N87fac4e68c7e45c6b8bebe9acac0ca23",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3322,7 +886,7 @@
     ]
   },
   {
-    "@id": "_:N3baae1d14ef542aab50e0da22ec1a62b",
+    "@id": "_:N71218184e1ca4556a39c88e85f31360a",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3339,13 +903,13 @@
     ]
   },
   {
-    "@id": "_:N9034478d7059410e95d2d8c179ac88dd",
+    "@id": "_:N7c46fa471b39424c881e718e0cfe27d6",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N202f82378e8f45b6bc37e83fa63c22f3"
+        "@id": "_:N1141114ad1f44301a0e2ee56eb658cf1"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -3355,7 +919,7 @@
     ]
   },
   {
-    "@id": "_:N202f82378e8f45b6bc37e83fa63c22f3",
+    "@id": "_:N1141114ad1f44301a0e2ee56eb658cf1",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3366,17 +930,17 @@
             "@id": "http://www.w3.org/2001/XMLSchema#integer"
           },
           {
-            "@id": "_:Nc9a229a7e1904e0e8c08c2fa00b69925"
+            "@id": "_:N09ce5cfdae4b4fd38a39b9c70bc772fe"
           },
           {
-            "@id": "_:Ne724d9e46ef543be9961189afd187c8b"
+            "@id": "_:Nd68d7d5a885648dd8f0350a9e52f7b27"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Nc9a229a7e1904e0e8c08c2fa00b69925",
+    "@id": "_:N09ce5cfdae4b4fd38a39b9c70bc772fe",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3389,14 +953,14 @@
       {
         "@list": [
           {
-            "@id": "_:Nee52d217c96a45b3b435445bc868f1be"
+            "@id": "_:N929506c4ba584a4bb7d042df18d84e56"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Nee52d217c96a45b3b435445bc868f1be",
+    "@id": "_:N929506c4ba584a4bb7d042df18d84e56",
     "http://www.w3.org/2001/XMLSchema#minInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -3405,7 +969,7 @@
     ]
   },
   {
-    "@id": "_:Ne724d9e46ef543be9961189afd187c8b",
+    "@id": "_:Nd68d7d5a885648dd8f0350a9e52f7b27",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3418,14 +982,14 @@
       {
         "@list": [
           {
-            "@id": "_:N76e0d09811284df5a8b48d22f509eeac"
+            "@id": "_:N12e6c70dd26148459d5cf951bb928ad4"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N76e0d09811284df5a8b48d22f509eeac",
+    "@id": "_:N12e6c70dd26148459d5cf951bb928ad4",
     "http://www.w3.org/2001/XMLSchema#maxInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -3434,7 +998,7 @@
     ]
   },
   {
-    "@id": "_:N38deb3644d3b4356a989efc116b6b987",
+    "@id": "_:N817dcb2abf204d8593e77099a5a420e2",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3451,7 +1015,7 @@
     ]
   },
   {
-    "@id": "_:N2b6dd06293f948fb8d5482bc922c017d",
+    "@id": "_:N2ab1989a04264f88a1e84c73942d82e2",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3468,7 +1032,7 @@
     ]
   },
   {
-    "@id": "_:N8facb47c2e2a4738a2b1b18fb514f465",
+    "@id": "_:N8f74ea72ec104a85acd125ee9b09942f",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3484,7 +1048,7 @@
     ]
   },
   {
-    "@id": "_:N625d5fa2b54749138a92224e3a0bcd7c",
+    "@id": "_:Nf1127e5b19114f4e99855f13b7d5ed93",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3501,7 +1065,7 @@
     ]
   },
   {
-    "@id": "_:Nd96afbffa77147f49d0e31caceb5d6a0",
+    "@id": "_:Nc1087fcc1d464d98894e5121de94eed7",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3518,7 +1082,7 @@
     ]
   },
   {
-    "@id": "_:Nac73eb21fa88477b8fceff7f53a38521",
+    "@id": "_:Nf2aa561daca244a3aeb0d0eff86b4e3b",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3534,7 +1098,7 @@
     ]
   },
   {
-    "@id": "_:Ne6c47b4d69004bb28121817841fb8299",
+    "@id": "_:Ncf50bbc81cd24fc2b4fb03e487b15373",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3551,7 +1115,7 @@
     ]
   },
   {
-    "@id": "_:N3e452e60da174f359349dfbc16590aa5",
+    "@id": "_:N0d5e270e16fe4e9e86dce864deacae15",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3567,7 +1131,7 @@
     ]
   },
   {
-    "@id": "_:Nadd85f4544d4432894e22255372a6d69",
+    "@id": "_:N1812fbab23ba41e39b3213351b158d0f",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3584,7 +1148,7 @@
     ]
   },
   {
-    "@id": "_:N2b264b9bb0584b4b8e7d393f58c3404d",
+    "@id": "_:Nb49e527ec64946f4beb95e510e8657cd",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3600,7 +1164,7 @@
     ]
   },
   {
-    "@id": "_:N8564abd4caa04365af6625b7aad2eb46",
+    "@id": "_:Ne12a4c1e95b3450ba4c7aa6d9de3b611",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3617,7 +1181,7 @@
     ]
   },
   {
-    "@id": "_:N0c0123e4a3774977b71481db8a07d270",
+    "@id": "_:N3df1788a7e4b4f6ab5db209381b01fe9",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3633,7 +1197,7 @@
     ]
   },
   {
-    "@id": "_:Na03b79a62c594564ad7108c2e8b77f89",
+    "@id": "_:N8a4934fea51a4d418cb20ecfda23820e",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3650,7 +1214,7 @@
     ]
   },
   {
-    "@id": "_:N05ce0025eaa543ed8df3bb7aa76e33a2",
+    "@id": "_:Ne8425292369b4c3c88c7a9b5c134aef9",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3667,7 +1231,7 @@
     ]
   },
   {
-    "@id": "_:Ncd84fc71af244308b56a6e0b91cc80d2",
+    "@id": "_:N384bc0f3195d4f60abaf0ed0f526e5ae",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3683,7 +1247,7 @@
     ]
   },
   {
-    "@id": "_:N96d0ea967d5e4f3ca0b1306f02e412ed",
+    "@id": "_:Nf731a3b8e48d433d81b6d50522f9045d",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3700,7 +1264,7 @@
     ]
   },
   {
-    "@id": "_:N407d603beb9b475bac3d6e12b1c2c7cf",
+    "@id": "_:N6e1b0087a84548a2859a54fcb4ddcd74",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3717,13 +1281,13 @@
     ]
   },
   {
-    "@id": "_:N62d4fea68eb84812810bf44362d99d25",
+    "@id": "_:Na37b0b94fec84d3eaa48f13bda731239",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N7c6415f78a1a4265b4e5c36b27137f2c"
+        "@id": "_:N94a5792d35914edc86f27046aff685a0"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -3733,7 +1297,7 @@
     ]
   },
   {
-    "@id": "_:N7c6415f78a1a4265b4e5c36b27137f2c",
+    "@id": "_:N94a5792d35914edc86f27046aff685a0",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3746,14 +1310,14 @@
       {
         "@list": [
           {
-            "@id": "_:N1ea66c86e82043cdb4dd7bf4f5d6f646"
+            "@id": "_:N28d31e1e66fb43c185e37f936b5ed48c"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N1ea66c86e82043cdb4dd7bf4f5d6f646",
+    "@id": "_:N28d31e1e66fb43c185e37f936b5ed48c",
     "http://www.w3.org/2001/XMLSchema#pattern": [
       {
         "@value": "^\\S+ \\S+$"
@@ -3761,7 +1325,7 @@
     ]
   },
   {
-    "@id": "_:N5072b25be4cc4f8ead32cbd7e28c8f89",
+    "@id": "_:N3da66f975f5848fa833bc9ce558ba249",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3778,7 +1342,7 @@
     ]
   },
   {
-    "@id": "_:N9552de244b39498c82e31d4416b73e73",
+    "@id": "_:Nccc09b03eb604cd3af2ec4aaaaabd77d",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3795,13 +1359,13 @@
     ]
   },
   {
-    "@id": "_:Nf811450e54984d7789968f74589a2d8d",
+    "@id": "_:Nf493e7142a6e4c5d8251be3fdc3f1649",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N542b9930d33d4d1bbd565b36d003b0bc"
+        "@id": "_:N7b962931acb449e594996b53addfae7a"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -3811,7 +1375,7 @@
     ]
   },
   {
-    "@id": "_:N542b9930d33d4d1bbd565b36d003b0bc",
+    "@id": "_:N7b962931acb449e594996b53addfae7a",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3824,14 +1388,14 @@
       {
         "@list": [
           {
-            "@id": "_:N63c4dc7611ac4c1786e6c5c1663f6466"
+            "@id": "_:N9bcae89d6733451e9155c4ceb563f8ca"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N63c4dc7611ac4c1786e6c5c1663f6466",
+    "@id": "_:N9bcae89d6733451e9155c4ceb563f8ca",
     "http://www.w3.org/2001/XMLSchema#pattern": [
       {
         "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
@@ -3839,7 +1403,7 @@
     ]
   },
   {
-    "@id": "_:Nfbec8fe4939c4c83856fcda9989d091d",
+    "@id": "_:N7d2baaaf8718446481fa3681e85a3855",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3856,7 +1420,7 @@
     ]
   },
   {
-    "@id": "_:N8ce7630ad9854ab38cae69a364177825",
+    "@id": "_:N92ddf9f970604c9aa3fd9a70075b6d98",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3873,13 +1437,13 @@
     ]
   },
   {
-    "@id": "_:Nc79fcd3ac492462ca7f58488f9e89372",
+    "@id": "_:Nf33a0b4553f34a8f9052a5a0afe5376a",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N92e002120a704d58b827a1f8956da518"
+        "@id": "_:Nf0d61d1e52a1445e8dc7f71fa5b72e55"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
@@ -3889,7 +1453,7 @@
     ]
   },
   {
-    "@id": "_:N92e002120a704d58b827a1f8956da518",
+    "@id": "_:Nf0d61d1e52a1445e8dc7f71fa5b72e55",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3900,17 +1464,17 @@
             "@id": "http://www.w3.org/2001/XMLSchema#integer"
           },
           {
-            "@id": "_:Nc6333ea7b6d34099bf90dfb213704f7a"
+            "@id": "_:Nb38fbd87592a4c438708e2755300caef"
           },
           {
-            "@id": "_:Ncb4ee53abf6b4fd5a31d388c4b7e8fe0"
+            "@id": "_:Nedf304748ccf407f9bb7f966618db52c"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Nc6333ea7b6d34099bf90dfb213704f7a",
+    "@id": "_:Nb38fbd87592a4c438708e2755300caef",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3923,14 +1487,14 @@
       {
         "@list": [
           {
-            "@id": "_:Nc61fe03a6a4f4b2ab26aa0f1433cc701"
+            "@id": "_:Nb8acd474d6cb472e8487400859234407"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Nc61fe03a6a4f4b2ab26aa0f1433cc701",
+    "@id": "_:Nb8acd474d6cb472e8487400859234407",
     "http://www.w3.org/2001/XMLSchema#minInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -3939,7 +1503,7 @@
     ]
   },
   {
-    "@id": "_:Ncb4ee53abf6b4fd5a31d388c4b7e8fe0",
+    "@id": "_:Nedf304748ccf407f9bb7f966618db52c",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -3952,14 +1516,14 @@
       {
         "@list": [
           {
-            "@id": "_:Nbb2747068e0740e08f4ec7d5c609762c"
+            "@id": "_:Nf5acd0c4049c4305a38e229114c70f6e"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Nbb2747068e0740e08f4ec7d5c609762c",
+    "@id": "_:Nf5acd0c4049c4305a38e229114c70f6e",
     "http://www.w3.org/2001/XMLSchema#maxInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -3968,7 +1532,7 @@
     ]
   },
   {
-    "@id": "_:Nb816593414344204ac870d657f6d9b9a",
+    "@id": "_:N5f16c940eec847218ce32853ad4475d6",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3985,7 +1549,7 @@
     ]
   },
   {
-    "@id": "_:N6048331a52de46a98f00fb48e63a8ec8",
+    "@id": "_:N295cbda8cc284409828bcbe8eaf6df2f",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -4002,157 +1566,223 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place",
+    "@id": "https://w3id.org/linkml/tests/core/Agent",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Place"
+        "@value": "agent"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+        "@id": "_:N8fad9e8dd5fa4259bab9b093eaab3718"
       },
       {
-        "@id": "_:N57e1344358c04139ab1f572ff324561c"
+        "@id": "_:N7fcbddb19c954693b587fa458e098d50"
       },
       {
-        "@id": "_:Naa943064128b4f779958a38d06a01a88"
+        "@id": "_:Nc698e96d13a346e38fe1e62116d37080"
       },
       {
-        "@id": "_:N402d07e6dadb42a6b3df4c7996c9d88a"
+        "@id": "_:Ncd3ac71c776641e9bee475172029d4b0"
       },
       {
-        "@id": "_:Nca32327f7c4441fea8ba9daa2a02bc5b"
+        "@id": "_:N58ce723a06b741028bc5eec7672bfc2b"
       },
       {
-        "@id": "_:Ne5452fe0a2e34602b942455a94464879"
+        "@id": "_:N08d5c31227284600b1fefb2ca25120b3"
       },
       {
-        "@id": "_:Nda531b5fb7b5459ebd98e0946acf6c65"
+        "@id": "_:N6c50ef52bf574ff9ac48e61e649c02d2"
+      },
+      {
+        "@id": "_:N9e11e9df899e4916a1930635dc2135fb"
+      },
+      {
+        "@id": "_:N75693d3ac5074f0a88887e0bb9db94d9"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "a provence-generating agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#exactMatch": [
+      {
+        "@id": "http://www.w3.org/ns/prov#Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8fad9e8dd5fa4259bab9b093eaab3718",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7fcbddb19c954693b587fa458e098d50",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc698e96d13a346e38fe1e62116d37080",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncd3ac71c776641e9bee475172029d4b0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N58ce723a06b741028bc5eec7672bfc2b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N08d5c31227284600b1fefb2ca25120b3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6c50ef52bf574ff9ac48e61e649c02d2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9e11e9df899e4916a1930635dc2135fb",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:N75693d3ac5074f0a88887e0bb9db94d9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/type",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "type"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N57e1344358c04139ab1f572ff324561c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Naa943064128b4f779958a38d06a01a88",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N402d07e6dadb42a6b3df4c7996c9d88a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nca32327f7c4441fea8ba9daa2a02bc5b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne5452fe0a2e34602b942455a94464879",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nda531b5fb7b5459ebd98e0946acf6c65",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#LIVING",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "LIVING"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
       }
     ]
   },
@@ -4168,7 +1798,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "_:Ndf58a1e21bb84f27a026379abac883ec"
+        "@id": "_:N7b8d39a2b89a41faacbaed4b084f060c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
@@ -4183,7 +1813,7 @@
     ]
   },
   {
-    "@id": "_:Ndf58a1e21bb84f27a026379abac883ec",
+    "@id": "_:N7b8d39a2b89a41faacbaed4b084f060c",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -4194,17 +1824,17 @@
             "@id": "http://www.w3.org/2001/XMLSchema#integer"
           },
           {
-            "@id": "_:N8a79804174a244d48acea480756f5062"
+            "@id": "_:Ndcd1381edcd140ca95065eda85800d24"
           },
           {
-            "@id": "_:N389073cf91a84e90aca91f8c48097d7a"
+            "@id": "_:Nf14c57fe1d0744e3b02aba2a18ad0edf"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N8a79804174a244d48acea480756f5062",
+    "@id": "_:Ndcd1381edcd140ca95065eda85800d24",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -4217,14 +1847,14 @@
       {
         "@list": [
           {
-            "@id": "_:Ne026826136fc47618c58c267c1f5b3a0"
+            "@id": "_:N3470c9f989a9481097ff79569d493c42"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Ne026826136fc47618c58c267c1f5b3a0",
+    "@id": "_:N3470c9f989a9481097ff79569d493c42",
     "http://www.w3.org/2001/XMLSchema#minInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -4233,7 +1863,7 @@
     ]
   },
   {
-    "@id": "_:N389073cf91a84e90aca91f8c48097d7a",
+    "@id": "_:Nf14c57fe1d0744e3b02aba2a18ad0edf",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -4246,14 +1876,14 @@
       {
         "@list": [
           {
-            "@id": "_:Nb047905b437143c19a30d43574ca0a5e"
+            "@id": "_:Nd55e4895e4ad44b89eb26fc54d7a4692"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:Nb047905b437143c19a30d43574ca0a5e",
+    "@id": "_:Nd55e4895e4ad44b89eb26fc54d7a4692",
     "http://www.w3.org/2001/XMLSchema#maxInclusive": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
@@ -4262,13 +1892,24 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Friend",
     "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "attribute2"
+        "@value": "Friend"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nd203f089062c4a4585c2a0b29a92baeb"
+      },
+      {
+        "@id": "_:N2fac7139173141f6a3a8362821414c7d"
+      },
+      {
+        "@id": "_:N4518716573194f79905c4c63728e6af8"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -4278,29 +1919,328 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
+    "@id": "_:Nd203f089062c4a4585c2a0b29a92baeb",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@value": "CLEAN"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+        "@id": "https://w3id.org/linkml/tests/core/name"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/was_associated_with",
+    "@id": "_:N2fac7139173141f6a3a8362821414c7d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4518716573194f79905c4c63728e6af8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "was associated with"
+        "@value": "has employment history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 7
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "test_attribute"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "https://w3id.org/biolink/Disease"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_C",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_C"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfEnums",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfEnums"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nf5973617045247e383c9d9bb49ba4ab6"
+      },
+      {
+        "@id": "_:N75a99fe1be264cb28e0e3b2b5806a564"
+      },
+      {
+        "@id": "_:Nb4f1b785bbac4c1f86a13fdcf8d13c1e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf5973617045247e383c9d9bb49ba4ab6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N039ab33bf57b446585d7349d38d8f24f"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "_:N039ab33bf57b446585d7349d38d8f24f",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N75a99fe1be264cb28e0e3b2b5806a564",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb4f1b785bbac4c1f86a13fdcf8d13c1e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Company"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
+      },
+      {
+        "@id": "_:Nd5e2b1c0f215425b8dd60669b2d690c3"
+      },
+      {
+        "@id": "_:N8cac2a56c10d485b91e8f93583ea83b9"
+      },
+      {
+        "@id": "_:Nc938fd4a560141acbd23645373f913b1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd5e2b1c0f215425b8dd60669b2d690c3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8cac2a56c10d485b91e8f93583ea83b9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc938fd4a560141acbd23645373f913b1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/agent_set",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "agent set"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
@@ -4315,379 +2255,333 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#UNKNOWN",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "https://w3id.org/linkml/permissible_values": [
       {
-        "@value": "UNKNOWN"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "stomach count"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Relationship"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nfb0cd1af9b714cffb5fc19b5dbc80ba4"
-      },
-      {
-        "@id": "_:Nacdfc042663c4fb88fb58ec17a87e9de"
-      },
-      {
-        "@id": "_:Nf1e08aed8217458892ef5cc684e81002"
-      },
-      {
-        "@id": "_:Nabab51099a974b3c95fd7f5e1dfacb88"
-      },
-      {
-        "@id": "_:Na396cb219f8b4860af1840b5175716e5"
-      },
-      {
-        "@id": "_:Ne01364bf37f14395bd1e077b53f2d3fb"
-      },
-      {
-        "@id": "_:Nab29f6a641bb4b4181b05663a48824d6"
-      },
-      {
-        "@id": "_:N3c3b70dd1cdb46bb8fe467ea694fa4ef"
-      },
-      {
-        "@id": "_:N7584420aea864c31a74d421c33c3ac81"
-      },
-      {
-        "@id": "_:N928571cad418459289de44b218774463"
-      },
-      {
-        "@id": "_:Nec4352077dad427faf87d0c465d53bd2"
-      },
-      {
-        "@id": "_:N24ae3f6f6ff94cd58471222d533f1fd6"
-      },
-      {
-        "@id": "_:N2316a552eafe48e482fe545a4c8bb9e3"
-      },
-      {
-        "@id": "_:N09029d2491f243dd83f903e881057318"
-      },
-      {
-        "@id": "_:N282b8cdd5208401bac03e8492e586c18"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfb0cd1af9b714cffb5fc19b5dbc80ba4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nacdfc042663c4fb88fb58ec17a87e9de",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf1e08aed8217458892ef5cc684e81002",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nabab51099a974b3c95fd7f5e1dfacb88",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na396cb219f8b4860af1840b5175716e5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne01364bf37f14395bd1e077b53f2d3fb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nab29f6a641bb4b4181b05663a48824d6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3c3b70dd1cdb46bb8fe467ea694fa4ef",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7584420aea864c31a74d421c33c3ac81",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N928571cad418459289de44b218774463",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nec4352077dad427faf87d0c465d53bd2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N24ae3f6f6ff94cd58471222d533f1fd6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2316a552eafe48e482fe545a4c8bb9e3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N09029d2491f243dd83f903e881057318",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N282b8cdd5208401bac03e8492e586c18",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "has medical history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
+        "@value": "code systems"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/ns/shacl#order": [
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Address"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N58c56d132c40441ab89f4cb002a6de72"
+      },
+      {
+        "@id": "_:Nac7f8f0f6ecf4c3f840227a269de85f8"
+      },
+      {
+        "@id": "_:N7877be6517744ceb963fe92a47a3ef26"
+      },
+      {
+        "@id": "_:Nf93bdb9b7bf74e44acd6c9013d14d83a"
+      },
+      {
+        "@id": "_:N9d6f3046716544d8adb3768f582ba0d4"
+      },
+      {
+        "@id": "_:N020fe31e3ea54905a786ef9350616c5c"
+      },
+      {
+        "@id": "_:Ne822ee9de3994bdf8fea7f9edcf422ee"
+      },
+      {
+        "@id": "_:Nf3613d42eaf84807bd4d3a722a9a5a16"
+      },
+      {
+        "@id": "_:N44b75092101b4b2685c95d03cc861321"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N58c56d132c40441ab89f4cb002a6de72",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nac7f8f0f6ecf4c3f840227a269de85f8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 5
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7877be6517744ceb963fe92a47a3ef26",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf93bdb9b7bf74e44acd6c9013d14d83a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9d6f3046716544d8adb3768f582ba0d4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:N020fe31e3ea54905a786ef9350616c5c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne822ee9de3994bdf8fea7f9edcf422ee",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf3613d42eaf84807bd4d3a722a9a5a16",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "_:N44b75092101b4b2685c95d03cc861321",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FakeClass",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FakeClass"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N38feb8a443534feba3c4c333ad9fedbd"
+      },
+      {
+        "@id": "_:Nebba068ac02f40f8bc7f5fb570f8443c"
+      },
+      {
+        "@id": "_:Nba4ededcc1a04770b3668f39a252a672"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N38feb8a443534feba3c4c333ad9fedbd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nebba068ac02f40f8bc7f5fb570f8443c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nba4ededcc1a04770b3668f39a252a672",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "procedure"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -4730,1093 +2624,6 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DIRTY"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "BirthEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:Ncada55e7d2984d2c920926e0bf4ac9b8"
-      },
-      {
-        "@id": "_:N184f79aa08174b6782b29cf408f9080a"
-      },
-      {
-        "@id": "_:Ne57a640108a847c1946a157fc9444fb3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncada55e7d2984d2c920926e0bf4ac9b8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N184f79aa08174b6782b29cf408f9080a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne57a640108a847c1946a157fc9444fb3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "class with spaces"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N371b85af415043f8b52b76f02f4f2728"
-      },
-      {
-        "@id": "_:Nfbe930f979694a7ca476faa2f06f7216"
-      },
-      {
-        "@id": "_:Nb282ef8cab0b4457a9b436179f53f5f5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N371b85af415043f8b52b76f02f4f2728",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfbe930f979694a7ca476faa2f06f7216",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb282ef8cab0b4457a9b436179f53f5f5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "is current"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Ontology"
-    ],
-    "http://purl.org/dc/terms/title": [
-      {
-        "@value": "Kitchen Sink Schema"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
-      {
-        "@id": "https://example.org/"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Kitchen Sink Schema\n\nThis schema does not do anything useful. It exists to test all features of linkml.\n\nThis particular text field exists to demonstrate markdown within a text field:\n\nLists:\n\n   * a\n   * b\n   * c\n\nAnd links, e.g to [Person](Person.md)"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyObject"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Example of unconstrained class"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#exactMatch": [
-      {
-        "@id": "https://w3id.org/linkml/Any"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has employment history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 7
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "MedicalEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:N06799c228bb24cf696423b9004674f00"
-      },
-      {
-        "@id": "_:N354c77517a14408c920f3e89c2929f23"
-      },
-      {
-        "@id": "_:Ne3b557b72ec64e65832cf26da40c643b"
-      },
-      {
-        "@id": "_:N8e6bc75dc75a4ff6b9b838ad1563b189"
-      },
-      {
-        "@id": "_:N4d5b4cefb4104bf7a0632431174e6581"
-      },
-      {
-        "@id": "_:N07c2fbc7c8ca45f588aa7213a20fe0be"
-      },
-      {
-        "@id": "_:N74adcdfa4ccc46718f197edaac5a3ad3"
-      },
-      {
-        "@id": "_:N6fd24611e22d4df08a7acf0f15d65266"
-      },
-      {
-        "@id": "_:N7e22f19ba1ef4da1b8e534e18926c530"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N06799c228bb24cf696423b9004674f00",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:N354c77517a14408c920f3e89c2929f23",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne3b557b72ec64e65832cf26da40c643b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8e6bc75dc75a4ff6b9b838ad1563b189",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4d5b4cefb4104bf7a0632431174e6581",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N07c2fbc7c8ca45f588aa7213a20fe0be",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N74adcdfa4ccc46718f197edaac5a3ad3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6fd24611e22d4df08a7acf0f15d65266",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7e22f19ba1ef4da1b8e534e18926c530",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/002",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FIRE"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/name",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "name"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 2
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsString",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EqualsString"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nc1d8370cf6ef4116a17b91e925866f62"
-      },
-      {
-        "@id": "_:N9832097601084f27b701f624569d2cf7"
-      },
-      {
-        "@id": "_:N597f4e6a0d2e47d18409dc4b18c18c41"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc1d8370cf6ef4116a17b91e925866f62",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9832097601084f27b701f624569d2cf7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "_:N597f4e6a0d2e47d18409dc4b18c18c41",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "SIBLING_OF"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsStringIn",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EqualsStringIn"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N6620344702e148889e5c963f95ed4480"
-      },
-      {
-        "@id": "_:Nf0fd3a9bc03f4bab9e2b72ff42389eaf"
-      },
-      {
-        "@id": "_:Nb5cb891f312d4a708ed8180e1ac58662"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6620344702e148889e5c963f95ed4480",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N6b0e0070923f4ffb9f707b144394eb72"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6b0e0070923f4ffb9f707b144394eb72",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#oneOf": [
-      {
-        "@list": [
-          {
-            "@value": "foo"
-          },
-          {
-            "@value": "bar"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf0fd3a9bc03f4bab9e2b72ff42389eaf",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb5cb891f312d4a708ed8180e1ac58662",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/ended_at_time",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ended at time"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:Ncc6abd5f112d4099a4b21058002e614b"
-      },
-      {
-        "@id": "_:Nd647fe8be1be48bb9ddcc01e03f87f5f"
-      },
-      {
-        "@id": "_:Nf298f95fb7a9445fa6b45e5ccfe76d78"
-      },
-      {
-        "@id": "_:N9ab0315c7b424b2ca9329ecca5ed4a8f"
-      },
-      {
-        "@id": "_:Nbbfa0694238b40dfa3700ff787d6d215"
-      },
-      {
-        "@id": "_:N6b7840b5d57d4c0cb1de7d77ac885759"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 6
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncc6abd5f112d4099a4b21058002e614b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd647fe8be1be48bb9ddcc01e03f87f5f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf298f95fb7a9445fa6b45e5ccfe76d78",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9ab0315c7b424b2ca9329ecca5ed4a8f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N12affc9624b04571b29a6802293346dd"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N12affc9624b04571b29a6802293346dd",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbbfa0694238b40dfa3700ff787d6d215",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6b7840b5d57d4c0cb1de7d77ac885759",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "altitude"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/street",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "street"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "diagnosis"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "addresses"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "WithLocation"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nb0990dc1f007491c8f6f924aba22824a"
-      },
-      {
-        "@id": "_:Nb3b58f605ce84220816c2a4aa14cb4d4"
-      },
-      {
-        "@id": "_:N861958fe0ebd40f98814c18bff297c06"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb0990dc1f007491c8f6f924aba22824a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb3b58f605ce84220816c2a4aa14cb4d4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N861958fe0ebd40f98814c18bff297c06",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/city",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
@@ -5833,880 +2640,18 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/was_informed_by",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "was informed by"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_B"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A"
+        "@value": "slot with space 2"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ceo"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "companies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "is_living"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/agent_set",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "agent set"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfClasses",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfClasses"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N727fcb1b78dd4acdbda599b950cdc897"
-      },
-      {
-        "@id": "_:Nc9f6f244f75242918d10f1fdc0565e82"
-      },
-      {
-        "@id": "_:Nf38d1de391294020b5b3b770b7ab643a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N727fcb1b78dd4acdbda599b950cdc897",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N3fcabe11e195484c96cfa0e7c2017900"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3fcabe11e195484c96cfa0e7c2017900",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc9f6f244f75242918d10f1fdc0565e82",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf38d1de391294020b5b3b770b7ab643a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "married to"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Concept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N0fb959fc744b4998aa803507c7b1a0d2"
-      },
-      {
-        "@id": "_:N5369f89f4f074d3c8128d87d0919f2fd"
-      },
-      {
-        "@id": "_:Na467d9cbba1d48d48615ecb0893c7069"
-      },
-      {
-        "@id": "_:Ndb3bdf507b2a45199029eaa28f2e1d22"
-      },
-      {
-        "@id": "_:N9a0a1169817e4eef952054a0d3303fdb"
-      },
-      {
-        "@id": "_:N27a87b29dc654e67a39fbd95e7bdc5ad"
-      },
-      {
-        "@id": "_:N1f82c29fe8604c649d1a4fdf840e611e"
-      },
-      {
-        "@id": "_:N96b5b9505c474ccbbc612e72f4590376"
-      },
-      {
-        "@id": "_:N9f46693907134980ad881b3bc6510eb7"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0fb959fc744b4998aa803507c7b1a0d2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5369f89f4f074d3c8128d87d0919f2fd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na467d9cbba1d48d48615ecb0893c7069",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndb3bdf507b2a45199029eaa28f2e1d22",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9a0a1169817e4eef952054a0d3303fdb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N27a87b29dc654e67a39fbd95e7bdc5ad",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1f82c29fe8604c649d1a4fdf840e611e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N96b5b9505c474ccbbc612e72f4590376",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9f46693907134980ad881b3bc6510eb7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "procedure"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Company"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
-      },
-      {
-        "@id": "_:N8962a4302a744737a18c85422aa79434"
-      },
-      {
-        "@id": "_:Nc40f12e442f3411ea364544f1b6a458f"
-      },
-      {
-        "@id": "_:Nd8ec399e9f9e40ddab407cf52378abed"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8962a4302a744737a18c85422aa79434",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc40f12e442f3411ea364544f1b6a458f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd8ec399e9f9e40ddab407cf52378abed",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FakeClass",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FakeClass"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N505fd56fccc345f69be9dff403867b88"
-      },
-      {
-        "@id": "_:N7059d191d342409a81483cde2ff91a1e"
-      },
-      {
-        "@id": "_:Nf11637b0ba3b4c4a897bf35748789f63"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N505fd56fccc345f69be9dff403867b88",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7059d191d342409a81483cde2ff91a1e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf11637b0ba3b4c4a897bf35748789f63",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubSubClass2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Sub sub class 2"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "a b"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_marriage_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has marriage history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF"
-          }
-        ]
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "aliases"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DEAD"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "mixin_slot_I"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has birth event"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfSimpleType",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfSimpleType"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N289cdc57ee014d3cb09deeca068e0780"
-      },
-      {
-        "@id": "_:N7482ecc79d1641fb9c7513ba51ddd4fb"
-      },
-      {
-        "@id": "_:N4c34229116ec4e1bafb911a9811d3373"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N289cdc57ee014d3cb09deeca068e0780",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N4c91b032ebfc46a5b44b5f364aac927b"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4c91b032ebfc46a5b44b5f364aac927b",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#string"
-          },
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N7482ecc79d1641fb9c7513ba51ddd4fb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4c34229116ec4e1bafb911a9811d3373",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
       }
     ]
   },
@@ -6737,13 +2682,4068 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/type",
+    "@id": "https://w3id.org/linkml/tests/core/was_informed_by",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was informed by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nfb0d601626b0426ab0a6d8b46b996e84"
+      },
+      {
+        "@id": "_:Ndaf8d3f9fc87451ab5acc2521581954c"
+      },
+      {
+        "@id": "_:N85c1fa659e6e497cb2066dcf242e3fdf"
+      },
+      {
+        "@id": "_:N2f94f8f03763474a91efea2d778550c1"
+      },
+      {
+        "@id": "_:N4bf7e40dfa9247c99da8268e7b23992e"
+      },
+      {
+        "@id": "_:N8bf7139a10124124a090567ac18a7f93"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfb0d601626b0426ab0a6d8b46b996e84",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndaf8d3f9fc87451ab5acc2521581954c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N85c1fa659e6e497cb2066dcf242e3fdf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2f94f8f03763474a91efea2d778550c1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4bf7e40dfa9247c99da8268e7b23992e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8bf7139a10124124a090567ac18a7f93",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "in code system"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfClasses",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfClasses"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N01caa4bf53d541c89386d33775f45d67"
+      },
+      {
+        "@id": "_:N6629744579be47f7aaecb09429266730"
+      },
+      {
+        "@id": "_:N0bcc40a6d02240b585f32278c636594a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N01caa4bf53d541c89386d33775f45d67",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Na9b80aac5b9f4d57a2e1185845993148"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na9b80aac5b9f4d57a2e1185845993148",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N6629744579be47f7aaecb09429266730",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0bcc40a6d02240b585f32278c636594a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/started_at_time",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "type"
+        "@value": "started at time"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "related to"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "a b"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/was_associated_with",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was associated with"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Place"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:N76e426d2cbf24cf2bcf2893036a3ca32"
+      },
+      {
+        "@id": "_:Nd7cd61d1aee44781812be9021446b2d5"
+      },
+      {
+        "@id": "_:N2cbdb94fcbd74ea9bc128be57722dad8"
+      },
+      {
+        "@id": "_:N512ba7b5c5654763bfb7890cdf426e40"
+      },
+      {
+        "@id": "_:N3e708df32c764764877b4d7999336b48"
+      },
+      {
+        "@id": "_:N873fe977332d41329ed836e5d6f83bef"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N76e426d2cbf24cf2bcf2893036a3ca32",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd7cd61d1aee44781812be9021446b2d5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2cbdb94fcbd74ea9bc128be57722dad8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N512ba7b5c5654763bfb7890cdf426e40",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3e708df32c764764877b4d7999336b48",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N873fe977332d41329ed836e5d6f83bef",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CHILD_OF"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsStringIn",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EqualsStringIn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N30b82566b21c4ee7b736b0ecc9762da9"
+      },
+      {
+        "@id": "_:Nf96b76f6df2b40da91d8e2e54c6db617"
+      },
+      {
+        "@id": "_:N9398dc4495e940fca5707cc69c9ba4cb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N30b82566b21c4ee7b736b0ecc9762da9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N809868ad86e44d3bac186842a905ed61"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "_:N809868ad86e44d3bac186842a905ed61",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#oneOf": [
+      {
+        "@list": [
+          {
+            "@value": "foo"
+          },
+          {
+            "@value": "bar"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf96b76f6df2b40da91d8e2e54c6db617",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9398dc4495e940fca5707cc69c9ba4cb",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfSimpleType",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfSimpleType"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N647759373616416fa36c01a34193fc62"
+      },
+      {
+        "@id": "_:Nda6bb1df263440dfb016967ff84edaae"
+      },
+      {
+        "@id": "_:Nb0e9741163294b99b2f978eb6336d637"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N647759373616416fa36c01a34193fc62",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N77cd770e14a1433c8760c57470169d9b"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N77cd770e14a1433c8760c57470169d9b",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#string"
+          },
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nda6bb1df263440dfb016967ff84edaae",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb0e9741163294b99b2f978eb6336d637",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/004",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "TRANSFER"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "acted on behalf of"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Dataset",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Dataset"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nc9b4b1a7c3e946bca2a25a593321a42e"
+      },
+      {
+        "@id": "_:N46fecf7079a44e908105031ae236d2a4"
+      },
+      {
+        "@id": "_:Ne9b9903e4ade4569a5f022dd576505af"
+      },
+      {
+        "@id": "_:N28a361594ced4076b8f4937bb3e10189"
+      },
+      {
+        "@id": "_:Ne1878e45da034ecea14ce6d9c67d4c79"
+      },
+      {
+        "@id": "_:N0b3baf90b32c429a9379ee24545e363b"
+      },
+      {
+        "@id": "_:N0a1a18dcba644ccb8cf7d5eddca7f6e5"
+      },
+      {
+        "@id": "_:Nec00578202e6402fbe39fe36a7f4f90a"
+      },
+      {
+        "@id": "_:N15ecd6efa7eb4294b5afb9fcbe0ef996"
+      },
+      {
+        "@id": "_:Nc93862180c2640bbbf701c589994bdf3"
+      },
+      {
+        "@id": "_:Ne9dd2a4163af42c19faf727c70c25f0e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc9b4b1a7c3e946bca2a25a593321a42e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
+      }
+    ]
+  },
+  {
+    "@id": "_:N46fecf7079a44e908105031ae236d2a4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne9b9903e4ade4569a5f022dd576505af",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
+      }
+    ]
+  },
+  {
+    "@id": "_:N28a361594ced4076b8f4937bb3e10189",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne1878e45da034ecea14ce6d9c67d4c79",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0b3baf90b32c429a9379ee24545e363b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0a1a18dcba644ccb8cf7d5eddca7f6e5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nec00578202e6402fbe39fe36a7f4f90a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:N15ecd6efa7eb4294b5afb9fcbe0ef996",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc93862180c2640bbbf701c589994bdf3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne9dd2a4163af42c19faf727c70c25f0e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DIRTY"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubSubClass2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Sub sub class 2"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DEAD"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "species name"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "_:N9ca5aa13a93c4bab93ed8ae83657e498"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9ca5aa13a93c4bab93ed8ae83657e498",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:Nf72a4f4f7ad1497aa4ef4ce11d43404e"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf72a4f4f7ad1497aa4ef4ce11d43404e",
+    "http://www.w3.org/2001/XMLSchema#pattern": [
+      {
+        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Relationship"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N16533d5b60cf4cc7a224cb08f2d2cf52"
+      },
+      {
+        "@id": "_:N2083883aab854e729f8e0f8c89122c8d"
+      },
+      {
+        "@id": "_:N78cbf1c3cdf541049cf238d0a13175fe"
+      },
+      {
+        "@id": "_:N496110e950de460a87e1b3c320afe496"
+      },
+      {
+        "@id": "_:N8c6421a46b474bfda418361a3dcee393"
+      },
+      {
+        "@id": "_:N9360c9fd854749508920ce563e2718df"
+      },
+      {
+        "@id": "_:Nc64230a72aef4562830332124a7f122a"
+      },
+      {
+        "@id": "_:N3cd96d5d778744daba10a77952bae9a1"
+      },
+      {
+        "@id": "_:N3528073fc488460b8c15bc9b9176c132"
+      },
+      {
+        "@id": "_:N48ca2ded54d74deab0564f648fe66098"
+      },
+      {
+        "@id": "_:N79ac080bfbbe4dd0958e733983fd3d86"
+      },
+      {
+        "@id": "_:N9f7caeaee4e24d71a618080edf2f3591"
+      },
+      {
+        "@id": "_:N8c295a0ade1248309471402f83d45bad"
+      },
+      {
+        "@id": "_:N52fdc4784d584ec898459a50e1dcf5d1"
+      },
+      {
+        "@id": "_:Nbf974184d307468982fde39ac8e01ea9"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N16533d5b60cf4cc7a224cb08f2d2cf52",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2083883aab854e729f8e0f8c89122c8d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N78cbf1c3cdf541049cf238d0a13175fe",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N496110e950de460a87e1b3c320afe496",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8c6421a46b474bfda418361a3dcee393",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9360c9fd854749508920ce563e2718df",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc64230a72aef4562830332124a7f122a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3cd96d5d778744daba10a77952bae9a1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3528073fc488460b8c15bc9b9176c132",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N48ca2ded54d74deab0564f648fe66098",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N79ac080bfbbe4dd0958e733983fd3d86",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9f7caeaee4e24d71a618080edf2f3591",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8c295a0ade1248309471402f83d45bad",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N52fdc4784d584ec898459a50e1dcf5d1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbf974184d307468982fde39ac8e01ea9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "companies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute4"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/Activity",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "activity"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N28ba51769657413aac05c423d0ed0808"
+      },
+      {
+        "@id": "_:N72ebce5ecd5440b5b059ce86daa72c05"
+      },
+      {
+        "@id": "_:N1504188138894a06b1dd5a0061bfe212"
+      },
+      {
+        "@id": "_:Ncb878bb242df4a0996c65a86dffdbc2c"
+      },
+      {
+        "@id": "_:N510a29a4c71b4ff4a9abae0c11feff8e"
+      },
+      {
+        "@id": "_:N749224b56b534b37b34935a5e35cc299"
+      },
+      {
+        "@id": "_:N5bd9c5ac84eb4169b56c6f9b62a1dab4"
+      },
+      {
+        "@id": "_:N3f8b8ce8213b413c82be0a020922f4bf"
+      },
+      {
+        "@id": "_:Ne46416f948ee490f80943c2b55bb70c1"
+      },
+      {
+        "@id": "_:Nff9ed08dacbb4da6b2aa8ab930394cbf"
+      },
+      {
+        "@id": "_:Ndd516d3506c148e4b2a8ae4fbba60a6b"
+      },
+      {
+        "@id": "_:N7174862f2d3e40858b0cf1242c90f799"
+      },
+      {
+        "@id": "_:Naa2140eaefa242fc91cd8743551e38d5"
+      },
+      {
+        "@id": "_:N6c9fb98db59249a4ab5b102b94007d1a"
+      },
+      {
+        "@id": "_:Na641c361328f4fa59adda95fe4c5b84b"
+      },
+      {
+        "@id": "_:N1e88475268694983bf652311eb80dcd5"
+      },
+      {
+        "@id": "_:Nc1d789d43f564613ae44039dbb6db69d"
+      },
+      {
+        "@id": "_:N03e9a1addf58412889e7e52c1244d035"
+      },
+      {
+        "@id": "_:N161c24cbf2c74dc5bb334e90b87902e6"
+      },
+      {
+        "@id": "_:N5b7a8216701940caa90428ae759a864e"
+      },
+      {
+        "@id": "_:N0d7b293c4dbe433488619f0d8726166c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "a provence-generating activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#mappingRelation": [
+      {
+        "@id": "http://www.w3.org/ns/prov#Activity"
+      }
+    ]
+  },
+  {
+    "@id": "_:N28ba51769657413aac05c423d0ed0808",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:N72ebce5ecd5440b5b059ce86daa72c05",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1504188138894a06b1dd5a0061bfe212",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncb878bb242df4a0996c65a86dffdbc2c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N510a29a4c71b4ff4a9abae0c11feff8e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N749224b56b534b37b34935a5e35cc299",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5bd9c5ac84eb4169b56c6f9b62a1dab4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3f8b8ce8213b413c82be0a020922f4bf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne46416f948ee490f80943c2b55bb70c1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nff9ed08dacbb4da6b2aa8ab930394cbf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndd516d3506c148e4b2a8ae4fbba60a6b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7174862f2d3e40858b0cf1242c90f799",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Naa2140eaefa242fc91cd8743551e38d5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6c9fb98db59249a4ab5b102b94007d1a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na641c361328f4fa59adda95fe4c5b84b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1e88475268694983bf652311eb80dcd5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc1d789d43f564613ae44039dbb6db69d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:N03e9a1addf58412889e7e52c1244d035",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:N161c24cbf2c74dc5bb334e90b87902e6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5b7a8216701940caa90428ae759a864e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0d7b293c4dbe433488619f0d8726166c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has medical history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 5
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "cordialness"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "employed at"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/002",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FIRE"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "married to"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "PARENT_OF"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Event"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N17605e1c15fd4fbda44694f94d7c2b35"
+      },
+      {
+        "@id": "_:N394735f0e6db47f9be2a126fef8a8cf5"
+      },
+      {
+        "@id": "_:N0e63a5dad4bd486390a8e77a6770447f"
+      },
+      {
+        "@id": "_:N8de1cc00eaa64d4093536772eaf9d876"
+      },
+      {
+        "@id": "_:Nbec15c678cf042bd8786c720d9018dc9"
+      },
+      {
+        "@id": "_:Nfd0ac852fbea49ac9ab68dbaf3e19c78"
+      },
+      {
+        "@id": "_:N1b74ef1a710b4050802a32c6be5a040e"
+      },
+      {
+        "@id": "_:N2ae8d275dd71464ca9ca739298c76c28"
+      },
+      {
+        "@id": "_:N8e45b9778ec64e4aa884c231f6d63dde"
+      },
+      {
+        "@id": "_:Nf8400fdf7a894b92bab37c874c516ce7"
+      },
+      {
+        "@id": "_:N99a3392688df4541bc4ae2f6beafbb4e"
+      },
+      {
+        "@id": "_:N0dfe54769e2b40cb86e4033ee6b81a99"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N17605e1c15fd4fbda44694f94d7c2b35",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N394735f0e6db47f9be2a126fef8a8cf5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0e63a5dad4bd486390a8e77a6770447f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8de1cc00eaa64d4093536772eaf9d876",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbec15c678cf042bd8786c720d9018dc9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfd0ac852fbea49ac9ab68dbaf3e19c78",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1b74ef1a710b4050802a32c6be5a040e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2ae8d275dd71464ca9ca739298c76c28",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8e45b9778ec64e4aa884c231f6d63dde",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf8400fdf7a894b92bab37c874c516ce7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N99a3392688df4541bc4ae2f6beafbb4e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0dfe54769e2b40cb86e4033ee6b81a99",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/description",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "description"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/was_generated_by",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was generated by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "hateful"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "addresses"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Organization"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:Na8261401031a4c4cadcbe60dbff3d110"
+      },
+      {
+        "@id": "_:N1f35a14489a84146b3f0cbefa1cffa01"
+      },
+      {
+        "@id": "_:N89bcd55203574829b4f6377cb59906eb"
+      },
+      {
+        "@id": "_:Nc9a8c3383d9e4b8bbc4956821b829680"
+      },
+      {
+        "@id": "_:N47841f876088488492840f0dd975da69"
+      },
+      {
+        "@id": "_:N6f3c1b810b4e451d9059a21b640415ac"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 3
+      }
+    ]
+  },
+  {
+    "@id": "_:Na8261401031a4c4cadcbe60dbff3d110",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1f35a14489a84146b3f0cbefa1cffa01",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N89bcd55203574829b4f6377cb59906eb",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc9a8c3383d9e4b8bbc4956821b829680",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N47841f876088488492840f0dd975da69",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6f3c1b810b4e451d9059a21b640415ac",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "diagnosis"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Concept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Ncae7921d1d26497b9399e3782ebdafc8"
+      },
+      {
+        "@id": "_:N179e8e4dec6441dfb5a079d0f76446c3"
+      },
+      {
+        "@id": "_:Nb2183c14643248de9dfee8c64dd23f34"
+      },
+      {
+        "@id": "_:N88ab04bc080e4b99b90d18500b7c241a"
+      },
+      {
+        "@id": "_:N03f4f5e7d8584fd3a799ac4e2dd73541"
+      },
+      {
+        "@id": "_:N6990016393af483fb0eef9fa881a66cb"
+      },
+      {
+        "@id": "_:Nc7b1674e4aa94c69af037bd4bab829c9"
+      },
+      {
+        "@id": "_:N3e026783ed1149be8b86c86abd9c0ae2"
+      },
+      {
+        "@id": "_:N5920c50cb4634dc7a0f972dceee96945"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncae7921d1d26497b9399e3782ebdafc8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N179e8e4dec6441dfb5a079d0f76446c3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb2183c14643248de9dfee8c64dd23f34",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N88ab04bc080e4b99b90d18500b7c241a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:N03f4f5e7d8584fd3a799ac4e2dd73541",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6990016393af483fb0eef9fa881a66cb",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc7b1674e4aa94c69af037bd4bab829c9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3e026783ed1149be8b86c86abd9c0ae2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5920c50cb4634dc7a0f972dceee96945",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyObject"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Example of unconstrained class"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#exactMatch": [
+      {
+        "@id": "https://w3id.org/linkml/Any"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ceo"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/id",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "id"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent"
+          }
+        ]
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "subclass test"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
+      },
+      {
+        "@id": "_:Ne86a9a36519147c0b02ea558654d579f"
+      },
+      {
+        "@id": "_:Nabb21404e4fb46a890d86a78ca207a3a"
+      },
+      {
+        "@id": "_:Nd9c3072be3d14923826845628efaabe6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne86a9a36519147c0b02ea558654d579f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nabb21404e4fb46a890d86a78ca207a3a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd9c3072be3d14923826845628efaabe6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "HasAliases"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N17278bd706934e6699ff1f744c6e4e40"
+      },
+      {
+        "@id": "_:Nded50f6840af4b96a080a5172b47fe9f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N17278bd706934e6699ff1f744c6e4e40",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nded50f6840af4b96a080a5172b47fe9f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Ontology"
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@value": "Kitchen Sink Schema"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+      {
+        "@id": "https://example.org/"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Kitchen Sink Schema\n\nThis schema does not do anything useful. It exists to test all features of linkml.\n\nThis particular text field exists to demonstrate markdown within a text field:\n\nLists:\n\n   * a\n   * b\n   * c\n\nAnd links, e.g to [Person](Person.md)"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "MedicalEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:N4c9dd5e84ffe4a8b81b8d6d95fe9f4d7"
+      },
+      {
+        "@id": "_:Nec32f044f4064f5eb9af7caf6ac8fe4c"
+      },
+      {
+        "@id": "_:Nd46e3db0248e4862a8857e6bd5661c1a"
+      },
+      {
+        "@id": "_:N47160c98d0e041a2b23ee9a2bc258db4"
+      },
+      {
+        "@id": "_:Ne40d6a4d338d4eae8b92afde66d6872c"
+      },
+      {
+        "@id": "_:N6a7d1b711d8f41828f0aa866e6981908"
+      },
+      {
+        "@id": "_:N3bc56c4835954fb49acd9651ddbd73e9"
+      },
+      {
+        "@id": "_:N775c3b94617544f49794a398fd63459a"
+      },
+      {
+        "@id": "_:Nd8cb1569b47346a0bbe9d16f9ab2dece"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4c9dd5e84ffe4a8b81b8d6d95fe9f4d7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nec32f044f4064f5eb9af7caf6ac8fe4c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd46e3db0248e4862a8857e6bd5661c1a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:N47160c98d0e041a2b23ee9a2bc258db4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne40d6a4d338d4eae8b92afde66d6872c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6a7d1b711d8f41828f0aa866e6981908",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3bc56c4835954fb49acd9651ddbd73e9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "_:N775c3b94617544f49794a398fd63459a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd8cb1569b47346a0bbe9d16f9ab2dece",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FamilialRelationship"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship"
+      },
+      {
+        "@id": "_:N42061eb6854944259d66c3ec253dfd6c"
+      },
+      {
+        "@id": "_:N3d982a9e2d844c16b0d1ca44a75d5496"
+      },
+      {
+        "@id": "_:N83da0b433bca473fa01a75bda5df6bef"
+      },
+      {
+        "@id": "_:N4a9058e47e2743b5b78399818b7ec8c9"
+      },
+      {
+        "@id": "_:Ndf1134ba7e1b455bb774729f3eb29ff2"
+      },
+      {
+        "@id": "_:N5b28e0f07f854f22825e01edb9de1dd8"
+      },
+      {
+        "@id": "_:N0b35f176b9484f288a322f118739ff77"
+      },
+      {
+        "@id": "_:N66841dc5c75f4cc184edcd38ace315f5"
+      },
+      {
+        "@id": "_:Ndae50a93aff343989f1cc3512a695d14"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 5
+      }
+    ]
+  },
+  {
+    "@id": "_:N42061eb6854944259d66c3ec253dfd6c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3d982a9e2d844c16b0d1ca44a75d5496",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N83da0b433bca473fa01a75bda5df6bef",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4a9058e47e2743b5b78399818b7ec8c9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndf1134ba7e1b455bb774729f3eb29ff2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5b28e0f07f854f22825e01edb9de1dd8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0b35f176b9484f288a322f118739ff77",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N66841dc5c75f4cc184edcd38ace315f5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndae50a93aff343989f1cc3512a695d14",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "class with spaces"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N089e163e128546dfaf7d29ee81851ba2"
+      },
+      {
+        "@id": "_:Nbada299da3094f49a47ebdb965ea7914"
+      },
+      {
+        "@id": "_:Ne8e5a0d2c123431eaa3007aa039c10e1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N089e163e128546dfaf7d29ee81851ba2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbada299da3094f49a47ebdb965ea7914",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne8e5a0d2c123431eaa3007aa039c10e1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "aliases"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "slot with space 1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "BirthEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:Ne6ec2ad6369f428ba70a4d02e8a3efdd"
+      },
+      {
+        "@id": "_:N9985846ff4154e6f8a004ad677b549ec"
+      },
+      {
+        "@id": "_:Nab737f5212a74eaebd0d1a8508a27144"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne6ec2ad6369f428ba70a4d02e8a3efdd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9985846ff4154e6f8a004ad677b549ec",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nab737f5212a74eaebd0d1a8508a27144",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "stomach count"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/street",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "street"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/ended_at_time",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ended at time"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "altitude"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "mixin_slot_I"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#indifferent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "indifferent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "SIBLING_OF"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfMix",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfMix"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Ne8c08130ade04b808f3abfe74fb7b239"
+      },
+      {
+        "@id": "_:N1e1ac1a2f1ab4935a247de0d6c1e907b"
+      },
+      {
+        "@id": "_:Nb5892cc1979042cebc5bbe63d562fdc0"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne8c08130ade04b808f3abfe74fb7b239",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N8848e63a8cdc464e93b1a8bccb870e42"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8848e63a8cdc464e93b1a8bccb870e42",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N1e1ac1a2f1ab4935a247de0d6c1e907b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb5892cc1979042cebc5bbe63d562fdc0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "MarriageEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation"
+      },
+      {
+        "@id": "_:N12486b21df0a4dc39a64b99ce1f1e181"
+      },
+      {
+        "@id": "_:Nbaa1f4ced2c240979d771e5b713ddaea"
+      },
+      {
+        "@id": "_:N87606c3ea2f04676abdc1e0b7016b7b1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N12486b21df0a4dc39a64b99ce1f1e181",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbaa1f4ced2c240979d771e5b713ddaea",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N87606c3ea2f04676abdc1e0b7016b7b1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+      }
+    ]
+  },
+  {
+    "@id": "http://www.w3.org/2001/XMLSchema#integer",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_marriage_history",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has marriage history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+          }
+        ]
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsString",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EqualsString"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nb4137b68f3ed4536bfa841be5a00963d"
+      },
+      {
+        "@id": "_:N3d406933646149dcbc0ee2e8e669577f"
+      },
+      {
+        "@id": "_:N16677cd2700e46239abda61131e1bbd8"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb4137b68f3ed4536bfa841be5a00963d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3d406933646149dcbc0ee2e8e669577f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "_:N16677cd2700e46239abda61131e1bbd8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#LIVING",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "LIVING"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "persons"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/001",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "HIRE"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "is current"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.n3
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.n3
@@ -48,50 +48,50 @@ And links, e.g to [Person](Person.md)""" .
 ks:AnyOfClasses a owl:Class ;
     rdfs:label "AnyOfClasses" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:attribute2 ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute2 ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:Person ks:Organization ) ] ;
-            owl:onProperty ks:attribute2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:attribute2 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfEnums a owl:Class ;
     rdfs:label "AnyOfEnums" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute3 ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:DiagnosisType ks:EmploymentEventType ) ] ;
+            owl:onProperty ks:attribute3 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute3 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfMix a owl:Class ;
     rdfs:label "AnyOfMix" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute4 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfSimpleType a owl:Class ;
     rdfs:label "AnyOfSimpleType" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute1 ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:unionOf ( xsd:string xsd:integer ) ] ;
+            owl:onProperty ks:attribute1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute1 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -101,29 +101,8 @@ ks:AnyOfSimpleType a owl:Class ;
 ks:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:Company ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:activities ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
-            owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:persons ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty ks:activities ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:Person ;
             owl:onProperty ks:persons ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:metadata ],
@@ -131,8 +110,29 @@ ks:Dataset a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:code_systems ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Company ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:CodeSystem ;
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:persons ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty ks:activities ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
-            owl:onProperty ks:metadata ] ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:activities ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 1 .
 
@@ -142,24 +142,24 @@ ks:EqualsString a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute5 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:EqualsStringIn a owl:Class ;
     rdfs:label "EqualsStringIn" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:oneOf ( "foo" "bar" ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:oneOf ( "foo" "bar" ) ] ;
             owl:onProperty ks:attribute6 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -179,13 +179,13 @@ ks:FakeClass a owl:Class ;
 ks:Friend a owl:Class ;
     rdfs:label "Friend" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -223,22 +223,22 @@ ks:tree_slot_C a owl:DatatypeProperty ;
 ks:MarriageEvent a owl:Class ;
     rdfs:label "MarriageEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:married_to ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ks:Person ;
             owl:onProperty ks:married_to ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:married_to ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:married_to ],
         ks:Event,
         ks:WithLocation ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:OtherCodes a owl:Class ;
-    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b> .
+    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b> .
 
-<https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b> a owl:Class ;
+<https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b> a owl:Class ;
     rdfs:label "a b" ;
     rdfs:subClassOf ks:OtherCodes .
 
@@ -246,61 +246,61 @@ ks:Relationship a owl:Class ;
     rdfs:label "Relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CordialnessEnum ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:related_to ] ;
+            owl:onProperty ks:cordialness ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:WithLocation a owl:Class ;
     rdfs:label "WithLocation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -336,32 +336,32 @@ bizcodes:004 a owl:Class ;
 ks:Address a owl:Class ;
     rdfs:label "Address" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:altitude ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:altitude ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:decimal ;
-            owl:onProperty ks:altitude ] ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:city ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:BirthEvent a owl:Class ;
@@ -370,10 +370,10 @@ ks:BirthEvent a owl:Class ;
             owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -381,10 +381,10 @@ ks:BirthEvent a owl:Class ;
 ks:ClassWithSpaces a owl:Class ;
     rdfs:label "class with spaces" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
@@ -394,31 +394,31 @@ ks:ClassWithSpaces a owl:Class ;
 ks:Concept a owl:Class ;
     rdfs:label "Concept" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_code_system ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -452,17 +452,17 @@ ks:EmploymentEvent a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:employed_at ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:employed_at ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:employed_at ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 6 .
@@ -470,29 +470,29 @@ ks:EmploymentEvent a owl:Class ;
 ks:FamilialRelationship a owl:Class ;
     rdfs:label "FamilialRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
+            owl:minCardinality 1 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:FamilialRelationshipType ;
             owl:onProperty ks:type ],
@@ -540,55 +540,55 @@ ks:KitchenStatus a owl:Class ;
 ks:MedicalEvent a owl:Class ;
     rdfs:label "MedicalEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ks:DiagnosisConcept ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ks:Place ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:ProcedureConcept ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:DiagnosisConcept ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:procedure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
-            owl:onProperty ks:in_location ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:definition """An organization.
 
@@ -614,10 +614,10 @@ ks:SubclassTest a owl:Class ;
             owl:allValuesFrom ks:ClassWithSpaces ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_2 ],
         ks:ClassWithSpaces ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -692,35 +692,35 @@ ks:AnyObject a owl:Class ;
 ks:CodeSystem a owl:Class ;
     rdfs:label "CodeSystem" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Company a owl:Class ;
     rdfs:label "Company" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:ceo ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:ceo ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:ceo ],
         ks:Organization ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -853,41 +853,41 @@ ks:test_attribute a owl:DatatypeProperty ;
 ks:Event a owl:Class ;
     rdfs:label "Event" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:boolean ;
+            owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:metadata ] ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FamilialRelationshipType a owl:Class ;
@@ -899,22 +899,22 @@ ks:FamilialRelationshipType a owl:Class ;
 ks:Place a owl:Class ;
     rdfs:label "Place" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -925,10 +925,13 @@ ks:Place a owl:Class ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -937,17 +940,14 @@ ks:Place a owl:Class ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ] ;
     skos:definition "a provence-generating agent" ;
     skos:exactMatch prov:Agent ;
     skos:inScheme <https://w3id.org/linkml/tests/core> .
@@ -986,68 +986,68 @@ ks:related_to a owl:DatatypeProperty ;
 <https://w3id.org/linkml/tests/core/Activity> a owl:Class ;
     rdfs:label "activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ] ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ] ;
     skos:definition "a provence-generating activity" ;
     skos:inScheme <https://w3id.org/linkml/tests/core> ;
     skos:mappingRelation prov:Activity .
@@ -1064,6 +1064,21 @@ ks:Person a owl:Class ;
     rdfs:seeAlso schema1:Person,
         <https://en.wikipedia.org/wiki/Person> ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationship ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:integer ;
@@ -1072,31 +1087,54 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 1 ] ) ] ) ] ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationship ;
-            owl:onProperty ks:has_familial_relationships ],
+            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:BirthEvent ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:EmploymentEvent ;
-            owl:onProperty ks:has_employment_history ],
+            owl:allValuesFrom ks:Address ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:has_birth_event ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_medical_history ],
+            owl:allValuesFrom ks:EmploymentEvent ;
+            owl:onProperty ks:has_employment_history ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Address ;
-            owl:onProperty ks:addresses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:onDatatype xsd:string ;
+                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:species_name ],
@@ -1105,36 +1143,7 @@ ks:Person a owl:Class ;
             owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:LifeStatusEnum ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:BirthEvent ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1148,22 +1157,13 @@ ks:Person a owl:Class ;
             owl:onProperty ks:addresses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:has_birth_event ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         ks:HasAliases ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;

--- a/tests/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.ttl
+++ b/tests/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.ttl
@@ -48,23 +48,23 @@ And links, e.g to [Person](Person.md)""" .
 ks:AnyOfClasses a owl:Class ;
     rdfs:label "AnyOfClasses" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:attribute2 ],
+        [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:Person ks:Organization ) ] ;
             owl:onProperty ks:attribute2 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:attribute2 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfEnums a owl:Class ;
     rdfs:label "AnyOfEnums" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ owl:unionOf ( ks:DiagnosisType ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( ks:DiagnosisType ks:EmploymentEventType ) ] ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -87,14 +87,14 @@ ks:AnyOfMix a owl:Class ;
 ks:AnyOfSimpleType a owl:Class ;
     rdfs:label "AnyOfSimpleType" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:attribute1 ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute1 ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:unionOf ( xsd:string xsd:integer ) ] ;
-            owl:onProperty ks:attribute1 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:attribute1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -102,37 +102,37 @@ ks:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
-            owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:AnyObject ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Company ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty ks:activities ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:persons ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:persons ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty ks:activities ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:activities ] ;
+            owl:onProperty ks:activities ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Company ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:AnyObject ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:CodeSystem ;
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:persons ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 1 .
 
@@ -142,50 +142,50 @@ ks:EqualsString a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute5 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:EqualsStringIn a owl:Class ;
     rdfs:label "EqualsStringIn" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:oneOf ( "foo" "bar" ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:oneOf ( "foo" "bar" ) ] ;
             owl:onProperty ks:attribute6 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FakeClass a owl:Class ;
     rdfs:label "FakeClass" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:test_attribute ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:test_attribute ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:test_attribute ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Friend a owl:Class ;
     rdfs:label "Friend" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -236,71 +236,71 @@ ks:MarriageEvent a owl:Class ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:OtherCodes a owl:Class ;
-    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b> .
+    linkml:permissible_values <https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b> .
 
-<https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a+b> a owl:Class ;
+<https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b> a owl:Class ;
     rdfs:label "a b" ;
     rdfs:subClassOf ks:OtherCodes .
 
 ks:Relationship a owl:Class ;
     rdfs:label "Relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:related_to ],
+            owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CordialnessEnum ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:type ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:WithLocation a owl:Class ;
     rdfs:label "WithLocation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -336,17 +336,17 @@ bizcodes:004 a owl:Class ;
 ks:Address a owl:Class ;
     rdfs:label "Address" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:decimal ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:altitude ],
+            owl:onProperty ks:street ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:street ],
@@ -358,7 +358,7 @@ ks:Address a owl:Class ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:street ],
+            owl:onProperty ks:city ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:city ] ;
@@ -381,13 +381,13 @@ ks:BirthEvent a owl:Class ;
 ks:ClassWithSpaces a owl:Class ;
     rdfs:label "class with spaces" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:slot_with_space_1 ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:slot_with_space_1 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:slot_with_space_1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -395,31 +395,31 @@ ks:Concept a owl:Class ;
     rdfs:label "Concept" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_code_system ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_code_system ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
-            owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ks:CodeSystem ;
+            owl:onProperty ks:in_code_system ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:in_code_system ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_code_system ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 <https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful> a owl:Class ;
@@ -449,8 +449,8 @@ ks:EmploymentEvent a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Company ;
-            owl:onProperty ks:employed_at ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
             owl:onProperty ks:type ],
@@ -458,8 +458,8 @@ ks:EmploymentEvent a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
+            owl:allValuesFrom ks:Company ;
+            owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:employed_at ],
@@ -470,32 +470,32 @@ ks:EmploymentEvent a owl:Class ;
 ks:FamilialRelationship a owl:Class ;
     rdfs:label "FamilialRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Person ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:related_to ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:FamilialRelationshipType ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
         ks:Relationship ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 5 .
@@ -540,20 +540,17 @@ ks:KitchenStatus a owl:Class ;
 ks:MedicalEvent a owl:Class ;
     rdfs:label "MedicalEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:procedure ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:in_location ],
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:ProcedureConcept ;
-            owl:onProperty ks:procedure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:procedure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:DiagnosisConcept ;
-            owl:onProperty ks:diagnosis ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:diagnosis ],
@@ -561,10 +558,13 @@ ks:MedicalEvent a owl:Class ;
             owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:DiagnosisConcept ;
             owl:onProperty ks:diagnosis ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:ProcedureConcept ;
             owl:onProperty ks:procedure ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -573,13 +573,13 @@ ks:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
@@ -587,7 +587,7 @@ ks:Organization a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:definition """An organization.
@@ -611,13 +611,13 @@ ks:ProcedureConcept a owl:Class ;
 ks:SubclassTest a owl:Class ;
     rdfs:label "subclass test" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:slot_with_space_2 ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:ClassWithSpaces ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:slot_with_space_2 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_2 ],
         ks:ClassWithSpaces ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -695,16 +695,16 @@ ks:CodeSystem a owl:Class ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -714,13 +714,13 @@ ks:CodeSystem a owl:Class ;
 ks:Company a owl:Class ;
     rdfs:label "Company" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Person ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:ceo ],
         ks:Organization ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -853,40 +853,40 @@ ks:test_attribute a owl:DatatypeProperty ;
 ks:Event a owl:Class ;
     rdfs:label "Event" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:boolean ;
             owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:AnyObject ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -899,23 +899,23 @@ ks:FamilialRelationshipType a owl:Class ;
 ks:Place a owl:Class ;
     rdfs:label "Place" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         ks:HasAliases ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -925,26 +925,26 @@ ks:Place a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ] ;
@@ -986,68 +986,68 @@ ks:related_to a owl:DatatypeProperty ;
 <https://w3id.org/linkml/tests/core/Activity> a owl:Class ;
     rdfs:label "activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
     skos:definition "a provence-generating activity" ;
     skos:inScheme <https://w3id.org/linkml/tests/core> ;
     skos:mappingRelation prov:Activity .
@@ -1064,57 +1064,45 @@ ks:Person a owl:Class ;
     rdfs:seeAlso schema1:Person,
         <https://en.wikipedia.org/wiki/Person> ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:LifeStatusEnum ;
-            owl:onProperty ks:is_living ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_employment_history ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
-            owl:onProperty ks:species_name ],
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
+            owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:has_birth_event ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_employment_history ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:MedicalEvent ;
             owl:onProperty ks:has_medical_history ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:EmploymentEvent ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationship ;
-            owl:onProperty ks:has_familial_relationships ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:BirthEvent ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1125,7 +1113,42 @@ ks:Person a owl:Class ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:has_medical_history ],
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationship ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:onDatatype xsd:string ;
+                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:EmploymentEvent ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:stomach_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:BirthEvent ;
+            owl:onProperty ks:has_birth_event ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Address ;
             owl:onProperty ks:addresses ],
@@ -1134,36 +1157,13 @@ ks:Person a owl:Class ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:species_name ],
+            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:addresses ],
         ks:HasAliases ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;


### PR DESCRIPTION
This PR fixes a bug in which permissible values involving `{}`s (such as for example a units Enum that uses UCUM curly braces - although this is often discouraged - e.g. https://terminology.hl7.org/UCUM.html) were not correctly quoted, leading to invalid RDF when generating OWL

This PR also adds additional edge case PVs to the compliance tests.