### PR TITLE
Follow-up of PR #3271 - remove xfails

### DIFF
--- a/tests/linkml_runtime/test_utils/test_schemaview.py
+++ b/tests/linkml_runtime/test_utils/test_schemaview.py
@@ -966,18 +966,10 @@ for value in CREATURE_EXPECTED.values():
         "creature_view",
         pytest.param(
             "creature_view_remote",
-            marks=pytest.mark.xfail(
-                reason="Remote files on main still have old linkml-runtime IDs. "
-                "Remove xfail after PR #3271 is merged to main."
-            ),
         ),
         "creature_view_local",
         pytest.param(
             "creature_view_direct_url",
-            marks=pytest.mark.xfail(
-                reason="Remote files on main still have old linkml-runtime IDs. "
-                "Remove xfail after PR #3271 is merged to main."
-            ),
         ),
     ],
 )


### PR DESCRIPTION
In #3271 two tests that import a schema via URL had to be temporarily marked as xfail to update the URL from the linkml-runtime to the new linkml mono-repository without breaking CI. 

This PR reactivates the tests.