### PR TITLE
Feature: Remote Schema Support in CLI

### DIFF
--- a/packages/linkml/src/linkml/validator/cli.py
+++ b/packages/linkml/src/linkml/validator/cli.py
@@ -176,7 +176,7 @@ def cli(
             fg="yellow",
         )
 
-    if schema is not None and schema_remote is not None :
+    if schema is not None and schema_remote is not None:
         raise click.ClickException(
             "Both a remote and a local schema were provided. Please use either the -s/--schema "
             "option or the -r/--schema-remote option to define a schema, not both."
@@ -198,7 +198,7 @@ def cli(
             "the -s/--schema option or the -r/--schema-remote option "
             "as an argument or in a config file."
         )
-    
+
     config = Config(**config_args)
 
     plugins = _resolve_plugins(config.plugins) if config.plugins else []

--- a/tests/linkml/test_validator/test_cli.py
+++ b/tests/linkml/test_validator/test_cli.py
@@ -10,7 +10,7 @@ from linkml.validator.cli import cli
 VALID_PERSON_1 = {"id": "id:1", "name": "John Doe", "age": 35}
 VALID_PERSON_2 = {"id": "id:2", "name": "Jane Smith", "age": 25, "telephone": "555-555-5550"}
 PERSONINFO_SCHEMA = str(Path(__file__).parent / "input/personinfo.yaml")
-REMOTE_SCHEMA = "hhttps://w3id.org/linkml/meta.yaml"
+REMOTE_SCHEMA = "https://w3id.org/linkml/meta.yaml"
 
 
 @pytest.fixture
@@ -81,10 +81,11 @@ def test_no_schema_provided(cli_runner):
     assert "No schema specified" in result.output
     assert result.exit_code == 1
 
+
 def test_two_schema_provided(cli_runner):
     """Verify a useful message is emitted when both a local and a remote schema were specified via options or config"""
 
-    result = cli_runner.invoke(cli, ['-s', PERSONINFO_SCHEMA, '-r', REMOTE_SCHEMA])
+    result = cli_runner.invoke(cli, ["-s", PERSONINFO_SCHEMA, "-r", REMOTE_SCHEMA])
     assert "Both a remote and a local" in result.output
     assert result.exit_code == 1
 


### PR DESCRIPTION
A project of mine would like to validate against NMDC's schema without fetching the schema and all of its dependencies to ensure the most recent version of the schema is being used. This functionality appears to be in the runtime but not supported by the CLI because of Click's `File` type validation. This PR is a proposal/implementation of a new parameter, `-r`/`--schema-remote` that accepts a URL and bypasses pre-validation.

### What it does:

Adds the `-r`/`--schema-remote` option to the CLI.

Since the linkml runtime can handle URLs for schemas, I just made `config_args` take `schema_remote` if `schema` is `None`, and continue the existing `None` checking logic from there.

Also added logic to make sure that both `-r` and `-s` are not specified.

### Other Notes

This code doesn't do any logic to validate whether the remote URL exists and depends entirely on bubbling up the runtime's errors in response to an invalid URL. Is this acceptable? Or should I add some validation logic to make sure the remote URL exists and have the CLI fail early? Should I also add checks to ensure a user doesn't put a file path in the `-r` field?