### PR TITLE
feat(owlgen): add --enum-inherits-as-subclass-of flag

### DIFF
--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -174,6 +174,9 @@ class OwlSchemaGenerator(Generator):
     enum_iri_separator: str = "#"
     """Separator for enum IRI. Can be overridden for example if your namespace IRI already contains a #"""
 
+    enum_inherits_as_subclass_of: bool = False
+    """If True, translate LinkML enum ``inherits`` relationships into OWL ``rdfs:subClassOf`` axioms."""
+
     def as_graph(self) -> Graph:
         """
         Generate an rdflib Graph from the LinkML schema.
@@ -890,6 +893,9 @@ class OwlSchemaGenerator(Generator):
             else:
                 has_parent = True
             self.graph.add((enum_uri, RDFS.subClassOf, parent))
+        if self.enum_inherits_as_subclass_of:
+            for parent_name in e.inherits:
+                self.graph.add((enum_uri, RDFS.subClassOf, self._enum_uri(parent_name)))
         if not has_parent and self.add_root_classes:
             self.graph.add((enum_uri, RDFS.subClassOf, URIRef(EnumDefinition.class_class_uri)))
         if self.metaclasses:
@@ -1366,6 +1372,12 @@ class OwlSchemaGenerator(Generator):
     is_flag=False,
     show_default=True,
     help="IRI separator for enums.",
+)
+@click.option(
+    "--enum-inherits-as-subclass-of/--no-enum-inherits-as-subclass-of",
+    default=False,
+    show_default=True,
+    help="If true, translate LinkML enum inherits relationships into OWL rdfs:subClassOf axioms.",
 )
 @click.version_option(__version__, "-V", "--version")
 def cli(yamlfile, metadata_profile: str, **kwargs):

--- a/tests/linkml/test_generators/test_owlgen.py
+++ b/tests/linkml/test_generators/test_owlgen.py
@@ -384,3 +384,31 @@ def test_permissible_values(
             assert isinstance(pv, URIRef) or isinstance(pv, Literal)
         else:
             raise AssertionError("all combinations must be accounted for")
+
+
+@pytest.mark.parametrize("enum_inherits_as_subclass_of", [True, False])
+def test_enum_inherits_as_subclass_of(enum_inherits_as_subclass_of: bool) -> None:
+    """Test that enum inherits relationships are translated to rdfs:subClassOf when the flag is set.
+
+    With the flag enabled, a child enum that lists a parent in its inherits field should
+    be asserted as a subclass of that parent in the generated OWL. With the flag disabled
+    (the default), no such axiom should be emitted.
+    """
+    sb = SchemaBuilder()
+    sb.add_enum("ParentEnum", permissible_values=["A", "B"])
+    sb.add_enum("ChildEnum", permissible_values=["A"], inherits=["ParentEnum"])
+    sb.add_defaults()
+    gen = OwlSchemaGenerator(
+        sb.schema,
+        mergeimports=False,
+        metaclasses=False,
+        type_objects=False,
+        enum_inherits_as_subclass_of=enum_inherits_as_subclass_of,
+    )
+    g = Graph()
+    g.parse(data=gen.serialize(), format="turtle")
+    subclass_axiom = (EX.ChildEnum, RDFS.subClassOf, EX.ParentEnum)
+    if enum_inherits_as_subclass_of:
+        assert subclass_axiom in g
+    else:
+        assert subclass_axiom not in g


### PR DESCRIPTION
LinkML EnumDefinition supports an `inherits` field that records parent enums, but the OWL generator previously ignored it.

Add a new flag `--enum-inherits-as-subclass-of` (default: false). When enabled, each entry in `inherits` on an EnumDefinition is emitted as an `rdfs:subClassOf` axiom, making the enum hierarchy visible to OWL reasoners.

Fixes #3188