### PR TITLE
Switch class_uri from mapping to exact_mapping

### DIFF
--- a/packages/linkml/src/linkml/utils/schemaloader.py
+++ b/packages/linkml/src/linkml/utils/schemaloader.py
@@ -260,9 +260,9 @@ class SchemaLoader:
                         f'Class "{cls.name}" unknown apply_to target: {apply_to_cls}',
                         apply_to_cls,
                     )
-            # Class URI's also count as (trivial) mappings
-            if cls.class_uri is not None:
-                cls.mappings.insert(0, cls.class_uri)
+            # TODO: discussion point is whether class_uri should always be defined as exact mappings
+            if cls.class_uri is not None and self.useuris:
+                cls.exact_mappings.insert(0, cls.class_uri)
             if cls.class_uri is None or not self.useuris:
                 from_schema = cls.from_schema
                 if from_schema is None:


### PR DESCRIPTION
## Summary

closes: #2687 

Fixes #

This PR makes it so that `class_uri` are deemed an `exact_mapping` as opposed to the current coarser `mapping`.

## How was this tested?

For now just manual debugging using example schema used in the issue refered to above. I will check whether tests pass.

## Areas of uncertainty

The main discussion point would be whether a `class_uri` should always be seen as an `exact_mapping`.

## Checklist

- [ ] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [ ] I have added tests that prove my fix/feature works
- [ ] Existing tests pass locally with my changes

## AI Assistance

No AI was used for this PR. Quick debugging by using the generator was enough to identify the source of the issue.
