### PR TITLE
Fix linkml-runtime version floor for multivalued inlined slots (#3182)

### DIFF
--- a/packages/linkml/pyproject.toml
+++ b/packages/linkml/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [ # Specifier syntax: https://peps.python.org/pep-0631/
     "jinja2 >= 3.1.0",
     "jsonasobj2 >= 1.0.3, < 2.0.0",
     "jsonschema[format] >= 4.0.0",
-    "linkml-runtime >= 1.10.0rc5, < 2.0.0",
+    "linkml-runtime >= 1.10.0, < 2.0.0",
     "openpyxl",
     "parse",
     "prefixcommons >= 0.1.7",


### PR DESCRIPTION
## Summary

Fixes a split-package version skew that causes a crash in linkml when paired with an older linkml-runtime. Also adds regression tests so this class of problem is detectable in the future.

## The general problem

linkml and linkml-runtime are developed together in a monorepo but published as separate PyPI packages. When a bug fix requires coordinated changes in both packages, the monorepo's own CI doesn't catch mismatches — it tests both from source simultaneously. But downstream users installing from PyPI can end up with:

- a new `linkml` (from PyPI or git main)
- an old `linkml-runtime` (whatever pip/poetry resolves to)

...and the fix in linkml is silently broken because the runtime half is missing. Issue #3241 tracks this general version-skew failure mode.

## This instance

The fix for `TypeError: unhashable type: 'list'` (PR #3165) was split across:
- `pythongen.py` in linkml — changed how `_normalize_inlined_as_list` is emitted
- `yamlutils.py` in linkml-runtime — changed how normalization is handled at runtime

Both halves shipped together, but `pyproject.toml` still allowed `linkml-runtime >= 1.9.5`, letting pip resolve to a runtime that lacked the yamlutils fix.

**Real-world discovery:** nmdc-schema hit this when upgrading linkml. Their schema uses `CreditAssociation`, a class with a multivalued enum slot (`applied_roles`) as a fallback key in `_normalize_inlined_as_list`. The crash only appears for schemas that use this pattern.

## Fix

One-line change: bump the floor to `>= 1.10.0` (stable, now on PyPI) so the runtime half of the fix is always present.

## Tests

17 regression tests covering the nmdc-schema `CreditAssociation` pattern (multivalued enum slot as fallback key in `_normalize_inlined_as_list`):
- pythongen output verification (exact `key_name`/`keyed=False` args — intentionally tight, since these control runtime behavior)
- yaml_loader with single, multiple, and duplicate roles
- linkml-validate accepts valid data, rejects missing required fields
- ExampleRunner code paths (the original crash site from #3182)
- Direct Python constructor with list-valued keys

The tight coupling to codegen output is intentional: a wrong `key_name` (e.g. picking the class-ranged slot instead of the enum slot) would silently break runtime normalization. The behavioral tests below provide complementary end-to-end coverage but wouldn't catch that specific regression.

## Related

- #3182 — the specific bug (closes this)
- #3165 — the original fix that was split across packages
- #3241 — tracks the general version-skew problem
- #3247 — complementary fix in the same `_normalize_inlined` function (tested together: 33 passed, 1 xfailed)

Closes #3182