### PR TITLE
Extend Bool to accept common truthy/falsy values from CSV/TSV

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/utils/metamodelcore.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/metamodelcore.py
@@ -203,10 +203,15 @@ class Curie(URIorCURIE):
 
 
 class Bool:
-    """Wrapper for boolean datatype"""
+    """Wrapper for boolean datatype
 
-    bool_true = re.compile(r"([Tt]rue)|(1)$")
-    bool_false = re.compile(r"([Ff]alse)|(0)$")
+    Accepts common truthy/falsy string representations:
+    - True: true, True, TRUE, 1, yes, Yes, YES
+    - False: false, False, FALSE, 0, no, No, NO
+    """
+
+    bool_true = re.compile(r"^(true|1|yes)$", re.IGNORECASE)
+    bool_false = re.compile(r"^(false|0|no)$", re.IGNORECASE)
 
     def __new__(cls, v: Union[str, bool, "Bool"]) -> bool:
         if isinstance(v, bool):

--- a/tests/linkml_runtime/test_utils/test_metamodelcore.py
+++ b/tests/linkml_runtime/test_utils/test_metamodelcore.py
@@ -152,6 +152,43 @@ def test_bool():
     assert Bool.is_valid(Bool(True))
 
 
+def test_bool_extended_truthy_falsy():
+    """Test extended truthy/falsy values for CSV/TSV compatibility.
+
+    See https://github.com/linkml/linkml/issues/2580
+    Common representations used in spreadsheets should be accepted.
+    """
+    # Extended truthy values (case-insensitive)
+    assert Bool("TRUE")
+    assert Bool("True")
+    assert Bool("true")
+    assert Bool("yes")
+    assert Bool("Yes")
+    assert Bool("YES")
+    assert Bool("1")
+    assert Bool(1)
+
+    # Extended falsy values (case-insensitive)
+    assert not Bool("FALSE")
+    assert not Bool("False")
+    assert not Bool("false")
+    assert not Bool("no")
+    assert not Bool("No")
+    assert not Bool("NO")
+    assert not Bool("0")
+    assert not Bool(0)
+
+    # Verify is_valid works for all extended values
+    assert Bool.is_valid("TRUE")
+    assert Bool.is_valid("FALSE")
+    assert Bool.is_valid("yes")
+    assert Bool.is_valid("YES")
+    assert Bool.is_valid("no")
+    assert Bool.is_valid("NO")
+    assert Bool.is_valid("1")
+    assert Bool.is_valid("0")
+
+
 def test_time():
     v = datetime.time(13, 17, 43, 279000)
     assert "13:17:43.279000" == XSDTime(v)  # A date can be a datetime


### PR DESCRIPTION
## Summary
- Extends the `Bool` class to accept common truthy/falsy string representations that users commonly enter in spreadsheets and CSV/TSV files
- **Truthy values now accepted**: `true`, `True`, `TRUE`, `1`, `yes`, `Yes`, `YES`
- **Falsy values now accepted**: `false`, `False`, `FALSE`, `0`, `no`, `No`, `NO`
- All matching is case-insensitive and exactly anchored

## Motivation
When loading data from CSV/TSV files, users commonly enter boolean values as "TRUE", "YES", or "No" rather than the strict "true"/"false" expected by the original implementation. This caused validation failures with common spreadsheet exports. See #2580.

This change aligns with conventions in:
- Schemasheets (common LinkML data entry tool)
- MIxS/GSC standards that use CSV/TSV extensively

## Related Issues
- Fixes #2580 (Boolean coercion from CSV/TSV)
- Related to #2581 (Multivalued primitive handling - separate PR planned)
- Related to MIxS issues about data entry conventions

## Future Configurability
This PR implements a sensible default set of truthy/falsy synonyms. For future extensibility, potential options could include:
1. **Slot-level annotation** - `boolean_true_values: [y, yes, 1]` in slot metadata
2. **Schema-level configuration** - A `settings` block defining global truthy/falsy patterns
3. **Loader/dumper parameter** - Custom `truthy_values`/`falsy_values` lists
4. **linkml-runtime config** - Similar to schemasheets' `internal_separator` configuration

Additional synonyms that future configuration might support:
- `y`/`n`, `t`/`f`, `on`/`off`, `enabled`/`disabled`
- Localized values like `ja`/`nein` (German), `oui`/`non` (French)

## Test plan
- [x] Added `test_bool_extended_truthy_falsy()` test covering all new accepted values
- [x] Existing `test_bool()` test continues to pass
- [x] All tests in `test_metamodelcore.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)