### PR TITLE
Flag broken Docker Hub auth token

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0
 
+      # TODO(#3330): DOCKER_HUB_ACCESS_TOKEN appears expired/revoked as of 2026-03-27.
+      #   setup-buildx and setup-qemu fail pulling images from Docker Hub.
+      #   This token needs to be rotated by the account owner (cjmungall).
       - name: Login to DockerHub
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v3.7.0


### PR DESCRIPTION
Adds a TODO comment pointing to #3330. This PR's own CI failure demonstrates the issue — the Docker build step will fail with the auth error.

Closes #3330 once the token is rotated and this comment is removed.