### PR TITLE
Submit releases to the LinkML Zenodo community

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,4 +1,8 @@
 {
+  "access_right": "open",
+  "communities": [
+    {"identifier": "linkml"}
+  ],
   "creators": [
     {
       "name": "Moxon, Sierra A.T.",
@@ -69,7 +73,8 @@
       "name": "Kroll, Carlo"
     },
     {
-      "name": "Linke, David"
+      "name": "Linke, David",
+      "orcid": "0000-0002-5898-1820"
     },
     {
       "name": "Ly, Ryan"
@@ -139,5 +144,6 @@
       "relation": "isSupplementTo",
       "scheme": "url"
     }
-  ]
+  ],
+  "upload_type": "software"
 }


### PR DESCRIPTION
This PR adds a community section to the `.zenodo.json` configuration file. 

The other additions (access_right and upload_type key) are also present in [other working configurations](https://github.com/dalito/linkml-project-copier/blob/main/.zenodo.json) so I added them here, too. I also added my ORCID.

Closes #3205 