### PR TITLE
Add SKIP_KROKI_IO env var to skip Kroki in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@
 name: Build and test linkml
 env:
   UV_VERSION: "0.7.13"
+  SKIP_KROKI_IO: "1"
 on:
   push:
     branches:

--- a/packages/linkml/src/linkml/generators/markdowndatadictgen.py
+++ b/packages/linkml/src/linkml/generators/markdowndatadictgen.py
@@ -214,6 +214,11 @@ class DiagramRenderer:
         if not self.kroki_server:
             return f"```{diagram_type}\n{clean_source}\n```"
 
+        # Allow skipping Kroki in test environments via environment variable
+        if os.environ.get("SKIP_KROKI_IO"):
+            logging.debug("Skipping Kroki rendering (SKIP_KROKI_IO is set)")
+            return f"```{diagram_type}\n{clean_source}\n```"
+
         try:
             svg_content = None
             cache = SvgCache(self.diagram_dir)

--- a/tests/linkml/test_generators/test_markdowndatadictgen.py
+++ b/tests/linkml/test_generators/test_markdowndatadictgen.py
@@ -37,6 +37,18 @@ def test_diagram_renderer_kroki_failure():
     assert "A --> B" in result
 
 
+def test_diagram_renderer_skip_kroki_env(monkeypatch):
+    """Test DiagramRenderer skips Kroki when SKIP_KROKI_IO environment variable is set."""
+    monkeypatch.setenv("SKIP_KROKI_IO", "1")
+    renderer = DiagramRenderer(kroki_server="https://kroki.io")
+    result = renderer.render("classDiagram\nA --> B", diagram_name="test")
+    assert result.startswith("```mermaid")
+    assert "classDiagram" in result
+    assert "A --> B" in result
+    assert "<svg" not in result
+    assert "</svg>" not in result
+
+
 def test_diagram_renderer_large_diagram_post(tmp_path):
     """Test DiagramRenderer uses POST for large diagrams (>1KB)."""
     # Create a diagram source larger than 1KB


### PR DESCRIPTION
Closes #3099 

Adds `SKIP_KROKI_IO` environment variable to skip Kroki API calls in CI.

When set, the diagram renderer returns mermaid code blocks without attempting any network calls. This avoids flaky test failures from Kroki 403 errors.

## Changes:

- Add env var check in `DiagramRenderer.render()`
- Set `SKIP_KROKI_IO=1` in CI workflow
- Add test for the skip behavior
