### PR TITLE
Remove obsolete info on testing from pre-monorepo times

### DIFF
--- a/docs/maintainers/contributing.md
+++ b/docs/maintainers/contributing.md
@@ -145,38 +145,9 @@ New tests in any directory should be written using pytest.
   Debugging tip: sometimes a snapshot-based test may fail on GitHub actions, but may appear to pass locally. This can happen if the test is marked as a slow test,
   in which case you may need to use `--generate-snapshots` in combination with `--with-slow` (see below).
 
-### Testing linkml PRs with development versions of linkml-runtime
-
-`linkml` is tightly coupled to upstream `linkml-runtime`.
-
-In some circumstances, paired changes need to be made against *both* `linkml` and `linkml-runtime`.
-Then testing with the last release of `linkml-runtime` is insufficient.
-
-In such cases, you can specify that your PR needs to be tested with a specific linkml-runtime branch and repository.
-Specifying this information in the first two lines of your pull request´s opening message like this:
-
-> upstream_repo: user-or-org-name/linkml-runtime<BR>
-> upstream_branch: some-complicated-feature
->
-> Hey everyone ... (PR continues)
-
-The order of the lines with `upstream_repo` and `upstream_branch` tags does not matter,
-but they must be the first two lines of the pull request comment.
-
-Maintainers can also specify upstream branches to test against when dispatching the `test_with_unreleased_runtime` workflow manually via the GUI prompt.
-
-Testing against an unverified upstream branch is not necessarily dangerous.
-The [input is stored as a variable first and not executed as untrusted code](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).
-But maintainers should take care to verify that the upstream branch and repo are correct and expected given the context of the PR.
-
-### Testing linkml-runtime PRs against any upstream linkml repository/branch
-
-For linkml-runtime a similar action as above is available allowing you to select a linkml repository to test against.
-For more see [linkml-runtime/CONTRIBUTING](https://github.com/linkml/linkml-runtime/blob/main/CONTRIBUTING.md).
-
 ## Code formatting and linting
 
-This repository is configured to use [Black](https://black.readthedocs.io/en/stable/index.html#) and [Ruff](https://beta.ruff.rs/docs/) to ensure good  formatting and code quality standards.
+This repository is configured to use [Ruff](https://beta.ruff.rs/docs/) to ensure good formatting and code quality standards.
 
 Each of these tools can be run on-demand via `tox`. To check the code for issues run:
 


### PR DESCRIPTION
This PR
- removes the sections that described how to testing across repos worked.
- updates the info on the formatter (ruff format replaced black a while ago)

Closes #3267