### PR TITLE
doc: do point to Zenodo "transient" DOI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ from linkml.utils.deprecation import DEPRECATIONS
 # -- Project information -----------------------------------------------------
 
 project = 'linkml'
-copyright = '2021-2024, LinkML Authors'
+copyright = '2021-2026, LinkML Authors'
 author = 'LinkML Authors'
 
 

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -145,5 +145,7 @@ serializations such as HDF5 and Zarr.
 
 ## How do I cite LinkML?
 
-A paper is in progress, for now, cite the main GitHub repo Zotero archive doi:
+Moxon SAT, et al. **LinkML: an open data modeling framework**. _GigaScience_. 2026;15:giaf152. doi: [10.1093/gigascience/giaf152](https://doi.org/10.1093/gigascience/giaf152)
+
+You can also cite the main GitHub repo Zotero archive doi:
 [10.5281/zenodo.5703670](https://doi.org/10.5281/zenodo.5703670).

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -145,4 +145,5 @@ serializations such as HDF5 and Zarr.
 
 ## How do I cite LinkML?
 
-A paper is in progress, for now, cite the GitHub repo
+A paper is in progress, for now, cite the main GitHub repo Zotero archive doi:
+[10.5281/zenodo.5703670](https://doi.org/10.5281/zenodo.5703670).


### PR DESCRIPTION
Used DOI which would always redirect to the most recent and that is why did not ember any particular instance of rendered version since should change across releases

> ## AI Assistance
> 
> If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.

*well -- this is one of the few fully HI ones ;) -- enjoy while they last*