### PR TITLE
fix(generators): pass importmap and base_dir through ShaclGenerator

### DIFF
--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -45,7 +45,11 @@ class ShaclGenerator(Generator):
     uses_schemaloader = True
 
     def __post_init__(self) -> None:
-        self.schemaview = SchemaView(self.schema)
+        self.schemaview = SchemaView(
+            self.schema,
+            importmap=self.importmap,
+            base_dir=self.base_dir,
+        )
         super().__post_init__()
         self.generate_header()
 

--- a/tests/linkml/test_generators/test_shaclgen.py
+++ b/tests/linkml/test_generators/test_shaclgen.py
@@ -1005,3 +1005,80 @@ classes:
         URIRef("https://example.org/related_to"),
     ]
     assert sorted(in_values, key=str) == expected_uris
+
+
+def test_shacl_generator_respects_importmap(tmp_path):
+    """ShaclGenerator must pass importmap and base_dir to SchemaView.
+
+    When a schema uses imports resolved via an importmap (e.g. remapping
+    a schema ID to a local file path), the SHACL generator must propagate
+    these parameters to its internal SchemaView. Previously, __post_init__
+    hardcoded SchemaView(self.schema) without forwarding importmap/base_dir,
+    causing FileNotFoundError for cross-directory imports.
+
+    See: https://github.com/linkml/linkml/issues/2913
+    """
+    # Create a "library" schema in a subdirectory
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir()
+    (lib_dir / "base_types.yaml").write_text(
+        """
+id: https://example.org/base-types
+name: base_types
+default_prefix: bt
+prefixes:
+  linkml: https://w3id.org/linkml/
+  bt: https://example.org/base-types/
+imports:
+  - linkml:types
+classes:
+  BaseEntity:
+    attributes:
+      id: {identifier: true, range: string}
+      name: {range: string}
+""",
+        encoding="utf-8",
+    )
+
+    # Create a main schema that imports the library schema by ID
+    (tmp_path / "main.yaml").write_text(
+        """
+id: https://example.org/main
+name: main
+default_prefix: main
+prefixes:
+  linkml: https://w3id.org/linkml/
+  main: https://example.org/main/
+  bt: https://example.org/base-types/
+imports:
+  - linkml:types
+  - https://example.org/base-types
+classes:
+  Person:
+    is_a: BaseEntity
+    attributes:
+      age: {range: integer}
+""",
+        encoding="utf-8",
+    )
+
+    # Build an importmap that resolves the library schema ID to its file.
+    # SchemaView.load_import() appends ".yaml" to the mapped value, so
+    # the importmap must point to the path WITHOUT the .yaml suffix.
+    importmap = {"https://example.org/base-types": str(lib_dir / "base_types")}
+
+    # This would raise FileNotFoundError without the fix
+    gen = ShaclGenerator(
+        str(tmp_path / "main.yaml"),
+        importmap=importmap,
+        base_dir=str(tmp_path),
+    )
+    shacl = gen.serialize()
+
+    g = rdflib.Graph()
+    g.parse(data=shacl)
+
+    # Verify the Person shape exists and has the age property
+    shapes = list(g.subjects(RDF.type, SH.NodeShape))
+    shape_names = [str(s) for s in shapes]
+    assert any("Person" in s for s in shape_names), f"Person shape not found in {shape_names}"


### PR DESCRIPTION
## Summary

`ShaclGenerator.__post_init__` constructs its own `SchemaView` but previously hardcoded `SchemaView(self.schema)` without forwarding the `importmap` or `base_dir` keyword arguments. This causes `FileNotFoundError` when generating SHACL for schemas that use cross-directory imports resolved via an importmap.

## Problem

The `Generator` base class (line 211 of `generator.py`) correctly passes both parameters:
```python
self.schemaview = SchemaView(schema, importmap=self.importmap, base_dir=self.base_dir)
```

But `ShaclGenerator` overrides `__post_init__` with:
```python
self.schemaview = SchemaView(self.schema)  # missing importmap and base_dir!
```

This means any schema that relies on an importmap to resolve imports (e.g. mapping a schema ID to a local file path in a different directory) fails with a `FileNotFoundError` when using the SHACL generator, even though other generators (OWL, JSON-LD context) work correctly.

## Fix

Pass `importmap` and `base_dir` to the `SchemaView` constructor in `ShaclGenerator.__post_init__`:
```python
self.schemaview = SchemaView(
    self.schema,
    importmap=self.importmap,
    base_dir=self.base_dir,
)
```

## Test Coverage

Added `test_shacl_generator_respects_importmap` — creates a schema that imports a library from a subdirectory via an importmap, then verifies SHACL generation succeeds and produces the expected shapes.

## References

- Fixes #2913