### PR TITLE
Update all get-involved pages to remove direct slack join link

### DIFF
--- a/docs/get-involved/Community-Meetings.md
+++ b/docs/get-involved/Community-Meetings.md
@@ -10,7 +10,7 @@ Join the LinkML community for regular sessions featuring presentations on LinkML
 [Sarah Gehrke](https://tislab.org/members/sarah-gehrke.html), University of North Carolina at Chapel Hill <br>
 
 ## What to present at a Community meeting?
-Contact Sarah Gehrke on [Slack](https://join.slack.com/t/obo-communitygroup/shared_invite/zt-1oq48ttk7-kKo0i6TwntYtAq~Jcjjg4g) and they can help get you on the schedule!
+Contact Sarah Gehrke on Slack and they can help get you on the schedule!
 
 ## Helpful links
 - [Community Meeting Agenda](https://docs.google.com/document/d/1MStpDyh9LOZYJTjLtnpOsNYc3HaeU-bz0CHAI9xOjfQ/edit?tab=t.0#heading=h.6sqkx1xhumse): In this document you can find the zoom link to join the monthly call as well as recordings of previous sessions.

--- a/docs/get-involved/index.rst
+++ b/docs/get-involved/index.rst
@@ -4,7 +4,7 @@ Get Involved
 Learn about ways to get involved with the LinkML community.
 
 - **Mailing list**: This is low traffic; this list is mainly used to share a monthly newsletter that includes current developments and upcoming workshops or meeting opportunities. `Sign up <https://groups.google.com/g/linkml-community>`_
-- **Slack**: There are separate Slack channels for the core development team and the LinkML community: To join, make a ticket in [LinkML GitHub](https://github.com/linkml/linkml/issues) with the subject line "Join LinkML Slack - *insert your name*" and comment why you'd like to join.
+- **Slack**: There are separate Slack channels for the core development team and the LinkML community: To join, make a ticket in `LinkML GitHub <https://github.com/linkml/linkml/issues>`_ with the subject line "Join LinkML Slack - *insert your name*" and comment why you'd like to join.
 - **LinkedIn group**: `join <https://www.linkedin.com/groups/14303246/>`_
 - **Mastodon**: `follow us <https://fosstodon.org/@linkml>`_
 

--- a/docs/get-involved/index.rst
+++ b/docs/get-involved/index.rst
@@ -4,7 +4,7 @@ Get Involved
 Learn about ways to get involved with the LinkML community.
 
 - **Mailing list**: This is low traffic; this list is mainly used to share a monthly newsletter that includes current developments and upcoming workshops or meeting opportunities. `Sign up <https://groups.google.com/g/linkml-community>`_
-- **Slack**: There are separate Slack channels for the core development team and the LinkML community: `join here <https://join.slack.com/t/obo-communitygroup/shared_invite/zt-1oq48ttk7-kKo0i6TwntYtAq~Jcjjg4g>`_
+- **Slack**: There are separate Slack channels for the core development team and the LinkML community: To join, make a ticket in [LinkML GitHub](https://github.com/linkml/linkml/issues) with the subject line "Join LinkML Slack - *insert your name*" and comment why you'd like to join.
 - **LinkedIn group**: `join <https://www.linkedin.com/groups/14303246/>`_
 - **Mastodon**: `follow us <https://fosstodon.org/@linkml>`_
 

--- a/docs/get-involved/office-hours.md
+++ b/docs/get-involved/office-hours.md
@@ -20,4 +20,4 @@ There is no agenda! Any community member is welcome to join the office hours to 
 | December 3 |
 
 ## Questions?
-Contact Sarah Gehrke on [Slack](https://join.slack.com/t/obo-communitygroup/shared_invite/zt-1oq48ttk7-kKo0i6TwntYtAq~Jcjjg4g) and they can direct you to someone who can help.
+Contact Sarah Gehrke on Slack and they can direct you to someone who can help.


### PR DESCRIPTION
Due to annoying impersonators, we are changing up how people will join the OBO / LinkML slack. For now, I am doing the following: To join, make a ticket in [LinkML GitHub](https://github.com/linkml/linkml/issues) with the subject line "Join LinkML Slack - *insert your name*" and comment why you'd like to join.

However, I will eventually make a "sign up form" that will replace this language. When that happens, I will update the docs.
