### PR TITLE
Add a new line between CREATE statements in sqltablegen

### DIFF
--- a/packages/linkml/src/linkml/generators/sqltablegen.py
+++ b/packages/linkml/src/linkml/generators/sqltablegen.py
@@ -167,7 +167,7 @@ class SQLTableGenerator(Generator):
 
         def dump(sql, *multiparams, **params):
             nonlocal ddl_str
-            ddl_str += f"{str(sql.compile(dialect=engine.dialect)).rstrip()};"
+            ddl_str += f"{str(sql.compile(dialect=engine.dialect)).rstrip()};\n"
 
         engine = create_mock_engine(f"{self.dialect}://./MyDb", strategy="mock", executor=dump)
         schema_metadata = MetaData()


### PR DESCRIPTION
Solves #2831

This PR is part of the [Developer Days 2025](https://github.com/orgs/linkml/projects/37) :christmas_tree: 

## How to reproduce
Have a `test.yaml` file like in the root of the linkml repo.
Then run `linkml generate sqltables test.yaml`


<details><summary>Result with current linkml</summary>
<p>

```sql
-- # Class: Person
--     * Slot: uid
--     * Slot: id
--     * Slot: full_name
--     * Slot: aliases
--     * Slot: phone
--     * Slot: age

CREATE TABLE "Person" (
	uid INTEGER NOT NULL,
	id TEXT,
	full_name TEXT,
	aliases TEXT,
	phone TEXT,
	age TEXT,
	PRIMARY KEY (uid)
);CREATE INDEX "ix_Person_uid" ON "Person" (uid);
```
</p>
</details> 

<details><summary>Result with this PR</summary>
<p>

```sql
-- # Class: Person
--     * Slot: uid
--     * Slot: id
--     * Slot: full_name
--     * Slot: aliases
--     * Slot: phone
--     * Slot: age

CREATE TABLE "Person" (
	uid INTEGER NOT NULL,
	id TEXT,
	full_name TEXT,
	aliases TEXT,
	phone TEXT,
	age TEXT,
	PRIMARY KEY (uid)
);
CREATE INDEX "ix_Person_uid" ON "Person" (uid);


```
</p>
</details> 