### PR TITLE
OnePerClass linter rules for `identifier` and `key` attributes

### DIFF
--- a/linkml/linter/config/datamodel/config.py
+++ b/linkml/linter/config/datamodel/config.py
@@ -504,4 +504,3 @@ slots.canonicalPrefixesConfig__prefixmaps_contexts = Slot(uri=LINTCFG.prefixmaps
 
 slots.noEmptyTitleConfig__exclude_type = Slot(uri=LINTCFG.exclude_type, name="noEmptyTitleConfig__exclude_type", curie=LINTCFG.curie('exclude_type'),
                    model_uri=LINTCFG.noEmptyTitleConfig__exclude_type, domain=None, range=Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]])
-

--- a/linkml/linter/config/datamodel/config.py
+++ b/linkml/linter/config/datamodel/config.py
@@ -1,5 +1,5 @@
 # Auto generated from config.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-07-28T09:29:10
+# Generation date: 2025-09-30T13:24:19
 # Schema: linter-config
 #
 # id: https://w3id.org/linkml/linter/config
@@ -9,18 +9,52 @@
 import dataclasses
 import re
 from dataclasses import dataclass
-from datetime import date, datetime, time
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Union
+)
 
-from jsonasobj2 import JsonObj, as_dict
-from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
+from jsonasobj2 import (
+    JsonObj,
+    as_dict
+)
+from linkml_runtime.linkml_model.meta import (
+    EnumDefinition,
+    PermissibleValue,
+    PvFormulaOptions
+)
 from linkml_runtime.utils.curienamespace import CurieNamespace
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
-from linkml_runtime.utils.formatutils import camelcase, sfx, underscore
-from linkml_runtime.utils.metamodelcore import bnode, empty_dict, empty_list
+from linkml_runtime.utils.formatutils import (
+    camelcase,
+    sfx,
+    underscore
+)
+from linkml_runtime.utils.metamodelcore import (
+    bnode,
+    empty_dict,
+    empty_list
+)
 from linkml_runtime.utils.slot import Slot
-from linkml_runtime.utils.yamlutils import YAMLRoot, extended_float, extended_int, extended_str
-from rdflib import Namespace, URIRef
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_float,
+    extended_int,
+    extended_str
+)
+from rdflib import (
+    Namespace,
+    URIRef
+)
 
 from linkml_runtime.linkml_model.types import Boolean, String
 from linkml_runtime.utils.metamodelcore import Bool
@@ -29,8 +63,8 @@ metamodel_version = "1.7.0"
 version = None
 
 # Namespaces
-LINKML = CurieNamespace("linkml", "https://w3id.org/linkml/")
-LINTCFG = CurieNamespace("lintcfg", "https://w3id.org/linkml/linter/config")
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+LINTCFG = CurieNamespace('lintcfg', 'https://w3id.org/linkml/linter/config')
 DEFAULT_ = LINTCFG
 
 
@@ -39,13 +73,13 @@ DEFAULT_ = LINTCFG
 # Class references
 
 
+
 @dataclass(repr=False)
 class Config(YAMLRoot):
     """
     This is the top-level representation of a LinkML linter configuration file. It allows defining a set of rules
     while also optionally extending a predefined set of rules.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["Config"]
@@ -71,7 +105,6 @@ class Rules(YAMLRoot):
     """
     Each attribute of this class represents a rule that can be enabled and possibly configured by a configuration file.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["Rules"]
@@ -79,37 +112,26 @@ class Rules(YAMLRoot):
     class_name: ClassVar[str] = "Rules"
     class_model_uri: ClassVar[URIRef] = LINTCFG.Rules
 
+    canonical_prefixes: Optional[Union[dict, "CanonicalPrefixesConfig"]] = None
     no_empty_title: Optional[Union[dict, "NoEmptyTitleConfig"]] = None
-    permissible_values_format: Optional[Union[dict, "PermissibleValuesFormatRuleConfig"]] = None
-    tree_root_class: Optional[Union[dict, "TreeRootClassRuleConfig"]] = None
-    recommended: Optional[Union[dict, "RecommendedRuleConfig"]] = None
-    no_xsd_int_type: Optional[Union[dict, "RuleConfig"]] = None
     no_invalid_slot_usage: Optional[Union[dict, "RuleConfig"]] = None
     no_undeclared_slots: Optional[Union[dict, "RuleConfig"]] = None
     no_undeclared_ranges: Optional[Union[dict, "RuleConfig"]] = None
+    no_xsd_int_type: Optional[Union[dict, "RuleConfig"]] = None
+    one_identifier_per_class: Optional[Union[dict, "RuleConfig"]] = None
+    one_key_per_class: Optional[Union[dict, "RuleConfig"]] = None
+    permissible_values_format: Optional[Union[dict, "PermissibleValuesFormatRuleConfig"]] = None
+    recommended: Optional[Union[dict, "RecommendedRuleConfig"]] = None
     root_type_checks: Optional[Union[dict, "RuleConfig"]] = None
     standard_naming: Optional[Union[dict, "StandardNamingConfig"]] = None
-    canonical_prefixes: Optional[Union[dict, "CanonicalPrefixesConfig"]] = None
+    tree_root_class: Optional[Union[dict, "TreeRootClassRuleConfig"]] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
+        if self.canonical_prefixes is not None and not isinstance(self.canonical_prefixes, CanonicalPrefixesConfig):
+            self.canonical_prefixes = CanonicalPrefixesConfig(**as_dict(self.canonical_prefixes))
+
         if self.no_empty_title is not None and not isinstance(self.no_empty_title, NoEmptyTitleConfig):
             self.no_empty_title = NoEmptyTitleConfig(**as_dict(self.no_empty_title))
-
-        if self.permissible_values_format is not None and not isinstance(
-            self.permissible_values_format, PermissibleValuesFormatRuleConfig
-        ):
-            self.permissible_values_format = PermissibleValuesFormatRuleConfig(
-                **as_dict(self.permissible_values_format)
-            )
-
-        if self.tree_root_class is not None and not isinstance(self.tree_root_class, TreeRootClassRuleConfig):
-            self.tree_root_class = TreeRootClassRuleConfig(**as_dict(self.tree_root_class))
-
-        if self.recommended is not None and not isinstance(self.recommended, RecommendedRuleConfig):
-            self.recommended = RecommendedRuleConfig(**as_dict(self.recommended))
-
-        if self.no_xsd_int_type is not None and not isinstance(self.no_xsd_int_type, RuleConfig):
-            self.no_xsd_int_type = RuleConfig(**as_dict(self.no_xsd_int_type))
 
         if self.no_invalid_slot_usage is not None and not isinstance(self.no_invalid_slot_usage, RuleConfig):
             self.no_invalid_slot_usage = RuleConfig(**as_dict(self.no_invalid_slot_usage))
@@ -120,14 +142,29 @@ class Rules(YAMLRoot):
         if self.no_undeclared_ranges is not None and not isinstance(self.no_undeclared_ranges, RuleConfig):
             self.no_undeclared_ranges = RuleConfig(**as_dict(self.no_undeclared_ranges))
 
+        if self.no_xsd_int_type is not None and not isinstance(self.no_xsd_int_type, RuleConfig):
+            self.no_xsd_int_type = RuleConfig(**as_dict(self.no_xsd_int_type))
+
+        if self.one_identifier_per_class is not None and not isinstance(self.one_identifier_per_class, RuleConfig):
+            self.one_identifier_per_class = RuleConfig(**as_dict(self.one_identifier_per_class))
+
+        if self.one_key_per_class is not None and not isinstance(self.one_key_per_class, RuleConfig):
+            self.one_key_per_class = RuleConfig(**as_dict(self.one_key_per_class))
+
+        if self.permissible_values_format is not None and not isinstance(self.permissible_values_format, PermissibleValuesFormatRuleConfig):
+            self.permissible_values_format = PermissibleValuesFormatRuleConfig(**as_dict(self.permissible_values_format))
+
+        if self.recommended is not None and not isinstance(self.recommended, RecommendedRuleConfig):
+            self.recommended = RecommendedRuleConfig(**as_dict(self.recommended))
+
         if self.root_type_checks is not None and not isinstance(self.root_type_checks, RuleConfig):
             self.root_type_checks = RuleConfig(**as_dict(self.root_type_checks))
 
         if self.standard_naming is not None and not isinstance(self.standard_naming, StandardNamingConfig):
             self.standard_naming = StandardNamingConfig(**as_dict(self.standard_naming))
 
-        if self.canonical_prefixes is not None and not isinstance(self.canonical_prefixes, CanonicalPrefixesConfig):
-            self.canonical_prefixes = CanonicalPrefixesConfig(**as_dict(self.canonical_prefixes))
+        if self.tree_root_class is not None and not isinstance(self.tree_root_class, TreeRootClassRuleConfig):
+            self.tree_root_class = TreeRootClassRuleConfig(**as_dict(self.tree_root_class))
 
         super().__post_init__(**kwargs)
 
@@ -137,7 +174,6 @@ class RuleConfig(YAMLRoot):
     """
     This is the base class for linter rules. It contains configuration options that are common to all rules.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["RuleConfig"]
@@ -161,7 +197,6 @@ class PermissibleValuesFormatRuleConfig(RuleConfig):
     """
     Additional configuration options for the `permissible_values_format` rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["PermissibleValuesFormatRuleConfig"]
@@ -184,7 +219,6 @@ class TreeRootClassRuleConfig(RuleConfig):
     """
     Additional configuration options for the `tree_root_class` rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["TreeRootClassRuleConfig"]
@@ -211,7 +245,6 @@ class RecommendedRuleConfig(RuleConfig):
     """
     Additional configuration options for the `recommended` rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["RecommendedRuleConfig"]
@@ -222,9 +255,7 @@ class RecommendedRuleConfig(RuleConfig):
     level: Union[str, "RuleLevel"] = None
     include: Optional[Union[str, list[str]]] = empty_list()
     exclude: Optional[Union[str, list[str]]] = empty_list()
-    exclude_type: Optional[
-        Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]
-    ] = empty_list()
+    exclude_type: Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if not isinstance(self.include, list):
@@ -237,9 +268,7 @@ class RecommendedRuleConfig(RuleConfig):
 
         if not isinstance(self.exclude_type, list):
             self.exclude_type = [self.exclude_type] if self.exclude_type is not None else []
-        self.exclude_type = [
-            v if isinstance(v, MetamodelElementTypeEnum) else MetamodelElementTypeEnum(v) for v in self.exclude_type
-        ]
+        self.exclude_type = [v if isinstance(v, MetamodelElementTypeEnum) else MetamodelElementTypeEnum(v) for v in self.exclude_type]
 
         super().__post_init__(**kwargs)
 
@@ -249,7 +278,6 @@ class StandardNamingConfig(RuleConfig):
     """
     Additional configuration options for the `standard_naming` rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["StandardNamingConfig"]
@@ -259,9 +287,7 @@ class StandardNamingConfig(RuleConfig):
 
     level: Union[str, "RuleLevel"] = None
     permissible_values_upper_case: Optional[Union[bool, Bool]] = None
-    exclude_type: Optional[
-        Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]
-    ] = empty_list()
+    exclude_type: Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]] = empty_list()
     exclude: Optional[Union[str, list[str]]] = empty_list()
     class_pattern: Optional[str] = None
     slot_pattern: Optional[str] = None
@@ -272,9 +298,7 @@ class StandardNamingConfig(RuleConfig):
 
         if not isinstance(self.exclude_type, list):
             self.exclude_type = [self.exclude_type] if self.exclude_type is not None else []
-        self.exclude_type = [
-            v if isinstance(v, MetamodelElementTypeEnum) else MetamodelElementTypeEnum(v) for v in self.exclude_type
-        ]
+        self.exclude_type = [v if isinstance(v, MetamodelElementTypeEnum) else MetamodelElementTypeEnum(v) for v in self.exclude_type]
 
         if not isinstance(self.exclude, list):
             self.exclude = [self.exclude] if self.exclude is not None else []
@@ -294,7 +318,6 @@ class CanonicalPrefixesConfig(RuleConfig):
     """
     Additional configuration options for the canonical_prefixes rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["CanonicalPrefixesConfig"]
@@ -318,7 +341,6 @@ class NoEmptyTitleConfig(RuleConfig):
     """
     Additional configuration options for the no_empty_title rule
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = LINTCFG["NoEmptyTitleConfig"]
@@ -327,16 +349,12 @@ class NoEmptyTitleConfig(RuleConfig):
     class_model_uri: ClassVar[URIRef] = LINTCFG.NoEmptyTitleConfig
 
     level: Union[str, "RuleLevel"] = None
-    exclude_type: Optional[
-        Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]
-    ] = empty_list()
+    exclude_type: Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if not isinstance(self.exclude_type, list):
             self.exclude_type = [self.exclude_type] if self.exclude_type is not None else []
-        self.exclude_type = [
-            v if isinstance(v, MetamodelElementTypeEnum) else MetamodelElementTypeEnum(v) for v in self.exclude_type
-        ]
+        self.exclude_type = [v if isinstance(v, MetamodelElementTypeEnum) else MetamodelElementTypeEnum(v) for v in self.exclude_type]
 
         super().__post_init__(**kwargs)
 
@@ -346,294 +364,144 @@ class ExtendableConfigs(EnumDefinitionImpl):
     """
     The permissible values for the `extends` field of a config file
     """
-
-    recommended = PermissibleValue(text="recommended", description="Extend the recommended rule set")
+    recommended = PermissibleValue(
+        text="recommended",
+        description="Extend the recommended rule set")
 
     _defn = EnumDefinition(
         name="ExtendableConfigs",
         description="The permissible values for the `extends` field of a config file",
     )
 
-
 class RuleLevel(EnumDefinitionImpl):
     """
     The permissible values for the `level` option of all rules
     """
-
-    disabled = PermissibleValue(text="disabled", description="The rule will not be checked")
+    disabled = PermissibleValue(
+        text="disabled",
+        description="The rule will not be checked")
     warning = PermissibleValue(
-        text="warning", description="A violation of a rule at this level is a minor issue that should be fixed"
-    )
+        text="warning",
+        description="A violation of a rule at this level is a minor issue that should be fixed")
     error = PermissibleValue(
-        text="error", description="A violation of a rule at this level is a major issue that must be fixed"
-    )
+        text="error",
+        description="A violation of a rule at this level is a major issue that must be fixed")
 
     _defn = EnumDefinition(
         name="RuleLevel",
         description="The permissible values for the `level` option of all rules",
     )
 
-
 class MetamodelElementTypeEnum(EnumDefinitionImpl):
     """
     The permissible values for the exclude_type slot
     """
-
-    class_definition = PermissibleValue(text="class_definition", meaning=LINKML["ClassDefinition"])
-    enum_definition = PermissibleValue(text="enum_definition", meaning=LINKML["EnumDefinition"])
-    permissible_value = PermissibleValue(text="permissible_value", meaning=LINKML["PermissibleValue"])
-    slot_definition = PermissibleValue(text="slot_definition", meaning=LINKML["SlotDefinition"])
+    class_definition = PermissibleValue(
+        text="class_definition",
+        meaning=LINKML["ClassDefinition"])
+    enum_definition = PermissibleValue(
+        text="enum_definition",
+        meaning=LINKML["EnumDefinition"])
+    permissible_value = PermissibleValue(
+        text="permissible_value",
+        meaning=LINKML["PermissibleValue"])
+    slot_definition = PermissibleValue(
+        text="slot_definition",
+        meaning=LINKML["SlotDefinition"])
 
     _defn = EnumDefinition(
         name="MetamodelElementTypeEnum",
         description="The permissible values for the exclude_type slot",
     )
 
-
 # Slots
 class slots:
     pass
 
+slots.config__extends = Slot(uri=LINTCFG.extends, name="config__extends", curie=LINTCFG.curie('extends'),
+                   model_uri=LINTCFG.config__extends, domain=None, range=Optional[Union[str, "ExtendableConfigs"]])
 
-slots.config__extends = Slot(
-    uri=LINTCFG.extends,
-    name="config__extends",
-    curie=LINTCFG.curie("extends"),
-    model_uri=LINTCFG.config__extends,
-    domain=None,
-    range=Optional[Union[str, "ExtendableConfigs"]],
-)
+slots.config__rules = Slot(uri=LINTCFG.rules, name="config__rules", curie=LINTCFG.curie('rules'),
+                   model_uri=LINTCFG.config__rules, domain=None, range=Optional[Union[dict, Rules]])
 
-slots.config__rules = Slot(
-    uri=LINTCFG.rules,
-    name="config__rules",
-    curie=LINTCFG.curie("rules"),
-    model_uri=LINTCFG.config__rules,
-    domain=None,
-    range=Optional[Union[dict, Rules]],
-)
+slots.rules__canonical_prefixes = Slot(uri=LINTCFG.canonical_prefixes, name="rules__canonical_prefixes", curie=LINTCFG.curie('canonical_prefixes'),
+                   model_uri=LINTCFG.rules__canonical_prefixes, domain=None, range=Optional[Union[dict, CanonicalPrefixesConfig]])
 
-slots.rules__no_empty_title = Slot(
-    uri=LINTCFG.no_empty_title,
-    name="rules__no_empty_title",
-    curie=LINTCFG.curie("no_empty_title"),
-    model_uri=LINTCFG.rules__no_empty_title,
-    domain=None,
-    range=Optional[Union[dict, NoEmptyTitleConfig]],
-)
+slots.rules__no_empty_title = Slot(uri=LINTCFG.no_empty_title, name="rules__no_empty_title", curie=LINTCFG.curie('no_empty_title'),
+                   model_uri=LINTCFG.rules__no_empty_title, domain=None, range=Optional[Union[dict, NoEmptyTitleConfig]])
 
-slots.rules__permissible_values_format = Slot(
-    uri=LINTCFG.permissible_values_format,
-    name="rules__permissible_values_format",
-    curie=LINTCFG.curie("permissible_values_format"),
-    model_uri=LINTCFG.rules__permissible_values_format,
-    domain=None,
-    range=Optional[Union[dict, PermissibleValuesFormatRuleConfig]],
-)
+slots.rules__no_invalid_slot_usage = Slot(uri=LINTCFG.no_invalid_slot_usage, name="rules__no_invalid_slot_usage", curie=LINTCFG.curie('no_invalid_slot_usage'),
+                   model_uri=LINTCFG.rules__no_invalid_slot_usage, domain=None, range=Optional[Union[dict, RuleConfig]])
 
-slots.rules__tree_root_class = Slot(
-    uri=LINTCFG.tree_root_class,
-    name="rules__tree_root_class",
-    curie=LINTCFG.curie("tree_root_class"),
-    model_uri=LINTCFG.rules__tree_root_class,
-    domain=None,
-    range=Optional[Union[dict, TreeRootClassRuleConfig]],
-)
+slots.rules__no_undeclared_slots = Slot(uri=LINTCFG.no_undeclared_slots, name="rules__no_undeclared_slots", curie=LINTCFG.curie('no_undeclared_slots'),
+                   model_uri=LINTCFG.rules__no_undeclared_slots, domain=None, range=Optional[Union[dict, RuleConfig]])
 
-slots.rules__recommended = Slot(
-    uri=LINTCFG.recommended,
-    name="rules__recommended",
-    curie=LINTCFG.curie("recommended"),
-    model_uri=LINTCFG.rules__recommended,
-    domain=None,
-    range=Optional[Union[dict, RecommendedRuleConfig]],
-)
+slots.rules__no_undeclared_ranges = Slot(uri=LINTCFG.no_undeclared_ranges, name="rules__no_undeclared_ranges", curie=LINTCFG.curie('no_undeclared_ranges'),
+                   model_uri=LINTCFG.rules__no_undeclared_ranges, domain=None, range=Optional[Union[dict, RuleConfig]])
 
-slots.rules__no_xsd_int_type = Slot(
-    uri=LINTCFG.no_xsd_int_type,
-    name="rules__no_xsd_int_type",
-    curie=LINTCFG.curie("no_xsd_int_type"),
-    model_uri=LINTCFG.rules__no_xsd_int_type,
-    domain=None,
-    range=Optional[Union[dict, RuleConfig]],
-)
+slots.rules__no_xsd_int_type = Slot(uri=LINTCFG.no_xsd_int_type, name="rules__no_xsd_int_type", curie=LINTCFG.curie('no_xsd_int_type'),
+                   model_uri=LINTCFG.rules__no_xsd_int_type, domain=None, range=Optional[Union[dict, RuleConfig]])
 
-slots.rules__no_invalid_slot_usage = Slot(
-    uri=LINTCFG.no_invalid_slot_usage,
-    name="rules__no_invalid_slot_usage",
-    curie=LINTCFG.curie("no_invalid_slot_usage"),
-    model_uri=LINTCFG.rules__no_invalid_slot_usage,
-    domain=None,
-    range=Optional[Union[dict, RuleConfig]],
-)
+slots.rules__one_identifier_per_class = Slot(uri=LINTCFG.one_identifier_per_class, name="rules__one_identifier_per_class", curie=LINTCFG.curie('one_identifier_per_class'),
+                   model_uri=LINTCFG.rules__one_identifier_per_class, domain=None, range=Optional[Union[dict, RuleConfig]])
 
-slots.rules__no_undeclared_slots = Slot(
-    uri=LINTCFG.no_undeclared_slots,
-    name="rules__no_undeclared_slots",
-    curie=LINTCFG.curie("no_undeclared_slots"),
-    model_uri=LINTCFG.rules__no_undeclared_slots,
-    domain=None,
-    range=Optional[Union[dict, RuleConfig]],
-)
+slots.rules__one_key_per_class = Slot(uri=LINTCFG.one_key_per_class, name="rules__one_key_per_class", curie=LINTCFG.curie('one_key_per_class'),
+                   model_uri=LINTCFG.rules__one_key_per_class, domain=None, range=Optional[Union[dict, RuleConfig]])
 
-slots.rules__no_undeclared_ranges = Slot(
-    uri=LINTCFG.no_undeclared_ranges,
-    name="rules__no_undeclared_ranges",
-    curie=LINTCFG.curie("no_undeclared_ranges"),
-    model_uri=LINTCFG.rules__no_undeclared_ranges,
-    domain=None,
-    range=Optional[Union[dict, RuleConfig]],
-)
+slots.rules__permissible_values_format = Slot(uri=LINTCFG.permissible_values_format, name="rules__permissible_values_format", curie=LINTCFG.curie('permissible_values_format'),
+                   model_uri=LINTCFG.rules__permissible_values_format, domain=None, range=Optional[Union[dict, PermissibleValuesFormatRuleConfig]])
 
-slots.rules__root_type_checks = Slot(
-    uri=LINTCFG.root_type_checks,
-    name="rules__root_type_checks",
-    curie=LINTCFG.curie("root_type_checks"),
-    model_uri=LINTCFG.rules__root_type_checks,
-    domain=None,
-    range=Optional[Union[dict, RuleConfig]],
-)
+slots.rules__recommended = Slot(uri=LINTCFG.recommended, name="rules__recommended", curie=LINTCFG.curie('recommended'),
+                   model_uri=LINTCFG.rules__recommended, domain=None, range=Optional[Union[dict, RecommendedRuleConfig]])
 
-slots.rules__standard_naming = Slot(
-    uri=LINTCFG.standard_naming,
-    name="rules__standard_naming",
-    curie=LINTCFG.curie("standard_naming"),
-    model_uri=LINTCFG.rules__standard_naming,
-    domain=None,
-    range=Optional[Union[dict, StandardNamingConfig]],
-)
+slots.rules__root_type_checks = Slot(uri=LINTCFG.root_type_checks, name="rules__root_type_checks", curie=LINTCFG.curie('root_type_checks'),
+                   model_uri=LINTCFG.rules__root_type_checks, domain=None, range=Optional[Union[dict, RuleConfig]])
 
-slots.rules__canonical_prefixes = Slot(
-    uri=LINTCFG.canonical_prefixes,
-    name="rules__canonical_prefixes",
-    curie=LINTCFG.curie("canonical_prefixes"),
-    model_uri=LINTCFG.rules__canonical_prefixes,
-    domain=None,
-    range=Optional[Union[dict, CanonicalPrefixesConfig]],
-)
+slots.rules__standard_naming = Slot(uri=LINTCFG.standard_naming, name="rules__standard_naming", curie=LINTCFG.curie('standard_naming'),
+                   model_uri=LINTCFG.rules__standard_naming, domain=None, range=Optional[Union[dict, StandardNamingConfig]])
 
-slots.ruleConfig__level = Slot(
-    uri=LINTCFG.level,
-    name="ruleConfig__level",
-    curie=LINTCFG.curie("level"),
-    model_uri=LINTCFG.ruleConfig__level,
-    domain=None,
-    range=Union[str, "RuleLevel"],
-)
+slots.rules__tree_root_class = Slot(uri=LINTCFG.tree_root_class, name="rules__tree_root_class", curie=LINTCFG.curie('tree_root_class'),
+                   model_uri=LINTCFG.rules__tree_root_class, domain=None, range=Optional[Union[dict, TreeRootClassRuleConfig]])
 
-slots.permissibleValuesFormatRuleConfig__format = Slot(
-    uri=LINTCFG.format,
-    name="permissibleValuesFormatRuleConfig__format",
-    curie=LINTCFG.curie("format"),
-    model_uri=LINTCFG.permissibleValuesFormatRuleConfig__format,
-    domain=None,
-    range=Optional[str],
-)
+slots.ruleConfig__level = Slot(uri=LINTCFG.level, name="ruleConfig__level", curie=LINTCFG.curie('level'),
+                   model_uri=LINTCFG.ruleConfig__level, domain=None, range=Union[str, "RuleLevel"])
 
-slots.treeRootClassRuleConfig__root_class_name = Slot(
-    uri=LINTCFG.root_class_name,
-    name="treeRootClassRuleConfig__root_class_name",
-    curie=LINTCFG.curie("root_class_name"),
-    model_uri=LINTCFG.treeRootClassRuleConfig__root_class_name,
-    domain=None,
-    range=Optional[str],
-)
+slots.permissibleValuesFormatRuleConfig__format = Slot(uri=LINTCFG.format, name="permissibleValuesFormatRuleConfig__format", curie=LINTCFG.curie('format'),
+                   model_uri=LINTCFG.permissibleValuesFormatRuleConfig__format, domain=None, range=Optional[str])
 
-slots.treeRootClassRuleConfig__validate_existing_class_name = Slot(
-    uri=LINTCFG.validate_existing_class_name,
-    name="treeRootClassRuleConfig__validate_existing_class_name",
-    curie=LINTCFG.curie("validate_existing_class_name"),
-    model_uri=LINTCFG.treeRootClassRuleConfig__validate_existing_class_name,
-    domain=None,
-    range=Optional[Union[bool, Bool]],
-)
+slots.treeRootClassRuleConfig__root_class_name = Slot(uri=LINTCFG.root_class_name, name="treeRootClassRuleConfig__root_class_name", curie=LINTCFG.curie('root_class_name'),
+                   model_uri=LINTCFG.treeRootClassRuleConfig__root_class_name, domain=None, range=Optional[str])
 
-slots.recommendedRuleConfig__include = Slot(
-    uri=LINTCFG.include,
-    name="recommendedRuleConfig__include",
-    curie=LINTCFG.curie("include"),
-    model_uri=LINTCFG.recommendedRuleConfig__include,
-    domain=None,
-    range=Optional[Union[str, list[str]]],
-)
+slots.treeRootClassRuleConfig__validate_existing_class_name = Slot(uri=LINTCFG.validate_existing_class_name, name="treeRootClassRuleConfig__validate_existing_class_name", curie=LINTCFG.curie('validate_existing_class_name'),
+                   model_uri=LINTCFG.treeRootClassRuleConfig__validate_existing_class_name, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.recommendedRuleConfig__exclude = Slot(
-    uri=LINTCFG.exclude,
-    name="recommendedRuleConfig__exclude",
-    curie=LINTCFG.curie("exclude"),
-    model_uri=LINTCFG.recommendedRuleConfig__exclude,
-    domain=None,
-    range=Optional[Union[str, list[str]]],
-)
+slots.recommendedRuleConfig__include = Slot(uri=LINTCFG.include, name="recommendedRuleConfig__include", curie=LINTCFG.curie('include'),
+                   model_uri=LINTCFG.recommendedRuleConfig__include, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.recommendedRuleConfig__exclude_type = Slot(
-    uri=LINTCFG.exclude_type,
-    name="recommendedRuleConfig__exclude_type",
-    curie=LINTCFG.curie("exclude_type"),
-    model_uri=LINTCFG.recommendedRuleConfig__exclude_type,
-    domain=None,
-    range=Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]],
-)
+slots.recommendedRuleConfig__exclude = Slot(uri=LINTCFG.exclude, name="recommendedRuleConfig__exclude", curie=LINTCFG.curie('exclude'),
+                   model_uri=LINTCFG.recommendedRuleConfig__exclude, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.standardNamingConfig__permissible_values_upper_case = Slot(
-    uri=LINTCFG.permissible_values_upper_case,
-    name="standardNamingConfig__permissible_values_upper_case",
-    curie=LINTCFG.curie("permissible_values_upper_case"),
-    model_uri=LINTCFG.standardNamingConfig__permissible_values_upper_case,
-    domain=None,
-    range=Optional[Union[bool, Bool]],
-)
+slots.recommendedRuleConfig__exclude_type = Slot(uri=LINTCFG.exclude_type, name="recommendedRuleConfig__exclude_type", curie=LINTCFG.curie('exclude_type'),
+                   model_uri=LINTCFG.recommendedRuleConfig__exclude_type, domain=None, range=Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]])
 
-slots.standardNamingConfig__exclude_type = Slot(
-    uri=LINTCFG.exclude_type,
-    name="standardNamingConfig__exclude_type",
-    curie=LINTCFG.curie("exclude_type"),
-    model_uri=LINTCFG.standardNamingConfig__exclude_type,
-    domain=None,
-    range=Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]],
-)
+slots.standardNamingConfig__permissible_values_upper_case = Slot(uri=LINTCFG.permissible_values_upper_case, name="standardNamingConfig__permissible_values_upper_case", curie=LINTCFG.curie('permissible_values_upper_case'),
+                   model_uri=LINTCFG.standardNamingConfig__permissible_values_upper_case, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.standardNamingConfig__exclude = Slot(
-    uri=LINTCFG.exclude,
-    name="standardNamingConfig__exclude",
-    curie=LINTCFG.curie("exclude"),
-    model_uri=LINTCFG.standardNamingConfig__exclude,
-    domain=None,
-    range=Optional[Union[str, list[str]]],
-)
+slots.standardNamingConfig__exclude_type = Slot(uri=LINTCFG.exclude_type, name="standardNamingConfig__exclude_type", curie=LINTCFG.curie('exclude_type'),
+                   model_uri=LINTCFG.standardNamingConfig__exclude_type, domain=None, range=Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]])
 
-slots.standardNamingConfig__class_pattern = Slot(
-    uri=LINTCFG.class_pattern,
-    name="standardNamingConfig__class_pattern",
-    curie=LINTCFG.curie("class_pattern"),
-    model_uri=LINTCFG.standardNamingConfig__class_pattern,
-    domain=None,
-    range=Optional[str],
-)
+slots.standardNamingConfig__exclude = Slot(uri=LINTCFG.exclude, name="standardNamingConfig__exclude", curie=LINTCFG.curie('exclude'),
+                   model_uri=LINTCFG.standardNamingConfig__exclude, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.standardNamingConfig__slot_pattern = Slot(
-    uri=LINTCFG.slot_pattern,
-    name="standardNamingConfig__slot_pattern",
-    curie=LINTCFG.curie("slot_pattern"),
-    model_uri=LINTCFG.standardNamingConfig__slot_pattern,
-    domain=None,
-    range=Optional[str],
-)
+slots.standardNamingConfig__class_pattern = Slot(uri=LINTCFG.class_pattern, name="standardNamingConfig__class_pattern", curie=LINTCFG.curie('class_pattern'),
+                   model_uri=LINTCFG.standardNamingConfig__class_pattern, domain=None, range=Optional[str])
 
-slots.canonicalPrefixesConfig__prefixmaps_contexts = Slot(
-    uri=LINTCFG.prefixmaps_contexts,
-    name="canonicalPrefixesConfig__prefixmaps_contexts",
-    curie=LINTCFG.curie("prefixmaps_contexts"),
-    model_uri=LINTCFG.canonicalPrefixesConfig__prefixmaps_contexts,
-    domain=None,
-    range=Optional[Union[str, list[str]]],
-)
+slots.standardNamingConfig__slot_pattern = Slot(uri=LINTCFG.slot_pattern, name="standardNamingConfig__slot_pattern", curie=LINTCFG.curie('slot_pattern'),
+                   model_uri=LINTCFG.standardNamingConfig__slot_pattern, domain=None, range=Optional[str])
 
-slots.noEmptyTitleConfig__exclude_type = Slot(
-    uri=LINTCFG.exclude_type,
-    name="noEmptyTitleConfig__exclude_type",
-    curie=LINTCFG.curie("exclude_type"),
-    model_uri=LINTCFG.noEmptyTitleConfig__exclude_type,
-    domain=None,
-    range=Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]],
-)
+slots.canonicalPrefixesConfig__prefixmaps_contexts = Slot(uri=LINTCFG.prefixmaps_contexts, name="canonicalPrefixesConfig__prefixmaps_contexts", curie=LINTCFG.curie('prefixmaps_contexts'),
+                   model_uri=LINTCFG.canonicalPrefixesConfig__prefixmaps_contexts, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.noEmptyTitleConfig__exclude_type = Slot(uri=LINTCFG.exclude_type, name="noEmptyTitleConfig__exclude_type", curie=LINTCFG.curie('exclude_type'),
+                   model_uri=LINTCFG.noEmptyTitleConfig__exclude_type, domain=None, range=Optional[Union[Union[str, "MetamodelElementTypeEnum"], list[Union[str, "MetamodelElementTypeEnum"]]]])
+

--- a/linkml/linter/config/datamodel/config.yaml
+++ b/linkml/linter/config/datamodel/config.yaml
@@ -37,32 +37,17 @@ classes:
       Each attribute of this class represents a rule that can be enabled and possibly
       configured by a configuration file.
     attributes:
+      canonical_prefixes:
+        range: CanonicalPrefixesConfig
+        description: >-
+          Enforce canonical prefixes by verifying that the mappings defined in the `prefixes`
+          slot agree with those provided by the [prefixmaps](https://github.com/linkml/prefixmaps)
+          package. Not auto-fixable.
       no_empty_title:
         range: NoEmptyTitleConfig
         description: >-
           Disallow empty titles on schema elements. Autofix will transform the element's
           name into a title.
-      permissible_values_format:
-        range: PermissibleValuesFormatRuleConfig
-        description: >-
-          Enforce consistent formatting of enum permissible values. This rule may conflict
-          with the standard_naming rule. Not auto-fixable.
-      tree_root_class:
-        range: TreeRootClassRuleConfig
-        description: >-
-          Require a single class with `tree_root: true` and optionally verify that class's
-          name. Autofix will create a new class with `tree_root: true`, a name based on
-          the rule configuration, and slots for existing classes.
-      recommended:
-        range: RecommendedRuleConfig
-        description: >-
-          Require any slot in the metamodel with `recommended: true` (e.g. description)
-          to be provided. Not auto-fixable.
-      no_xsd_int_type:
-        range: RuleConfig
-        description: >-
-          Disallow use of `uri: xsd:int` in type definitions. Autofix will change the
-          uri to xsd:integer.
       no_invalid_slot_usage:
         range: RuleConfig
         description: >-
@@ -78,6 +63,29 @@ classes:
         description: >-
           Disallow the use of ranges in slot specifications if any of the ranges used
           do not refer to an existing type, class, or enum. Not auto-fixable.
+      no_xsd_int_type:
+        range: RuleConfig
+        description: >-
+          Disallow use of `uri: xsd:int` in type definitions. Autofix will change the
+          uri to xsd:integer.
+      one_identifier_per_class:
+        range: RuleConfig
+        description: >-
+          Ensure that there is only one slot with the `identifier` attribute set to True per class.
+      one_key_per_class:
+        range: RuleConfig
+        description: >-
+          Ensure that there is only one slot with the `key` attribute set to True per class.
+      permissible_values_format:
+        range: PermissibleValuesFormatRuleConfig
+        description: >-
+          Enforce consistent formatting of enum permissible values. This rule may conflict
+          with the standard_naming rule. Not auto-fixable.
+      recommended:
+        range: RecommendedRuleConfig
+        description: >-
+          Require any slot in the metamodel with `recommended: true` (e.g. description)
+          to be provided. Not auto-fixable.
       root_type_checks:
         range: RuleConfig
         description: >-
@@ -90,12 +98,12 @@ classes:
           CamelCase for enums, snake_case (default) or UPPER_SNAKE for permissible_values
           (see permissible_values_upper_case option). This rule may conflict with the
           permissible_values_format rule. Not auto-fixable.
-      canonical_prefixes:
-        range: CanonicalPrefixesConfig
+      tree_root_class:
+        range: TreeRootClassRuleConfig
         description: >-
-          Enforce canonical prefixes by verifying that the mappings defined in the `prefixes`
-          slot agree with those provided by the [prefixmaps](https://github.com/linkml/prefixmaps)
-          package. Not auto-fixable.
+          Require a single class with `tree_root: true` and optionally verify that class's
+          name. Autofix will create a new class with `tree_root: true`, a name based on
+          the rule configuration, and slots for existing classes.
 
   RuleConfig:
     description: >-

--- a/linkml/linter/config/default.yaml
+++ b/linkml/linter/config/default.yaml
@@ -22,6 +22,10 @@ rules:
     level: disabled
   no_undeclared_ranges:
     level: disabled
+  one_identifier_per_class:
+    level: disabled
+  one_key_per_class:
+    level: disabled
   root_type_checks:
     level: disabled
   standard_naming:

--- a/linkml/linter/config/recommended.yaml
+++ b/linkml/linter/config/recommended.yaml
@@ -9,6 +9,10 @@ rules:
     level: error
   no_undeclared_ranges:
     level: error
+  one_identifier_per_class:
+    level: error
+  one_key_per_class:
+    level: error
   root_type_checks:
     level: error
   standard_naming:

--- a/linkml/linter/linter.py
+++ b/linkml/linter/linter.py
@@ -45,8 +45,7 @@ def get_metamodel_validator() -> Validator:
     meta_json_gen = JsonSchemaGenerator(LOCAL_METAMODEL_YAML_FILE, not_closed=False)
     meta_json_schema = meta_json_gen.generate()
     validator_cls = jsonschema.validators.validator_for(meta_json_schema, default=jsonschema.Draft7Validator)
-    validator = validator_cls(meta_json_schema, format_checker=validator_cls.FORMAT_CHECKER)
-    return validator
+    return validator_cls(meta_json_schema, format_checker=validator_cls.FORMAT_CHECKER)
 
 
 def merge_configs(original: dict, other: dict):

--- a/linkml/linter/rules.py
+++ b/linkml/linter/rules.py
@@ -319,6 +319,43 @@ class RootTypeChecks(LinterRule):
                 yield LinterProblem(f"Root type '{t}' is missing the required 'uri' attribute")
 
 
+class OnePerClass(LinterRule):
+    """Ensures that there is only one slot with the specified attribute per class."""
+
+    id = "one_per_class"
+
+    def _check(self, schema_view: SchemaView, attr_name: str) -> Iterable[LinterProblem]:
+        for cn in schema_view.all_classes():
+            slots_with_attr = [
+                slot
+                for slot in schema_view.class_induced_slots(cn)
+                if hasattr(slot, attr_name) and getattr(slot, attr_name)
+            ]
+            if len(slots_with_attr) > 1:
+                naughty_slots = ", ".join(sorted([slot.name for slot in slots_with_attr]))
+                yield LinterProblem(f"Class '{cn}' has more than one '{attr_name}' slot: {naughty_slots}")
+
+
+class OneIdentifierPerClass(OnePerClass):
+    """Ensure that there is only one slot with the `identifier` attribute set to True per class."""
+
+    id = "one_identifier_per_class"
+
+    def check(self, schema_view: SchemaView, fix: bool = False) -> Iterable[LinterProblem]:
+        """Run the one_identifier_per_class check."""
+        return self._check(schema_view, "identifier")
+
+
+class OneKeyPerClass(OnePerClass):
+    """Ensure that there is only one slot with the `key` attribute set to True per class."""
+
+    id = "one_key_per_class"
+
+    def check(self, schema_view: SchemaView, fix: bool = False) -> Iterable[LinterProblem]:
+        """Run the one_key_per_class check."""
+        return self._check(schema_view, "key")
+
+
 class StandardNamingRule(LinterRule):
     id = "standard_naming"
 

--- a/tests/test_linter/test_one_per_class.py
+++ b/tests/test_linter/test_one_per_class.py
@@ -1,0 +1,126 @@
+"""Tests of the linter's one per class checks."""
+
+import pytest
+from linkml_runtime import SchemaView
+
+from linkml.linter.config.datamodel.config import RuleConfig, RuleLevel
+from linkml.linter.linter import LinterProblem
+from linkml.linter.rules import OneIdentifierPerClass, OneKeyPerClass
+
+EMPTY = ""
+ID = "identifier"
+KEY = "key"
+
+
+@pytest.fixture(scope="module")
+def identifier_key_schema() -> str:
+    """Return a schema that defines a set of slots with identifiers and keys, and a test class to populate."""
+    return """
+# yaml-language-server: $schema=https://linkml.io/linkml-model/linkml_model/jsonschema/meta.schema.json
+id: https://w3id.org/linkml/examples/identifiers
+title: Identifiers, Keys, Primary Keys, and More!
+name: identifiers
+description: Schema for testing identifiers, keys, primary keys, and much, much more.
+
+prefixes:
+  ex: https://w3id.org/linkml/examples/patterns/
+
+default_prefix: ex
+
+slots:
+  slot_a:
+  slot_b:
+  id_slot_a:
+    identifier: true
+  id_slot_b:
+    identifier: true
+  id_slot_false:
+    identifier: false
+  key_slot_a:
+    key: true
+  key_slot_b:
+    key: true
+  key_slot_false:
+    key: false
+  pk_slot_a:
+    annotations:
+      primary_key: true
+  pk_slot_b:
+    annotations:
+      primary_key: true
+  pk_slot_false:
+    annotations:
+      primary_key: false
+
+classes:
+  TestClass:
+    slots:
+      - slot_a
+      - slot_b
+"""
+
+
+@pytest.mark.parametrize("id_slot_a", [EMPTY, "id_slot_a"])
+@pytest.mark.parametrize("id_slot_b", [EMPTY, "id_slot_b"])
+@pytest.mark.parametrize("id_slot_false", [EMPTY, "id_slot_false"])
+@pytest.mark.parametrize("key_slot_a", [EMPTY, "key_slot_a"])
+@pytest.mark.parametrize("key_slot_b", [EMPTY, "key_slot_b"])
+@pytest.mark.parametrize("key_slot_false", [EMPTY, "key_slot_false"])
+def test_get_identifier_get_key_slot(
+    identifier_key_schema: str,
+    id_slot_a: str,
+    id_slot_b: str,
+    id_slot_false: str,
+    key_slot_a: str,
+    key_slot_b: str,
+    key_slot_false: str,
+) -> None:
+    """Test the detection of multiple "identifier" and "key" slots in classes in the schema.
+
+    The parameters represent the slots to be added to the test class; if the value of the parameter is EMPTY,
+    the slot is not added. If the parameter is a string, that slot is added to the test class.
+    """
+    all_id_slots = [id_slot_a, id_slot_b, id_slot_false]
+    all_key_slots = [key_slot_a, key_slot_b, key_slot_false]
+
+    for k in [*all_id_slots, *all_key_slots]:
+        if k:
+            identifier_key_schema += f"      - {k}\n"
+
+    sv = SchemaView(identifier_key_schema)
+    test_class_slots = sv.class_slots("TestClass")
+    # ensure that the correct slots are in the schema
+    assert set(test_class_slots) == {"slot_a", "slot_b", *[s for s in [*all_id_slots, *all_key_slots] if s]}
+
+    exp_slots = {ID: {id_slot_a, id_slot_b}, KEY: {key_slot_a, key_slot_b}}
+    for slot_set in exp_slots.values():
+        slot_set.discard(EMPTY)
+
+    problems = {
+        ID: check_schema(identifier_key_schema, check_identifier=True),
+        KEY: check_schema(identifier_key_schema, check_identifier=False),
+    }
+
+    for attr_type, val in exp_slots.items():
+        if len(val) > 1:
+            assert len(problems[attr_type]) == 1
+            msg = f"Class 'TestClass' has more than one '{attr_type}' slot: "
+            msg += ", ".join(sorted(val))
+            assert {p.message for p in problems[attr_type]} == {msg}
+
+
+def check_schema(test_schema: str, check_identifier: bool) -> list[LinterProblem]:  # noqa: FBT001
+    """Check a schema using a OnePerClass linter.
+
+    :param test_schema: schema to test, as a string
+    :type test_schema: str
+    :param check_identifier: whether to check the `identifier` field or the `key` field
+    :type check_identifier: bool
+    :return: list of linting problems discovered
+    :rtype: list[LinterProblem]
+    """
+    schema_view = SchemaView(test_schema)
+    config = RuleConfig(level=RuleLevel.error.text)
+
+    rule = OneIdentifierPerClass(config) if check_identifier else OneKeyPerClass(config)
+    return list(rule.check(schema_view, fix=False))

--- a/tests/test_linter/test_one_per_class.py
+++ b/tests/test_linter/test_one_per_class.py
@@ -137,6 +137,10 @@ def test_get_identifier_get_key_slot(
     # ensure that the correct slots are in the schema
     assert set(test_class_slots) == {"slot_a", "slot_b", *[s for s in [*all_id_slots, *all_key_slots] if s]}
 
+    # Collect the expected slots to be returned by `get_***_slot` for identifiers and keys.
+    # Note that id_slot_false and key_slot_false have `identifier` and `key` set to `false`,
+    # so we would not expect `get_identifier_slot` or `get_key_slot` to return these slots.
+    # If the value from the parameters is EMPTY, the attribute is not present and should be deleted.
     exp_slots = {ID: {id_slot_a, id_slot_b}, KEY: {key_slot_a, key_slot_b}}
     for slot_set in exp_slots.values():
         slot_set.discard(EMPTY)
@@ -147,8 +151,11 @@ def test_get_identifier_get_key_slot(
     }
 
     for attr_type, val in exp_slots.items():
+        # if there is more than one slot of the identifier or key type present, we expect an error
         if len(val) > 1:
             assert len(problems[attr_type]) == 1
             msg = f"Class 'TestClass' has more than one '{attr_type}' slot: "
             msg += ", ".join(sorted(val))
             assert {p.message for p in problems[attr_type]} == {msg}
+        else:
+            assert problems[attr_type] == []


### PR DESCRIPTION
Adding linter rules to enforce rules that ensure that `identifier` and `key` only appear once per class