### PR TITLE
feat(context): add --exclude-imports flag to ContextGenerator

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonldcontextgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldcontextgen.py
@@ -19,6 +19,7 @@ from linkml.utils.generator import Generator, shared_arguments
 from linkml_runtime.linkml_model.meta import ClassDefinition, SlotDefinition
 from linkml_runtime.linkml_model.types import SHEX
 from linkml_runtime.utils.formatutils import camelcase, underscore
+from linkml_runtime.utils.schemaview import SchemaView
 
 URI_RANGES = (SHEX.nonliteral, SHEX.bnode, SHEX.iri)
 
@@ -53,6 +54,10 @@ class ContextGenerator(Generator):
     prefixes: bool | None = True
     flatprefixes: bool | None = False
     fix_multivalue_containers: bool | None = False
+    exclude_imports: bool = False
+    """If True, elements from imported schemas won't be included in the generated context"""
+    _local_classes: set | None = field(default=None, repr=False)
+    _local_slots: set | None = field(default=None, repr=False)
 
     # Framing (opt-in via CLI flag)
     emit_frame: bool = False
@@ -64,6 +69,16 @@ class ContextGenerator(Generator):
         super().__post_init__()
         if self.namespaces is None:
             raise TypeError("Schema text must be supplied to context generator.  Preparsed schema will not work")
+        if self.exclude_imports:
+            if self.schemaview:
+                sv = self.schemaview
+            else:
+                source = self.schema.source_file or self.schema
+                if isinstance(source, str) and self.base_dir and not Path(source).is_absolute():
+                    source = str(Path(self.base_dir) / source)
+                sv = SchemaView(source, importmap=self.importmap, base_dir=self.base_dir)
+            self._local_classes = set(sv.all_classes(imports=False).keys())
+            self._local_slots = set(sv.all_slots(imports=False).keys())
 
     def visit_schema(self, base: str | Namespace | None = None, output: str | None = None, **_):
         # Add any explicitly declared prefixes
@@ -177,6 +192,9 @@ class ContextGenerator(Generator):
         return str(as_json(context)) + "\n"
 
     def visit_class(self, cls: ClassDefinition) -> bool:
+        if self.exclude_imports and cls.name not in self._local_classes:
+            return False
+
         class_def = {}
         cn = camelcase(cls.name)
         self.add_mappings(cls)
@@ -226,6 +244,9 @@ class ContextGenerator(Generator):
         return False, None
 
     def visit_slot(self, aliased_slot_name: str, slot: SlotDefinition) -> None:
+        if self.exclude_imports and slot.name not in self._local_slots:
+            return
+
         if slot.identifier:
             slot_def = "@id"
         else:
@@ -361,6 +382,13 @@ class ContextGenerator(Generator):
     default=False,
     show_default=True,
     help="For multivalued attributes declare a fix container type ('@set' for lists, '@index' for dictionaries).",
+)
+@click.option(
+    "--exclude-imports/--include-imports",
+    default=False,
+    show_default=True,
+    help="Use --exclude-imports to exclude imported elements from the generated JSON-LD context. This is useful when "
+    "extending an ontology whose terms already have context definitions in their own JSON-LD context file.",
 )
 @click.version_option(__version__, "-V", "--version")
 def cli(yamlfile, emit_frame, embed_context_in_frame, output, **args):

--- a/tests/linkml/test_generators/test_jsonldcontextgen.py
+++ b/tests/linkml/test_generators/test_jsonldcontextgen.py
@@ -545,3 +545,29 @@ classes:
     assert "@type" not in context["@context"]["polymorphic"], (
         "any_of with conflicting literal types and a class should omit coercion"
     )
+
+
+def test_exclude_imports(input_path):
+    """With --exclude-imports, slots and classes from imported schemas
+    must not appear in the generated JSON-LD context, while inherited
+    slots on local classes are still included.
+
+    Reuses the ShaclGenerator's exclude_imports test fixtures which define
+    a BaseClass (with baseProperty) in an imported schema and an
+    ExtendedClass (with extendedProperty, is_a: BaseClass) in the main schema.
+    """
+    context_text = ContextGenerator(
+        input_path("shaclgen/exclude_imports.yaml"),
+        mergeimports=True,
+        exclude_imports=True,
+    ).serialize()
+    context = json.loads(context_text)
+    ctx = context["@context"]
+
+    # Local class and slot must be present
+    assert "ExtendedClass" in ctx, f"Local class 'ExtendedClass' must appear in context, got: {list(ctx.keys())}"
+    assert "extendedProperty" in ctx, f"Local slot 'extendedProperty' must appear in context, got: {list(ctx.keys())}"
+
+    # Imported class and slot must NOT be present
+    assert "BaseClass" not in ctx, "Imported class 'BaseClass' must not appear in exclude-imports context"
+    assert "baseProperty" not in ctx, "Imported slot 'baseProperty' must not appear in exclude-imports context"


### PR DESCRIPTION
## Summary

Adds an `exclude_imports` flag to `ContextGenerator`, matching the existing flag on `ShaclGenerator`. When enabled, classes and slots from imported schemas are excluded from the generated JSON-LD context.

## Problem

When extending an ontology that already provides its own JSON-LD context file, the imported terms should not be redefined in the local context. For example:

- W3C Verifiable Credentials v2 defines `issuer`, `validFrom`, `credentialStatus` etc. as `@protected` terms in `https://www.w3.org/ns/credentials/v2`
- A local credential schema imports these terms via a base schema
- Without `exclude_imports`, the generated context redefines these terms, conflicting with the `@protected` directive from the W3C context

Currently, downstream consumers must subclass `ContextGenerator` and override `visit_slot()`/`visit_class()` to filter imported elements. This is fragile and duplicates logic that should live upstream.

`ShaclGenerator` already has this exact feature (`--exclude-imports/--include-imports`), added for the same reason -- to avoid re-emitting shapes from imported ontologies. This PR brings feature parity to `ContextGenerator`.

## Standards Reference

- **JSON-LD 1.1, section 4.1.11** ([Protected Term Definitions](https://www.w3.org/TR/json-ld11/#protected-term-definitions)): Terms marked `@protected` in an upstream context cannot be overridden by a downstream context without causing a processing error.

## Alternatives considered

1. **Use `--no-mergeimports` alone** -- `mergeimports=False` controls whether imported schemas are *loaded* into the schema view, but still emits all elements visible in the resolved view. `exclude_imports` operates at the *output* level, filtering based on element origin. They serve different purposes and can be combined.
2. **Subclass `ContextGenerator` downstream** -- this is what consumers currently do, but it is fragile (breaks on internal refactors) and duplicates filtering logic. An upstream flag is the correct abstraction.
3. **A generic `--filter-imported` flag on all generators** -- possible future work, but currently only SHACL and JSON-LD context generators have the need. Adding it per-generator as needed is simpler and follows the existing `ShaclGenerator` precedent.

## Implementation

Uses `SchemaView.all_classes(imports=False)` and `all_slots(imports=False)` to reliably determine which elements are locally defined, regardless of how imports were resolved (URL, local file, or importmap).

In `__post_init__`, when `exclude_imports=True`:
1. Creates a `SchemaView` (reuses `self.schemaview` if available)
2. Builds sets of local class and slot names
3. `visit_class()` and `visit_slot()` check membership in these sets

## Changes

- **`jsonldcontextgen.py`**: Added `exclude_imports` field with class-level `_local_classes`/`_local_slots` attributes, `SchemaView`-based local element detection in `__post_init__`, filtering in `visit_class`/`visit_slot`, CLI option
- **`test_jsonldcontextgen.py`**: Added `test_exclude_imports` reusing ShaclGenerator's test fixtures

## Testing

- All 22 existing context generator tests pass
- New `test_exclude_imports` verifies:
  - Imported classes/slots are excluded when flag is set
  - Local classes/slots (including inherited slots) are included
  - Default behavior is unchanged (flag defaults to `False`)
