### PR TITLE
[FOR DISCUSSION] Interface-preserving indexing updates in sqltablegen.py

### DIFF
--- a/linkml/generators/sqltablegen.py
+++ b/linkml/generators/sqltablegen.py
@@ -445,6 +445,11 @@ def cli(
     **args,
 ):
     """Generate SQL DDL representation."""
+    args.update({
+        'autogenerate_pk_index': args['autogenerate_index'],
+        'autogenerate_fk_index': args['autogenerate_index'] and use_foreign_keys,
+    })
+    del args['autogenerate_index']
     if relmodel_output:
         sv = SchemaView(yamlfile)
         rtr = RelationalModelTransformer(sv)


### PR DESCRIPTION
I am unable to use the `gen-sqltables` command, it fails with exit status code 1:
```bash 
> gen-sqltables /some/working/yaml/schema.yaml
TypeError: SQLTableGenerator.__init__() got an unexpected keyword argument 'autogenerate_index'. Did you mean 'autogenerate_pk_index'?
```
This was introduced in #2775 

## Issue
`SqlTableGenerator` was updated to add `autogenerate_fk_index` and `autogenerate_pk_index` instance variables in #2775 , and a new `click` argument was added to `cli()` named `autogenerate_index`. Because the Click args are passed directly to the table generator instance, and this is not a valid class member, it fails (with a cool and useful error message I might add).

## Correct Solution
The "right" way to do this would be to modify the command line arguments to match the class behavior, but I do not know what would break, who is using the cli upstream, what changes are needed in the docs etc. I am just here "throwing the pig over the wall" so to speak.

## This Solution
To preserve the command-line interface, I just munge the `args` from Click in `cli()` to map the cli arg to the class args.
I am unsure if the FK behavior is correct, just took a guess and set `autogenerate_fk_index` to match the incoming param value iif `use_foreign_keys` is also true.