### PR TITLE
fix(gen-json): include mixins/abstracts for union(anyof) support

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -183,8 +183,6 @@ class JsonSchemaGenerator(Generator):
         })
 
     def handle_class(self, cls: ClassDefinition) -> None:
-        if cls.mixin or cls.abstract:
-            return
         
         additional_properties = False
         if self.is_class_unconstrained(cls):


### PR DESCRIPTION
This PR is to resovle issue with dangling references in JSON schema.

- Classes with abstract=true or mixin:true may be referenced by `anyOf` (or `mixin` classes). But the generator skips them so they are missing under $defs.
- The pydantic model includes the class definitions missing in JSON schema.


