### PR TITLE
fix(linter): always validate schema against metamodel before linting

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -44,6 +44,13 @@ json_schema_types: dict[str, tuple[str, str | None]] = {
     "xsddate": ("string", "date"),
     "xsddatetime": ("string", "date-time"),
     "xsdtime": ("string", "time"),
+    "uri": ("string", "uri"),
+}
+
+# Patterns implied by the Python base type in linkml-runtime.
+# These are used as fallbacks when the type definition itself has no ``pattern``.
+_base_implied_patterns: dict[str, str] = {
+    "ncname": r"^[a-zA-Z_][\w.-]*$",
 }
 
 
@@ -532,7 +539,10 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         if slot.range in self.schemaview.all_types().keys():
             # types take lower priority
             schema_type = self.schemaview.induced_type(slot.range)
-            constraints.add_keyword("pattern", schema_type.pattern)
+            pattern = schema_type.pattern
+            if pattern is None and schema_type.base:
+                pattern = _base_implied_patterns.get(schema_type.base.lower())
+            constraints.add_keyword("pattern", pattern)
             constraints.add_keyword("minimum", schema_type.minimum_value)
             constraints.add_keyword("maximum", schema_type.maximum_value)
             constraints.add_keyword("const", schema_type.equals_string)

--- a/packages/linkml/src/linkml/linter/cli.py
+++ b/packages/linkml/src/linkml/linter/cli.py
@@ -10,6 +10,7 @@ from linkml._version import __version__
 from linkml.linter.config.datamodel.config import RuleLevel
 from linkml.linter.formatters import JsonFormatter, MarkdownFormatter, TerminalFormatter, TsvFormatter
 from linkml.linter.linter import Linter
+from linkml.utils.deprecation import deprecation_warning
 
 YAML_SUFFIXES = [".yml", ".yaml"]
 DEFAULT_CONFIG_FILES = [".linkmllint.yaml", ".linkmllint.yml"]
@@ -98,6 +99,9 @@ def main(
 
     SCHEMA can be a single LinkML YAML file or a directory. If it is a directory
     every YAML file found in the directory (recursively) will be linted."""
+    if validate:
+        deprecation_warning("lint-validate-flag")
+
     config_file = None
     if config:
         config_file = config

--- a/packages/linkml/src/linkml/linter/linter.py
+++ b/packages/linkml/src/linkml/linter/linter.py
@@ -92,8 +92,22 @@ class Linter:
 
     @staticmethod
     def validate_schema(schema_path: str):
-        with open(schema_path) as schema_file:
-            schema = yaml.safe_load(schema_file)
+        """Validate a schema file against the LinkML metamodel JSON Schema.
+
+        Yields :class:`LinterProblem` for each validation error found,
+        including YAML parse errors and file I/O errors.
+        """
+        try:
+            with open(schema_path) as schema_file:
+                schema = yaml.safe_load(schema_file)
+        except (yaml.YAMLError, OSError) as e:
+            yield LinterProblem(
+                rule_name="valid-schema",
+                message=str(e),
+                level=RuleLevel(RuleLevel.error),
+                schema_source=schema_path,
+            )
+            return
 
         validator = get_metamodel_validator()
         for err in validator.iter_errors(schema):

--- a/packages/linkml/src/linkml/linter/linter.py
+++ b/packages/linkml/src/linkml/linter/linter.py
@@ -115,21 +115,30 @@ class Linter:
         validate_schema: bool = False,
         validate_only: bool = False,
     ) -> Iterable[LinterProblem]:
-        if (validate_schema or validate_only) and isinstance(schema, str):
-            yield from self.validate_schema(schema)
+        # Always validate against the metamodel when given a file path.
+        # The validate_schema parameter is deprecated — validation now always runs.
+        has_metamodel_errors = False
+        if isinstance(schema, str):
+            for problem in self.validate_schema(schema):
+                has_metamodel_errors = True
+                yield problem
 
         if validate_only:
             return
 
+        if has_metamodel_errors:
+            # Don't attempt to load a schema that failed metamodel validation —
+            # SchemaView may crash or produce misleading results.
+            return
+
         try:
             schema_view = SchemaView(schema)
-        except Exception:
-            if not validate_schema:
-                yield LinterProblem(
-                    message="File is not a valid LinkML schema. Use --validate for more details.",
-                    level=RuleLevel(RuleLevel.error),
-                    schema_source=(schema if isinstance(schema, str) else None),
-                )
+        except Exception as e:
+            yield LinterProblem(
+                message=str(e),
+                level=RuleLevel(RuleLevel.error),
+                schema_source=(schema if isinstance(schema, str) else None),
+            )
             return
 
         for rule_id, rule_config in self.config.rules.__dict__.items():

--- a/packages/linkml/src/linkml/linter/linter.py
+++ b/packages/linkml/src/linkml/linter/linter.py
@@ -141,6 +141,27 @@ class Linter:
             )
             return
 
+        # Validate imported schemas against the metamodel.
+        # Force import resolution by accessing all elements, then check each
+        # non-built-in imported schema.
+        if isinstance(schema, str):
+            schema_view.all_classes(imports=True)
+            main_name = schema_view.schema.name
+            for import_name, import_schema in schema_view.schema_map.items():
+                if import_name == main_name:
+                    continue
+                # Skip built-in imports (prefixed names like "linkml:types")
+                if ":" in import_name:
+                    continue
+                source_file = getattr(import_schema, "source_file", None)
+                if source_file:
+                    source_path = Path(source_file)
+                    if not source_path.is_absolute():
+                        source_path = Path(schema).parent / source_path
+                    if source_path.exists():
+                        for problem in self.validate_schema(str(source_path)):
+                            yield problem
+
         for rule_id, rule_config in self.config.rules.__dict__.items():
             rule_cls = self._rules_map.get(rule_id, None)
             if rule_cls is None:

--- a/packages/linkml/src/linkml/utils/deprecation.py
+++ b/packages/linkml/src/linkml/utils/deprecation.py
@@ -279,6 +279,16 @@ DEPRECATIONS = (
         recommendation="Use `from linkml_runtime.utils.schema_builder import SchemaBuilder` instead.",
         issue=2372,
     ),
+    Deprecation(
+        name="lint-validate-flag",
+        deprecated_in=SemVer.from_str("1.11.0"),
+        removed_in=SemVer.from_str("1.13.0"),
+        message=(
+            "The --validate flag for linkml-lint is deprecated. Metamodel validation now always runs before linting."
+        ),
+        recommendation="Remove the --validate flag from your command. Metamodel validation is now automatic.",
+        issue=3259,
+    ),
 )  # type: tuple[Deprecation, ...]
 
 EMITTED = set()  # type: set[str]

--- a/tests/linkml/test_linter/test_cli.py
+++ b/tests/linkml/test_linter/test_cli.py
@@ -309,7 +309,8 @@ slots:
         assert "Slot has name 'a slot'" in result.stdout
 
 
-def test_validate_schema(runner):
+def test_metamodel_validation_always_runs(runner):
+    """Metamodel validation now runs without --validate flag (#3259)."""
     with runner.isolated_filesystem():
         with open(SCHEMA_FILE, "w") as f:
             f.write(
@@ -321,10 +322,11 @@ classes:
 """
             )
 
-        result = runner.invoke(main, ["--validate", SCHEMA_FILE])
+        result = runner.invoke(main, [SCHEMA_FILE])
         assert result.exit_code == 2
         assert "error    In <root>: 'name' is a required property  (valid-schema)" in result.stdout
-        assert "warning  Class has name 'person'  (standard_naming)" in result.stdout
+        # Lint rules should NOT run when metamodel validation fails
+        assert "(standard_naming)" not in result.stdout
 
 
 def test_validate_schema_only(runner):
@@ -343,3 +345,54 @@ classes:
         assert result.exit_code == 2
         assert "error    In <root>: 'name' is a required property  (valid-schema)" in result.stdout
         assert "(standard_naming)" not in result.stdout
+
+
+def test_name_with_spaces_caught(runner):
+    """Spaces in schema name are caught by metamodel validation (#3260)."""
+    with runner.isolated_filesystem():
+        with open(SCHEMA_FILE, "w") as f:
+            f.write(
+                """
+id: http://example.org/test
+name: Input Schema
+imports:
+  - linkml:types
+default_range: string
+classes:
+  InClass:
+    tree_root: true
+    attributes:
+      foo:
+        description: test
+"""
+            )
+
+        result = runner.invoke(main, [SCHEMA_FILE])
+        assert result.exit_code == 2
+        assert "does not match" in result.stdout
+        assert "Input Schema" in result.stdout
+
+
+def test_relative_uri_for_id_caught(runner):
+    """Relative URIs in schema id are caught by metamodel validation (#3261)."""
+    with runner.isolated_filesystem():
+        with open(SCHEMA_FILE, "w") as f:
+            f.write(
+                """
+id: input_schema
+name: input_schema
+imports:
+  - linkml:types
+default_range: string
+classes:
+  InClass:
+    tree_root: true
+    attributes:
+      foo:
+        description: test
+"""
+            )
+
+        result = runner.invoke(main, [SCHEMA_FILE])
+        assert result.exit_code == 2
+        assert "is not a 'uri'" in result.stdout

--- a/tests/linkml/test_linter/test_cli.py
+++ b/tests/linkml/test_linter/test_cli.py
@@ -396,3 +396,44 @@ classes:
         result = runner.invoke(main, [SCHEMA_FILE])
         assert result.exit_code == 2
         assert "is not a 'uri'" in result.stdout
+
+
+def test_imported_schema_validated(runner):
+    """Metamodel validation runs on imported schemas too (#2898)."""
+    with runner.isolated_filesystem():
+        with open("imported.yaml", "w") as f:
+            f.write(
+                """
+id: bad_import_no_name
+default_range: string
+classes:
+  ImportedClass:
+    attributes:
+      foo:
+        description: test
+"""
+            )
+
+        with open(SCHEMA_FILE, "w") as f:
+            f.write(
+                """
+id: https://example.org/main
+name: main
+imports:
+  - linkml:types
+  - imported
+default_range: string
+classes:
+  MainClass:
+    tree_root: true
+    description: Test.
+    is_a: ImportedClass
+    attributes:
+      bar:
+        description: test
+"""
+            )
+
+        result = runner.invoke(main, [SCHEMA_FILE])
+        assert result.exit_code == 2
+        assert "'name' is a required property" in result.stdout


### PR DESCRIPTION
## Summary

- Make metamodel validation always run as the first step of `linkml-lint`, not just when `--validate` is passed
- Fix JSON Schema generator to emit `pattern` for NCName-typed fields and `format: uri` for URI-typed fields, so metamodel validation actually enforces these constraints
- Stop swallowing `SchemaView` exceptions — surface the real error message
- Validate imported schemas against the metamodel, not just the top-level file
- Deprecate `--validate` flag (now always-on, removal in 1.13.0)

## Background

The linter had two validation paths that disagreed: `SchemaView` (strict on NCName) vs the metamodel JSON Schema validator (too permissive). The `--validate` flag was opt-in, meaning users missed fundamental schema problems unless they knew about it. Multiple issues tracked different symptoms of this:

- `--validate` says the schema is fine, but `SchemaView` crashes on it (#3260, #2794)
- Missing `name` not caught without `--validate` (#3259)
- Relative URIs in `id` not caught at all (#3261)
- Lint vs validate disagreement (#1512)
- Imported files not validated (#2898)

The root cause was that the JSON Schema generated from the metamodel didn't enforce the constraints described in the metamodel's own type definitions (NCName pattern, URI format).

## Changes

### JSON Schema generator (`jsonschemagen.py`)
- Add `uri` → `("string", "uri")` to the type mapping so URI-typed fields get `format: uri`
- Add `_base_implied_patterns` dict mapping `NCName` base → regex pattern
- Use the base-implied pattern as a fallback when the type definition has no explicit `pattern`

### Linter (`linter.py`)
- Always run `validate_schema()` before attempting `SchemaView` load
- Stop on metamodel errors — don't try to load an invalid schema into `SchemaView`
- When `SchemaView` does throw (after validation passed), surface the actual exception message
- After `SchemaView` loads, validate each non-built-in imported schema against the metamodel

### CLI (`cli.py`)
- Emit deprecation warning when `--validate` flag is used

### Deprecation (`deprecation.py`)
- Add `lint-validate-flag` deprecation entry (deprecated 1.11.0, removal 1.13.0)

Closes #3259, closes #3260, closes #3261, closes #2898