### PR TITLE
Create a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+Fixes #
+
+<!-- Briefly describe what this PR does and why. -->
+
+## How was this tested?
+
+<!-- Describe how you verified your changes (e.g. new tests, existing test suite, manual testing). -->
+
+## Areas of uncertainty
+
+<!-- Are there parts of this change you'd like reviewers to look at more closely? -->
+
+## Checklist
+
+- [ ] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
+- [ ] I have added tests that prove my fix/feature works
+- [ ] Existing tests pass locally with my changes
+
+## AI Assistance
+
+If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.


### PR DESCRIPTION
This PR template is quite simple and is mostly to ensure that folks are aware of our contribution guide and AI guidelines.