### PR TITLE
Remove erroneous @click.option definition (closes #2871)

### DIFF
--- a/linkml/generators/erdiagramgen.py
+++ b/linkml/generators/erdiagramgen.py
@@ -324,7 +324,6 @@ class ERDiagramGenerator(Generator):
     default=False,
     help="If True, follow references even if not inlined",
 )
-@click.option("--format", "-f", default="markdown", type=click.Choice(ERDiagramGenerator.valid_formats))
 @click.option("--max-hops", default=None, type=click.INT, help="Maximum number of hops")
 @click.option("--classes", "-c", multiple=True, help="List of classes to serialize")
 @click.option("--include-upstream", is_flag=True, help="Include upstream classes")


### PR DESCRIPTION
Act on a click warning indicating that the same option has been defined multiple times.