### PR TITLE
Relax `click` dependency specification

### DIFF
--- a/packages/linkml/pyproject.toml
+++ b/packages/linkml/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [ # Specifier syntax: https://peps.python.org/pep-0631/
     "antlr4-python3-runtime >= 4.9.0, < 4.10",
-    "click >= 8.0, < 8.2",
+    "click >= 8.0",
     "graphviz >= 0.10.1",
     "hbreader",
     "isodate >= 0.6.0",

--- a/tests/linkml/test_scripts/test_gen_python.py
+++ b/tests/linkml/test_scripts/test_gen_python.py
@@ -98,7 +98,7 @@ def test_metadata_flag(flag: str) -> None:
 
 def test_head_deprecated():
     'Test that expected deprecation warning appears when using "--head"'
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     with pytest.warns() as record:
         result = runner.invoke(cli, ["--head", KITCHEN_SINK_PATH])
     deprecation_shown = False

--- a/tests/linkml/test_utils/test_converter.py
+++ b/tests/linkml/test_utils/test_converter.py
@@ -9,7 +9,7 @@ from linkml.converter.cli import cli
 
 @pytest.fixture
 def cli_runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 def test_help(cli_runner):

--- a/tests/linkml/test_validator/test_cli.py
+++ b/tests/linkml/test_validator/test_cli.py
@@ -47,7 +47,7 @@ def test_valid_csv_file(cli_runner, csv_data_file):
 
     data_path = csv_data_file([VALID_PERSON_1, VALID_PERSON_2])
     result = cli_runner.invoke(cli, ["-s", PERSONINFO_SCHEMA, "-C", "Person", data_path])
-    assert result.output == "No issues found\n"
+    assert result.stdout == "No issues found\n"
     assert result.exception is None
     assert result.exit_code == 0
 
@@ -58,7 +58,7 @@ def test_valid_json_file_object(tmp_path, cli_runner, json_data_file):
     data_path = json_data_file({"persons": [VALID_PERSON_1, VALID_PERSON_2]})
     result = cli_runner.invoke(cli, ["-s", PERSONINFO_SCHEMA, data_path])
     assert result.exception is None
-    assert result.output == "No issues found\n"
+    assert result.stdout == "No issues found\n"
     assert result.exit_code == 0
 
 
@@ -69,7 +69,7 @@ def test_valid_json_file_list(cli_runner, json_data_file):
 
     result = cli_runner.invoke(cli, ["-s", PERSONINFO_SCHEMA, "-C", "Person", data_path])
     assert result.exception is None
-    assert result.output == "No issues found\n"
+    assert result.stdout == "No issues found\n"
     assert result.exit_code == 0
 
 
@@ -77,7 +77,7 @@ def test_no_schema_provided(cli_runner):
     """Verify a useful message is emitted when a schema is not specified via options or config"""
 
     result = cli_runner.invoke(cli, [])
-    assert "No schema specified" in result.output
+    assert "No schema specified" in result.stderr
     assert result.exit_code == 1
 
 
@@ -88,9 +88,9 @@ def test_invalid_json(cli_runner, json_data_file):
     data_path = json_data_file({"persons": [invalid_data]})
 
     result = cli_runner.invoke(cli, ["-s", PERSONINFO_SCHEMA, data_path])
-    assert "[ERROR]" in result.output
-    assert "'asdf' does not match" in result.output
-    assert "/persons/0/telephone" in result.output
+    assert "[ERROR]" in result.stdout
+    assert "'asdf' does not match" in result.stdout
+    assert "/persons/0/telephone" in result.stdout
     assert result.exit_code == 1
 
 
@@ -115,9 +115,9 @@ plugins:
     data_path = csv_data_file([VALID_PERSON_1, person2])
     result = cli_runner.invoke(cli, ["--config", str(config_path), data_path])
     assert result.exception is None
-    assert "[WARN]" in result.output
-    assert "'telephone' is recommended" in result.output
-    assert "[ERROR]" not in result.output
+    assert "[WARN]" in result.stdout
+    assert "'telephone' is recommended" in result.stdout
+    assert "[ERROR]" not in result.stdout
     assert result.exit_code == 0
 
 
@@ -146,5 +146,5 @@ data_sources:
     result = cli_runner.invoke(cli, ["--config", str(config_path)])
     print(str(result.exception))
     assert result.exception is None
-    assert result.output == "No issues found\n"
+    assert result.stdout == "No issues found\n"
     assert result.exit_code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -471,14 +471,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -2030,7 +2030,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = ">=4.9.0,<4.10" },
-    { name = "click", specifier = ">=8.0,<8.2" },
+    { name = "click", specifier = ">=8.0" },
     { name = "graphviz", specifier = ">=0.10.1" },
     { name = "hbreader" },
     { name = "isodate", specifier = ">=0.6.0" },


### PR DESCRIPTION
Fixes #3239 

These changes remove the upper bound on the `click` dependency specification. This is similar to what it was in `linkml` versions `1.9.3` and earlier. These changes also update the tests so that they no longer rely on the `mix_stderr` argument that was removed in `click` `8.2.0`.