### PR TITLE
Remove Pydantic v1 deprecation code for 1.10

### DIFF
--- a/packages/linkml/src/linkml/generators/pydanticgen/array.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/array.py
@@ -8,15 +8,8 @@ from typing import (
     Union,
 )
 
-from pydantic import VERSION as PYDANTIC_VERSION
-
-from linkml.utils.deprecation import deprecation_warning
 from linkml_runtime.linkml_model import Element
 from linkml_runtime.linkml_model.meta import ArrayExpression, DimensionExpression
-
-if int(PYDANTIC_VERSION[0]) < 2:
-    # Support for having pydantic 1 installed in the same environment will be dropped in 1.9.0
-    deprecation_warning("pydantic-v1")
 
 if sys.version_info.minor < 12:
     from typing_extensions import TypeAliasType

--- a/packages/linkml/src/linkml/utils/deprecation.py
+++ b/packages/linkml/src/linkml/utils/deprecation.py
@@ -220,25 +220,6 @@ class Deprecation:
 
 DEPRECATIONS = (
     Deprecation(
-        name="pydanticgen-v1",
-        deprecated_in=SemVer.from_str("1.7.5"),
-        removed_in=SemVer.from_str("1.10.0"),
-        message="Support for generating Pydantic v1.*.* models with pydanticgen is deprecated",
-        recommendation="Migrate any existing models to Pydantic v2",
-        issue=1925,
-    ),
-    Deprecation(
-        name="pydantic-v1",
-        deprecated_in=SemVer.from_str("1.7.5"),
-        removed_in=SemVer.from_str("1.10.0"),
-        message=(
-            "LinkML will set a dependency of pydantic>=2 and become incompatible "
-            "with packages with pydantic<2 as a runtime dependency"
-        ),
-        recommendation="Update dependent packages to use pydantic>=2",
-        issue=1925,
-    ),
-    Deprecation(
         name="validators",
         deprecated_in=SemVer.from_str("1.8.6"),
         removed_in=SemVer.from_str("1.10.0"),


### PR DESCRIPTION
## Summary
- Remove `pydanticgen-v1` and `pydantic-v1` deprecation entries from `deprecation.py` (reached `removed_in` 1.10.0)
- Remove dead Pydantic v1 version check and related imports from `pydanticgen/array.py`
- Dependency already requires `pydantic>=2`, so this code was unreachable

Relates to #1925

## Test plan
- [x] `uv run pytest tests/linkml/test_generators/test_pydanticgen.py -x` — 350 passed
- [x] `uv run pytest tests/linkml/test_utils/ -x` — 193 passed
- [x] `uv run ruff check` — clean