### PR TITLE
Use same version spec for setup-uv in rustgen as in other actions

### DIFF
--- a/.github/workflows/rustgen.yaml
+++ b/.github/workflows/rustgen.yaml
@@ -27,7 +27,7 @@ jobs:
           git fetch upstream --tags
 
       - name: Install uv and setup uv caching
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6.6.1
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true


### PR DESCRIPTION
This should be merged before #2990 where the different version spec for action/setup-uv in the rustgen action triggers misbehavior of dependabot.