### PR TITLE
Fix: use kwargs in _normalize_inlined to support inherited classes

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/utils/yamlutils.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/yamlutils.py
@@ -202,8 +202,12 @@ class YAMLRoot(JsonObj):
                         cooked_obj = slot_type(**as_dict(list_entry))
                         order_up(cooked_obj[key_name], cooked_obj)
                 elif isinstance(list_entry, list):
-                    # *args
-                    cooked_obj = slot_type(*list_entry)
+                    # First element is the key; remaining map to non-key fields in order
+                    non_key_fields = [f.name for f in dataclasses.fields(slot_type) if f.name != key_name]
+                    kwargs = {key_name: list_entry[0]}
+                    for fname, val in zip(non_key_fields, list_entry[1:]):
+                        kwargs[fname] = val
+                    cooked_obj = slot_type(**kwargs)
                     order_up(cooked_obj[key_name], cooked_obj)
                 else:
                     # lone key [key1: , key2: ... }

--- a/tests/linkml_runtime/test_utils/test_yaml_utils.py
+++ b/tests/linkml_runtime/test_utils/test_yaml_utils.py
@@ -366,3 +366,9 @@ def test_normalize_inlined_key_name_with_list_value():
     """[{key_name: [values]}] — multivalued field value must pass through."""
     c = _TaggedEntityContainer(items=[{"tags": ["t1"]}])
     assert c.items == [_TaggedEntity(tags=["t1"])]
+
+
+def test_normalize_inlined_list_of_lists_with_inheritance():
+    """List-of-lists: first element must map to key, not first MRO field."""
+    c = _ContainerList(items=[["n1", "t1"]])
+    assert c.items == [_ChildClass(notation="n1", title="t1")]


### PR DESCRIPTION
Changed all three sites to use keyword arguments. For the two SimpleDict paths, uses `dataclasses.fields()` to find the value field by name instead of by position.

Also fixed the `lek == key_name` guard to allow list values (multivalued fields) instead of falling through to `form_1` which crashes on lists.

Closes #3244