### PR TITLE
Fix extra slots for jsonschema

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -295,6 +295,12 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
     def start_schema(self, inline: bool = False):
         self.inline = inline
 
+        top_additional_properties = self.not_closed
+        if self.top_class:
+            top_class_def = self.schemaview.get_class(self.top_class)
+            if top_class_def is not None:
+                top_additional_properties = self.get_additional_properties(top_class_def)
+
         self.top_level_schema = JsonSchema(
             {
                 "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -303,7 +309,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                 "version": self.schema.version if self.schema.version else None,
                 "title": self.schema.title if self.title_from == "title" and self.schema.title else self.schema.name,
                 "type": "object",
-                "additionalProperties": self.not_closed,
+                "additionalProperties": top_additional_properties,
             }
         )
 

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -311,15 +311,13 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         cls = self.before_generate_class(cls, self.schemaview)
 
         subschema_type = "object"
-        additional_properties = False
         if self.is_class_unconstrained(cls):
             subschema_type = ["null", "boolean", "object", "number", "string"]
-            additional_properties = True
 
         class_subschema = JsonSchema(
             {
                 "type": subschema_type,
-                "additionalProperties": additional_properties,
+                "additionalProperties": self.get_additional_properties(cls),
                 "description": be(cls.description),
             }
         )
@@ -716,6 +714,24 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         if slot.designates_type:
             type_value = get_type_designator_value(self.schemaview, slot, cls)
             prop["enum"] = [type_value]
+
+    def get_additional_properties(self, cls: ClassDefinition) -> bool | JsonSchema:
+        """
+        Implements the `extra_slots` metamodel slot.
+
+        References:
+            https://github.com/linkml/linkml-model/pull/205
+        """
+        if self.is_class_unconstrained(cls):
+            return True
+        elif not cls.extra_slots:
+            return False
+        elif cls.extra_slots.allowed is not None:
+            return cls.extra_slots.allowed
+        elif cls.extra_slots.range_expression:
+            return self.get_subschema_for_slot(cls.extra_slots.range_expression)
+        else:
+            return False
 
     def generate(self) -> JsonSchema:
         self.schema = self.before_generate_schema(self.schema, self.schemaview)

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -725,7 +725,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         if self.is_class_unconstrained(cls):
             return True
         elif not cls.extra_slots:
-            return False
+            return self.not_closed
         elif cls.extra_slots.allowed is not None:
             return cls.extra_slots.allowed
         elif cls.extra_slots.range_expression:

--- a/tests/linkml/test_generators/input/extra_slots.yaml
+++ b/tests/linkml/test_generators/input/extra_slots.yaml
@@ -1,0 +1,82 @@
+id: extra_slots
+name: extra_slots
+title: extra_slots
+description: |
+  Test cases for `extra_slots`
+imports:
+  - linkml:types
+
+
+classes:
+  Base:
+    attributes:
+      x:
+        range: integer
+
+  Other:
+    attributes:
+      y:
+        range: string
+
+  ExtraAllowed:
+    is_a: Base
+    extra_slots:
+      allowed: true
+
+  ExtraNotAllowed:
+    is_a: Base
+    extra_slots:
+      allowed: false
+
+  ExtraString:
+    is_a: Base
+    description: "Only extra fields that are strings are valid"
+    extra_slots:
+      range_expression:
+        range: string
+
+  ExtraClass:
+    is_a: Base
+    description: "Only extra fields that match a class are valid"
+    extra_slots:
+      range_expression:
+        range: Other
+
+  ExtraAnyOf:
+    is_a: Base
+    description: "Union of allowed types"
+    extra_slots:
+      range_expression:
+        any_of:
+          - range: string
+          - range: integer
+
+  ExtraCardinality:
+    is_a: Base
+    description: "Limit cardinality of multivalued extra slots"
+    extra_slots:
+      range_expression:
+        range: integer
+        multivalued: true
+        maximum_cardinality: 5
+
+  AnyClass:
+    class_uri: linkml:Any
+    description: "The Any type implicitly allows any extra slots"
+
+  Container:
+    attributes:
+      allowed:
+        range: ExtraAllowed
+      not_allowed:
+        range: ExtraNotAllowed
+      extra_string:
+        range: ExtraString
+      extra_class:
+        range: ExtraClass
+      extra_anyof:
+        range: ExtraAnyOf
+      extra_cardinality:
+        range: ExtraCardinality
+      any_class:
+        range: AnyClass

--- a/tests/linkml/test_generators/test_jsonschemagen.py
+++ b/tests/linkml/test_generators/test_jsonschemagen.py
@@ -444,6 +444,124 @@ def test_lifecycle_slots(kitchen_sink_path):
             assert "faketype" in prop["type"]
 
 
+def test_extra_slots_false(input_path):
+    """
+    No extra slots allowed
+    """
+    valid_data = {"not_allowed": {"x": 1}}
+    invalid_data = {
+        "not_allowed": {
+            "x": 1,
+            "y": 2,
+        }
+    }
+    schema = input_path("extra_slots.yaml")
+    generator = JsonSchemaGenerator(schema, top_class="Container", mergeimports=True)
+    generated = json.loads(generator.serialize())
+
+    jsonschema.validate(valid_data, generated)
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(invalid_data, generated)
+
+
+@pytest.mark.parametrize("test_model", ["allowed", "any_class"])
+def test_extra_slots_true(input_path, test_model: str):
+    """
+    Extra slots allowed
+    """
+    valid_data = {
+        test_model: {"x": 1, "whatever": "else", "we": {"want": ["in", "here", True]}},
+    }
+    schema = input_path("extra_slots.yaml")
+    generator = JsonSchemaGenerator(schema, top_class="Container", mergeimports=True)
+    generated = json.loads(generator.serialize())
+
+    jsonschema.validate(valid_data, generated)
+
+
+def test_extra_slots_string(input_path):
+    """
+    Extra slots allowed if they are strings
+    """
+    valid_data = {
+        "extra_string": {"x": 1, "y": "string"},
+    }
+    invalid_data = {
+        "extra_string": {
+            "x": 1,
+            "y": 2,
+        }
+    }
+    schema = input_path("extra_slots.yaml")
+    generator = JsonSchemaGenerator(schema, top_class="Container", mergeimports=True)
+    generated = json.loads(generator.serialize())
+
+    jsonschema.validate(valid_data, generated)
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(invalid_data, generated)
+
+
+def test_extra_slots_class(input_path):
+    """
+    Extra slots allowed if they match some classdef
+    """
+    valid_data = {
+        "extra_class": {"x": 1, "another": {"y": "string"}, "third": {"y": "some string"}},
+    }
+    invalid_data = {
+        "extra_class": {
+            "x": 1,
+            "another": {"y": 1},
+        }
+    }
+    schema = input_path("extra_slots.yaml")
+    generator = JsonSchemaGenerator(schema, top_class="Container", mergeimports=True)
+    generated = json.loads(generator.serialize())
+
+    jsonschema.validate(valid_data, generated)
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(invalid_data, generated)
+
+
+def test_extra_slots_anyof(input_path):
+    """
+    Extra slots allowed if they match a union of types
+    """
+    valid_data = {
+        "extra_anyof": {"x": 1, "another": "hey", "third": 2},
+    }
+    invalid_data = {
+        "extra_anyof": {
+            "x": 1,
+            "another": True,
+        }
+    }
+    schema = input_path("extra_slots.yaml")
+    generator = JsonSchemaGenerator(schema, top_class="Container", mergeimports=True)
+    generated = json.loads(generator.serialize())
+
+    jsonschema.validate(valid_data, generated)
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(invalid_data, generated)
+
+
+def test_extra_slots_cardinality(input_path):
+    """
+    Extra slots allowed if they match some extended slot expression like `AnyOf`
+    """
+    valid_data = {
+        "extra_cardinality": {"x": 1, "another": [1, 2, 3, 4, 5]},
+    }
+    invalid_data = {"extra_cardinality": {"x": 1, "another": [1, 2, 3, 4, 5, 6]}}
+    schema = input_path("extra_slots.yaml")
+    generator = JsonSchemaGenerator(schema, top_class="Container", mergeimports=True)
+    generated = json.loads(generator.serialize())
+
+    jsonschema.validate(valid_data, generated)
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(invalid_data, generated)
+
+
 # **********************************************************
 #
 #    Utility functions


### PR DESCRIPTION
## Summary

Fixes #2238
Supersedes #2940

The PR does the same thing as PR #2940 from @sneakers-the-rat (the first commit is in fact a squash of that PR, minus the “monkey patch” to the meta model), with the following differences:

(a) it builds on top of #3388 instead of “monkey patching” the meta model;
(b) when a class does not have an explicit `extra_slots` slot, then we set the `additionalProperties` to a default value that is based on the global `not_closed` parameter (corresponding to the command line `--closed/--not-closed` option);
(c) the “top-level” `additionalProperties`, at the root of the schema, is set to the same value as the `additionalProperties` of the root class – this is necessary because the top-level `additionalProperties` is the only one that really matters for the root class: if it is set to `false`, then the JSON-Schema validator will reject any extra property at the root level, even if the root class itself has `additionalProperties` set to `true`.

@sneakers-the-rat If you agree with (b) and (c), feel free to cherry-pick the last two commits to your own #2940 PR. :)

## How was this tested?

New tests added to `test_jsonschemagen` (that is entirely @sneakers-the-rat ’s work, I claim zero credit here!)

## Areas of uncertainty

The entire test suite fails because of the meta model update in #3388.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] ~~I~~ @sneakers-the-rat  has added tests that prove my fix/feature works
- [ ] Existing tests pass locally with my changes