### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/code/metamodel.rst
+++ b/docs/code/metamodel.rst
@@ -6,7 +6,7 @@ MetaModel
 Definitions
 -----------
 
-See `Datamodel docs <https://linkml.io/linkml-model/docs/>`_ for full documentation
+See `Datamodel docs <https://linkml.io/linkml-model/latest/docs/>`_ for full documentation
 
 .. currentmodule:: linkml_runtime.linkml_model.meta
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -36,7 +36,7 @@ See [Cancer Research Data Commons - Harmonized Model](https://cancerdhc.github.i
 LinkML is itself described as a LinkML model
 
  * [linkml/linkml-model](https://github.com/linkml/linkml-model) repo
- * [generated docs](https://linkml.io/linkml-model/docs/)
+ * [generated docs](https://linkml.io/linkml-model/latest/docs/)
 
 ## INCLUDE Data Coordination Center
 

--- a/docs/faq/tools.md
+++ b/docs/faq/tools.md
@@ -71,7 +71,7 @@ You can use any of the generator tools distributed as part of linkml to check fo
 
 ## Is there a linter for LinkML?
 
-Yes! See the documentation for [the schema linter](https://linkml.io/linkml/schemas/linter).
+Yes! See the documentation for [the schema linter](https://linkml.io/linkml/schemas/linter.html).
 
 The linter will attempt to ensure your schema follows best practice.
 

--- a/docs/generators/jsonld-context.rst
+++ b/docs/generators/jsonld-context.rst
@@ -40,9 +40,9 @@ provides mapping from JSON to RDF.
    gen-jsonld-context personinfo.yaml > personinfo.context.jsonld
 
 You can control the output via
-`prefixes <https://linkml.io/linkml-model/docs/prefixes/>`__
+`prefixes <https://linkml.io/linkml-model/latest/docs/prefixes/>`__
 declarations and
-`default_curi_maps <https://linkml.io/linkml-model/docs/default_curi_maps/>`__.
+`default_curi_maps <https://linkml.io/linkml-model/latest/docs/default_curi_maps/>`__.
 
 Any JSON that conforms to the derived JSON Schema (see above) can be
 converted to RDF using this context.


### PR DESCRIPTION
## Summary

- Add missing `/latest/` path segment to linkml-model documentation URLs
- Add missing `.html` extension to the linter documentation link

The linkml-model site uses JavaScript redirects from `/docs/` to `/latest/docs/`, which return 404 HTTP status codes. The link checker doesn't execute JavaScript, so it sees these as broken links.

### Changes

| File | Old URL | New URL |
|------|---------|---------|
| `docs/code/metamodel.rst` | `linkml-model/docs/` | `linkml-model/latest/docs/` |
| `docs/examples.md` | `linkml-model/docs/` | `linkml-model/latest/docs/` |
| `docs/generators/jsonld-context.rst` | `linkml-model/docs/prefixes/` | `linkml-model/latest/docs/prefixes/` |
| `docs/generators/jsonld-context.rst` | `linkml-model/docs/default_curi_maps/` | `linkml-model/latest/docs/default_curi_maps/` |
| `docs/faq/tools.md` | `linkml/schemas/linter` | `linkml/schemas/linter.html` |

## Test plan

- [x] Verified all new URLs return HTTP 200
- [x] Verified old URLs return 404 (with JS redirect fallback for browsers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)