### PR TITLE
Fix uv workspaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,12 @@
 [tool.uv.workspace]
-members = ["packages/*"]
+members = [
+  "packages/linkml",
+  "packages/linkml_runtime",
+]
+[tool.uv.sources]
+linkml = { workspace = true }
+linkml-runtime = { workspace = true }
+
 
 [tool.codespell]
 skip = [
@@ -180,11 +187,3 @@ commands = [
   ["ruff", "check", "{posargs:.}"],
   ["ruff", "format", "{posargs:.}"],
 ]
-
-[tool.uv-dynamic-versioning]
-vcs = "git"
-style = "pep440"
-fallback-version = "0.0.0"
-
-[tool.hatch.version]
-source = "uv-dynamic-versioning"


### PR DESCRIPTION
This PR is a follow up to [this conversation](https://obo-communitygroup.slack.com/archives/C06SMUB1NK1/p1765404112966829)

The reason it works it pydantic-ai but not for linkml is because the pyproject files are organized differently.

PyDantic.AI -   The top level pyproject is actually buildable project with [project] table, versioning, and child projects like pydantic_ai_slim, pydantic_graph, clai  and others. The child projects are also buildable projects in their right.
LinkML -  The top level project is just a workspace that contains some tool configurations and references to the child projects.  They child projects linkml and linkml-runtime are the actual buildable projects, it is not possible to build / publish or install top level project.   

I tried to convert linkml  pyproject file to be more like PyDantic.AI, but main limitation is that we cannot use the name linkml for both top level and child project.   So to make it work we would need to rename the inner linkml package into something like linkml-core or rename it to the top level package to something not linkml.  I am sure it will bring a lot of havoc to pypi and dependencies, so it is probably the best to leave everything as is.  

Here is a link to the PyDantic.AI project file: [pyproject.toml](https://github.com/pydantic/pydantic-ai/blob/main/pyproject.toml#L46)

However we can still use some cleanup:

1.  It is better to list child project explicitly instead of just blank importing packages/*
2. Claude suggested we also add [tool.uv.sources] section listing dependencies, not sure what it does, but adding it allows for editable installs of `linkml` and `linkml-runtime` from other projects.
3. There is no need for hatch or dynamic versioning plugin in the top level project because we are not actually building anything at the top level.

Finally, back to the original problem:

1. With the changes applied to linkml monorepo I am now able to install linkml into downstream project as editable artifact. It has to be done like [this](https://github.com/vladistan/linkml-qudt/blob/301f3c070e0169ec959a61a9603b24c55edac676/pyproject.toml#L20) and `linkml` and `linkml-runtime` have to be imported separately.  
2. If we ever convert `linkml` to be more like `pydantic-ai` and be a buildable top level project then it would be possible to install as a single dependency into downstream project.  But probably the potential havoc is not worth getting rid of a two lines in pyproject file.