### PR TITLE
fix(rdfgen): binary-safe output with -o

### DIFF
--- a/linkml/generators/rdfgen.py
+++ b/linkml/generators/rdfgen.py
@@ -67,12 +67,21 @@ class RDFGenerator(Generator):
             base=str(self.namespaces._base),
             prefix=True,
         )
-        out = self._data(graph)
+        fmt = "turtle" if self.format == "ttl" else self.format
         if output:
+            # Binary-safe when -o/--output is used:
+            # delegate to RDFLib (Graph.serialize(destination=..., format=...)).
+            # Serializers that produce bytes write directly to the file; stdout stays empty.
+            try:
+                out = graph.serialize(format=fmt)
+            except UnicodeDecodeError:
+                graph.serialize(destination=output, format=fmt)
+                return ""
             with open(output, "w", encoding="UTF-8") as outf:
                 outf.write(out)
+            return out
 
-        return out
+        return self._data(graph)
 
 
 @shared_arguments(RDFGenerator)

--- a/tests/test_generators/test_rdfgen_binary.py
+++ b/tests/test_generators/test_rdfgen_binary.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+from typing import Dict, Any
+
+import pytest
+from rdflib import Graph
+from linkml.generators.rdfgen import RDFGenerator
+
+
+def _write_min_schema(p: Path) -> Path:
+    p.write_text(
+        "id: http://example.org/min\n"
+        "name: min\n"
+        "prefixes:\n"
+        "  ex: http://example.org/\n"
+        "default_curi_maps:\n"
+        "  - semweb_context\n"
+        "classes:\n"
+        "  A: {}\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_with_output_binary_path_on_decode_error(monkeypatch, tmp_path):
+    """On UnicodeDecodeError: write via destination, keep stdout empty."""
+    calls: Dict[str, Any] = {"destination_called": False, "format": None}
+
+    def fake_serialize(self, *args, **kwargs):
+        if "destination" not in kwargs:
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        calls["destination_called"] = True
+        calls["format"] = kwargs.get("format")
+        dest = kwargs["destination"]
+        Path(dest).write_bytes(b"\x00\x01\x02BINARY-DATA")
+        return None
+
+    monkeypatch.setattr(Graph, "serialize", fake_serialize, raising=True)
+
+    schema_path = _write_min_schema(tmp_path / "schema.yaml")
+    out_path = tmp_path / "out.bin"
+
+    gen = RDFGenerator(str(schema_path), mergeimports=False)
+    gen.format = "ttl"  # maps to 'turtle'
+
+    ret = gen.serialize(output=str(out_path))
+
+    assert ret.strip() == ""
+    assert calls["destination_called"] is True
+    assert calls["format"] == "turtle"
+    assert out_path.exists() and out_path.stat().st_size > 0
+
+    data = out_path.read_bytes()
+    assert data.startswith(b"\x00\x01\x02BINARY-DATA")
+
+
+def test_with_output_text_path_returns_text_and_writes_file(monkeypatch, tmp_path):
+    """If serialization returns text, write UTF-8 file and return the same text."""
+    calls: Dict[str, Any] = {"destination_called": False, "format": None}
+
+    def fake_serialize(self, *args, **kwargs):
+        if "destination" in kwargs:
+            calls["destination_called"] = True
+            calls["format"] = kwargs.get("format")
+            return None
+        fmt = kwargs.get("format")
+        return f"# fake {fmt} content"
+
+    monkeypatch.setattr(Graph, "serialize", fake_serialize, raising=True)
+
+    schema_path = _write_min_schema(tmp_path / "schema.yaml")
+    out_path = tmp_path / "out.ttl"
+
+    gen = RDFGenerator(str(schema_path), mergeimports=False)
+    gen.format = "ttl"  # => 'turtle'
+
+    ret = gen.serialize(output=str(out_path))
+
+    assert isinstance(ret, str) and ret.startswith("# fake turtle")
+    assert calls["destination_called"] is False
+    txt = out_path.read_text(encoding="utf-8")
+    assert txt.rstrip("\n") == ret.rstrip("\n")
+
+
+def test_without_output_returns_text(monkeypatch, tmp_path):
+    """Without -o, return text."""
+    def fake_serialize(self, *args, **kwargs):
+        assert "destination" not in kwargs
+        return "# fake turtle content"
+
+    monkeypatch.setattr(Graph, "serialize", fake_serialize, raising=True)
+
+    schema_path = _write_min_schema(tmp_path / "s.yaml")
+    gen = RDFGenerator(str(schema_path), mergeimports=False)
+    gen.format = "turtle"
+
+    ret = gen.serialize()
+    assert isinstance(ret, str) and ret.startswith("# fake turtle")

--- a/tests/test_generators/test_rdfgen_binary_integration.py
+++ b/tests/test_generators/test_rdfgen_binary_integration.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import pytest
+from linkml.generators.rdfgen import RDFGenerator
+
+
+def _write_min_schema(p: Path) -> Path:
+    p.write_text(
+        "id: http://example.org/min\n"
+        "name: min\n"
+        "prefixes:\n"
+        "  ex: http://example.org/\n"
+        "default_curi_maps:\n"
+        "  - semweb_context\n"
+        "classes:\n"
+        "  A: {}\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_binary_serializer_with_output_keeps_stdout_empty_and_writes_binary(tmp_path):
+    """With binary serializer and -o: stdout is empty, file contains binary data."""
+    pytest.importorskip("rdflib.plugins.serializers.jelly")
+
+    schema_path = _write_min_schema(tmp_path / "schema.yaml")
+    out_path = tmp_path / "out.jelly"
+
+    gen = RDFGenerator(str(schema_path), mergeimports=False)
+    gen.format = "jelly"
+
+    ret = gen.serialize(output=str(out_path))
+
+    assert ret.strip() == ""
+    assert out_path.exists() and out_path.stat().st_size > 0
+
+    with pytest.raises(UnicodeDecodeError):
+        _ = out_path.read_text(encoding="utf-8")
+
+
+def test_text_serializer_with_output_preserves_stdout_and_writes_text(tmp_path):
+    """With text serializer and -o: stdout returns text; file contains the same text."""
+    schema_path = _write_min_schema(tmp_path / "schema.yaml")
+    out_path = tmp_path / "out.ttl"
+
+    gen = RDFGenerator(str(schema_path), mergeimports=False)
+    gen.format = "ttl"
+
+    ret = gen.serialize(output=str(out_path))
+
+    assert isinstance(ret, str) and len(ret.strip()) > 0
+    txt = out_path.read_text(encoding="utf-8")
+    assert txt.rstrip("\n") == ret.rstrip("\n") and len(txt) > 0


### PR DESCRIPTION
Binary RDF serializers (e.g., [Jelly](https://w3id.org/jelly)) could raise a UnicodeDecodeError when writing to stdout.

With -o/--output, rdfgen now lets RDFLib write directly to the file (Graph.serialize with destination).
Binary serializers write to the file, leaving stdout empty.

Behaviour without -o is unchanged.

Tests:
Unit: mock Graph.serialize; verify file writing, empty stdout, and ttl still maps to turtle.
Integration: run with Jelly if available; check empty stdout and binary file output.
