### PR TITLE
Support bracket-free pipe-delimited format for multivalued primitives in CSV/TSV

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/dumpers/delimited_file_dumper.py
+++ b/packages/linkml_runtime/src/linkml_runtime/dumpers/delimited_file_dumper.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from linkml_runtime.dumpers.dumper_root import Dumper
 from linkml_runtime.dumpers.json_dumper import JSONDumper
 from linkml_runtime.linkml_model.meta import SchemaDefinition, SlotDefinitionName
-from linkml_runtime.utils.csvutils import get_configmap
+from linkml_runtime.utils.csvutils import CSV_LIST_MARKERS, get_configmap
 from linkml_runtime.utils.schemaview import SchemaView
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
@@ -35,7 +35,11 @@ class DelimitedFileDumper(Dumper, ABC):
         if schemaview is None:
             schemaview = SchemaView(schema)
         configmap = get_configmap(schemaview, index_slot)
-        config = GlobalConfig(key_configs=configmap, csv_delimiter=self.delimiter)
+        config = GlobalConfig(
+            key_configs=configmap,
+            csv_delimiter=self.delimiter,
+            csv_list_markers=CSV_LIST_MARKERS,
+        )
         output = io.StringIO()
         flatten_to_csv(objs, output, config=config, **kwargs)
         return output.getvalue()

--- a/packages/linkml_runtime/src/linkml_runtime/utils/csvutils.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/csvutils.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from json_flattener import KeyConfig, Serializer
 from json_flattener.flattener import CONFIGMAP
@@ -7,6 +8,60 @@ from linkml_runtime.linkml_model.meta import ClassDefinitionName, SlotDefinition
 from linkml_runtime.utils.schemaview import SchemaView
 
 logger = logging.getLogger(__name__)
+
+# Bracket-free list markers for CSV/TSV (pipe delimiter only, no surrounding brackets)
+# This aligns with schemasheets conventions and common spreadsheet data entry patterns
+CSV_LIST_MARKERS = ("", "")
+
+
+def clean_multivalued_nulls(data: Any, schemaview: SchemaView, index_slot: SlotDefinitionName) -> Any:
+    """
+    Clean up [null] or [None] values in multivalued slots after loading from CSV/TSV.
+
+    json-flattener converts empty cells in list columns to [null]. This function
+    converts those back to None (omitted) for a cleaner data structure.
+
+    :param data: Data structure loaded from CSV/TSV (dict with index_slot key)
+    :param schemaview: LinkML schema view
+    :param index_slot: The index slot name containing the list of objects
+    :return: Cleaned data structure
+    """
+    if not isinstance(data, dict) or index_slot not in data:
+        return data
+
+    slot = schemaview.get_slot(index_slot) if schemaview else None
+    if slot is None or slot.range not in schemaview.all_classes():
+        return data
+
+    target_class = slot.range
+    multivalued_slots = set()
+    for sn in schemaview.class_slots(target_class):
+        induced = schemaview.induced_slot(sn, target_class)
+        if induced.multivalued:
+            multivalued_slots.add(sn)
+
+    items = data.get(index_slot, [])
+    if not isinstance(items, list):
+        return data
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        for slot_name in multivalued_slots:
+            if slot_name in item:
+                value = item[slot_name]
+                # Convert [None] or [null] to None (omit the key)
+                if isinstance(value, list) and len(value) == 1 and value[0] is None:
+                    del item[slot_name]
+                # Also clean up lists that contain only None values
+                elif isinstance(value, list):
+                    cleaned = [v for v in value if v is not None]
+                    if not cleaned:
+                        del item[slot_name]
+                    elif cleaned != value:
+                        item[slot_name] = cleaned
+
+    return data
 
 
 def get_configmap(schemaview: SchemaView, index_slot: SlotDefinitionName) -> CONFIGMAP:
@@ -39,25 +94,52 @@ def get_configmap(schemaview: SchemaView, index_slot: SlotDefinitionName) -> CON
 
 
 def _get_key_config(schemaview: SchemaView, tgt_cls: ClassDefinitionName, sn: SlotDefinitionName, sep="_"):
+    """
+    Generate a KeyConfig for a slot that tells json-flattener how to handle it.
+
+    Returns KeyConfig for:
+    - Class-ranged inlined slots (existing behavior)
+    - Multivalued primitive slots (string[], integer[], etc.)
+
+    :param schemaview: LinkML schema view
+    :param tgt_cls: Target class containing the slot
+    :param sn: Slot name
+    :param sep: Separator for denormalized column names
+    :return: KeyConfig or None
+    """
     slot = schemaview.induced_slot(sn, tgt_cls)
     range = slot.range
     all_cls = schemaview.all_classes()
     if range in all_cls and schemaview.is_inlined(slot):
+        # Class-ranged inlined slot - flatten nested structure
         mappings = {}
-        is_complex = False
+        has_nested_multivalued = False
         for inner_sn in schemaview.class_slots(range):
             denormalized_sn = f"{sn}{sep}{inner_sn}"
             mappings[inner_sn] = denormalized_sn
             inner_slot = schemaview.induced_slot(inner_sn, range)
             inner_slot_range = inner_slot.range
-            if (inner_slot_range in all_cls and inner_slot.inlined) or inner_slot.multivalued:
-                is_complex = True
-        if is_complex:
+            if inner_slot.multivalued:
+                # Nested multivalued fields can't be properly tracked in bracket-free format
+                has_nested_multivalued = True
+            elif inner_slot_range in all_cls and inner_slot.inlined:
+                # Deeply nested inlined objects also require JSON serialization
+                has_nested_multivalued = True
+        if has_nested_multivalued:
+            # Use JSON-only serialization for objects with nested multivalued fields
+            # This avoids issues with bracket-free list parsing for nested fields
             serializers = [Serializer.json]
+            return KeyConfig(
+                is_list=slot.multivalued, delete=True, flatten=False, mappings={}, serializers=serializers
+            )
         else:
-            serializers = []
-        return KeyConfig(
-            is_list=slot.multivalued, delete=True, flatten=True, mappings=mappings, serializers=serializers
-        )
+            # Simple nested objects can be flattened
+            return KeyConfig(
+                is_list=slot.multivalued, delete=True, flatten=True, mappings=mappings, serializers=[]
+            )
+    elif slot.multivalued:
+        # Multivalued primitive slot (string[], integer[], enum[], etc.)
+        # Tell json-flattener this field is a list so it splits on pipe delimiter
+        return KeyConfig(is_list=True)
     else:
         return None


### PR DESCRIPTION
## Summary

This PR enables **bracket-free pipe-delimited format** for multivalued fields in CSV/TSV, aligning with schemasheets conventions and common spreadsheet data entry patterns.

**Note:** This PR does not add configuration options. Pipe-delimited with no square brackets is now the only format for multivalued primitives.

## Example: Two book series in one data file

**YAML data (two items):**
```yaml
all_book_series:
  - id: S001
    name: The Culture Series
    genres:
      - scifi
    creator:
      name: Iain M Banks
      from_country: Scotland
  - id: S002
    name: Book of the New Sun
    genres:
      - scifi
      - fantasy
    creator:
      name: Gene Wolfe
      from_country: USA
    reviews:
      - rating: 5
        review_text: "A masterpiece"
      - rating: 4
        review_text: "Dense but rewarding"
```

### Before this PR (brackets required, nested objects flattened)

```
id	name	genres	creator_name	creator_from_country	reviews_json
S001	The Culture Series	[scifi]	Iain M Banks	Scotland	
S002	Book of the New Sun	[scifi|fantasy]	Gene Wolfe	USA	[{"rating": 5, "review_text": "A masterpiece"}, {"rating": 4, "review_text": "Dense but rewarding"}]
```

| id | name | genres | creator_name | creator_from_country | reviews_json |
|----|------|--------|--------------|---------------------|-------------|
| S001 | The Culture Series | [scifi] | Iain M Banks | Scotland | |
| S002 | Book of the New Sun | [scifi\|fantasy] | Gene Wolfe | USA | [{"rating": 5, ...}, ...] |

### After this PR (bracket-free)

```
id	name	genres	creator_name	creator_from_country	reviews_json
S001	The Culture Series	scifi	Iain M Banks	Scotland	
S002	Book of the New Sun	scifi|fantasy	Gene Wolfe	USA	[{"rating": 5, "review_text": "A masterpiece"}, {"rating": 4, "review_text": "Dense but rewarding"}]
```

| id | name | genres | creator_name | creator_from_country | reviews_json |
|----|------|--------|--------------|---------------------|-------------|
| S001 | The Culture Series | scifi | Iain M Banks | Scotland | |
| S002 | Book of the New Sun | scifi\|fantasy | Gene Wolfe | USA | [{"rating": 5, ...}, ...] |

## What changed

| Feature | Before | After |
|---------|--------|-------|
| Top-level list format | `[scifi\|fantasy]` | `scifi\|fantasy` |

## Trade-off for nested objects with multivalued primitives

If a nested object contains multivalued primitives, it can no longer be flattened into separate columns. For example, if `author` had a multivalued `specialties` field:

| Before | After |
|--------|-------|
| `creator_name`, `creator_specialties` columns | `creator_json` column |
| `[editing\|writing]` | `{"name": "...", "specialties": ["editing", "writing"]}` |

**Why?** The json-flattener library needs explicit configuration to know which fields are lists. We can configure top-level fields like `genres`, but flattened nested fields like `creator_specialties` do not have their own configuration entry. Without brackets, json-flattener treats `editing|writing` as a string, not a list.

**Still flattened:** Simple nested objects without multivalued fields (like `creator` above with just `name` and `from_country`).

**Now JSON-only:** Nested objects containing multivalued primitives.

## Motivation

Users entering data in spreadsheets type `scifi|fantasy`, not `[scifi|fantasy]`. See #3041.

## Related Issues
- Fixes #3041
- Related to #2580 (PR #3040), #2581

## Test Plan
- [x] `test_bracket_free_multivalued_primitives()`
- [x] `test_load_bracket_free_csv()`  
- [x] `test_multivalued_primitive_roundtrip()`
- [x] All 1629 runtime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)