### PR TITLE
Update docs to reference docgen generator

### DIFF
--- a/docs/faq/tools.md
+++ b/docs/faq/tools.md
@@ -58,7 +58,7 @@ For small schemas with limited inheritance, it should be possible to mentally pi
 
 There are a few strategies:
 
-* Use [gen-doc](https://linkml.io/linkml/generators/markdown) to make markdown that can be viewed using mkdocs
+* Use [gen-doc](https://linkml.io/linkml/generators/docgen) to make markdown that can be viewed using mkdocs
     * note you get this "for free" if you set up your project using the LinkML project copier template
 * Use [gen-owl](https://linkml.io/linkml/generators/owl) to make an OWL ontology, which can be browsed:
     * Using an ontology editing tool like Protege
@@ -187,7 +187,7 @@ See the [tool developer guide](https://linkml.io/linkml/developers/tool-develope
 
 Yes!
 
-See the [markdown generator](https://linkml.io/linkml/generators/markdown) for details.
+See the [markdown generator](https://linkml.io/linkml/generators/docgen) for details.
 
 If you run:
 

--- a/docs/faq/why-linkml.md
+++ b/docs/faq/why-linkml.md
@@ -292,7 +292,7 @@ There are a number of reasons to use LinkML over UML:
 
 Currently there is no way to generate complete UML from a LinkML schema.
 
-However, the yUML generator (used in [the markdown generator](https://linkml.io/linkml/generators/markdown.html)) can be used to make yUML diagrams for any class or schema.
+However, [the doc generator](https://linkml.io/linkml/generators/docgen.html) can be used to make Mermaid class diagrams for any class or schema.
 
 ## Why should I use LinkML over OWL?
 


### PR DESCRIPTION
Replace references to the 'markdown' generator with 'docgen' across FAQ pages. Updated links in docs/faq/tools.md and docs/faq/why-linkml.md to point to linkml/generators/docgen (and docgen.html) so the documentation reflects the renamed/relocated generator. yUML reference removed in favour of mermaid.