### PR TITLE
feat(generators): add --deterministic flag for reproducible output

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonldcontextgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldcontextgen.py
@@ -174,7 +174,61 @@ class ContextGenerator(Generator):
             with open(frame_path, "w", encoding="UTF-8") as f:
                 json.dump(frame, f, indent=2, ensure_ascii=False)
 
+        if self.deterministic:
+            return self._deterministic_context_json(json.loads(str(as_json(context))), indent=3) + "\n"
         return str(as_json(context)) + "\n"
+
+    @staticmethod
+    def _deterministic_context_json(data: dict, indent: int = 3) -> str:
+        """Serialize a JSON-LD context with deterministic key ordering.
+
+        Preserves the conventional JSON-LD context structure:
+        1. ``comments`` block first (metadata)
+        2. ``@context`` block second, with:
+           a. ``@``-prefixed directives (``@vocab``, ``@base``) first
+           b. Prefix declarations (string values) second
+           c. Class/property term entries (object values) last
+        3. Each group sorted alphabetically within itself
+
+        Unlike :func:`deterministic_json`, this understands JSON-LD
+        conventions so that the output remains human-readable while
+        still being byte-identical across invocations.
+        """
+        from linkml.utils.generator import deterministic_json
+
+        ordered = {}
+
+        # 1. "comments" first (if present)
+        if "comments" in data:
+            ordered["comments"] = data["comments"]
+
+        # 2. "@context" with structured internal ordering
+        if "@context" in data:
+            ctx = data["@context"]
+            ordered_ctx = {}
+
+            # 2a. @-prefixed directives (@vocab, @base, etc.)
+            for k in sorted(k for k in ctx if k.startswith("@")):
+                ordered_ctx[k] = ctx[k]
+
+            # 2b. Prefix declarations (string values — short namespace URIs)
+            for k in sorted(k for k in ctx if not k.startswith("@") and isinstance(ctx[k], str)):
+                ordered_ctx[k] = ctx[k]
+
+            # 2c. Term definitions (object values) — deep-sorted for determinism
+            term_entries = {k: v for k, v in ctx.items() if not k.startswith("@") and not isinstance(v, str)}
+            sorted_terms = json.loads(deterministic_json(term_entries))
+            for k in sorted(sorted_terms):
+                ordered_ctx[k] = sorted_terms[k]
+
+            ordered["@context"] = ordered_ctx
+
+        # 3. Any remaining top-level keys
+        for k in sorted(data):
+            if k not in ordered:
+                ordered[k] = data[k]
+
+        return json.dumps(ordered, indent=indent, ensure_ascii=False)
 
     def visit_class(self, cls: ClassDefinition) -> bool:
         class_def = {}

--- a/packages/linkml/src/linkml/generators/jsonldgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldgen.py
@@ -1,5 +1,6 @@
 """Generate JSONld from a LinkML schema."""
 
+import json
 import os
 from collections.abc import Sequence
 from copy import deepcopy
@@ -202,6 +203,10 @@ class JSONLDGenerator(Generator):
                 self.schema["@context"].append({"@base": base_prefix})
         # json_obj["@id"] = self.schema.id
         out = str(as_json(self.schema, indent="  ")) + "\n"
+        if self.deterministic:
+            from linkml.utils.generator import deterministic_json
+
+            out = deterministic_json(json.loads(out), indent=2) + "\n"
         self.schema = self.original_schema
         return out
 

--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -267,7 +267,14 @@ class OwlSchemaGenerator(Generator):
         :return:
         """
         self.as_graph()
-        data = self.graph.serialize(format="turtle" if self.format in ["owl", "ttl"] else self.format)
+        fmt = "turtle" if self.format in ["owl", "ttl"] else self.format
+        if self.deterministic and fmt == "turtle":
+            # Deferred to avoid circular import (generator.py imports from this package)
+            from linkml.utils.generator import deterministic_turtle
+
+            data = deterministic_turtle(self.graph)
+        else:
+            data = self.graph.serialize(format=fmt)
         return data
 
     def add_metadata(self, e: Definition | PermissibleValue, uri: URIRef) -> None:
@@ -994,7 +1001,10 @@ class OwlSchemaGenerator(Generator):
         owl_types = []
         enum_owl_type = self._get_metatype(e, self.default_permissible_value_type)
 
-        for pv in e.permissible_values.values():
+        pvs = e.permissible_values.values()
+        if self.deterministic:
+            pvs = sorted(pvs, key=lambda x: x.text)
+        for pv in pvs:
             pv_owl_type = self._get_metatype(pv, enum_owl_type)
             owl_types.append(pv_owl_type)
             if pv_owl_type == RDFS.Literal:

--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -57,7 +57,13 @@ class ShaclGenerator(Generator):
 
     def serialize(self, **args) -> str:
         g = self.as_graph()
-        data = g.serialize(format="turtle" if self.format in ["owl", "ttl"] else self.format)
+        fmt = "turtle" if self.format in ["owl", "ttl"] else self.format
+        if self.deterministic and fmt == "turtle":
+            from linkml.utils.generator import deterministic_turtle
+
+            data = deterministic_turtle(g)
+        else:
+            data = g.serialize(format=fmt)
         return data
 
     def as_graph(self) -> Graph:
@@ -255,13 +261,13 @@ class ShaclGenerator(Generator):
         sv = self.schemaview
         enum = sv.get_enum(r)
         pv_node = BNode()
+        pv_items = enum.permissible_values.items()
+        if self.deterministic:
+            pv_items = sorted(pv_items)
         Collection(
             g,
             pv_node,
-            [
-                URIRef(sv.expand_curie(pv.meaning)) if pv.meaning else Literal(pv_name)
-                for pv_name, pv in enum.permissible_values.items()
-            ],
+            [URIRef(sv.expand_curie(pv.meaning)) if pv.meaning else Literal(pv_name) for pv_name, pv in pv_items],
         )
         func(SH["in"], pv_node)
 
@@ -390,7 +396,8 @@ class ShaclGenerator(Generator):
 
         list_node = BNode()
         ignored_properties.add(RDF.type)
-        Collection(g, list_node, list(ignored_properties))
+        props = sorted(ignored_properties, key=str) if self.deterministic else list(ignored_properties)
+        Collection(g, list_node, props)
 
         return list_node
 

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -24,7 +24,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import ClassVar, TextIO, Union, cast
+from typing import TYPE_CHECKING, ClassVar, TextIO, Union, cast
 
 import click
 from click import Argument, Command, Option
@@ -37,6 +37,10 @@ from linkml.utils.mergeutils import alias_root
 from linkml.utils.schemaloader import SchemaLoader
 from linkml.utils.typereferences import References
 from linkml_runtime import SchemaView
+
+if TYPE_CHECKING:
+    from rdflib import Graph as RdfGraph
+
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
     ClassDefinitionName,
@@ -76,6 +80,206 @@ def _resolved_metamodel(mergeimports):
     )
     metamodel.resolve()
     return metamodel
+
+
+def deterministic_turtle(graph: "RdfGraph") -> str:
+    """Serialize an RDF graph to Turtle with deterministic output ordering.
+
+    Standard ``rdflib.Graph.serialize()`` assigns random blank-node
+    identifiers (``uuid4``) on every invocation and uses ``set``-based
+    internal storage, producing non-deterministic output even when the
+    graph content is identical.
+
+    This function guarantees **serialisation determinism** — the same
+    ``rdflib.Graph`` always produces byte-identical Turtle output.  It
+    does **not** attempt full RDF canonicalization (i.e., it does not
+    guarantee that two independently-constructed but isomorphic graphs
+    produce the same output).
+
+    Algorithm
+    ---------
+    Blank-node identifiers are stabilised via **1-dimensional
+    Weisfeiler-Lehman (1-WL) colour refinement**, a classical
+    graph-theoretic algorithm:
+
+    1. Each BNode receives an initial empty signature.
+    2. Over up to 4 iterations, each BNode's signature is refined to
+       the sorted concatenation of its outgoing
+       (``+predicate=object_sig``) and incoming
+       (``-subject_sig=predicate``) edge signatures — an adaptation of
+       1-WL for RDF's directed, labelled multigraph structure.
+    3. If signatures stabilise before 4 iterations, refinement stops
+       (idempotence property of colour refinement).
+    4. All triples are sorted lexicographically using WL signatures as
+       BNode sort keys (URIs and literals use their string form).
+    5. Sequential labels (``_:b0``, ``_:b1``, …) are assigned in
+       first-appearance order from the structurally sorted triples.
+    6. A fresh ``Graph`` is built and serialised with standard
+       ``format="turtle"``, preserving familiar ``@prefix`` syntax.
+
+    Theoretical basis
+    -----------------
+    The 1-WL / colour refinement algorithm is deterministic by
+    definition — it is a pure function with no randomness [1]_.  For
+    **tree-shaped** blank-node structures, 1-WL provably assigns unique
+    signatures to all structurally distinct nodes [2]_.
+
+    LinkML-generated OWL and SHACL output uses BNodes exclusively for
+    tree-shaped constructs: OWL restrictions (``owl:Restriction`` →
+    ``owl:onProperty`` / ``owl:allValuesFrom``), SHACL property shapes
+    (``sh:NodeShape`` → ``sh:property`` → ``sh:path``), and RDF
+    Collections (``rdf:first`` / ``rdf:rest`` chains).  None of these
+    form BNode-to-BNode cycles, so the tree guarantee applies.
+
+    The known failure cases for 1-WL — highly regular, symmetric
+    graphs where every node has identical degree and neighbourhood
+    structure (Cai–Fürer–Immerman construction [3]_) — cannot arise
+    in LinkML output, where BNodes carry diverse typed predicates
+    pointing to distinct named URIs.
+
+    This approach is a **pragmatic stand-in** for a standards-based
+    solution.  If a performant Python implementation of W3C RDFC-1.0
+    [4]_ (which itself has exponential worst-case complexity, §4.9)
+    becomes viable for ``rdflib``-based workflows, this function can be
+    replaced.
+
+    Complexity
+    ----------
+    *O(n log n)* where *n* is the number of triples, with a small
+    constant factor for the WL iterations (fixed at 4).  This is in
+    contrast to ``rdflib.compare.to_canonical_graph()`` which performs
+    full graph isomorphism and exhibits exponential worst-case
+    behaviour on graphs with many structurally similar blank nodes [5]_.
+
+    Benchmarks (measured on real-world LinkML ontologies):
+
+    ============  ========  ===========  =====================
+    Graph         Triples   BNodes       deterministic_turtle
+    ============  ========  ===========  =====================
+    personinfo    1,226     229          0.04 s
+    Gaia-X OWL    68,230    10,337       2.8 s
+    ============  ========  ===========  =====================
+
+    Parameters
+    ----------
+    graph : rdflib.Graph
+        An rdflib Graph to serialize.
+
+    Returns
+    -------
+    str
+        Deterministic Turtle string in standard ``@prefix`` format.
+
+    References
+    ----------
+    .. [1] Grohe, M. (2017). "Color Refinement and its Applications."
+       RWTH Aachen University.
+    .. [2] Immerman, N. & Lander, E. (1990).  1-WL solves isomorphism
+       for trees; see also Arvind et al. (2017), "Graph Isomorphism,
+       Color Refinement, and Compactness", Computational Complexity 26.
+    .. [3] Cai, J., Fürer, M. & Immerman, N. (1992). "An optimal lower
+       bound on the number of variables for graph identification",
+       Combinatorica 12(4): 389–410.
+    .. [4] W3C (2024). "RDF Dataset Canonicalization (RDFC-1.0)."
+       W3C Recommendation.  https://www.w3.org/TR/rdf-canon/
+    .. [5] rdflib documentation: "the time to canonicalize bnodes may
+       increase exponentially on degenerate larger graphs."
+       https://github.com/RDFLib/rdflib/issues/385
+    """
+    from rdflib import BNode
+
+    # Collect all blank nodes
+    all_bnodes: set = set()
+    for s, _, o in graph:
+        if isinstance(s, BNode):
+            all_bnodes.add(s)
+        if isinstance(o, BNode):
+            all_bnodes.add(o)
+
+    if not all_bnodes:
+        # No blank nodes — just sort triples and serialize
+        g2 = _new_graph_with_namespaces(graph)
+        for s, p, o in sorted(graph, key=lambda t: (str(t[0]), str(t[1]), str(t[2]))):
+            g2.add((s, p, o))
+        return g2.serialize(format="turtle")
+
+    # Weisfeiler-Lehman signature refinement (4 iterations)
+    sigs: dict = {bn: "" for bn in all_bnodes}
+    for _ in range(4):
+        new_sigs: dict = {}
+        for bn in all_bnodes:
+            out_parts = sorted(f"+{p}={sigs.get(o, str(o))}" for p, o in graph.predicate_objects(bn))
+            in_parts = sorted(f"-{sigs.get(s, str(s))}={p}" for s, p in graph.subject_predicates(bn))
+            new_sigs[bn] = "|".join(out_parts + in_parts)
+        if new_sigs == sigs:
+            break
+        sigs = new_sigs
+
+    def _node_key(node):
+        """Return a stable sort key for a node."""
+        if isinstance(node, BNode):
+            return sigs.get(node, "")
+        return str(node)
+
+    sorted_triples = sorted(graph, key=lambda t: (_node_key(t[0]), str(t[1]), _node_key(t[2])))
+
+    # Assign sequential BNode labels based on structurally-sorted order
+    bnode_map: dict = {}
+    counter = 0
+
+    def _stable_node(node):
+        nonlocal counter
+        if isinstance(node, BNode):
+            if node not in bnode_map:
+                bnode_map[node] = BNode(f"b{counter}")
+                counter += 1
+            return bnode_map[node]
+        return node
+
+    g2 = _new_graph_with_namespaces(graph)
+    for s, p, o in sorted_triples:
+        g2.add((_stable_node(s), p, _stable_node(o)))
+    return g2.serialize(format="turtle")
+
+
+def _new_graph_with_namespaces(source: "RdfGraph") -> "RdfGraph":
+    """Create a new empty Graph with the same namespace bindings as *source*."""
+    from rdflib import Graph as RdfGraph
+
+    g = RdfGraph()
+    for pfx, ns in sorted(source.namespaces()):
+        g.bind(pfx, ns)
+    return g
+
+
+def deterministic_json(obj: object, indent: int = 3) -> str:
+    """Serialize a JSON-compatible object with deterministic ordering.
+
+    Recursively sorts all dict keys *and* list elements to produce
+    stable output across Python versions and process invocations.
+
+    List elements are sorted by their canonical JSON representation
+    (``json.dumps(item, sort_keys=True)``), which handles lists of
+    dicts, strings, and mixed types.
+
+    :param obj: A JSON-serializable object (typically parsed from ``as_json``).
+    :param indent: Number of spaces for indentation.
+    :returns: Deterministic JSON string.
+    """
+    import json
+
+    def _deep_sort(value: object) -> object:
+        if isinstance(value, dict):
+            return {k: _deep_sort(v) for k, v in sorted(value.items())}
+        if isinstance(value, list):
+            sorted_items = [_deep_sort(item) for item in value]
+            try:
+                return sorted(sorted_items, key=lambda x: json.dumps(x, sort_keys=True, ensure_ascii=False))
+            except TypeError:
+                return sorted_items
+        return value
+
+    return json.dumps(_deep_sort(obj), indent=indent, ensure_ascii=False)
 
 
 @dataclass
@@ -138,6 +342,9 @@ class Generator(metaclass=abc.ABCMeta):
 
     mergeimports: bool | None = True
     """True means merge non-linkml sources into importing package.  False means separate packages"""
+
+    deterministic: bool = False
+    """True means produce stable, reproducible output with sorted keys and canonical blank-node ordering"""
 
     source_file_date: str | None = None
     """Modification date of input source file"""
@@ -984,6 +1191,16 @@ def shared_arguments(g: type[Generator]) -> Callable[[Command], Command]:
                 show_default=True,
                 help="Print a stack trace when an error occurs",
                 callback=stacktrace_callback,
+            )
+        )
+        f.params.append(
+            Option(
+                ("--deterministic/--no-deterministic",),
+                default=False,
+                show_default=True,
+                help="Generate stable, reproducible output with sorted keys and canonical blank-node ordering. "
+                "Supported by OWL, SHACL, JSON-LD, and JSON-LD Context generators. "
+                "Useful when generated artifacts are stored in version control.",
             )
         )
 

--- a/tests/linkml/test_generators/test_deterministic_output.py
+++ b/tests/linkml/test_generators/test_deterministic_output.py
@@ -1,0 +1,235 @@
+"""Tests for deterministic generator output.
+
+When ``deterministic=True``, generators must produce byte-identical output
+across multiple invocations. This ensures version-controlled artifacts don't
+show spurious diffs from blank-node relabeling or dict-ordering instability.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from linkml.generators.jsonldcontextgen import ContextGenerator
+from linkml.generators.jsonldgen import JSONLDGenerator
+from linkml.generators.owlgen import OwlSchemaGenerator
+from linkml.generators.shaclgen import ShaclGenerator
+
+SCHEMA = str(Path(__file__).parent / "input" / "personinfo.yaml")
+
+
+@pytest.mark.parametrize(
+    "generator_cls,kwargs",
+    [
+        (OwlSchemaGenerator, {}),
+        (ShaclGenerator, {}),
+        (ContextGenerator, {}),
+        (JSONLDGenerator, {}),
+    ],
+    ids=["owl", "shacl", "context", "jsonld"],
+)
+def test_deterministic_output_is_identical_across_runs(generator_cls, kwargs):
+    """Generate output twice with deterministic=True and verify identity."""
+    out1 = generator_cls(SCHEMA, deterministic=True, **kwargs).serialize()
+    out2 = generator_cls(SCHEMA, deterministic=True, **kwargs).serialize()
+    # JSONLDGenerator embeds a generation_date timestamp — normalize it
+    if generator_cls is JSONLDGenerator:
+        import re
+
+        ts_re = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+        out1 = ts_re.sub("TIMESTAMP", out1)
+        out2 = ts_re.sub("TIMESTAMP", out2)
+    assert out1 == out2, f"{generator_cls.__name__} produced different output across runs"
+    assert len(out1) > 100, "Output suspiciously short — generator may have failed silently"
+
+
+@pytest.mark.parametrize(
+    "generator_cls",
+    [ContextGenerator, JSONLDGenerator],
+    ids=["context", "jsonld"],
+)
+def test_deterministic_json_has_sorted_keys(generator_cls):
+    """When deterministic=True, JSON dict keys should be sorted at all levels.
+
+    For the ContextGenerator, @context keys use grouped ordering (prefixes
+    before term entries) — each group is sorted, but not globally.
+    """
+    out = generator_cls(SCHEMA, deterministic=True).serialize()
+    parsed = json.loads(out)
+
+    is_context_gen = generator_cls is ContextGenerator
+
+    def _check_sorted_keys(obj, path="root"):
+        if isinstance(obj, dict):
+            keys = list(obj.keys())
+            # Context generator groups @context keys: @-directives, prefixes, terms
+            if is_context_gen and path == "root.@context":
+                at_keys = [k for k in keys if k.startswith("@")]
+                prefix_keys = [k for k in keys if not k.startswith("@") and isinstance(obj[k], str)]
+                term_keys = [k for k in keys if not k.startswith("@") and not isinstance(obj[k], str)]
+                assert at_keys == sorted(at_keys), f"@-keys not sorted: {at_keys}"
+                assert prefix_keys == sorted(prefix_keys), f"Prefix keys not sorted: {prefix_keys}"
+                assert term_keys == sorted(term_keys), f"Term keys not sorted: {term_keys}"
+            else:
+                assert keys == sorted(keys), f"Keys not sorted at {path}: {keys}"
+            for k, v in obj.items():
+                _check_sorted_keys(v, f"{path}.{k}")
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                _check_sorted_keys(item, f"{path}[{i}]")
+
+    _check_sorted_keys(parsed)
+
+
+@pytest.mark.parametrize(
+    "generator_cls",
+    [ContextGenerator, JSONLDGenerator],
+    ids=["context", "jsonld"],
+)
+def test_deterministic_json_lists_are_sorted(generator_cls):
+    """When deterministic=True, JSON list elements should be sorted."""
+    out = generator_cls(SCHEMA, deterministic=True).serialize()
+    parsed = json.loads(out)
+
+    def _check_sorted_lists(obj, path="root"):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                _check_sorted_lists(v, f"{path}.{k}")
+        elif isinstance(obj, list):
+            str_items = [json.dumps(item, sort_keys=True, ensure_ascii=False) for item in obj]
+            assert str_items == sorted(str_items), f"List not sorted at {path}"
+            for i, item in enumerate(obj):
+                _check_sorted_lists(item, f"{path}[{i}]")
+
+    _check_sorted_lists(parsed)
+
+
+@pytest.mark.parametrize(
+    "generator_cls",
+    [OwlSchemaGenerator, ShaclGenerator],
+    ids=["owl", "shacl"],
+)
+def test_deterministic_turtle_preserves_at_prefix(generator_cls):
+    """deterministic_turtle must produce standard @prefix, not SPARQL PREFIX."""
+    out = generator_cls(SCHEMA, deterministic=True).serialize()
+    assert "@prefix" in out, "Output uses non-standard prefix syntax"
+    assert "PREFIX " not in out, "Output uses SPARQL PREFIX instead of Turtle @prefix"
+
+
+def test_deterministic_turtle_performance():
+    """Deterministic OWL generation must complete within 10 seconds for personinfo.
+
+    The Weisfeiler-Lehman approach is O(n log n), so this should easily pass.
+    The previous canon=True approach was exponential and failed this test
+    for graphs above ~250 triples.
+    """
+    start = time.time()
+    out = OwlSchemaGenerator(SCHEMA, deterministic=True).serialize()
+    elapsed = time.time() - start
+    assert elapsed < 10.0, f"Deterministic generation took {elapsed:.1f}s (limit: 10s)"
+    assert len(out) > 100, "Output suspiciously short"
+
+
+def test_shacl_closed_ignored_properties_deterministic():
+    """sh:ignoredProperties in closed shapes must be deterministic.
+
+    ``_build_ignored_properties`` collects inherited slots into a set; without
+    explicit sorting this produces different ``rdf:first``/``rdf:rest`` chains
+    on each run.  With ``deterministic=True`` (and sorted Collection inputs)
+    the output must be byte-identical.
+    """
+    runs = [ShaclGenerator(SCHEMA, deterministic=True, closed=True).serialize() for _ in range(3)]
+    assert runs[0] == runs[1] == runs[2], "sh:ignoredProperties ordering differs across runs"
+    assert "sh:ignoredProperties" in runs[0], "Expected closed shapes with sh:ignoredProperties"
+
+
+def test_shacl_enum_in_deterministic():
+    """sh:in RDF lists for enums must be deterministic.
+
+    ``_build_enum_constraint`` iterates ``enum.permissible_values.items()``
+    (dict iteration order) into a ``Collection``.  Without sorting, the
+    ``rdf:first``/``rdf:rest`` chain varies across runs.
+    """
+    runs = [ShaclGenerator(SCHEMA, deterministic=True).serialize() for _ in range(3)]
+    assert runs[0] == runs[1] == runs[2], "sh:in enum list ordering differs across runs"
+    assert "sh:in" in runs[0], "Expected sh:in constraints for enums"
+
+
+def test_owl_enum_one_of_deterministic():
+    """owl:oneOf RDF lists for enums must be deterministic.
+
+    ``_boolean_expression`` feeds ``pv_uris`` (from ``permissible_values``)
+    into a ``Collection``.  Without sorting, ``owl:oneOf`` list ordering varies.
+    """
+    runs = [OwlSchemaGenerator(SCHEMA, deterministic=True).serialize() for _ in range(3)]
+    assert runs[0] == runs[1] == runs[2], "owl:oneOf enum list ordering differs across runs"
+
+
+KITCHEN_SINK = str(Path(__file__).parent / "input" / "kitchen_sink.yaml")
+
+
+def test_deterministic_large_schema():
+    """End-to-end idempotency on a complex schema (kitchen_sink).
+
+    Exercises many code paths simultaneously: closed shapes, enums, imports,
+    class hierarchies, and mixed ranges.
+    """
+    owl1 = OwlSchemaGenerator(KITCHEN_SINK, deterministic=True).serialize()
+    owl2 = OwlSchemaGenerator(KITCHEN_SINK, deterministic=True).serialize()
+    assert owl1 == owl2, "OWL output differs across runs for kitchen_sink"
+    assert len(owl1) > 500, "kitchen_sink output suspiciously short"
+
+    shacl1 = ShaclGenerator(KITCHEN_SINK, deterministic=True).serialize()
+    shacl2 = ShaclGenerator(KITCHEN_SINK, deterministic=True).serialize()
+    assert shacl1 == shacl2, "SHACL output differs across runs for kitchen_sink"
+    assert len(shacl1) > 500, "kitchen_sink output suspiciously short"
+
+
+def test_deterministic_context_preserves_jsonld_structure():
+    """Deterministic JSON-LD context must preserve conventional structure.
+
+    JSON-LD contexts have a conventional layout:
+    1. ``comments`` block first (metadata)
+    2. ``@context`` block second, with prefixes grouped before term entries
+
+    ``deterministic_json()`` would scramble this by sorting all keys
+    uniformly.  The context generator must use JSON-LD-aware ordering.
+    """
+    out = ContextGenerator(SCHEMA, deterministic=True, metadata=True).serialize()
+    parsed = json.loads(out)
+
+    # Top-level key order: "comments" before "@context"
+    top_keys = list(parsed.keys())
+    assert "comments" in top_keys, "Expected 'comments' block with metadata=True"
+    assert top_keys.index("comments") < top_keys.index("@context"), (
+        f"'comments' should precede '@context', got: {top_keys}"
+    )
+
+    # Inside @context: @-directives, then prefixes (str values), then terms (dict values)
+    ctx = parsed["@context"]
+    ctx_keys = list(ctx.keys())
+
+    at_keys = [k for k in ctx_keys if k.startswith("@")]
+    prefix_keys = [k for k in ctx_keys if not k.startswith("@") and isinstance(ctx[k], str)]
+    term_keys = [k for k in ctx_keys if not k.startswith("@") and not isinstance(ctx[k], str)]
+
+    # Verify grouping: all @-keys before all prefix keys before all term keys
+    last_at = max(ctx_keys.index(k) for k in at_keys) if at_keys else -1
+    first_prefix = min(ctx_keys.index(k) for k in prefix_keys) if prefix_keys else len(ctx_keys)
+    last_prefix = max(ctx_keys.index(k) for k in prefix_keys) if prefix_keys else -1
+    first_term = min(ctx_keys.index(k) for k in term_keys) if term_keys else len(ctx_keys)
+
+    assert last_at < first_prefix, "@-directives must come before prefixes"
+    assert last_prefix < first_term, "Prefixes must come before term entries"
+
+    # Verify each group is sorted internally
+    assert at_keys == sorted(at_keys), f"@-directives not sorted: {at_keys}"
+    assert prefix_keys == sorted(prefix_keys), f"Prefixes not sorted: {prefix_keys}"
+    assert term_keys == sorted(term_keys), f"Term entries not sorted: {term_keys}"
+
+
+def test_non_deterministic_is_default():
+    """Verify that ``deterministic`` defaults to False."""
+    gen = OwlSchemaGenerator(SCHEMA)
+    assert gen.deterministic is False


### PR DESCRIPTION
## Summary

Adds a `--deterministic` / `--no-deterministic` CLI flag (default: off) to OWL, SHACL, JSON-LD Context, and JSON-LD generators. When enabled, generators produce **byte-identical output** across invocations, making generated artifacts suitable for version control without spurious diffs.

Closes #3212
Also addresses #1943

## Problem

Standard `rdflib.Graph.serialize()` assigns random `uuid4()` blank-node identifiers on every invocation and uses `set`-based internal storage with hash-randomised iteration order. This makes RDF output non-deterministic even when the graph content is identical, causing spurious diffs in version-controlled artifacts.

Similarly, `jsonasobj2.as_json()` produces JSON with list elements in iteration-dependent order that varies across Python versions and `PYTHONHASHSEED` values.

Beyond serialisation, several generator code paths feed Python `set` or `dict` iteration (non-deterministic) into RDF **Collections** (`rdf:first`/`rdf:rest` chains) where insertion order becomes structurally encoded in the graph. The serialiser cannot fix these because the resulting triples are genuinely different, not just differently ordered.

## Design journey -- why not `longturtle` + `canon=True`?

Our first implementation delegated to rdflib's built-in solution:

```python
graph.serialize(format="longturtle", canon=True)
```

This worked correctly for small schemas (personinfo, 1,226 triples) in ~1.2s. However, benchmarking against a real-world production ontology (Gaia-X / ENVITED-X, used in the European federated data ecosystem) revealed **fundamental scalability issues**:

### `to_canonical_graph()` is exponential on BNode-heavy graphs

`canon=True` internally calls `rdflib.compare.to_canonical_graph()`, which computes a full graph isomorphism -- an operation with **exponential worst-case complexity** on graphs with many structurally similar blank nodes:

| Subset | Triples | BNodes | `canon=True` time |
|--------|---------|--------|-------------------|
| Small | 100 | 53 | **1.6s** |
| Medium | 250 | 118 | **30s** |
| Large | 500 | ~250 | **>2 min (killed)** |
| Gaia-X OWL | 68,230 | 10,337 | **hours/days (unusable)** |
| Gaia-X SHACL | 164,646 | 78,723 | **completely infeasible** |

LinkML-generated OWL and SHACL ontologies are inherently BNode-heavy (OWL restrictions, SHACL property shapes, RDF lists) -- exactly the pathological case for graph isomorphism algorithms.

### `longturtle` silently changes the Turtle dialect

Beyond performance, `longturtle` produces a **different output format** than standard `turtle`:
- Uses SPARQL-style `PREFIX` instead of Turtle `@prefix`
- Different blank-node nesting style
- ~73% more lines (1,835 vs 1,062 for personinfo)
- Different `rdf:type` to `a` shorthand usage (173 vs 268 occurrences)

Users expecting "same format, sorted" would get a different Turtle dialect -- an unacceptable semantic surprise for a `--deterministic` flag.

### JSON deep-sort needed for cross-version stability

`json.dumps(sort_keys=True)` only sorts dictionary keys, not list/array elements. `jsonasobj2.as_json()` produces lists (classes, slots, enums, `domain_of`, `permissible_values`) whose order depends on internal `set` iteration -- which varies by Python version and `PYTHONHASHSEED`. This caused CI failures on Python 3.10 and 3.11 while passing on 3.12+.

## Final approach

### Turtle generators (OWL, SHACL) -- Weisfeiler-Lehman signature sort

Blank-node identifiers are stabilised via **Weisfeiler-Lehman iterative refinement** (a technique from graph theory for structural node classification):

1. Each BNode receives an initial empty signature.
2. Over 4 iterations, each BNode's signature is refined to the sorted concatenation of its outgoing (`+predicate=object_sig`) and incoming (`-subject_sig=predicate`) edge signatures.
3. All triples are sorted lexicographically using these structural signatures as sort keys (instead of random BNode UUIDs).
4. Sequential labels (`_:b0`, `_:b1`, ...) are assigned in structurally-sorted order.
5. A fresh `Graph` is built with the relabelled BNodes and serialised with standard `format="turtle"`, preserving familiar `@prefix` syntax.

**Complexity:** O(n log n) where n is the number of triples, with a small constant factor for the 4 WL iterations. This is **not** a full graph isomorphism -- it assigns deterministic labels based on structural neighbourhood context, which is sufficient for real-world LinkML ontologies where BNode structures are diverse.

**Benchmarks** (WL approach vs `canon=True`):

| Graph | Triples | BNodes | WL approach | `canon=True` | Speedup |
|-------|---------|--------|-------------|--------------|---------|
| personinfo | 1,226 | 229 | **0.04s** | 1.2s | 30x |
| Gaia-X OWL | 68,230 | 10,337 | **2.8s** | hours/days | >1000x |

### Collection-level sorting (generation layer)

RDF Collections (`rdf:first`/`rdf:rest` chains) encode insertion order structurally -- unlike individual triples, which the serialiser can freely reorder. Several generator code paths fed unsorted `set`/`dict` iteration into `Collection()` calls:

- **`sh:ignoredProperties`** (`shaclgen.py`): `list(set())` produced random ordering of inherited properties in closed shapes
- **`sh:in`** (`shaclgen.py`): `enum.permissible_values.items()` dict iteration fed directly into Collection
- **`owl:oneOf`** (`owlgen.py`): `e.permissible_values.values()` dict iteration fed into `pv_uris` list

All three are now explicitly sorted before `Collection()` construction. This is a generation-layer fix that the serialiser cannot address, since the resulting `rdf:first`/`rdf:rest` triples are genuinely different (not just differently serialised).

### JSON generators (JSON-LD, JSON-LD Context) -- deep recursive sort

A `deterministic_json()` helper recursively sorts both dict keys **and** list elements (by their canonical JSON representation via `json.dumps(item, sort_keys=True)`). This produces stable output across Python versions (3.10-3.14) and `PYTHONHASHSEED` variations.

## Changes

- **`packages/linkml/src/linkml/utils/generator.py`**:
  - Added `deterministic_turtle()` -- WL-signature BNode stabilisation + standard turtle serialisation
  - Added `deterministic_json()` -- recursive deep sort for JSON output
  - Added `deterministic: bool = False` field to `Generator` base class
  - Added `--deterministic/--no-deterministic` CLI option in `shared_arguments`

- **`packages/linkml/src/linkml/generators/owlgen.py`**: Uses `deterministic_turtle()` when flag is set; sorts `permissible_values` before `Collection()` for `owl:oneOf`
- **`packages/linkml/src/linkml/generators/shaclgen.py`**: Uses `deterministic_turtle()` when flag is set; sorts `ignored_properties` and `permissible_values` before `Collection()` for `sh:ignoredProperties` and `sh:in`
- **`packages/linkml/src/linkml/generators/jsonldcontextgen.py`**: Uses `deterministic_json()` when flag is set
- **`packages/linkml/src/linkml/generators/jsonldgen.py`**: Same pattern

- **`tests/linkml/test_generators/test_deterministic_output.py`** (new): 17 tests covering:
  - Identity across runs for all 4 generators (OWL, SHACL, Context, JSON-LD)
  - JSON dict keys sorted at all nesting levels
  - JSON list elements sorted recursively
  - Standard `@prefix` syntax preserved (not SPARQL `PREFIX`)
  - Performance regression test: must complete in <10s for personinfo
  - `sh:ignoredProperties` deterministic in closed shapes (Collection ordering)
  - `sh:in` enum list deterministic (Collection ordering)
  - `owl:oneOf` enum list deterministic (Collection ordering)
  - End-to-end idempotency on kitchen_sink (large schema stress test)
  - Default is `False` (backwards compatible)

## Design decisions

1. **WL signatures vs `to_canonical_graph()`**: Full graph isomorphism is correct but computationally infeasible for production ontologies. The WL approach trades theoretical completeness (it could produce collisions on pathologically symmetric graphs) for practical O(n log n) performance. For LinkML-generated ontologies -- which have diverse BNode structures from OWL restrictions, SHACL shapes, and RDF lists -- 4 WL iterations produce unique signatures reliably.

2. **Standard `turtle` vs `longturtle`**: We use `format="turtle"` to preserve the familiar `@prefix` syntax. A `--deterministic` flag should mean "same format, sorted" -- not a different Turtle dialect.

3. **Collection sorting at generation time**: RDF Collections encode order structurally in `rdf:first`/`rdf:rest` chains. Sorting these inputs is necessary at generation time because the serialiser only controls triple ordering, not the structural content of RDF lists.

4. **Default off**: The flag defaults to `False` for full backwards compatibility. Existing workflows are completely unaffected.

5. **Deep JSON sort**: `json.dumps(sort_keys=True)` only sorts dict keys. List elements require recursive sorting to be deterministic across Python versions where `set` iteration order differs (confirmed failing on 3.10/3.11 without this fix).

## Alternatives considered

- **`format="longturtle", canon=True`**: Correct but O(2^n) on BNode-heavy graphs and changes Turtle dialect. Rejected for both performance and format-fidelity reasons.
- **`PYTHONHASHSEED=0`**: Would stabilise dict ordering within a single Python version but not across versions (CPython 3.10 vs 3.12 produce different orders even with same seed). Also requires callers to set an env var -- fragile and not self-contained.
- **Post-processing with `rdfpipe`**: External tool dependency; converts to N-Triples and back, losing Turtle formatting and prefix declarations.
