### PR TITLE
Fix bug in generation of OWL union, intersection, and none of

### DIFF
--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -708,24 +708,25 @@ class OwlSchemaGenerator(Generator):
         if slot.all_members:
             owl_exprs.append(self.transform_class_slot_expression(cls, slot.all_members, main_slot, owl_types))
 
-        if slot.any_of:
-            owl_exprs.append(
-                self._union_of(
-                    [self.transform_class_slot_expression(cls, x, main_slot, owl_types) for x in slot.any_of]
-                )
-            )
-        if slot.all_of:
-            owl_exprs.append(
-                self._intersection_of(
-                    [self.transform_class_slot_expression(cls, x, main_slot, owl_types) for x in slot.all_of]
-                )
-            )
-        if slot.none_of:
-            owl_exprs.append(
-                self._complement_of_union_of(
-                    [self.transform_class_slot_expression(cls, x, main_slot, owl_types) for x in slot.none_of]
-                )
-            )
+        def _get_slot_nodes(slot_definition) -> list[BNode | URIRef] | None:
+            if not slot_definition:
+                return None
+            rdflib_nodes = [
+                rdflib_node
+                for slot_expression in slot.any_of
+                if (rdflib_node := self.transform_class_slot_expression(cls, slot_expression, main_slot, owl_types))
+            ]
+            if rdflib_nodes:
+                return rdflib_nodes
+            return None
+
+        if any_of_rdflib_nodes := _get_slot_nodes(slot.any_of):
+            owl_exprs.append(self._union_of(any_of_rdflib_nodes))
+        if all_of_rdflib_nodes := _get_slot_nodes(slot.all_of):
+            owl_exprs.append(self._intersection_of(all_of_rdflib_nodes))
+        if none_of_rdflib_nodes := _get_slot_nodes(slot.none_of):
+            owl_exprs.append(self._complement_of_union_of(none_of_rdflib_nodes))
+
         if slot.exactly_one_of:
             disj_exprs = []
             for i, operand in enumerate(slot.exactly_one_of):


### PR DESCRIPTION
Closes #3358

This PR refactors the generation of union of, intersection of, and none of objects in the OWL generator. Previously, this could create lists that contained `None` values, which made RDFlib error. Now, none values are filtered out. The same logic was duplicated 3 times, so I refactored the logic into a helper function

## How was this tested?

This should already be covered by existing tests

## Areas of uncertainty

<!-- Are there parts of this change you'd like reviewers to look at more closely? -->

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [ ] ~I have added tests that prove my fix/feature works~
- [x] Existing tests pass locally with my changes - 🤷 running `uv run pytest` like suggested in the documentation results in thousands of unrelated test failures. I will just rely on CI.

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.