### PR TITLE
fix linting errors on main

### DIFF
--- a/docs/faq/contributing.md
+++ b/docs/faq/contributing.md
@@ -26,7 +26,7 @@ and you can [vote for your favorite issue here](https://github.com/linkml/linkml
 
 ## How do I stay involved?
 
-See [Get Involved](https://linkml.io/linkml/get-involved/index.html) for more information on how to get involved with the LinkML community.  
+See [Get Involved](https://linkml.io/linkml/get-involved/index.html) for more information on how to get involved with the LinkML community.
 
 
 ## How do I register my schema?

--- a/docs/get-involved/workshops-and-presentations.md
+++ b/docs/get-involved/workshops-and-presentations.md
@@ -1,6 +1,6 @@
 # Workshops and Presentations
 
-This page is regularly updated to share links to previous LinkML workshops and presentations. Happy viewing! 
+This page is regularly updated to share links to previous LinkML workshops and presentations. Happy viewing!
 _____
 
 ## Annotating Data with Ontologies: LinkML Can Help
@@ -17,4 +17,3 @@ This workshop provides an introduction to LinkML aimed at people who generate or
 
 [Workshop slides](https://docs.google.com/presentation/d/1IcVaRopn2HmvyFREWMd4k-k9cFLGDh9uZ1FszFSK9us/edit?slide=id.g274025f72a8_0_248#slide=id.g274025f72a8_0_248) <br>
 [Workshop recording](https://www.youtube.com/watch?v=ijCXDGO-NTU&t=4s)
-


### PR DESCRIPTION
This just removes trailing whitespace - it causes code quality checks to fail on main atm, so important to get it in for other PRs.  If the linting checks fail on PR, run `make lint-fix` from the command line and it will automatically fix the things it can.