### PR TITLE
use a kwarg when calling pytest's `_diff_text`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ class SnapshotFile(Snapshot):
             if not is_eq:
                 # TODO: probably better to use something other than this pytest
                 # private method. See https://docs.python.org/3/library/difflib.html
-                self.eq_state = "\n".join(_diff_text(actual, expected, self.config.getoption("verbose")))
+                self.eq_state = "\n".join(_diff_text(actual, expected, verbose=self.config.getoption("verbose")))
             return is_eq
 
 


### PR DESCRIPTION
fix: #2983