### PR TITLE
Add compatibility tests for bundled linkml-model schemas

### DIFF
--- a/tests/linkml/test_metamodel_compat/conftest.py
+++ b/tests/linkml/test_metamodel_compat/conftest.py
@@ -2,8 +2,19 @@
 
 import pytest
 
+# Schemas bundled with linkml-model that schema authors are expected to use
+# (via imports or `implements`). These must be loadable and processable by
+# the linkml toolkit, just like the core metamodel.
+BUNDLED_SCHEMAS = ["arrays", "extended_types"]
+
 
 @pytest.fixture
 def metamodel_path(input_path) -> str:
     """Return the path to the local copy of the LinkML metamodel."""
     return str(input_path("metamodel/meta.yaml"))
+
+
+@pytest.fixture(params=BUNDLED_SCHEMAS)
+def bundled_schema_path(request, input_path) -> str:
+    """Return the path to a schema bundled with linkml-model."""
+    return str(input_path(f"metamodel/{request.param}.yaml"))

--- a/tests/linkml/test_metamodel_compat/test_metamodel_projectgen.py
+++ b/tests/linkml/test_metamodel_compat/test_metamodel_projectgen.py
@@ -3,6 +3,8 @@ import py_compile
 import pytest
 
 from linkml.generators.projectgen import ProjectConfiguration, ProjectGenerator
+from linkml.generators.pythongen import PythonGenerator
+from linkml_runtime.utils.schemaview import SchemaView
 
 
 @pytest.mark.slow
@@ -43,3 +45,22 @@ def test_metamodel_python_compiles(metamodel_path, tmp_path):
     assert python_file.exists(), "Python file not generated"
     # py_compile.compile raises py_compile.PyCompileError if there are syntax errors
     py_compile.compile(str(python_file), doraise=True)
+
+
+@pytest.mark.slow
+def test_bundled_schema_loads(bundled_schema_path):
+    """Verify that each bundled schema can be loaded by SchemaView."""
+    sv = SchemaView(bundled_schema_path)
+    assert sv.schema is not None
+    assert sv.schema.name
+
+
+@pytest.mark.slow
+def test_bundled_schema_python_generates(bundled_schema_path, tmp_path):
+    """Verify that each bundled schema can generate compilable Python."""
+    gen = PythonGenerator(bundled_schema_path)
+    output = gen.serialize()
+    assert output
+    out_file = tmp_path / "output.py"
+    out_file.write_text(output)
+    py_compile.compile(str(out_file), doraise=True)


### PR DESCRIPTION
Fixes #3129

Depends on https://github.com/linkml/linkml/pull/3128

The metamodel compat test suite currently only tests `meta.yaml` (the core metamodel). But linkml-model also ships schemas like `arrays.yaml` and `extended_types.yaml` that users are expected to use in their own schemas. If these don't work with the toolkit, that might be a real problem.

This PR adds parametrized tests that load each bundled schema with `SchemaView` and generate Python with `PythonGenerator`. Currently both `arrays` and `extended_types` fail — see #3129 for details.

### Changes

- `conftest.py`: Added `bundled_schema_path` fixture parametrized over `["arrays", "extended_types"]`
- `test_metamodel_projectgen.py`: Added `test_bundled_schema_loads` and `test_bundled_schema_python_generates`

### Known failures

These tests will fail on main until the underlying issues are fixed:

- `arrays`: `slot_usage` on slots not supported by runtime loader
- `extended_types`: `union_of` on types not handled by `SchemaLoader`
