### PR TITLE
Skip duplicate key tracking in _normalize_inlined when keyed=False

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/utils/yamlutils.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/yamlutils.py
@@ -134,9 +134,10 @@ class YAMLRoot(JsonObj):
                     f"Slot: {loc(slot_name)} - attribute {loc(key_name)} "
                     f"value ({loc(cooked_entry[key_name])}) does not match key ({loc(key)})"
                 )
-            if keyed and key in cooked_keys:
-                raise ValueError(f"{loc(key)}: duplicate key")
-            cooked_keys.add(key)
+            if keyed:
+                if key in cooked_keys:
+                    raise ValueError(f"{loc(key)}: duplicate key")
+                cooked_keys.add(key)
             if is_list:
                 cooked_slot.append(cooked_entry)
             else:


### PR DESCRIPTION
Fixes #3161

- Guard `cooked_keys.add(key)` with `if keyed:` — duplicate detection only matters for keyed slots

## Changed files
- `packages/linkml_runtime/src/linkml_runtime/utils/yamlutils.py` — `order_up()` inner function

## Test plan
- [x] `test_linkml_issue_463::test_inlined` passes — TypeObj keys no longer crash (this has to be be tested against #3163)
- [x] Full suite passes — keyed slots still get duplicate detection
