### PR TITLE
fix(owlgen): enum ranged slots with none_of/all_of/any_of and equals_string

### DIFF
--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -713,9 +713,12 @@ class OwlSchemaGenerator(Generator):
         def _get_slot_nodes(slot_definition) -> list[BNode | URIRef] | None:
             if not slot_definition:
                 return None
+            # Iterate over `slot_definition` (the argument), not the enclosing `slot.any_of`.
+            # The original code always used `slot.any_of` regardless of which boolean list
+            # (any_of / all_of / none_of) was passed, so all_of and none_of were silently ignored.
             rdflib_nodes = [
                 rdflib_node
-                for slot_expression in slot.any_of
+                for slot_expression in slot_definition
                 if (rdflib_node := self.transform_class_slot_expression(cls, slot_expression, main_slot, owl_types))
             ]
             if rdflib_nodes:
@@ -795,7 +798,20 @@ class OwlSchemaGenerator(Generator):
         if element.equals_string is not None:
             equals_string = element.equals_string
             if is_literal is None:
-                logger.warning(f"ignoring equals_string={equals_string} as unable to tell if literal")
+                # Enum-ranged slots have is_literal=None because enums sit between
+                # literals and URIs in OWL.  Build a proper owl:oneOf datatype so that
+                # rules like `none_of: [{equals_string: "X"}]` on an enum slot produce
+                # a valid OWL DatatypeComplementOf instead of being silently dropped.
+                # _boolean_expression simplifies single-element lists to the element
+                # itself, so we create the rdfs:Datatype/owl:oneOf structure directly.
+                listnode = BNode()
+                Collection(self.graph, listnode, [Literal(equals_string)])
+                one_of_node = BNode()
+                self.graph.add((one_of_node, RDF.type, RDFS.Datatype))
+                self.graph.add((one_of_node, OWL.oneOf, listnode))
+                self.node_owltypes[one_of_node].add(RDFS.Literal)
+                owl_exprs.append(one_of_node)
+                owl_types.add(RDFS.Literal)
             elif is_literal:
                 constraints[XSD.pattern] = equals_string
             else:
@@ -1251,6 +1267,14 @@ class OwlSchemaGenerator(Generator):
     ) -> BNode | URIRef | None:
         if not exprs:
             raise ValueError("Must pass at least one")
+        # Guard against None values from constraints that couldn't be resolved
+        # (mirrors the filtering already done in _boolean_expression).  Without
+        # this, a single unresolvable operand causes graph.add(..., None) which
+        # raises an AssertionError deep in rdflib.
+        exprs = [x for x in exprs if x is not None]
+        if not exprs:
+            logger.warning("All operands in complement expression resolved to None; skipping")
+            return None
         neg_expr = BNode()
         if not owl_types:
             owl_types = self._get_owltypes(set(), exprs)

--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -828,11 +828,11 @@ class OwlSchemaGenerator(Generator):
         if element.equals_string is not None:
             equals_string = element.equals_string
             if is_literal is None:
-                # Enum-ranged slots have is_literal=None because enums sit between
-                # literals and URIs in OWL.  Build a proper owl:oneOf datatype so that
-                # rules like `none_of: [{equals_string: "X"}]` on an enum slot produce
+                # Enum-ranged slots have "is_literal=None" because enums sit between
+                # literals and URIs in OWL.  Build a proper "owl:oneOf" datatype so that
+                # rules like `none_of: [{equals_string: "X"}]` on enum slots produces
                 # a valid OWL DatatypeComplementOf instead of being silently dropped.
-                # _boolean_expression simplifies single-element lists to the element
+                # self._boolean_expression will simplify single-element lists to the element
                 # itself, so we create the rdfs:Datatype/owl:oneOf structure directly.
                 listnode = BNode()
                 Collection(self.graph, listnode, [Literal(equals_string)])

--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -3,11 +3,11 @@
 import logging
 import os
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Iterable, Sequence
 from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum, unique
-from typing import Any
+from typing import Any, TypeAlias, TypeVar
 
 import click
 import rdflib
@@ -44,7 +44,10 @@ from linkml_runtime.utils.introspection import package_schemaview
 
 logger = logging.getLogger(__name__)
 
-OWL_TYPE = URIRef  ## RDFS.Literal or OWL.Thing
+OWL_TYPE: TypeAlias = URIRef  ## RDFS.Literal or OWL.Thing
+OWL_EXPRESSION: TypeAlias = BNode | URIRef
+OWL_VALUE: TypeAlias = OWL_EXPRESSION | Literal
+_T = TypeVar("_T")
 
 SWRL = rdflib.Namespace("http://www.w3.org/2003/11/swrl#")
 SWRLB = rdflib.Namespace("http://www.w3.org/2003/11/swrlb#")
@@ -66,7 +69,7 @@ class MetadataProfile(Enum):
     ols = "ols"
 
     @staticmethod
-    def list():
+    def list() -> list[str]:
         return list(map(lambda c: c.value, MetadataProfile))
 
 
@@ -83,8 +86,8 @@ class OWLProfile(Enum):
     """May include punning (metaclasses)."""
 
     @staticmethod
-    def list():
-        return list(map(lambda c: c.value, MetadataProfile))
+    def list() -> list[str]:
+        return list(map(lambda c: c.value, OWLProfile))
 
 
 @dataclass
@@ -112,11 +115,11 @@ class OwlSchemaGenerator(Generator):
     file_extension = "owl"
     uses_schemaloader = False
 
-    ontology_uri_suffix: str = None
+    ontology_uri_suffix: str | None = None
     """Suffix to add to the schema name to create the ontology URI, e.g. .owl.ttl"""
 
     # ObjectVars
-    metadata_profile: MetadataProfile = None
+    metadata_profile: MetadataProfile | None = None
     """Deprecated - use metadata_profiles."""
 
     metadata_profiles: list[MetadataProfile] = field(default_factory=lambda: [])
@@ -129,8 +132,11 @@ class OwlSchemaGenerator(Generator):
     add_root_classes: bool = False
 
     add_ols_annotations: bool = True
-    graph: Graph | None = None
-    """Mutable graph that is being built up during OWL generation."""
+    graph: Graph = field(default_factory=Graph)
+    """Mutable graph that is being built up during OWL generation.
+
+    The graph is reinitialized in ``as_graph`` for each generation run.
+    """
 
     top_value_uri: URIRef | None = None
     """If metaclasses=True, then this property is used to connect object shadows to literals"""
@@ -148,15 +154,15 @@ class OwlSchemaGenerator(Generator):
     use_native_uris: bool = True
     """If True, use the definition_uris, otherwise use class_uris."""
 
-    mixins_as_expressions: bool = None
+    mixins_as_expressions: bool | None = None
     """EXPERIMENTAL: If True, use OWL existential restrictions to represent mixins"""
 
     default_permissible_value_type: str | URIRef = field(default_factory=lambda: OWL.Class)
 
-    slot_is_literal_map: Mapping[str, set[bool]] = field(default_factory=lambda: defaultdict(set))
+    slot_is_literal_map: defaultdict[str, set[bool]] = field(default_factory=lambda: defaultdict(set))
     """DEPRECATED: use node_owltypes"""
 
-    node_owltypes: Mapping[BNode | URIRef, set[OWL_TYPE]] = field(default_factory=lambda: defaultdict(set))
+    node_owltypes: defaultdict[OWL_EXPRESSION, set[OWL_TYPE]] = field(default_factory=lambda: defaultdict(set))
     """rdfs:Datatype, owl:Thing"""
 
     simplify: bool = True
@@ -202,6 +208,12 @@ class OwlSchemaGenerator(Generator):
     ``AbstractClass rdfs:subClassOf (Child1 or Child2 or …)``, expressing the open-world covering
     constraint that every instance of the abstract class must also be an instance of one of its
     direct subclasses."""
+
+    @staticmethod
+    def _present(values: Iterable[_T | None]) -> list[_T]:
+        """Return only the non-null values from *values* while preserving order."""
+
+        return [value for value in values if value is not None]
 
     def as_graph(self) -> Graph:
         """
@@ -259,7 +271,7 @@ class OwlSchemaGenerator(Generator):
         self.add_metadata(schema, base)
         return graph
 
-    def serialize(self, **kwargs) -> str:
+    def serialize(self, **kwargs: Any) -> str:
         """
         Serialize the OWL triple graph to a standard RDF serialization format.
 
@@ -424,7 +436,7 @@ class OwlSchemaGenerator(Generator):
                 Collection(self.graph, uk_props_listnode, uk_props)
                 self.graph.add((subject_expr, OWL.hasKey, uk_props_listnode))
 
-        def condition_to_bnode(expr: AnonymousClassExpression) -> BNode | None:
+        def condition_to_bnode(expr: AnonymousClassExpression) -> OWL_EXPRESSION | None:
             # inner function: translate a LinkML class expression to an OWL class expression.
             ixn_listnode = self.transform_class_expression(expr, quantifier_predicate=OWL.someValuesFrom)
             if not ixn_listnode:
@@ -446,6 +458,8 @@ class OwlSchemaGenerator(Generator):
         # classification rules yield OWL GCI subClassOf axioms
         for expr in cls.classification_rules:
             ixn_listnode = condition_to_bnode(expr)
+            if not ixn_listnode:
+                continue
             self.graph.add((ixn_listnode, RDFS.subClassOf, subject_expr))
         # Other axioms, including those from anonymous expressions
         superclass_expr = self.transform_class_expression(cls)
@@ -485,9 +499,7 @@ class OwlSchemaGenerator(Generator):
         """
         sv = self.schemaview
         if isinstance(cls, ClassDefinition):
-            own_slots = (
-                list(cls.slot_usage.values()) + list(cls.attributes.values()) + list(cls.slot_conditions.values())
-            )
+            own_slots = list(cls.slot_usage.values()) + list(cls.attributes.values())
             for slot_name in cls.slots:
                 # if slot_name not in cls.slot_usage:
                 slot = sv.get_slot(slot_name)
@@ -499,7 +511,7 @@ class OwlSchemaGenerator(Generator):
             own_slots = []
         own_slots.extend(cls.slot_conditions.values())
         # merge slots with the same name
-        slot_map = {}
+        slot_map: dict[str, dict[str, Any]] = {}
         for slot in own_slots:
             if slot.name in slot_map:
                 for k, v in slot.__dict__.items():
@@ -515,9 +527,9 @@ class OwlSchemaGenerator(Generator):
 
     def transform_class_expression(
         self,
-        cls: ClassDefinition | AnonymousClassExpression,
+        cls: ClassDefinition | AnonymousClassExpression | None,
         quantifier_predicate: URIRef = OWL.allValuesFrom,
-    ) -> BNode:
+    ) -> OWL_EXPRESSION | None:
         """
         Transform a LinkML class expression into an OWL expression.
 
@@ -534,29 +546,43 @@ class OwlSchemaGenerator(Generator):
         graph = self.graph
         sv = self.schemaview
         own_slots = self.get_own_slots(cls)
-        owl_exprs = []
+        owl_exprs: list[OWL_EXPRESSION] = []
         if cls.any_of:
-            owl_exprs.append(self._union_of([self.transform_class_expression(x) for x in cls.any_of]))
+            any_of_expr = self._union_of([self.transform_class_expression(x) for x in cls.any_of])
+            if any_of_expr:
+                owl_exprs.append(any_of_expr)
         if cls.exactly_one_of:
-            sub_exprs = [self.transform_class_expression(x) for x in cls.exactly_one_of]
+            sub_exprs: list[OWL_EXPRESSION] = self._present(
+                self.transform_class_expression(x) for x in cls.exactly_one_of
+            )
             if isinstance(cls, ClassDefinition):
                 cls_uri = self._class_uri(cls.name)
                 listnode = BNode()
                 Collection(graph, listnode, sub_exprs)
                 graph.add((cls_uri, OWL.disjointUnionOf, listnode))
             else:
-                sub_sub_exprs = []
+                sub_sub_exprs: list[OWL_EXPRESSION] = []
                 for i, x in enumerate(cls.exactly_one_of):
+                    operand_expr = self.transform_class_expression(x)
+                    if not operand_expr:
+                        continue
                     rest = cls.exactly_one_of[0:i] + cls.exactly_one_of[i + 1 :]
                     neg_expr = self._complement_of_union_of([self.transform_class_expression(nx) for nx in rest])
-                    pos_expr = self._intersection_of([self.transform_class_expression(x), neg_expr])
-                    sub_sub_exprs.append(pos_expr)
-                owl_exprs.append(self._union_of(sub_sub_exprs))
+                    pos_expr = self._intersection_of([operand_expr, neg_expr])
+                    if pos_expr:
+                        sub_sub_exprs.append(pos_expr)
+                union_expr = self._union_of(sub_sub_exprs)
+                if union_expr:
+                    owl_exprs.append(union_expr)
                 # owl_exprs.extend(sub_exprs)
         if cls.all_of:
-            owl_exprs.append(self._intersection_of([self.transform_class_expression(x) for x in cls.all_of]))
+            all_of_expr = self._intersection_of([self.transform_class_expression(x) for x in cls.all_of])
+            if all_of_expr:
+                owl_exprs.append(all_of_expr)
         if cls.none_of:
-            owl_exprs.append(self._complement_of_union_of([self.transform_class_expression(x) for x in cls.none_of]))
+            none_of_expr = self._complement_of_union_of([self.transform_class_expression(x) for x in cls.none_of])
+            if none_of_expr:
+                owl_exprs.append(none_of_expr)
         for slot in own_slots:
             if slot.name:
                 owltypes = self.slot_node_owltypes(sv.get_slot(slot.name), owning_class=cls)
@@ -651,7 +677,7 @@ class OwlSchemaGenerator(Generator):
         self,
         slot: SlotDefinition | AnonymousSlotExpression,
         owning_class: ClassDefinition | AnonymousClassExpression | None = None,
-    ) -> set[URIRef]:
+    ) -> set[OWL_TYPE]:
         """
         Determine the OWL types of a named slot or slot expression
 
@@ -662,7 +688,7 @@ class OwlSchemaGenerator(Generator):
         :return:
         """
         sv = self.schemaview
-        node_types = set()
+        node_types: set[OWL_TYPE] = set()
         if isinstance(slot, SlotDefinition):
             slot_range = slot.range
             if isinstance(owning_class, ClassDefinition):
@@ -674,8 +700,10 @@ class OwlSchemaGenerator(Generator):
             if slot.range in sv.all_types():
                 node_types.add(RDFS.Datatype)
         for k in ["any_of", "all_of", "exactly_one_of", "none_of"]:
-            subslot = getattr(slot, k, None)
-            if subslot:
+            subslots = getattr(slot, k, None)
+            if not subslots:
+                continue
+            for subslot in subslots:
                 node_types.update(self.slot_node_owltypes(subslot, owning_class=owning_class))
         return node_types
 
@@ -683,9 +711,9 @@ class OwlSchemaGenerator(Generator):
         self,
         cls: ClassDefinition | AnonymousClassExpression | None,
         slot: SlotDefinition | AnonymousSlotExpression,
-        main_slot: SlotDefinition = None,
-        owl_types: set[OWL_TYPE] = None,
-    ) -> BNode | URIRef | None:
+        main_slot: SlotDefinition | None = None,
+        owl_types: set[OWL_TYPE] | None = None,
+    ) -> OWL_EXPRESSION | None:
         """
         Take a ClassExpression and SlotExpression combination and transform to a node.
 
@@ -701,29 +729,29 @@ class OwlSchemaGenerator(Generator):
                 raise ValueError(f"Must pass main slot for {slot}")
             main_slot = slot
 
-        owl_exprs = []
+        owl_exprs: list[OWL_EXPRESSION] = []
 
         if slot.range_expression:
             if isinstance(slot.range_expression, AnonymousClassExpression):
-                owl_exprs.append(self.transform_class_expression(slot.range_expression))
+                range_expr = self.transform_class_expression(slot.range_expression)
+                if range_expr:
+                    owl_exprs.append(range_expr)
 
         if slot.all_members:
-            owl_exprs.append(self.transform_class_slot_expression(cls, slot.all_members, main_slot, owl_types))
+            all_members_expr = self.transform_class_slot_expression(cls, slot.all_members, main_slot, owl_types)
+            if all_members_expr:
+                owl_exprs.append(all_members_expr)
 
-        def _get_slot_nodes(slot_definition) -> list[BNode | URIRef] | None:
-            if not slot_definition:
+        def _get_slot_nodes(
+            slot_definitions: Sequence[SlotDefinition | AnonymousSlotExpression] | None,
+        ) -> list[OWL_EXPRESSION] | None:
+            if not slot_definitions:
                 return None
-            # Iterate over `slot_definition` (the argument), not the enclosing `slot.any_of`.
-            # The original code always used `slot.any_of` regardless of which boolean list
-            # (any_of / all_of / none_of) was passed, so all_of and none_of were silently ignored.
-            rdflib_nodes = [
-                rdflib_node
-                for slot_expression in slot_definition
-                if (rdflib_node := self.transform_class_slot_expression(cls, slot_expression, main_slot, owl_types))
-            ]
-            if rdflib_nodes:
-                return rdflib_nodes
-            return None
+            rdflib_nodes: list[OWL_EXPRESSION] = self._present(
+                self.transform_class_slot_expression(cls, slot_expression, main_slot, owl_types)
+                for slot_expression in slot_definitions
+            )
+            return rdflib_nodes or None
 
         if any_of_rdflib_nodes := _get_slot_nodes(slot.any_of):
             owl_exprs.append(self._union_of(any_of_rdflib_nodes))
@@ -731,44 +759,45 @@ class OwlSchemaGenerator(Generator):
             owl_exprs.append(self._intersection_of(all_of_rdflib_nodes))
         if none_of_rdflib_nodes := _get_slot_nodes(slot.none_of):
             owl_exprs.append(self._complement_of_union_of(none_of_rdflib_nodes))
-
         if slot.exactly_one_of:
-            disj_exprs = []
+            disj_exprs: list[OWL_EXPRESSION] = []
             for i, operand in enumerate(slot.exactly_one_of):
+                operand_expr = self.transform_class_slot_expression(cls, operand, main_slot, owl_types)
+                if not operand_expr:
+                    continue
                 rest = slot.exactly_one_of[0:i] + slot.exactly_one_of[i + 1 :]
                 neg_expr = self._complement_of_union_of(
                     [self.transform_class_slot_expression(cls, x, main_slot, owl_types) for x in rest],
                     owl_types=owl_types,
                 )
                 pos_expr = self._intersection_of(
-                    [self.transform_class_slot_expression(cls, operand, main_slot, owl_types), neg_expr],
+                    [operand_expr, neg_expr],
                     owl_types=owl_types,
                 )
-                disj_exprs.append(pos_expr)
-            owl_exprs.append(self._union_of(disj_exprs, owl_types=owl_types))
-        range = slot.range
+                if pos_expr:
+                    disj_exprs.append(pos_expr)
+            exactly_one_expr = self._union_of(disj_exprs, owl_types=owl_types)
+            if exactly_one_expr:
+                owl_exprs.append(exactly_one_expr)
+        slot_range = slot.range
         # if not range and not owl_exprs:
         #    range = sv.schema.default_range
-        this_owl_types = set()
-        if range:
-            if range in sv.all_types(imports=True):
+        this_owl_types: set[OWL_TYPE] = set()
+        if slot_range:
+            if slot_range in sv.all_types(imports=True):
                 self.slot_is_literal_map[main_slot.name].add(True)
                 this_owl_types.add(RDFS.Literal)
-                typ = sv.get_type(range)
-                if self.type_objects:
-                    # TODO
-                    owl_exprs.append(self._type_uri(typ.name))
-                else:
-                    owl_exprs.append(self._type_uri(typ.name))
-            elif range in sv.all_enums(imports=True):
+                typ = sv.get_type(slot_range)
+                owl_exprs.append(self._type_uri(typ.name))
+            elif slot_range in sv.all_enums(imports=True):
                 # TODO: enums fill this in
-                owl_exprs.append(self._enum_uri(EnumDefinitionName(range)))
-            elif range in sv.all_classes(imports=True):
+                owl_exprs.append(self._enum_uri(EnumDefinitionName(slot_range)))
+            elif slot_range in sv.all_classes(imports=True):
                 this_owl_types.add(OWL.Thing)
                 self.slot_is_literal_map[main_slot.name].add(False)
-                owl_exprs.append(self._class_uri(ClassDefinitionName(range)))
+                owl_exprs.append(self._class_uri(ClassDefinitionName(slot_range)))
             else:
-                raise ValueError(f"Unknown range {range}")
+                raise ValueError(f"Unknown range {slot_range}")
         is_literal = None
         if owl_types:
             is_literal = RDFS.Datatype in owl_types
@@ -776,16 +805,17 @@ class OwlSchemaGenerator(Generator):
         this_owl_types.update(constraints_owltypes)
         owl_exprs.extend(constraints_exprs)
         this_expr = self._intersection_of(owl_exprs, owl_types=this_owl_types)
-        self.node_owltypes[this_expr].update(self._get_owltypes(this_owl_types, owl_exprs))
+        if this_expr:
+            self.node_owltypes[this_expr].update(self._get_owltypes(this_owl_types, owl_exprs))
         return this_expr
 
     def add_constraints(
         self,
         element: SlotDefinition | AnonymousSlotExpression | TypeDefinition | AnonymousTypeExpression,
         is_literal: bool | None = None,
-    ) -> tuple[list[BNode], set[OWL_TYPE]]:
-        owl_types = set()
-        owl_exprs = []
+    ) -> tuple[list[OWL_EXPRESSION], set[OWL_TYPE]]:
+        owl_types: set[OWL_TYPE] = set()
+        owl_exprs: list[OWL_EXPRESSION] = []
         graph = self.graph
         constraints = {
             XSD.minInclusive: element.minimum_value,
@@ -820,9 +850,10 @@ class OwlSchemaGenerator(Generator):
         if element.equals_string_in:
             equals_string_in = element.equals_string_in
             literals = [Literal(s) for s in equals_string_in]
-            one_of_expr = self._boolean_expression(literals, OWL.oneOf, owl_types={RDFS.Literal})
-            owl_exprs.append(one_of_expr)
-            owl_types.add(RDFS.Literal)
+            one_of_expr = self._boolean_expression(literals, OWL.oneOf, node=BNode(), owl_types={RDFS.Literal})
+            if one_of_expr:
+                owl_exprs.append(one_of_expr)
+                owl_types.add(RDFS.Literal)
         for constraint_prop, constraint_val in constraints.items():
             if is_literal is not None and not is_literal:
                 # In LinkML, it is permissible to have a literal constraints on slots that refer to
@@ -850,7 +881,7 @@ class OwlSchemaGenerator(Generator):
                 owl_exprs.append(dr)
         return owl_exprs, owl_types
 
-    def add_slot(self, slot: SlotDefinition, attribute=False) -> None:
+    def add_slot(self, slot: SlotDefinition, attribute: bool = False) -> None:
         # determine if this is a slot that has been induced by slot_usage; if so
         # the meaning of the slot is context-specific and should not be used for
         # global properties
@@ -959,7 +990,7 @@ class OwlSchemaGenerator(Generator):
     def _get_metatype(
         self, element: Definition | PermissibleValue, default_value: str | URIRef | None = None
     ) -> URIRef | None:
-        impls = []
+        impls: list[str] = []
         if isinstance(element, Definition):
             impls.extend(element.implements)
         if isinstance(element, PermissibleValue):
@@ -1013,8 +1044,8 @@ class OwlSchemaGenerator(Generator):
                     URIRef(EnumDefinition.class_class_uri),
                 )
             )
-        pv_uris = []
-        owl_types = []
+        pv_uris: list[OWL_VALUE] = []
+        owl_types: list[URIRef | None] = []
         enum_owl_type = self._get_metatype(e, self.default_permissible_value_type)
 
         for pv in e.permissible_values.values():
@@ -1076,7 +1107,12 @@ class OwlSchemaGenerator(Generator):
                     # self._object_one_of(pv_uris, node=enum_uri)
                     sub_pred = RDF.type
                 if combo_pred:
-                    self._boolean_expression(pv_uris, combo_pred, enum_uri, owl_types=set(owl_types))
+                    self._boolean_expression(
+                        pv_uris,
+                        combo_pred,
+                        enum_uri,
+                        owl_types={owl_type for owl_type in owl_types if owl_type is not None},
+                    )
             for pv_node in pv_uris:
                 # this would normally be entailed, but we assert here so it is visible
                 # without reasoning
@@ -1141,17 +1177,17 @@ class OwlSchemaGenerator(Generator):
         Collection(self.graph, listnode, [self._class_uri(c.name) for c in children])
         self.graph.add((node, OWL.members, listnode))
 
-    def _add_rule(self, subject: URIRef | BNode, rule: ClassRule, cls: ClassDefinition):
+    def _add_rule(self, subject: URIRef | BNode, rule: ClassRule, cls: ClassDefinition) -> None:
         if not self.use_swrl:
             return
         logger.warning("SWRL support is experimental and incomplete")
-        head = []
-        body = []
+        head: list[BNode] = []
+        body: list[BNode] = []
         for pre in rule.preconditions:
             head.extend(self._add_rule_condition(subject, pre, cls))
         for post in rule.postconditions:
             body.extend(self._add_rule_condition(subject, post, cls))
-        self._swrl_rule(subject, body, head)
+        self._swrl_rule(body, head)
 
     def _add_rule_condition(
         self,
@@ -1159,12 +1195,14 @@ class OwlSchemaGenerator(Generator):
         condition: AnonymousClassExpression,
         cls: ClassDefinition,
     ) -> list[BNode]:
+        del subject, cls
         for slot_name, expr in condition.slot_conditions.items():
             var = self._swrl_var(slot_name)
             if expr.maximum_value is not None:
                 self.graph.add((var, SWRLB.lessThanOrEqual, Literal(expr.maximum_value)))
+        return []
 
-    def has_profile(self, profile: MetadataProfile, default=False) -> bool:
+    def has_profile(self, profile: MetadataProfile, default: bool = False) -> bool:
         """
         Determine if a metadata profile is active.
 
@@ -1176,7 +1214,7 @@ class OwlSchemaGenerator(Generator):
             return True
         return profile in self.metadata_profiles or profile == self.metadata_profile
 
-    def _get_owltypes(self, current: set[OWL_TYPE], exprs: list[BNode | URIRef]) -> set[OWL_TYPE]:
+    def _get_owltypes(self, current: set[OWL_TYPE], exprs: Sequence[OWL_VALUE]) -> set[OWL_TYPE]:
         """
         Gets the OWL types of specified expressions plus current owl types.
 
@@ -1186,6 +1224,8 @@ class OwlSchemaGenerator(Generator):
         """
         owltypes = set()
         for x in exprs:
+            if isinstance(x, Literal):
+                continue
             x_owltypes = self.node_owltypes.get(x, None)
             if x_owltypes:
                 owltypes.update(x_owltypes)
@@ -1207,29 +1247,31 @@ class OwlSchemaGenerator(Generator):
             if isinstance(obj, BNode):
                 triples.extend(graph.triples((obj, None, None)))
 
-    def _some_values_from(self, property: URIRef, filler: URIRef | BNode) -> BNode:
-        if not property:
+    def _some_values_from(self, property_uri: URIRef, filler: OWL_EXPRESSION) -> BNode:
+        if not property_uri:
             raise ValueError(f"Property is required, filler: {filler}")
         if not filler:
-            raise ValueError(f"Filler is required, property: {property}")
+            raise ValueError(f"Filler is required, property: {property_uri}")
         node = BNode()
         self.graph.add((node, RDF.type, OWL.Restriction))
-        self.graph.add((node, OWL.onProperty, property))
+        self.graph.add((node, OWL.onProperty, property_uri))
         self.graph.add((node, OWL.someValuesFrom, filler))
         return node
 
-    def _has_value(self, property: URIRef, filler: URIRef | BNode | Literal) -> BNode:
+    def _has_value(self, property_uri: URIRef, filler: OWL_VALUE) -> BNode:
         node = BNode()
         self.graph.add((node, RDF.type, OWL.Restriction))
-        self.graph.add((node, OWL.onProperty, property))
+        self.graph.add((node, OWL.onProperty, property_uri))
         self.graph.add((node, OWL.hasValue, filler))
         return node
 
-    def _add_cardinality_restriction(self, property: URIRef, cardinality_property: URIRef, cardinality: int) -> BNode:
+    def _add_cardinality_restriction(
+        self, property_uri: URIRef, cardinality_property: URIRef, cardinality: int
+    ) -> BNode:
         node = BNode()
         self.graph.add((node, RDF.type, OWL.Restriction))
         self.graph.add((node, cardinality_property, Literal(cardinality)))
-        self.graph.add((node, OWL.onProperty, property))
+        self.graph.add((node, OWL.onProperty, property_uri))
         return node
 
     @staticmethod
@@ -1243,7 +1285,7 @@ class OwlSchemaGenerator(Generator):
         self.graph.add((node, SWRL.argument1, self._swrl_var(var)))
         return node
 
-    def _swrl_abox_atom(self, pred_ref: BNode | URIRef, arg1: str, arg2: str) -> BNode:
+    def _swrl_abox_atom(self, pred_ref: OWL_EXPRESSION, arg1: str, arg2: str) -> BNode:
         node = BNode()
         self.graph.add((node, RDF.type, SWRL.IndividualPropertyAtom))
         self.graph.add((node, SWRL.classPredicate, pred_ref))
@@ -1251,11 +1293,15 @@ class OwlSchemaGenerator(Generator):
         self.graph.add((node, SWRL.argument2, self._swrl_var(arg2)))
         return node
 
-    def _swrl_rule(self, body, head) -> BNode:
+    def _swrl_rule(self, body: Sequence[BNode], head: Sequence[BNode]) -> BNode:
         node = BNode()
+        body_list = BNode()
+        head_list = BNode()
+        Collection(self.graph, body_list, body)
+        Collection(self.graph, head_list, head)
         self.graph.add((node, RDF.type, SWRL.Imp))
-        self.graph.add((node, SWRL.body, body))
-        self.graph.add((node, SWRL.head, head))
+        self.graph.add((node, SWRL.body, body_list))
+        self.graph.add((node, SWRL.head, head_list))
         return node
 
     @staticmethod
@@ -1263,52 +1309,53 @@ class OwlSchemaGenerator(Generator):
         return URIRef("https://w3id.org/linkml/" + name)
 
     def _complement_of_union_of(
-        self, exprs: list[BNode | URIRef], owl_types: set[OWL_TYPE] = None, **kwargs
-    ) -> BNode | URIRef | None:
-        if not exprs:
-            raise ValueError("Must pass at least one")
-        # Guard against None values from constraints that couldn't be resolved
-        # (mirrors the filtering already done in _boolean_expression).  Without
-        # this, a single unresolvable operand causes graph.add(..., None) which
-        # raises an AssertionError deep in rdflib.
-        exprs = [x for x in exprs if x is not None]
-        if not exprs:
+        self,
+        exprs: Sequence[OWL_EXPRESSION | None],
+        owl_types: set[OWL_TYPE] | None = None,
+        **kwargs: Any,
+    ) -> OWL_EXPRESSION | None:
+        expr_list: list[OWL_EXPRESSION] = self._present(exprs)
+        if not expr_list:
             logger.warning("All operands in complement expression resolved to None; skipping")
             return None
         neg_expr = BNode()
         if not owl_types:
-            owl_types = self._get_owltypes(set(), exprs)
+            owl_types = self._get_owltypes(set(), expr_list)
         complement_predicate = OWL.complementOf
         if len(owl_types) == 1:
             if RDFS.Literal in owl_types:
                 self.graph.add((neg_expr, RDF.type, RDFS.Datatype))
                 complement_predicate = OWL.datatypeComplementOf
-        self.graph.add((neg_expr, complement_predicate, self._union_of(exprs)), **kwargs)
+        union_expr = self._union_of(expr_list)
+        if union_expr is None:
+            return None
+        self.graph.add((neg_expr, complement_predicate, union_expr), **kwargs)
 
         return neg_expr
 
-    def _intersection_of(self, exprs: list[BNode | URIRef], **kwargs) -> BNode | URIRef | None:
+    def _intersection_of(self, exprs: Sequence[OWL_VALUE | None], **kwargs: Any) -> OWL_VALUE | None:
         return self._boolean_expression(exprs, OWL.intersectionOf, **kwargs)
 
-    def _union_of(self, exprs: list[BNode | URIRef], **kwargs) -> BNode | URIRef | None:
+    def _union_of(self, exprs: Sequence[OWL_VALUE | None], **kwargs: Any) -> OWL_VALUE | None:
         return self._boolean_expression(exprs, OWL.unionOf, **kwargs)
 
-    def _object_one_of(self, exprs: list[BNode | URIRef], **kwargs) -> BNode | URIRef | None:
+    def _object_one_of(self, exprs: Sequence[OWL_VALUE | None], **kwargs: Any) -> OWL_VALUE | None:
         return self._boolean_expression(exprs, OWL.oneOf, **kwargs)
 
-    def _exactly_one_of(self, exprs: list[BNode | URIRef]) -> BNode | URIRef | None:
-        if not exprs:
+    def _exactly_one_of(self, exprs: Sequence[OWL_EXPRESSION | None]) -> OWL_EXPRESSION | None:
+        expr_list: list[OWL_EXPRESSION] = self._present(exprs)
+        if not expr_list:
             raise ValueError("Must pass at least one")
-        if len(exprs) == 1:
-            return exprs[0]
-        sub_exprs = []
-        for i, x in enumerate(exprs):
-            rest = exprs[0:i] + exprs[i + 1 :]
+        if len(expr_list) == 1:
+            return expr_list[0]
+        sub_exprs: list[OWL_VALUE] = []
+        for i, x in enumerate(expr_list):
+            rest = expr_list[0:i] + expr_list[i + 1 :]
             neg_expr = self._complement_of_union_of(rest)
             sub_exprs.append(self._intersection_of([x, neg_expr]))
         return self._union_of(sub_exprs)
 
-    def _datatype_restriction(self, datatype: URIRef, facets: list[BNode | URIRef]) -> BNode:
+    def _datatype_restriction(self, datatype: URIRef, facets: Sequence[OWL_EXPRESSION]) -> BNode:
         node = BNode()
         graph = self.graph
         graph.add((node, RDF.type, RDFS.Datatype))
@@ -1318,7 +1365,7 @@ class OwlSchemaGenerator(Generator):
         graph.add((node, OWL.withRestrictions, listnode))
         return node
 
-    def _facet(self, typ: URIRef, val: Literal | Any):
+    def _facet(self, typ: URIRef, val: Literal | Any) -> BNode:
         if not isinstance(val, Literal):
             val = Literal(val)
         node = BNode()
@@ -1327,32 +1374,30 @@ class OwlSchemaGenerator(Generator):
 
     def _boolean_expression(
         self,
-        exprs: list[BNode | URIRef | Literal],
+        exprs: Sequence[OWL_VALUE | None],
         predicate: URIRef,
         node: URIRef | None = None,
-        owl_types: set[OWL_TYPE] = None,
-    ) -> BNode | URIRef | None:
+        owl_types: set[OWL_TYPE] | None = None,
+    ) -> OWL_VALUE | None:
         graph = self.graph
-        if [x for x in exprs if x is None]:
+        expr_list: list[OWL_VALUE] = self._present(exprs)
+        if len(expr_list) != len(exprs):
             logger.warning(f"Null expr in: {exprs} for {predicate} {node}")
-            exprs = [x for x in exprs if x is not None]
-        if len(exprs) == 0:
+        if len(expr_list) == 0:
             return None
-        elif len(exprs) == 1:
-            return exprs[0]
-        else:
-            if node is None:
-                node = BNode()
-            listnode = BNode()
-            Collection(graph, listnode, exprs)
-            graph.add((node, predicate, listnode))
-            if owl_types is None:
-                owl_types = set()
-            owl_types = owl_types.union(self._get_owltypes(set(), exprs))
-            if len(owl_types) == 1:
-                if RDFS.Literal in owl_types:
-                    graph.add((node, RDF.type, RDFS.Datatype))
-            return node
+        if len(expr_list) == 1:
+            return expr_list[0]
+        if node is None:
+            node = BNode()
+        listnode = BNode()
+        Collection(graph, listnode, expr_list)
+        graph.add((node, predicate, listnode))
+        if owl_types is None:
+            owl_types = set()
+        owl_types = owl_types.union(self._get_owltypes(set(), expr_list))
+        if len(owl_types) == 1 and RDFS.Literal in owl_types:
+            graph.add((node, RDF.type, RDFS.Datatype))
+        return node
 
     def _range_is_datatype(self, slot: SlotDefinition) -> bool:
         if self.type_objects:
@@ -1374,7 +1419,7 @@ class OwlSchemaGenerator(Generator):
             return self._class_uri(ClassDefinitionName(slot.range))
 
     @staticmethod
-    def _mixin_grouping_class_uri():
+    def _mixin_grouping_class_uri() -> URIRef:
         return URIRef(ClassDefinition.class_class_uri + "#Mixin")
 
     def _class_uri(self, cn: str | ClassDefinitionName) -> URIRef:
@@ -1411,7 +1456,7 @@ class OwlSchemaGenerator(Generator):
             default_prefix = self.schemaview.schema.default_prefix or ""
             return URIRef(self.schemaview.expand_curie(f"{default_prefix}:{scn}"))
 
-    def _type_uri(self, tn: TypeDefinitionName, native: bool = None) -> URIRef:
+    def _type_uri(self, tn: TypeDefinitionName, native: bool | None = None) -> URIRef:
         if native is None:
             # never use native unless type shadowing with objects is enabled
             native = self.type_objects
@@ -1431,7 +1476,7 @@ class OwlSchemaGenerator(Generator):
         return URIRef(expanded)
 
     def _permissible_value_uri(
-        self, pv: str | PermissibleValue, enum_uri: str, enum_def: EnumDefinition = None
+        self, pv: str | PermissibleValue, enum_uri: str, enum_def: EnumDefinition | None = None
     ) -> URIRef:
         if isinstance(pv, str):
             pv_name = pv
@@ -1456,15 +1501,15 @@ class OwlSchemaGenerator(Generator):
                 if t in slot.implements:
                     return OWL[t.replace("owl:", "")]
         if slot.range is None:
-            range = self.schemaview.schema.default_range
+            slot_range = self.schemaview.schema.default_range
         else:
-            range = slot.range
+            slot_range = slot.range
         if self.type_objects:
             return OWL.ObjectProperty
         is_literal_vals = self.slot_is_literal_map[slot.name]
         if len(is_literal_vals) > 1:
             logger.warning(f"Ambiguous type for: {slot.name}")
-        if range is None:
+        if slot_range is None:
             if not is_literal_vals:
                 logger.warning(f"Guessing type for {slot.name}")
                 return OWL.ObjectProperty
@@ -1472,11 +1517,11 @@ class OwlSchemaGenerator(Generator):
                 return OWL.DatatypeProperty
             else:
                 return OWL.ObjectProperty
-        elif range in sv.all_classes():
+        elif slot_range in sv.all_classes():
             return OWL.ObjectProperty
-        elif range in sv.all_enums():
+        elif slot_range in sv.all_enums():
             return OWL.ObjectProperty
-        elif range in sv.all_types():
+        elif slot_range in sv.all_types():
             return OWL.DatatypeProperty
         else:
             raise Exception(f"Unknown range: {slot.range}")
@@ -1600,7 +1645,7 @@ class OwlSchemaGenerator(Generator):
     ),
 )
 @click.version_option(__version__, "-V", "--version")
-def cli(yamlfile, metadata_profile: str, **kwargs):
+def cli(yamlfile: str, metadata_profile: str, **kwargs: Any) -> None:
     """Generate an OWL representation of a LinkML model
 
     Generate OWL using default parameters:

--- a/tests/linkml/test_generators/input/owlgen/slot_conditions.yaml
+++ b/tests/linkml/test_generators/input/owlgen/slot_conditions.yaml
@@ -1,0 +1,31 @@
+id: https://example.org/bug_repro
+name: bug_repro
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/
+imports:
+  - linkml:types
+default_range: string
+
+enums:
+  ColorEnum:
+    permissible_values:
+      Red: {}
+      Green: {}
+      Blue: {}
+
+classes:
+  Item:
+    attributes:
+      color:
+        range: ColorEnum
+    rules:
+      - preconditions:
+          slot_conditions:
+            color:
+              none_of:
+                - equals_string: Red
+        postconditions:
+          slot_conditions:
+            color:
+              required: true

--- a/tests/linkml/test_generators/test_owlgen.py
+++ b/tests/linkml/test_generators/test_owlgen.py
@@ -8,7 +8,12 @@ from rdflib.namespace import OWL, RDF
 from linkml import METAMODEL_CONTEXT_URI
 from linkml.generators.owlgen import MetadataProfile, OwlSchemaGenerator
 from linkml_runtime.linkml_model import SlotDefinition
-from linkml_runtime.linkml_model.meta import PermissibleValue
+from linkml_runtime.linkml_model.meta import (
+    AnonymousClassExpression,
+    AnonymousSlotExpression,
+    ClassRule,
+    PermissibleValue,
+)
 from linkml_runtime.utils.schema_builder import SchemaBuilder
 
 SYMP = Namespace("http://purl.obolibrary.org/obo/SYMP_")
@@ -101,6 +106,49 @@ def test_rdfs_profile(kitchen_sink_path):
         assert list(g.objects(c, SKOS.definition)) == []
     # check that definitions are present, and use the RDFS profile
     assert Literal("A person, living or dead") in g.objects(KS.Person, RDFS.comment)
+
+
+def test_rule_none_of_ignores_empty_slot_expression() -> None:
+    """Issue 3358: empty ``none_of`` operands in rules must not crash OWL generation."""
+
+    sb = SchemaBuilder()
+    sb.add_slot(SlotDefinition("object_category", range="string"))
+    sb.add_slot(SlotDefinition("object_source", range="string"))
+    sb.add_class("MappingRule", tree_root=True, slots=["object_category", "object_source"])
+    sb.add_defaults()
+    sb.schema.classes["MappingRule"].rules = [
+        ClassRule(
+            preconditions=AnonymousClassExpression(
+                slot_conditions={
+                    "object_category": SlotDefinition(
+                        "object_category",
+                        none_of=[AnonymousSlotExpression()],
+                    )
+                }
+            ),
+            postconditions=AnonymousClassExpression(
+                slot_conditions={
+                    "object_source": SlotDefinition(
+                        "object_source",
+                        equals_string="source",
+                    )
+                }
+            ),
+        )
+    ]
+
+    owl = OwlSchemaGenerator(
+        sb.schema,
+        mergeimports=False,
+        metaclasses=False,
+        type_objects=False,
+    ).serialize()
+    g = Graph()
+    g.parse(data=owl, format="turtle")
+
+    assert (EX.MappingRule, RDF.type, OWL.Class) in g
+    assert list(g.objects(None, OWL.complementOf)) == []
+    assert list(g.objects(None, OWL.datatypeComplementOf)) == []
 
 
 @pytest.mark.network

--- a/tests/linkml/test_generators/test_owlgen_unit.py
+++ b/tests/linkml/test_generators/test_owlgen_unit.py
@@ -1,0 +1,144 @@
+"""Unit / regression tests for owlgen bug-fixes.
+
+Covers:
+- Fix 1: equals_string on an enum-ranged slot (is_literal=None) must not silently
+  drop the constraint; it should produce an owl:oneOf expression with a Literal.
+- Fix 2: _complement_of_union_of must filter None operands instead of passing them
+  to rdflib.Graph.add(), which raises an AssertionError.
+"""
+
+import os
+
+import pytest
+from rdflib import OWL, RDF, Graph, Literal, URIRef
+from rdflib.collection import Collection
+
+from linkml.generators.owlgen import OwlSchemaGenerator
+from linkml_runtime.utils.schema_builder import SchemaBuilder
+
+
+def _input_path(name: str) -> str:
+    return os.path.join(os.path.dirname(__file__), "input", name)
+
+
+def _owl_graph(sb: SchemaBuilder, **gen_kwargs) -> Graph:
+    gen = OwlSchemaGenerator(sb.schema, mergeimports=False, metaclasses=False, type_objects=False, **gen_kwargs)
+    g = Graph()
+    g.parse(data=gen.serialize(), format="turtle")
+    return g
+
+
+def _literal_values_in_complement_filler(g: Graph) -> set[str]:
+    """Return all literal values inside datatypeComplementOf owl:oneOf fillers.
+
+    The fix produces: neg_expr owl:datatypeComplementOf [a rdfs:Datatype; owl:oneOf ("Red")].
+    We traverse: datatypeComplementOf → filler → owl:oneOf → RDF list → literals.
+    """
+    values: set[str] = set()
+    for filler in g.objects(None, OWL.datatypeComplementOf):
+        for list_node in g.objects(filler, OWL.oneOf):
+            try:
+                for v in Collection(g, list_node):
+                    if isinstance(v, Literal):
+                        values.add(str(v))
+            except Exception:
+                pass
+    return values
+
+
+# Fix 1 — equals_string on an enum-ranged slot must not be silently dropped
+
+
+def test_equals_string_enum_none_of_no_crash():
+    """Regression: gen-owl on owlgen/slot_conditions.yaml must not raise an AssertionError.
+
+    The bug was that equals_string on an enum-ranged slot produced is_literal=None,
+    which caused the constraint to be dropped, leaving None in the expression list
+    and ultimately triggering rdflib's assertion inside graph.add().
+    """
+    owl = OwlSchemaGenerator(_input_path("owlgen/slot_conditions.yaml")).serialize()
+    g = Graph()
+    g.parse(data=owl, format="turtle")
+    # Schema parses without error and the Item class is present.
+    assert any(str(s).endswith("Item") for s, _, _ in g.triples((None, RDF.type, OWL.Class)))
+
+
+def test_equals_string_enum_slot_emits_one_of_literal():
+    """equals_string on an enum-ranged slot must produce an owl:oneOf with a Literal.
+
+    Before the fix, is_literal=None caused a warning and the expression was skipped.
+    After the fix, the value is treated like equals_string_in (single-item list).
+    """
+    owl = OwlSchemaGenerator(_input_path("owlgen/slot_conditions.yaml")).serialize()
+    g = Graph()
+    g.parse(data=owl, format="turtle")
+    assert "Red" in _literal_values_in_complement_filler(g), (
+        "Expected owl:oneOf with literal 'Red' for equals_string on enum-ranged slot"
+    )
+
+
+def test_equals_string_enum_produces_complement_expression():
+    """A none_of rule using equals_string on an enum slot must produce a complement axiom.
+
+    The complement (owl:complementOf / owl:datatypeComplementOf) wraps the oneOf
+    expression, expressing "value is not Red".
+    """
+    owl = OwlSchemaGenerator(_input_path("owlgen/slot_conditions.yaml")).serialize()
+    g = Graph()
+    g.parse(data=owl, format="turtle")
+    # There must be at least one owl:datatypeComplementOf or owl:complementOf triple.
+    complement_triples = list(g.triples((None, OWL.datatypeComplementOf, None))) + list(
+        g.triples((None, OWL.complementOf, None))
+    )
+    assert complement_triples, "Expected an owl:complementOf/datatypeComplementOf axiom from none_of rule"
+
+
+# Fix 2 — _complement_of_union_of must handle None operands gracefully
+
+
+def test_complement_of_union_of_filters_none(caplog):
+    """_complement_of_union_of([None]) must return None and log a warning, not crash.
+
+    Without the guard, [None] is passed to _union_of which propagates None into
+    graph.add(), raising an AssertionError from rdflib.
+    """
+    import logging
+
+    gen = OwlSchemaGenerator(_input_path("owlgen/slot_conditions.yaml"))
+    gen.as_graph()  # initialises self.graph
+
+    with caplog.at_level(logging.WARNING, logger="linkml.generators.owlgen"):
+        result = gen._complement_of_union_of([None])
+
+    assert result is None, "_complement_of_union_of([None]) should return None"
+    assert any("None" in rec.message or "complement" in rec.message.lower() for rec in caplog.records), (
+        "Expected a warning about unresolvable complement operands"
+    )
+
+
+@pytest.mark.parametrize(
+    "exprs,expect_none",
+    [
+        ([None], True),
+        ([None, None], True),
+    ],
+)
+def test_complement_of_union_of_all_none_returns_none(exprs, expect_none):
+    """_complement_of_union_of with only None operands must return None without crashing."""
+    gen = OwlSchemaGenerator(_input_path("owlgen/slot_conditions.yaml"))
+    gen.as_graph()
+    result = gen._complement_of_union_of(exprs)
+    assert (result is None) == expect_none
+
+
+def test_complement_of_union_of_mixed_none_filters_silently():
+    """_complement_of_union_of with some valid and some None operands uses only valid ones."""
+    from rdflib import BNode
+
+    gen = OwlSchemaGenerator(_input_path("owlgen/slot_conditions.yaml"))
+    gen.as_graph()
+    valid_node = URIRef("http://example.org/Foo")
+    result = gen._complement_of_union_of([None, valid_node])
+    # Should succeed and return a BNode (the complement expression).
+    assert result is not None
+    assert isinstance(result, BNode)

--- a/tests/linkml/test_generators/test_owlgen_unit.py
+++ b/tests/linkml/test_generators/test_owlgen_unit.py
@@ -1,9 +1,9 @@
 """Unit / regression tests for owlgen bug-fixes.
 
 Covers:
-- Fix 1: equals_string on an enum-ranged slot (is_literal=None) must not silently
+- equals_string on an enum-ranged slot (is_literal=None) must not silently
   drop the constraint; it should produce an owl:oneOf expression with a Literal.
-- Fix 2: _complement_of_union_of must filter None operands instead of passing them
+- _complement_of_union_of must filter None operands instead of passing them
   to rdflib.Graph.add(), which raises an AssertionError.
 """
 
@@ -46,7 +46,7 @@ def _literal_values_in_complement_filler(g: Graph) -> set[str]:
     return values
 
 
-# Fix 1 — equals_string on an enum-ranged slot must not be silently dropped
+# equals_string on an enum-ranged slot must not be silently dropped
 
 
 def test_equals_string_enum_none_of_no_crash():
@@ -93,7 +93,7 @@ def test_equals_string_enum_produces_complement_expression():
     assert complement_triples, "Expected an owl:complementOf/datatypeComplementOf axiom from none_of rule"
 
 
-# Fix 2 — _complement_of_union_of must handle None operands gracefully
+# _complement_of_union_of must handle None operands gracefully
 
 
 def test_complement_of_union_of_filters_none(caplog):

--- a/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl.jsonld
+++ b/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl.jsonld
@@ -1,38 +1,12 @@
 [
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/type",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "heartfelt"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "warm and hearty friendliness"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+        "@value": "type"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -42,18 +16,34 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DEAD"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "employed at"
+        "@value": "in code system"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -63,53 +53,39 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Dataset",
+    "@id": "https://w3id.org/linkml/tests/core/started_at_time",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Dataset"
+        "@value": "started at time"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "_:Nc3ab64a8cf87499282cab3a6e4a99106"
-      },
-      {
-        "@id": "_:N3080ef395f9b450ca50e7628a2b09997"
-      },
-      {
-        "@id": "_:Nd8162ed52d384cd49b38d97e6b7bfaae"
-      },
-      {
-        "@id": "_:Na074c26d19ba4955aa36bae8b5ddcc3e"
-      },
-      {
-        "@id": "_:Nefdf436e83c14e3eb9fbf65368119ecb"
-      },
-      {
-        "@id": "_:Na13dd702dcee4ea2b5662c179152ce91"
-      },
-      {
-        "@id": "_:N62521c85193b4523a3be113cdf5491ee"
-      },
-      {
-        "@id": "_:N4ff4c39e046f496ebc6f3d2b3a48ccba"
-      },
-      {
-        "@id": "_:N73b47737d45241bb925b6cfaa95c0bcd"
-      },
-      {
-        "@id": "_:N46e7fe265fab4133b185114668151d34"
-      },
-      {
-        "@id": "_:N1dfa5ec231d84828bc1eb408230ab6c6"
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/id",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "id"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
       }
     ],
     "http://www.w3.org/ns/shacl#order": [
@@ -120,206 +96,24 @@
     ]
   },
   {
-    "@id": "_:Nc3ab64a8cf87499282cab3a6e4a99106",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3080ef395f9b450ca50e7628a2b09997",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd8162ed52d384cd49b38d97e6b7bfaae",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na074c26d19ba4955aa36bae8b5ddcc3e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nefdf436e83c14e3eb9fbf65368119ecb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na13dd702dcee4ea2b5662c179152ce91",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
-      }
-    ]
-  },
-  {
-    "@id": "_:N62521c85193b4523a3be113cdf5491ee",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4ff4c39e046f496ebc6f3d2b3a48ccba",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N73b47737d45241bb925b6cfaa95c0bcd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N46e7fe265fab4133b185114668151d34",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1dfa5ec231d84828bc1eb408230ab6c6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FakeClass",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "WithLocation"
+        "@value": "FakeClass"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:Nccc9b5a0008649608f19cdd3cb6573c0"
+        "@id": "_:N3581b055477949008d71207b006b69f3"
       },
       {
-        "@id": "_:N109a9fc43c704a5aa1dc86eb54c09485"
+        "@id": "_:Nd59532bfdbfd44308f7606a243c89be8"
       },
       {
-        "@id": "_:Nfbf3b0fb68e542c1ae4bb6ac8f0b262b"
+        "@id": "_:N1d59a3a352b64cc5bc67d96146f6bb80"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -329,23 +123,23 @@
     ]
   },
   {
-    "@id": "_:Nccc9b5a0008649608f19cdd3cb6573c0",
+    "@id": "_:N3581b055477949008d71207b006b69f3",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
       }
     ]
   },
   {
-    "@id": "_:N109a9fc43c704a5aa1dc86eb54c09485",
+    "@id": "_:Nd59532bfdbfd44308f7606a243c89be8",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -357,12 +151,12 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
       }
     ]
   },
   {
-    "@id": "_:Nfbf3b0fb68e542c1ae4bb6ac8f0b262b",
+    "@id": "_:N1d59a3a352b64cc5bc67d96146f6bb80",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -374,28 +168,124 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "acted on behalf of"
+        "@value": "has medical history"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
-        "@id": "https://w3id.org/linkml/tests/core"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 5
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "other codes"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "hateful"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "spiteful"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "mixin_slot_I"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "cordialness"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ceo"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -406,12 +296,12 @@
     ],
     "http://www.w3.org/2002/07/owl#equivalentClass": [
       {
-        "@id": "_:N0df1a899910f44b383a0c317af26e7da"
+        "@id": "_:Nfe4ef74c22ae426bb184aac92dc7a1fd"
       }
     ]
   },
   {
-    "@id": "_:N0df1a899910f44b383a0c317af26e7da",
+    "@id": "_:Nfe4ef74c22ae426bb184aac92dc7a1fd",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -424,17 +314,1260 @@
       {
         "@list": [
           {
-            "@id": "_:N213d212926e94a9ca13706c7666ccbe3"
+            "@id": "_:N221904a095644208afaf873ee0c50c25"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N213d212926e94a9ca13706c7666ccbe3",
+    "@id": "_:N221904a095644208afaf873ee0c50c25",
     "http://www.w3.org/2001/XMLSchema#pattern": [
       {
         "@value": "^[\\\\+\\\\d+ +][\\\\d\\\\- ]+$"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_C",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_C"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/was_generated_by",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was generated by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "aliases"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/was_informed_by",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was informed by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Person"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+      {
+        "@id": "https://en.wikipedia.org/wiki/Person"
+      },
+      {
+        "@id": "http://schema.org/Person"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:N6b2b96c330b044f194484a4177e93897"
+      },
+      {
+        "@id": "_:Nf0eacd3e75134536b3e178f7bc1e5b93"
+      },
+      {
+        "@id": "_:Na94e2e4420064f50b4781dd85ce1849b"
+      },
+      {
+        "@id": "_:Nbf77a676f5d1493eb928ff3340c91fbd"
+      },
+      {
+        "@id": "_:N1aa0c2e4bab045d88336f79aa5bddff6"
+      },
+      {
+        "@id": "_:N373b758b1213434cb8591555ebb2b94e"
+      },
+      {
+        "@id": "_:N6dd4e814704f46a2bae3300f1aa3e82e"
+      },
+      {
+        "@id": "_:Nc9a45f38aa974917b006ed6a7994f96f"
+      },
+      {
+        "@id": "_:N9eab5141c39f4c46a2b3da4dd47c741f"
+      },
+      {
+        "@id": "_:N534926963a4e45ae8e4dbc9e965c3fed"
+      },
+      {
+        "@id": "_:Nfcd0de37189a44d68130c238cec2e450"
+      },
+      {
+        "@id": "_:Nda437736cf434d4d99c4ae32186b11b8"
+      },
+      {
+        "@id": "_:N6d928b0301bc449689cb85ef6c934adf"
+      },
+      {
+        "@id": "_:N7133706a778a43589ef3c8e7d0751327"
+      },
+      {
+        "@id": "_:N6b4247cdea6240d5a29e0b2f0becda31"
+      },
+      {
+        "@id": "_:N845107892af3450ead2b8419cb44c507"
+      },
+      {
+        "@id": "_:N18c97d62c0b14d2eb939865ed2088ad7"
+      },
+      {
+        "@id": "_:Nbf74fc8dfb304e4ab47f68e514989675"
+      },
+      {
+        "@id": "_:N6e8252944e2c4f25852e396dbbbefef9"
+      },
+      {
+        "@id": "_:Ne8f4fecf1ef846a5b2ac58314dbda659"
+      },
+      {
+        "@id": "_:N14a2e45287fd483186819acef15d33b9"
+      },
+      {
+        "@id": "_:Nf7a99b783df74cecb76a68c6cd895c13"
+      },
+      {
+        "@id": "_:N332b8e13c1c3415fb43ded163efbde3d"
+      },
+      {
+        "@id": "_:Nbe1fb8fb4ea74c41a5090565e35850fe"
+      },
+      {
+        "@id": "_:N6915399427744caf9e82760c86c8ebc0"
+      },
+      {
+        "@id": "_:N72d0c6d999644826a22139368517464f"
+      },
+      {
+        "@id": "_:Nd64c251e729f42148ae4191411fe1197"
+      },
+      {
+        "@id": "_:N2555daceb6704e539715a7215f06f29d"
+      },
+      {
+        "@id": "_:N4c1a03192dda42699885804681133c03"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A person, living or dead"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#exactMatch": [
+      {
+        "@id": "http://schema.org/Person"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 2
+      }
+    ],
+    "https://w3id.org/linkml/tests/kitchen_sink/fallible": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": true
+      }
+    ],
+    "https://w3id.org/linkml/tests/kitchen_sink/opinions": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1000
+      }
+    ],
+    "https://w3id.org/linkml/tests/kitchen_sink/resting": [
+      {
+        "@value": "supine"
+      }
+    ],
+    "https://w3id.org/linkml/tests/kitchen_sink/viewer": [
+      {
+        "@value": "ks:PersonViewer"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6b2b96c330b044f194484a4177e93897",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf0eacd3e75134536b3e178f7bc1e5b93",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na94e2e4420064f50b4781dd85ce1849b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N835313e46aae4a5eb1a6400e15d044ae"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
+      }
+    ]
+  },
+  {
+    "@id": "_:N835313e46aae4a5eb1a6400e15d044ae",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#intersectionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "_:N3af0f8f23db64fb0917da3ed9c2a76bb"
+          },
+          {
+            "@id": "_:N45643bc2778b4b49bfb1251b15b5da37"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N3af0f8f23db64fb0917da3ed9c2a76bb",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N6c0b28cde3394974aebc63838c8ec779"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N6c0b28cde3394974aebc63838c8ec779",
+    "http://www.w3.org/2001/XMLSchema#minInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ]
+  },
+  {
+    "@id": "_:N45643bc2778b4b49bfb1251b15b5da37",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N49923694f6384e599bbbfa2ebb4e080c"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N49923694f6384e599bbbfa2ebb4e080c",
+    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 999
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbf77a676f5d1493eb928ff3340c91fbd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1aa0c2e4bab045d88336f79aa5bddff6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
+      }
+    ]
+  },
+  {
+    "@id": "_:N373b758b1213434cb8591555ebb2b94e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6dd4e814704f46a2bae3300f1aa3e82e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc9a45f38aa974917b006ed6a7994f96f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9eab5141c39f4c46a2b3da4dd47c741f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history"
+      }
+    ]
+  },
+  {
+    "@id": "_:N534926963a4e45ae8e4dbc9e965c3fed",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfcd0de37189a44d68130c238cec2e450",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nda437736cf434d4d99c4ae32186b11b8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6d928b0301bc449689cb85ef6c934adf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7133706a778a43589ef3c8e7d0751327",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6b4247cdea6240d5a29e0b2f0becda31",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N845107892af3450ead2b8419cb44c507",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N18c97d62c0b14d2eb939865ed2088ad7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbf74fc8dfb304e4ab47f68e514989675",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6e8252944e2c4f25852e396dbbbefef9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne8f4fecf1ef846a5b2ac58314dbda659",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
+      }
+    ]
+  },
+  {
+    "@id": "_:N14a2e45287fd483186819acef15d33b9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nbaca4d58931e44799ff02e5fc9a29ca8"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbaca4d58931e44799ff02e5fc9a29ca8",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N89afe9a65bf04484bf8ef8923e3b7d93"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N89afe9a65bf04484bf8ef8923e3b7d93",
+    "http://www.w3.org/2001/XMLSchema#pattern": [
+      {
+        "@value": "^\\S+ \\S+$"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf7a99b783df74cecb76a68c6cd895c13",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N332b8e13c1c3415fb43ded163efbde3d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbe1fb8fb4ea74c41a5090565e35850fe",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N129f6d469bb04f46828618bff3340bb3"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N129f6d469bb04f46828618bff3340bb3",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#intersectionOf": [
+      {
+        "@list": [
+          {
+            "@id": "_:N564d0451f60740ca9cbca864005f6789"
+          },
+          {
+            "@id": "_:N71485db1a99d4dab845f9afc96bbc818"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N564d0451f60740ca9cbca864005f6789",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#oneOf": [
+      {
+        "@list": [
+          {
+            "@value": "human"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N71485db1a99d4dab845f9afc96bbc818",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N27489b477101458aa9aa9d7c97bef22b"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N27489b477101458aa9aa9d7c97bef22b",
+    "http://www.w3.org/2001/XMLSchema#pattern": [
+      {
+        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6915399427744caf9e82760c86c8ebc0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N72d0c6d999644826a22139368517464f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd64c251e729f42148ae4191411fe1197",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N184d337a71ee455d9fc77f1da171bd6d"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
+      }
+    ]
+  },
+  {
+    "@id": "_:N184d337a71ee455d9fc77f1da171bd6d",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#intersectionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "_:N8689d5787a354c18b1f2d988185f72b5"
+          },
+          {
+            "@id": "_:N6c9631347a7f46828c041237c723e7c5"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N8689d5787a354c18b1f2d988185f72b5",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N394ed94d0f2b41149a8f6f83b97e402f"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N394ed94d0f2b41149a8f6f83b97e402f",
+    "http://www.w3.org/2001/XMLSchema#minInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ]
+  },
+  {
+    "@id": "_:N6c9631347a7f46828c041237c723e7c5",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N5dbdd1e0fa8940008f0a6e641a35e6e6"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N5dbdd1e0fa8940008f0a6e641a35e6e6",
+    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ]
+  },
+  {
+    "@id": "_:N2555daceb6704e539715a7215f06f29d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4c1a03192dda42699885804681133c03",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "KitchenStatus"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+          }
+        ]
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/002",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FIRE"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ],
+    "https://w3id.org/biolink/opposite": [
+      {
+        "@value": "HIRE"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/Agent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "agent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nfbee45a0bfb44468b49a445a16165ddd"
+      },
+      {
+        "@id": "_:N586d69cbd1124a22b489a189454ba3b8"
+      },
+      {
+        "@id": "_:Nf7f3f16783bd4e5697e336564b3464fe"
+      },
+      {
+        "@id": "_:Nf20f5aef22eb4de69c939935ae9987d2"
+      },
+      {
+        "@id": "_:Nc96be2d782224a39aaa11055e01deac5"
+      },
+      {
+        "@id": "_:N60caa7eac856408297776797c0cfe43a"
+      },
+      {
+        "@id": "_:N2e0c32be8d1f4d3e87aefef73540364b"
+      },
+      {
+        "@id": "_:Nd899bdc6bf7142f68217e067940e9812"
+      },
+      {
+        "@id": "_:Ne489ab708a4b43aea565aec78e896817"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "a provence-generating agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#exactMatch": [
+      {
+        "@id": "http://www.w3.org/ns/prov#Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfbee45a0bfb44468b49a445a16165ddd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:N586d69cbd1124a22b489a189454ba3b8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf7f3f16783bd4e5697e336564b3464fe",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf20f5aef22eb4de69c939935ae9987d2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc96be2d782224a39aaa11055e01deac5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N60caa7eac856408297776797c0cfe43a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2e0c32be8d1f4d3e87aefef73540364b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd899bdc6bf7142f68217e067940e9812",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne489ab708a4b43aea565aec78e896817",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "persons"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -497,430 +1630,18 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship"
-      },
-      {
-        "@id": "_:N2b30b04dcbe24e40bf3f0784d71868da"
-      },
-      {
-        "@id": "_:N22ad10b862e3489f9f3152ea414a6044"
-      },
-      {
-        "@id": "_:Ned2685e6ab9a4f33a6a5dcd67effb2ee"
-      },
-      {
-        "@id": "_:Nb51361e3d3344d33acd11150efc79762"
-      },
-      {
-        "@id": "_:N58bed2a164a14a0f8b94bce12326cd9d"
-      },
-      {
-        "@id": "_:Naded9e4c6f60460f935883e2db768271"
-      },
-      {
-        "@id": "_:Na3bf92a3bc6a4ec2b66b4e2978008958"
-      },
-      {
-        "@id": "_:N19bfebc93dc04a8c828e823e8812bf4f"
-      },
-      {
-        "@id": "_:N52978ebe573f45fb93515587ed278936"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 5
-      }
-    ]
-  },
-  {
-    "@id": "_:N2b30b04dcbe24e40bf3f0784d71868da",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N22ad10b862e3489f9f3152ea414a6044",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ned2685e6ab9a4f33a6a5dcd67effb2ee",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb51361e3d3344d33acd11150efc79762",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N58bed2a164a14a0f8b94bce12326cd9d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Naded9e4c6f60460f935883e2db768271",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na3bf92a3bc6a4ec2b66b4e2978008958",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N19bfebc93dc04a8c828e823e8812bf4f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N52978ebe573f45fb93515587ed278936",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/description",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "description"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_B"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:N071ae27d9a5c44ca9dd32d25ae5598c8"
-      },
-      {
-        "@id": "_:N792b07ff80cf4f25b59aeb6839de5ae6"
-      },
-      {
-        "@id": "_:Ncbfb2296a87f42f3ad156ccb6c72aa61"
-      },
-      {
-        "@id": "_:N95cc49cebe564190a6a5a77f132dd28c"
-      },
-      {
-        "@id": "_:N6de6ab8d165b4d9c86285006ec3f5c15"
-      },
-      {
-        "@id": "_:Nd6e871fecbcd40ac8d7bc6d43c62e505"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 6
-      }
-    ]
-  },
-  {
-    "@id": "_:N071ae27d9a5c44ca9dd32d25ae5598c8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:N792b07ff80cf4f25b59aeb6839de5ae6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncbfb2296a87f42f3ad156ccb6c72aa61",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:N95cc49cebe564190a6a5a77f132dd28c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nec9a2208d31d403eb5ab9f55b3d5e58b"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nec9a2208d31d403eb5ab9f55b3d5e58b",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N6de6ab8d165b4d9c86285006ec3f5c15",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd6e871fecbcd40ac8d7bc6d43c62e505",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "companies"
+        "@value": "diagnosis"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -930,112 +1651,141 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/Agent",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "agent"
+        "@value": "SIBLING_OF"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N5fa049a9e68d44aca0e4c8be56ccd83d"
-      },
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@id": "_:Nf998dc7dc3d14ee8ad61ac952050cbfe"
-      },
-      {
-        "@id": "_:N5ee543a0e98c4ddab8a7e735822629fe"
-      },
-      {
-        "@id": "_:N404a1d4ba93841c48e6194b4ef8208a9"
-      },
-      {
-        "@id": "_:N39f396481af5405a991e2e50b34cf6ad"
-      },
-      {
-        "@id": "_:Ncfae68d2ddad4c1a8313622d5c547b0b"
-      },
-      {
-        "@id": "_:N589c32fd14f54a9195bfbeea65e78969"
-      },
-      {
-        "@id": "_:N2e9fa8e2f3d049dbb53372573c772646"
-      },
-      {
-        "@id": "_:Nfd29ec5f958c4acd86c14bf45924b1be"
+        "@value": "AnyObject"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "a provence-generating agent"
+        "@value": "Example of unconstrained class"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#exactMatch": [
       {
-        "@id": "http://www.w3.org/ns/prov#Agent"
+        "@id": "https://w3id.org/linkml/Any"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
-        "@id": "https://w3id.org/linkml/tests/core"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
   {
-    "@id": "_:N5fa049a9e68d44aca0e4c8be56ccd83d",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+    "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
+        "@value": "DIRTY"
       }
     ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
       }
     ]
   },
   {
-    "@id": "_:Nf998dc7dc3d14ee8ad61ac952050cbfe",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "https://w3id.org/biolink/Disease"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Organization"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:N151d19cc9b59469e8bba1ce895bb9348"
+      },
+      {
+        "@id": "_:N91ef4c1e7fbf499f8b650acf6c49eb3e"
+      },
+      {
+        "@id": "_:N69c0fba8093540d78e039782ab465047"
+      },
+      {
+        "@id": "_:N8de5a2b83e4f4938a614209b238b0c24"
+      },
+      {
+        "@id": "_:N58a57865621f4509a4081faed9f9d546"
+      },
+      {
+        "@id": "_:N5539591b34f84c43b72007bcccd323dd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+        "@value": 3
       }
     ]
   },
   {
-    "@id": "_:N5ee543a0e98c4ddab8a7e735822629fe",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
-      }
-    ]
-  },
-  {
-    "@id": "_:N404a1d4ba93841c48e6194b4ef8208a9",
+    "@id": "_:N151d19cc9b59469e8bba1ce895bb9348",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1051,7 +1801,7 @@
     ]
   },
   {
-    "@id": "_:N39f396481af5405a991e2e50b34cf6ad",
+    "@id": "_:N91ef4c1e7fbf499f8b650acf6c49eb3e",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1068,7 +1818,7 @@
     ]
   },
   {
-    "@id": "_:Ncfae68d2ddad4c1a8313622d5c547b0b",
+    "@id": "_:N69c0fba8093540d78e039782ab465047",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1085,23 +1835,23 @@
     ]
   },
   {
-    "@id": "_:N589c32fd14f54a9195bfbeea65e78969",
+    "@id": "_:N8de5a2b83e4f4938a614209b238b0c24",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+        "@id": "https://w3id.org/linkml/tests/core/name"
       }
     ]
   },
   {
-    "@id": "_:N2e9fa8e2f3d049dbb53372573c772646",
+    "@id": "_:N58a57865621f4509a4081faed9f9d546",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1113,12 +1863,12 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+        "@id": "https://w3id.org/linkml/tests/core/name"
       }
     ]
   },
   {
-    "@id": "_:Nfd29ec5f958c4acd86c14bf45924b1be",
+    "@id": "_:N5539591b34f84c43b72007bcccd323dd",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1130,44 +1880,23 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+        "@id": "https://w3id.org/linkml/tests/core/name"
       }
     ]
   },
   {
-    "@id": "https://example.org/bizcodes/001",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "HIRE"
+        "@value": "CHILD_OF"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "event for a new employee"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/city",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "city"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
       }
     ]
   },
@@ -1188,37 +1917,24 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "mixin_slot_I"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "HasAliases"
+        "@value": "WithLocation"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N4d567a498d4f4675b0adaace02e58e23"
+        "@id": "_:N3d7e1f5f6dd74c8a9d304e80d2848f27"
       },
       {
-        "@id": "_:N784d54929ba34550b24aeae38a087f2b"
+        "@id": "_:Nbf5b9d3bb11544f2b3b0f13b96578c5b"
+      },
+      {
+        "@id": "_:N50a054e794ed4028ab4b31cf682284e0"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1228,23 +1944,23 @@
     ]
   },
   {
-    "@id": "_:N4d567a498d4f4675b0adaace02e58e23",
+    "@id": "_:N3d7e1f5f6dd74c8a9d304e80d2848f27",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
       }
     ]
   },
   {
-    "@id": "_:N784d54929ba34550b24aeae38a087f2b",
+    "@id": "_:Nbf5b9d3bb11544f2b3b0f13b96578c5b",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1256,7 +1972,809 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N50a054e794ed4028ab4b31cf682284e0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "slot with space 1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/name",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "name"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 2
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/life_status",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "life_status"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfMix",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfMix"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Na101e91858d9488796e40ae19002a82b"
+      },
+      {
+        "@id": "_:N19b9a660690b4ac1bdbb5140f9902137"
+      },
+      {
+        "@id": "_:N8f58878bfb244e75aabd0113ddf21077"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na101e91858d9488796e40ae19002a82b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Ndb438f1145024c67bf4bc0f36d1b0379"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndb438f1145024c67bf4bc0f36d1b0379",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N19b9a660690b4ac1bdbb5140f9902137",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8f58878bfb244e75aabd0113ddf21077",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "procedure"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "acted on behalf of"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has familial relationships"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfEnums",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfEnums"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nd9ebc7ca6de4490b9ccd7b93fef5f447"
+      },
+      {
+        "@id": "_:N6459a10ef31345e68ddd630333eb736c"
+      },
+      {
+        "@id": "_:N3096b1903c1347c6b3ac12cbe53e9328"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd9ebc7ca6de4490b9ccd7b93fef5f447",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nb14d76fba5f8421ab885329fa93233df"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb14d76fba5f8421ab885329fa93233df",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N6459a10ef31345e68ddd630333eb736c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3096b1903c1347c6b3ac12cbe53e9328",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "a b"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/004",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "TRANSFER"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "transfer internally"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/ended_at_time",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ended at time"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Ontology"
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@value": "Kitchen Sink Schema"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+      {
+        "@id": "https://example.org/"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Kitchen Sink Schema\n\nThis schema does not do anything useful. It exists to test all features of linkml.\n\nThis particular text field exists to demonstrate markdown within a text field:\n\nLists:\n\n   * a\n   * b\n   * c\n\nAnd links, e.g to [Person](Person.md)"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Relationship"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nd68e50db50fb467f9e39c687a56ba849"
+      },
+      {
+        "@id": "_:N1acc64b50c8f482789f96cd8c29fa82c"
+      },
+      {
+        "@id": "_:N52e5846e3ba1485ca46573dccba691ab"
+      },
+      {
+        "@id": "_:N397bc3b246704993bb0c2b9e59502016"
+      },
+      {
+        "@id": "_:Nc057fe1483a8489e940b5769eb6aae5d"
+      },
+      {
+        "@id": "_:Ne0de2f1f7c7c4986b1d923d86578f45e"
+      },
+      {
+        "@id": "_:N1fab58e1b6304109938697022ec168ab"
+      },
+      {
+        "@id": "_:N4ab6d6f6289b4dccb7bfe7a16c209f9e"
+      },
+      {
+        "@id": "_:Ne14586515c114338bf11f9bd0eb2537c"
+      },
+      {
+        "@id": "_:N2c7855c0d6eb4ea8a72dded6b3130d2e"
+      },
+      {
+        "@id": "_:Ne4d1e3a537c74f04a43f6f6cee33d47f"
+      },
+      {
+        "@id": "_:N90bd6db667b7412ea99f21b97c2bf21c"
+      },
+      {
+        "@id": "_:Nb54235d5763744aeb5fb2263147ea630"
+      },
+      {
+        "@id": "_:Ndb941be67e8b477c9fb2806dfc0133ae"
+      },
+      {
+        "@id": "_:Nbe951b4760b14bcfa3dc950f495f8ce5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd68e50db50fb467f9e39c687a56ba849",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1acc64b50c8f482789f96cd8c29fa82c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N52e5846e3ba1485ca46573dccba691ab",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N397bc3b246704993bb0c2b9e59502016",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc057fe1483a8489e940b5769eb6aae5d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne0de2f1f7c7c4986b1d923d86578f45e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1fab58e1b6304109938697022ec168ab",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4ab6d6f6289b4dccb7bfe7a16c209f9e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne14586515c114338bf11f9bd0eb2537c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2c7855c0d6eb4ea8a72dded6b3130d2e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne4d1e3a537c74f04a43f6f6cee33d47f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N90bd6db667b7412ea99f21b97c2bf21c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb54235d5763744aeb5fb2263147ea630",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndb941be67e8b477c9fb2806dfc0133ae",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbe951b4760b14bcfa3dc950f495f8ce5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#UNKNOWN",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "UNKNOWN"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/city",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "city"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "in location"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "https://w3id.org/biolink/opposite": [
+      {
+        "@value": "location_of"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DiagnosisType"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO"
       }
     ]
   },
@@ -1282,272 +2800,83 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsStringIn",
+    "@id": "https://w3id.org/linkml/tests/core/Activity",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "EqualsStringIn"
+        "@value": "activity"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N9e2e9bf963bf4ee1853fcd14b75a7fde"
+        "@id": "_:N9f02b7a894504ae78b2e1efe937403cb"
       },
       {
-        "@id": "_:N0943ea82ee2b42a5947b674e70d988af"
+        "@id": "_:Nd658da0e628d45d297ef3e4e97bd8b30"
       },
       {
-        "@id": "_:Nee0c6eb8948a488b81bc2138b9247a3e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9e2e9bf963bf4ee1853fcd14b75a7fde",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nb1e84975d6f04e6091d6dcdf94c30a8e"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb1e84975d6f04e6091d6dcdf94c30a8e",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#oneOf": [
-      {
-        "@list": [
-          {
-            "@value": "foo"
-          },
-          {
-            "@value": "bar"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N0943ea82ee2b42a5947b674e70d988af",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nee0c6eb8948a488b81bc2138b9247a3e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "related to"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Ned1ce704f1264700b3c33a43c5ebabf3"
+        "@id": "_:N645e2853b4ff4eea9ff4f182c012e3fa"
       },
       {
-        "@id": "_:N84a711ee4cc944019139fa987fc16ac5"
+        "@id": "_:Nf2611566f67d4c6b8f2082f3a7ce97a8"
       },
       {
-        "@id": "_:Ne0146b6150f143b99ebc4d1b10c547c1"
+        "@id": "_:Nc861b52aebd04bff87bdbb3838a22dc4"
       },
       {
-        "@id": "_:N074f5611e6724ee6a917d234e52d4062"
+        "@id": "_:N55d5c23c9353400c954916fa2328df2a"
       },
       {
-        "@id": "_:Nfbf7b8d987aa437185356e6b741eeacc"
+        "@id": "_:N5e2f1be3f9e343708c59fe25c44799de"
       },
       {
-        "@id": "_:Ncf6267b0afa34c60b7e9f81fb710ff9d"
+        "@id": "_:N33d2436badf04391a4fa10aeeb672684"
+      },
+      {
+        "@id": "_:Nce94d1d4b7c3427cabf194d212163d72"
+      },
+      {
+        "@id": "_:Ne326936d61d84c2381131cd77ec3efc5"
+      },
+      {
+        "@id": "_:N2d0dbf8fd70048c7b7ae7fe3b1af65f5"
+      },
+      {
+        "@id": "_:N97b4b0994858491884bc8b8c53a7d24f"
+      },
+      {
+        "@id": "_:N9d8b40756549433dbd642a83c63d51b8"
+      },
+      {
+        "@id": "_:Nd2fd0dd316cd477b96c2b00831bac935"
+      },
+      {
+        "@id": "_:N3d853bc17cbe426c91ca4f002939191f"
+      },
+      {
+        "@id": "_:Nfd2b1c95a2aa4941ba130bd6627d3e39"
+      },
+      {
+        "@id": "_:N8fa3056b70684880acae251716d80d52"
+      },
+      {
+        "@id": "_:N61084f7bcdcf402d90e11ab556c8a96a"
+      },
+      {
+        "@id": "_:Nea8a2f9e57f146d0b60259fae5360ee2"
+      },
+      {
+        "@id": "_:N340f41187edf4c2aa40dd79fc970bf60"
+      },
+      {
+        "@id": "_:Nc5a76e3fcde84449af67f8cbe00e6f90"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
+    "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ned1ce704f1264700b3c33a43c5ebabf3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N84a711ee4cc944019139fa987fc16ac5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne0146b6150f143b99ebc4d1b10c547c1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N074f5611e6724ee6a917d234e52d4062",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfbf7b8d987aa437185356e6b741eeacc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncf6267b0afa34c60b7e9f81fb710ff9d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "KitchenStatus"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
-          }
-        ]
+        "@value": "a provence-generating activity"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1555,120 +2884,330 @@
         "@id": "https://w3id.org/linkml/tests/core"
       }
     ],
-    "https://w3id.org/linkml/permissible_values": [
+    "http://www.w3.org/2004/02/skos/core#mappingRelation": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+        "@id": "http://www.w3.org/ns/prov#Activity"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/was_generated_by",
+    "@id": "_:N9f02b7a894504ae78b2e1efe937403cb",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@value": "was generated by"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd658da0e628d45d297ef3e4e97bd8b30",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:N645e2853b4ff4eea9ff4f182c012e3fa",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf2611566f67d4c6b8f2082f3a7ce97a8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc861b52aebd04bff87bdbb3838a22dc4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N55d5c23c9353400c954916fa2328df2a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5e2f1be3f9e343708c59fe25c44799de",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N33d2436badf04391a4fa10aeeb672684",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nce94d1d4b7c3427cabf194d212163d72",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne326936d61d84c2381131cd77ec3efc5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2d0dbf8fd70048c7b7ae7fe3b1af65f5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N97b4b0994858491884bc8b8c53a7d24f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9d8b40756549433dbd642a83c63d51b8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd2fd0dd316cd477b96c2b00831bac935",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3d853bc17cbe426c91ca4f002939191f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfd2b1c95a2aa4941ba130bd6627d3e39",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8fa3056b70684880acae251716d80d52",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:N61084f7bcdcf402d90e11ab556c8a96a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nea8a2f9e57f146d0b60259fae5360ee2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
         "@id": "https://w3id.org/linkml/tests/core/Activity"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "other codes"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfSimpleType",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfSimpleType"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N212f9b8f0d6d4e778d7d0812f09cf33a"
-      },
-      {
-        "@id": "_:N373cc3b0a4b942b981e84fa354121f57"
-      },
-      {
-        "@id": "_:Nf2d14a7ed8e44c52ab36b91d8405b61e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N212f9b8f0d6d4e778d7d0812f09cf33a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nb756ee96c0b040a79366ed1c158a76c9"
-      }
-    ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
       }
     ]
   },
   {
-    "@id": "_:Nb756ee96c0b040a79366ed1c158a76c9",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#string"
-          },
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N373cc3b0a4b942b981e84fa354121f57",
+    "@id": "_:N340f41187edf4c2aa40dd79fc970bf60",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1680,12 +3219,12 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
       }
     ]
   },
   {
-    "@id": "_:Nf2d14a7ed8e44c52ab36b91d8405b61e",
+    "@id": "_:Nc5a76e3fcde84449af67f8cbe00e6f90",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1697,71 +3236,7 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has medical history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 5
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "activities"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "altitude"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
       }
     ]
   },
@@ -1808,60 +3283,1865 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/type",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "type"
+        "@value": "age in years"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "a b"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyObject"
+        "@id": "_:Nb1325c1d2da94d64a66dc9292c91ff74"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "Example of unconstrained class"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#exactMatch": [
-      {
-        "@id": "https://w3id.org/linkml/Any"
+        "@value": "number of years since birth"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb1325c1d2da94d64a66dc9292c91ff74",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#intersectionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "_:N618967b6494c4e218885cbb75e650896"
+          },
+          {
+            "@id": "_:N99b44c4787734b389303ea37b5e919cc"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N618967b6494c4e218885cbb75e650896",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N6c24a5dc543244e59ff9cf5f7634434c"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N6c24a5dc543244e59ff9cf5f7634434c",
+    "http://www.w3.org/2001/XMLSchema#minInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ]
+  },
+  {
+    "@id": "_:N99b44c4787734b389303ea37b5e919cc",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N21b78315d2f442a5adf208214fe9e9ce"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N21b78315d2f442a5adf208214fe9e9ce",
+    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 999
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_marriage_history",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has marriage history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#LIVING",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "LIVING"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "test_attribute"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nbf8273dd47594f62b55cffbebc6ba6a4"
+      },
+      {
+        "@id": "_:N8c298597993243be8ec551a27acca092"
+      },
+      {
+        "@id": "_:Nab7c6b1bcf6e4235ae1920aa4308bd4e"
+      },
+      {
+        "@id": "_:N30667f115eef4abd944bda94c3106e92"
+      },
+      {
+        "@id": "_:Nb0b9e36a0cd74c179421025c4ff5aa91"
+      },
+      {
+        "@id": "_:N91d86f9f0e9e47d086b690dbf0a2ba15"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbf8273dd47594f62b55cffbebc6ba6a4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8c298597993243be8ec551a27acca092",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nab7c6b1bcf6e4235ae1920aa4308bd4e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N30667f115eef4abd944bda94c3106e92",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb0b9e36a0cd74c179421025c4ff5aa91",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N91d86f9f0e9e47d086b690dbf0a2ba15",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:Ne3e841659fa44b0ca7a2f184d125db02"
+      },
+      {
+        "@id": "_:N6e1e268872bb432394576509427c4824"
+      },
+      {
+        "@id": "_:N2fc256ddf9de4abc9e0ed4c7e14acb85"
+      },
+      {
+        "@id": "_:N87ad19d2e1014b65b5182c3394a0eb51"
+      },
+      {
+        "@id": "_:N456f0a6692574c68be3e78a3424b416c"
+      },
+      {
+        "@id": "_:N4bc14fb1c6fe417ead248fa15e1ba48a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 6
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne3e841659fa44b0ca7a2f184d125db02",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6e1e268872bb432394576509427c4824",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2fc256ddf9de4abc9e0ed4c7e14acb85",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:N87ad19d2e1014b65b5182c3394a0eb51",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N8f55ee987e304b96940edc4ddd482f0f"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8f55ee987e304b96940edc4ddd482f0f",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N456f0a6692574c68be3e78a3424b416c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4bc14fb1c6fe417ead248fa15e1ba48a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Friend",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Friend"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N41abce0b0c494efd81f1a9b38e3965b6"
+      },
+      {
+        "@id": "_:N136cb4f2d6f1447e9a42c48da96243c3"
+      },
+      {
+        "@id": "_:N4bb3272859b1469b93ec6b31d6470e43"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N41abce0b0c494efd81f1a9b38e3965b6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N136cb4f2d6f1447e9a42c48da96243c3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4bb3272859b1469b93ec6b31d6470e43",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "TODO"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfClasses",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfClasses"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N0c8bab9921754b9ea291a232078cd6d2"
+      },
+      {
+        "@id": "_:N32f598d9bbfd46cca57e80f754a02735"
+      },
+      {
+        "@id": "_:N9b4d014c769b41548fffddfc1e1a7038"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0c8bab9921754b9ea291a232078cd6d2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N24ce39ee89d343ceab68adc30136ba0e"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "_:N24ce39ee89d343ceab68adc30136ba0e",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N32f598d9bbfd46cca57e80f754a02735",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9b4d014c769b41548fffddfc1e1a7038",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has employment history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 7
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsStringIn",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EqualsStringIn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N6f80c451215d43d3aa4c7bb6a042e461"
+      },
+      {
+        "@id": "_:Nc64858d4eb034ce781fc22fc4d29ffc0"
+      },
+      {
+        "@id": "_:N6d3434b676ff4d319644fa324d4bbb76"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6f80c451215d43d3aa4c7bb6a042e461",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N3ff4a0dbe13b4785a86029d97e7c7bf0"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3ff4a0dbe13b4785a86029d97e7c7bf0",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#oneOf": [
+      {
+        "@list": [
+          {
+            "@value": "foo"
+          },
+          {
+            "@value": "bar"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc64858d4eb034ce781fc22fc4d29ffc0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6d3434b676ff4d319644fa324d4bbb76",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Company"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
+      },
+      {
+        "@id": "_:Nc070c90274d34e10a338015295d17cdd"
+      },
+      {
+        "@id": "_:Nde9979594c024caabb976dcb7b638c96"
+      },
+      {
+        "@id": "_:N4e4e46bac0d9460494436b2b749e2543"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc070c90274d34e10a338015295d17cdd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nde9979594c024caabb976dcb7b638c96",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4e4e46bac0d9460494436b2b749e2543",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CLEAN"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/activity_set",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "activity set"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "related to"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "married to"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "slot with space 2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfSimpleType",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfSimpleType"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nb416220398b841b1bd3f13c47f516bac"
+      },
+      {
+        "@id": "_:N15da565328a6457bbfd1e80894c43fa5"
+      },
+      {
+        "@id": "_:N3311a09bacf049d9a4c84e2ec523a84f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb416220398b841b1bd3f13c47f516bac",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N8593fbcacde34cff9999edc4fa9e2309"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8593fbcacde34cff9999edc4fa9e2309",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#string"
+          },
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N15da565328a6457bbfd1e80894c43fa5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3311a09bacf049d9a4c84e2ec523a84f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute3"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "class with spaces"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N6ba9ca25b84242e4af17c2d4cbe347af"
+      },
+      {
+        "@id": "_:N0962f80bd9b4417ab65c50e808fd0155"
+      },
+      {
+        "@id": "_:N3894e572e70e4231a37ffacf97736f1f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6ba9ca25b84242e4af17c2d4cbe347af",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0962f80bd9b4417ab65c50e808fd0155",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3894e572e70e4231a37ffacf97736f1f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/001",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "HIRE"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "event for a new employee"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Place"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:Ne37264876cd8495ab4aecc50f332d045"
+      },
+      {
+        "@id": "_:N922224e411e044f19c8f7f46130a3003"
+      },
+      {
+        "@id": "_:Nadb0752e064a4da481cd0b90a343199c"
+      },
+      {
+        "@id": "_:Ndeea6dcd3a2e45149d545c47e520cbb7"
+      },
+      {
+        "@id": "_:Nc0b450624bd444c889bcda3eac7acc3f"
+      },
+      {
+        "@id": "_:N063244179c9a4d72bc2e526ed0d0a7e5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne37264876cd8495ab4aecc50f332d045",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N922224e411e044f19c8f7f46130a3003",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nadb0752e064a4da481cd0b90a343199c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndeea6dcd3a2e45149d545c47e520cbb7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc0b450624bd444c889bcda3eac7acc3f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N063244179c9a4d72bc2e526ed0d0a7e5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_B"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "stomach count"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_A"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "altitude"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "metadata"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Example of a slot that has an unconstrained range"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/description",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "description"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/agent_set",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "agent set"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/003",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "PROMOTION"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "promotion event"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "activities"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "species name"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "_:Nbf0bdc74acd7465baf4afce65324cc86"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbf0bdc74acd7465baf4afce65324cc86",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N5237900b07414727bc87fba2f9b7e574"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N5237900b07414727bc87fba2f9b7e574",
+    "http://www.w3.org/2001/XMLSchema#pattern": [
+      {
+        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "PARENT_OF"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsString",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EqualsString"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N67bbb91cc1b348db983d78d5f7fbb721"
+      },
+      {
+        "@id": "_:Na9e68d211dcd469c906f2e246d222c3c"
+      },
+      {
+        "@id": "_:N2a21dcc716514316a2ca02ece9582cb9"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N67bbb91cc1b348db983d78d5f7fbb721",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N65e18a40bd1f4e158069495f8db7eef6"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "_:N65e18a40bd1f4e158069495f8db7eef6",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#oneOf": [
+      {
+        "@list": [
+          {
+            "@value": "foo"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Na9e68d211dcd469c906f2e246d222c3c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2a21dcc716514316a2ca02ece9582cb9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "HasAliases"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N1e9d6d8c88584073a52e24f5ce2110a5"
+      },
+      {
+        "@id": "_:Ncbaed685a1884061b3badbf549ac42ab"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1e9d6d8c88584073a52e24f5ce2110a5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncbaed685a1884061b3badbf549ac42ab",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/TubSubClass1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tub sub class 1"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Same depth as Sub sub class 1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "BirthEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:Nf41d0fd79b844ce5aad44ebb0b0a7031"
+      },
+      {
+        "@id": "_:N4ff9967da9c548dd823bbb5acb266447"
+      },
+      {
+        "@id": "_:N52caf2eb736c4b67af00b909b34fd5c9"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf41d0fd79b844ce5aad44ebb0b0a7031",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4ff9967da9c548dd823bbb5acb266447",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N52caf2eb736c4b67af00b909b34fd5c9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
       }
     ]
   },
@@ -1882,34 +5162,69 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "CHILD_OF"
+        "@value": "heartfelt"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "warm and hearty friendliness"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Dataset",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "in location"
+        "@value": "Dataset"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+        "@id": "_:Neb661cad25764e6db49fb107932d8f36"
+      },
+      {
+        "@id": "_:Nd8ecaa28e4964ae58f4cef6be7767c4e"
+      },
+      {
+        "@id": "_:Nf93d5d549a0a42b6b3c8bfd74e8e004b"
+      },
+      {
+        "@id": "_:Nbe575fa9dc004be5b06f6575df7d2dcf"
+      },
+      {
+        "@id": "_:N0f48b0372e0640948930d6f4aa350f3a"
+      },
+      {
+        "@id": "_:N8f2ca16fdb574c21b34d9550f9a04c67"
+      },
+      {
+        "@id": "_:Nf0b260b873f34dcd8dd1c1fb74046066"
+      },
+      {
+        "@id": "_:Ndb0750bd1a8f40d9abf8843e5dbb4026"
+      },
+      {
+        "@id": "_:N415bb51c654849bd8a8a23f3abd90744"
+      },
+      {
+        "@id": "_:Nc6daf21ff1cf4bef973213797b9e7d22"
+      },
+      {
+        "@id": "_:N89fdc6d4f31243e498417615277acf95"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1917,119 +5232,31 @@
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ],
-    "https://w3id.org/biolink/opposite": [
+    "http://www.w3.org/ns/shacl#order": [
       {
-        "@value": "location_of"
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Place"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
-      },
-      {
-        "@id": "_:N71cffb776f174db89144fbe1f93dbec0"
-      },
-      {
-        "@id": "_:N95234c60e39143d6a15903e225b1acc8"
-      },
-      {
-        "@id": "_:N454b4a2f3e7b467bb1df46c0e4dd1fc1"
-      },
-      {
-        "@id": "_:N1bca75f9c30f49edb4ab34f47f113a9d"
-      },
-      {
-        "@id": "_:N2e9ddc37fbc44e6186126dfbc637c72d"
-      },
-      {
-        "@id": "_:Nec2faa8ddac54e1c9ff365999d8dea77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N71cffb776f174db89144fbe1f93dbec0",
+    "@id": "_:Neb661cad25764e6db49fb107932d8f36",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/id"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
       }
     ]
   },
   {
-    "@id": "_:N95234c60e39143d6a15903e225b1acc8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N454b4a2f3e7b467bb1df46c0e4dd1fc1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1bca75f9c30f49edb4ab34f47f113a9d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2e9ddc37fbc44e6186126dfbc637c72d",
+    "@id": "_:Nd8ecaa28e4964ae58f4cef6be7767c4e",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -2041,243 +5268,177 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/name"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
       }
     ]
   },
   {
-    "@id": "_:Nec2faa8ddac54e1c9ff365999d8dea77",
+    "@id": "_:Nf93d5d549a0a42b6b3c8bfd74e8e004b",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "in code system"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
+    "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent",
+    "@id": "_:Nbe575fa9dc004be5b06f6575df7d2dcf",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0f48b0372e0640948930d6f4aa350f3a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8f2ca16fdb574c21b34d9550f9a04c67",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf0b260b873f34dcd8dd1c1fb74046066",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndb0750bd1a8f40d9abf8843e5dbb4026",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:N415bb51c654849bd8a8a23f3abd90744",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc6daf21ff1cf4bef973213797b9e7d22",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
+      }
+    ]
+  },
+  {
+    "@id": "_:N89fdc6d4f31243e498417615277acf95",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "MedicalEvent"
+        "@value": "has birth event"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:N75cbf73b5ecc4fc4b1c337a4c8124882"
-      },
-      {
-        "@id": "_:Na9d7fb9a0f0845c0b7a571d6cec8c174"
-      },
-      {
-        "@id": "_:N3c6e5d0870624451ae6e3903d509c8d4"
-      },
-      {
-        "@id": "_:N65b0c1135a644a849123a27415f94d90"
-      },
-      {
-        "@id": "_:N784c7788e33d4d09a82ea65457893875"
-      },
-      {
-        "@id": "_:N19b750d17d5c40989a4ea7580fb9cf12"
-      },
-      {
-        "@id": "_:N6576574763d24d078a4ede39c6433c00"
-      },
-      {
-        "@id": "_:N9578bcc0a7384ebab0eeee6f91161fbb"
-      },
-      {
-        "@id": "_:Nf70d709ded9e4642a15329d4ed24984a"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N75cbf73b5ecc4fc4b1c337a4c8124882",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na9d7fb9a0f0845c0b7a571d6cec8c174",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3c6e5d0870624451ae6e3903d509c8d4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:N65b0c1135a644a849123a27415f94d90",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N784c7788e33d4d09a82ea65457893875",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N19b750d17d5c40989a4ea7580fb9cf12",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6576574763d24d078a4ede39c6433c00",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9578bcc0a7384ebab0eeee6f91161fbb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf70d709ded9e4642a15329d4ed24984a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
       }
     ]
   },
@@ -2288,24 +5449,39 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfClasses",
+    "@id": "https://w3id.org/linkml/tests/core/was_associated_with",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was associated with"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubSubClass2",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "AnyOfClasses"
+        "@value": "Sub sub class 2"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:Ne9bf3de3b07d4a65a9087ff2d067968e"
-      },
-      {
-        "@id": "_:Nc5c44528439e4fa0b0a6733ace1189ea"
-      },
-      {
-        "@id": "_:Nd8468d18f7f3497988c9e647279afd60"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2315,55 +5491,85 @@
     ]
   },
   {
-    "@id": "_:Ne9bf3de3b07d4a65a9087ff2d067968e",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Concept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Ne785c66f9f884019a2b1450b67f37333"
+      },
+      {
+        "@id": "_:N8f78188235d842a7898ad1859907f145"
+      },
+      {
+        "@id": "_:Nb449ac89eb7644d788689e82621f950b"
+      },
+      {
+        "@id": "_:N1d21a56708914333950f728a6d35db7a"
+      },
+      {
+        "@id": "_:Nee76a47b14a34dd9b33cbe7ad36e76ea"
+      },
+      {
+        "@id": "_:N76e1753d396c493f8faff81908005f42"
+      },
+      {
+        "@id": "_:N5779263eb475422885e99a141a9fe7da"
+      },
+      {
+        "@id": "_:N5ce16e9086604ddeb57cf854bb7f3b77"
+      },
+      {
+        "@id": "_:N033215053de546ad9e24b32301dc16fd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne785c66f9f884019a2b1450b67f37333",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N8aa72f072c684a899f25a0d9cfd48901"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+        "@id": "https://w3id.org/linkml/tests/core/id"
       }
     ]
   },
   {
-    "@id": "_:N8aa72f072c684a899f25a0d9cfd48901",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc5c44528439e4fa0b0a6733ace1189ea",
+    "@id": "_:N8f78188235d842a7898ad1859907f145",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#minCardinality": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
+        "@value": 1
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+        "@id": "https://w3id.org/linkml/tests/core/id"
       }
     ]
   },
   {
-    "@id": "_:Nd8468d18f7f3497988c9e647279afd60",
+    "@id": "_:Nb449ac89eb7644d788689e82621f950b",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -2375,28 +5581,135 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+        "@id": "https://w3id.org/linkml/tests/core/id"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years",
+    "@id": "_:N1d21a56708914333950f728a6d35db7a",
     "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nee76a47b14a34dd9b33cbe7ad36e76ea",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:N76e1753d396c493f8faff81908005f42",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5779263eb475422885e99a141a9fe7da",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5ce16e9086604ddeb57cf854bb7f3b77",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N033215053de546ad9e24b32301dc16fd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "age in years"
+        "@value": "MarriageEvent"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:Nc2446a4b459f40e98a7ac28deda1f40d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
       {
-        "@value": "number of years since birth"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation"
+      },
+      {
+        "@id": "_:N443c78f20edc4c4faa6b995d433bc13e"
+      },
+      {
+        "@id": "_:Naf961fd450534e968a85c9a81fffc2c6"
+      },
+      {
+        "@id": "_:N00c922c5315c4bf2911d46ec18162a33"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2406,92 +5719,263 @@
     ]
   },
   {
-    "@id": "_:Nc2446a4b459f40e98a7ac28deda1f40d",
+    "@id": "_:N443c78f20edc4c4faa6b995d433bc13e",
     "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2002/07/owl#intersectionOf": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "_:Nd9511a54a5e34d7f8cadfe52f16acbba"
-          },
-          {
-            "@id": "_:Nd98f7ab79db14418870a3d5f1f690555"
-          }
-        ]
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
       }
     ]
   },
   {
-    "@id": "_:Nd9511a54a5e34d7f8cadfe52f16acbba",
+    "@id": "_:Naf961fd450534e968a85c9a81fffc2c6",
     "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N8afdfd02da5e4470b94d352870254c6d"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N8afdfd02da5e4470b94d352870254c6d",
-    "http://www.w3.org/2001/XMLSchema#minInclusive": [
+    "http://www.w3.org/2002/07/owl#minCardinality": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
         "@value": 0
       }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+      }
     ]
   },
   {
-    "@id": "_:Nd98f7ab79db14418870a3d5f1f690555",
+    "@id": "_:N00c922c5315c4bf2911d46ec18162a33",
     "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N2196ad46963149889612406539b174b4"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N2196ad46963149889612406539b174b4",
-    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 999
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Address"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nc90fea0059d049df890d89ee295299b8"
+      },
+      {
+        "@id": "_:Nd4060b8fa89c45f19b7962addcaefe59"
+      },
+      {
+        "@id": "_:N896e2897b9ad43b1ab35fc06cd17788f"
+      },
+      {
+        "@id": "_:Nd1166d4814354e9bae56d60377939b2f"
+      },
+      {
+        "@id": "_:Na39caba74398426f8c0c42d3367c2af1"
+      },
+      {
+        "@id": "_:Nbeeee3ba80694a92a6fe663474963663"
+      },
+      {
+        "@id": "_:N246fc5a88e9d40d69561ea9e12698858"
+      },
+      {
+        "@id": "_:N9fa21fbc68b744509ecf62f7ff6e672a"
+      },
+      {
+        "@id": "_:N837cad1c23004528945ea15a2cb1f8ec"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc90fea0059d049df890d89ee295299b8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd4060b8fa89c45f19b7962addcaefe59",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:N896e2897b9ad43b1ab35fc06cd17788f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd1166d4814354e9bae56d60377939b2f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na39caba74398426f8c0c42d3367c2af1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbeeee3ba80694a92a6fe663474963663",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:N246fc5a88e9d40d69561ea9e12698858",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9fa21fbc68b744509ecf62f7ff6e672a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "_:N837cad1c23004528945ea15a2cb1f8ec",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "ceo"
+        "@value": "employed at"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2543,149 +6027,6 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "cordialness"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_marriage_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has marriage history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "slot with space 2"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "married to"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/was_associated_with",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "was associated with"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "TODO"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
-      }
-    ]
-  },
-  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/street",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
@@ -2702,811 +6043,6 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FakeClass",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FakeClass"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N6e1a6985e04240c3a96671da96fafe98"
-      },
-      {
-        "@id": "_:Ne130fbd077684d52b0e9b645791e626c"
-      },
-      {
-        "@id": "_:N3a2e2fc5aae548bd9c966175ae81556d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6e1a6985e04240c3a96671da96fafe98",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne130fbd077684d52b0e9b645791e626c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3a2e2fc5aae548bd9c966175ae81556d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "procedure"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "persons"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "metadata"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Example of a slot that has an unconstrained range"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Concept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N15140d827c0c4415a40d4e85adcaa32c"
-      },
-      {
-        "@id": "_:Ne7b1d0b17f2844f1b8a87fcb701d9b72"
-      },
-      {
-        "@id": "_:Nd01721ab1eb042ab878d78f098e15be8"
-      },
-      {
-        "@id": "_:Naf738ce2c18546bda392b74e47324ad5"
-      },
-      {
-        "@id": "_:N7d42fc1da93b43ddbfe3d1f00163d594"
-      },
-      {
-        "@id": "_:N280fd42db63047d9a6934472fe3e57a5"
-      },
-      {
-        "@id": "_:Nc358932eabac432582b237f48c39f48c"
-      },
-      {
-        "@id": "_:N9f07a91c9f67437eb97b6bfacd793fe1"
-      },
-      {
-        "@id": "_:N32a524125db84cc1a89ed23af6423ec4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N15140d827c0c4415a40d4e85adcaa32c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne7b1d0b17f2844f1b8a87fcb701d9b72",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd01721ab1eb042ab878d78f098e15be8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Naf738ce2c18546bda392b74e47324ad5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7d42fc1da93b43ddbfe3d1f00163d594",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N280fd42db63047d9a6934472fe3e57a5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc358932eabac432582b237f48c39f48c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9f07a91c9f67437eb97b6bfacd793fe1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N32a524125db84cc1a89ed23af6423ec4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Organization"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
-      },
-      {
-        "@id": "_:N41b200ca4cf54664a637bb1957197000"
-      },
-      {
-        "@id": "_:N66a8a70279f54333be26a325c1476a0b"
-      },
-      {
-        "@id": "_:Nde79c54b4fe441be8bca5b82ac0f1ae5"
-      },
-      {
-        "@id": "_:Nbacb1a41e4e6442c8c50650583e4359b"
-      },
-      {
-        "@id": "_:N76501b0964e14981939881bc7212e144"
-      },
-      {
-        "@id": "_:Na416d4c255964bca956a892cec1b3a45"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 3
-      }
-    ]
-  },
-  {
-    "@id": "_:N41b200ca4cf54664a637bb1957197000",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N66a8a70279f54333be26a325c1476a0b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nde79c54b4fe441be8bca5b82ac0f1ae5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbacb1a41e4e6442c8c50650583e4359b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N76501b0964e14981939881bc7212e144",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na416d4c255964bca956a892cec1b3a45",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/activity_set",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "activity set"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DEAD"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfMix",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfMix"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N549a36d1b285473e95915400289ff4ec"
-      },
-      {
-        "@id": "_:Nff6066ab0d7d49faa8a2c02e8802f32b"
-      },
-      {
-        "@id": "_:N70cfa5e57862433fbe829c15cff0ebbc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N549a36d1b285473e95915400289ff4ec",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N1501d51647ad4187b912d498896863c1"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1501d51647ad4187b912d498896863c1",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nff6066ab0d7d49faa8a2c02e8802f32b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "_:N70cfa5e57862433fbe829c15cff0ebbc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/ended_at_time",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ended at time"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfEnums",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfEnums"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N4a3cd83e6c9941dd8b394630dc6556b1"
-      },
-      {
-        "@id": "_:Na79c836a069342a6aa90cd020b967c3d"
-      },
-      {
-        "@id": "_:N36f301335cf54613b6ec33fe3ffeffab"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4a3cd83e6c9941dd8b394630dc6556b1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Ndedaa5329c4547eaad9af499423dc65d"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndedaa5329c4547eaad9af499423dc65d",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Na79c836a069342a6aa90cd020b967c3d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "_:N36f301335cf54613b6ec33fe3ffeffab",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "CLEAN"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_A"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has employment history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 7
-      }
-    ]
-  },
-  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -3518,40 +6054,40 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N52848c8f91db4798ad810b5b374d8ca2"
+        "@id": "_:Nabea0603f5534a36b51c4367f5b258cd"
       },
       {
-        "@id": "_:N3ea3529dd4ee4c7e9d3103a5c4f94062"
+        "@id": "_:N3f1f489443e74b3eb3e3cd6f4b27eddd"
       },
       {
-        "@id": "_:N1e9e7637beb842bba996d2e068a60f39"
+        "@id": "_:N2767381cd925482986d63a2307147454"
       },
       {
-        "@id": "_:N63ebccfa077e41ebb777f62694906cb1"
+        "@id": "_:Nc35e4f7aff95428fa8693ca1b4646695"
       },
       {
-        "@id": "_:N1136a8d3ce86428c8a05f3500d739177"
+        "@id": "_:Nbeb0b1fd909949fba65614fc24158979"
       },
       {
-        "@id": "_:N47a7f41ffaeb4bdbbf9230d3ce2dd003"
+        "@id": "_:Nac2a4302cffa4ddc94a995bec0d4e662"
       },
       {
-        "@id": "_:N6c1ead930e60476da733cf6957f44705"
+        "@id": "_:N5dab78cd05fa46cc88c09c4e3ff9c92a"
       },
       {
-        "@id": "_:N40ac08eff29a4fa98361c246cc122b38"
+        "@id": "_:Nedc4b3f4e8234f19acf12a525b2d9a07"
       },
       {
-        "@id": "_:Nc91f05682699491bbeb549f2e44ed7c5"
+        "@id": "_:Nb880abf84d25498fa34b62b3b884c094"
       },
       {
-        "@id": "_:Nf0298af87e744a7e80383d6baac3a900"
+        "@id": "_:Nbdc7da76b55d4d52a85ebf8637755338"
       },
       {
-        "@id": "_:Nb6232f2c0ed640f29ddb033b244d8327"
+        "@id": "_:N905c0bb0b3e746fdb107189e1d90e3bc"
       },
       {
-        "@id": "_:N6a2a0a102f5141e8a7140d244864f004"
+        "@id": "_:N11c0256ccf4949b0a1f089e3c87df4e6"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3561,7 +6097,7 @@
     ]
   },
   {
-    "@id": "_:N52848c8f91db4798ad810b5b374d8ca2",
+    "@id": "_:Nabea0603f5534a36b51c4367f5b258cd",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3577,7 +6113,7 @@
     ]
   },
   {
-    "@id": "_:N3ea3529dd4ee4c7e9d3103a5c4f94062",
+    "@id": "_:N3f1f489443e74b3eb3e3cd6f4b27eddd",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3594,7 +6130,7 @@
     ]
   },
   {
-    "@id": "_:N1e9e7637beb842bba996d2e068a60f39",
+    "@id": "_:N2767381cd925482986d63a2307147454",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3611,7 +6147,7 @@
     ]
   },
   {
-    "@id": "_:N63ebccfa077e41ebb777f62694906cb1",
+    "@id": "_:Nc35e4f7aff95428fa8693ca1b4646695",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3627,7 +6163,7 @@
     ]
   },
   {
-    "@id": "_:N1136a8d3ce86428c8a05f3500d739177",
+    "@id": "_:Nbeb0b1fd909949fba65614fc24158979",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3644,7 +6180,7 @@
     ]
   },
   {
-    "@id": "_:N47a7f41ffaeb4bdbbf9230d3ce2dd003",
+    "@id": "_:Nac2a4302cffa4ddc94a995bec0d4e662",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3661,7 +6197,7 @@
     ]
   },
   {
-    "@id": "_:N6c1ead930e60476da733cf6957f44705",
+    "@id": "_:N5dab78cd05fa46cc88c09c4e3ff9c92a",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3677,7 +6213,7 @@
     ]
   },
   {
-    "@id": "_:N40ac08eff29a4fa98361c246cc122b38",
+    "@id": "_:Nedc4b3f4e8234f19acf12a525b2d9a07",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3694,7 +6230,7 @@
     ]
   },
   {
-    "@id": "_:Nc91f05682699491bbeb549f2e44ed7c5",
+    "@id": "_:Nb880abf84d25498fa34b62b3b884c094",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3711,7 +6247,7 @@
     ]
   },
   {
-    "@id": "_:Nf0298af87e744a7e80383d6baac3a900",
+    "@id": "_:Nbdc7da76b55d4d52a85ebf8637755338",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3727,7 +6263,7 @@
     ]
   },
   {
-    "@id": "_:Nb6232f2c0ed640f29ddb033b244d8327",
+    "@id": "_:N905c0bb0b3e746fdb107189e1d90e3bc",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3744,7 +6280,7 @@
     ]
   },
   {
-    "@id": "_:N6a2a0a102f5141e8a7140d244864f004",
+    "@id": "_:N11c0256ccf4949b0a1f089e3c87df4e6",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3757,2913 +6293,6 @@
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
         "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubSubClass2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Sub sub class 2"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Person"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
-      {
-        "@id": "https://en.wikipedia.org/wiki/Person"
-      },
-      {
-        "@id": "http://schema.org/Person"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
-      },
-      {
-        "@id": "_:Ned1ca74a5a1a442b9152227801ff6bc4"
-      },
-      {
-        "@id": "_:N01bafefe7f7d496f87fa722758710602"
-      },
-      {
-        "@id": "_:Nfb1de3bca5ac4bfc8efd043eea240c27"
-      },
-      {
-        "@id": "_:N24cf145a41ed4ab09d0724c3dcb57050"
-      },
-      {
-        "@id": "_:N3b672bb6897e4929a5fd971134516b44"
-      },
-      {
-        "@id": "_:N207e4bd98c484b25993dc880e6e46864"
-      },
-      {
-        "@id": "_:Na148092f94c74e22bef85fa89849123a"
-      },
-      {
-        "@id": "_:N63d9eb4b69f749b9af8841321da32064"
-      },
-      {
-        "@id": "_:Nc62fd629acae4034a0d50f2b135ab628"
-      },
-      {
-        "@id": "_:N4190216eaf1a409ebb7c38ac296c2bee"
-      },
-      {
-        "@id": "_:Nff967d4c70ca428d931b7918ca1a1520"
-      },
-      {
-        "@id": "_:Nb4b452f4adf34a85bceaedadb0945b96"
-      },
-      {
-        "@id": "_:Ne9dda638857a43ae8e7fed32a3588a0e"
-      },
-      {
-        "@id": "_:Nfda1af3e63d6491c869cdb8673381077"
-      },
-      {
-        "@id": "_:N44b88f4ed01c41f29f438ffac4a6d4bd"
-      },
-      {
-        "@id": "_:Nbdb658e62fd54863bcc59cb83b5502e0"
-      },
-      {
-        "@id": "_:N479e90e4f475463383db1ca0edd9eb43"
-      },
-      {
-        "@id": "_:N9bc56afd4c3d4b75b5e2090dd3c01bbe"
-      },
-      {
-        "@id": "_:Ne522ed6421044dabbe5d8313065a9768"
-      },
-      {
-        "@id": "_:N57dcda8f948a493a83af7e6ff7dbd033"
-      },
-      {
-        "@id": "_:N28874c42cfd2406daecf96a665db222d"
-      },
-      {
-        "@id": "_:N7133a0a545d540d0a7baf02b059a0d68"
-      },
-      {
-        "@id": "_:Ne9ddfedf1a07430e8641d5c83cec0e89"
-      },
-      {
-        "@id": "_:N3223335066a74d36b4ed23c951d9e92c"
-      },
-      {
-        "@id": "_:Nd9ade086ba01499d8e1f00df2b00c956"
-      },
-      {
-        "@id": "_:N652c2d88987946658a0945ae29600050"
-      },
-      {
-        "@id": "_:N9caffeb8162440088766ba77156cb590"
-      },
-      {
-        "@id": "_:N089f6eb5c1164b718c58434729085031"
-      },
-      {
-        "@id": "_:Nd3acd1e4012e442d9ecdc199a857f905"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "A person, living or dead"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#exactMatch": [
-      {
-        "@id": "http://schema.org/Person"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 2
-      }
-    ],
-    "https://w3id.org/linkml/tests/kitchen_sink/fallible": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-        "@value": true
-      }
-    ],
-    "https://w3id.org/linkml/tests/kitchen_sink/opinions": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1000
-      }
-    ],
-    "https://w3id.org/linkml/tests/kitchen_sink/resting": [
-      {
-        "@value": "supine"
-      }
-    ],
-    "https://w3id.org/linkml/tests/kitchen_sink/viewer": [
-      {
-        "@value": "ks:PersonViewer"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ned1ca74a5a1a442b9152227801ff6bc4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses"
-      }
-    ]
-  },
-  {
-    "@id": "_:N01bafefe7f7d496f87fa722758710602",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfb1de3bca5ac4bfc8efd043eea240c27",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nc630d44943f1459aa27f6c99033f82d0"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc630d44943f1459aa27f6c99033f82d0",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#intersectionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "_:N1ce2c0399aff4900bb4c1c4fbb306df7"
-          },
-          {
-            "@id": "_:N67c762084b034fdf8ab20ca987b7d85f"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N1ce2c0399aff4900bb4c1c4fbb306df7",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Nadd1db7707234b269cb5dfcc7d3617b0"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nadd1db7707234b269cb5dfcc7d3617b0",
-    "http://www.w3.org/2001/XMLSchema#minInclusive": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ]
-  },
-  {
-    "@id": "_:N67c762084b034fdf8ab20ca987b7d85f",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Nde21d15beeea4c5b9485c1ed9e1786d9"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nde21d15beeea4c5b9485c1ed9e1786d9",
-    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 999
-      }
-    ]
-  },
-  {
-    "@id": "_:N24cf145a41ed4ab09d0724c3dcb57050",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3b672bb6897e4929a5fd971134516b44",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
-      }
-    ]
-  },
-  {
-    "@id": "_:N207e4bd98c484b25993dc880e6e46864",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na148092f94c74e22bef85fa89849123a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
-      }
-    ]
-  },
-  {
-    "@id": "_:N63d9eb4b69f749b9af8841321da32064",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc62fd629acae4034a0d50f2b135ab628",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4190216eaf1a409ebb7c38ac296c2bee",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nff967d4c70ca428d931b7918ca1a1520",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb4b452f4adf34a85bceaedadb0945b96",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne9dda638857a43ae8e7fed32a3588a0e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfda1af3e63d6491c869cdb8673381077",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history"
-      }
-    ]
-  },
-  {
-    "@id": "_:N44b88f4ed01c41f29f438ffac4a6d4bd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbdb658e62fd54863bcc59cb83b5502e0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N479e90e4f475463383db1ca0edd9eb43",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9bc56afd4c3d4b75b5e2090dd3c01bbe",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne522ed6421044dabbe5d8313065a9768",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
-      }
-    ]
-  },
-  {
-    "@id": "_:N57dcda8f948a493a83af7e6ff7dbd033",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
-      }
-    ]
-  },
-  {
-    "@id": "_:N28874c42cfd2406daecf96a665db222d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N91523f0a5f4c4a67bc7ac529b2007ca5"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N91523f0a5f4c4a67bc7ac529b2007ca5",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N45998bf9f32949a9b42f430faf05c3f7"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N45998bf9f32949a9b42f430faf05c3f7",
-    "http://www.w3.org/2001/XMLSchema#pattern": [
-      {
-        "@value": "^\\S+ \\S+$"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7133a0a545d540d0a7baf02b059a0d68",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne9ddfedf1a07430e8641d5c83cec0e89",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3223335066a74d36b4ed23c951d9e92c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N10f63e130bce411588b7fdfb99008aa5"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N10f63e130bce411588b7fdfb99008aa5",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N4762a9ebf27c4372b1a394049d3565a6"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N4762a9ebf27c4372b1a394049d3565a6",
-    "http://www.w3.org/2001/XMLSchema#pattern": [
-      {
-        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd9ade086ba01499d8e1f00df2b00c956",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N652c2d88987946658a0945ae29600050",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9caffeb8162440088766ba77156cb590",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N1502f17ff5e04e16b6031ecf470295f9"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1502f17ff5e04e16b6031ecf470295f9",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#intersectionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "_:N8ae749a22d7142c8822bc26b63c5b816"
-          },
-          {
-            "@id": "_:N67cddf314160472db0c2b2f57b97bdad"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N8ae749a22d7142c8822bc26b63c5b816",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Ndca2b1dc6c3a4a4298126685f68c8478"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndca2b1dc6c3a4a4298126685f68c8478",
-    "http://www.w3.org/2001/XMLSchema#minInclusive": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "_:N67cddf314160472db0c2b2f57b97bdad",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N5eb3629f7b4f4b4ca24a43f7f65895ca"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N5eb3629f7b4f4b4ca24a43f7f65895ca",
-    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "_:N089f6eb5c1164b718c58434729085031",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd3acd1e4012e442d9ecdc199a857f905",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/was_informed_by",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "was informed by"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#closeMatch": [
-      {
-        "@id": "https://w3id.org/biolink/Disease"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "class with spaces"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Na1963b85e5fd4366aa9c72a38f04ba97"
-      },
-      {
-        "@id": "_:Nba3519c6d1e2415ca6e0547dab3a8370"
-      },
-      {
-        "@id": "_:Nbe0483f401354f1383d50c3d5244f157"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na1963b85e5fd4366aa9c72a38f04ba97",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nba3519c6d1e2415ca6e0547dab3a8370",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbe0483f401354f1383d50c3d5244f157",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "stomach count"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "addresses"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#UNKNOWN",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "UNKNOWN"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_C",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_C"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Company"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
-      },
-      {
-        "@id": "_:N0adb4828d5584b7798dc7adff01989d8"
-      },
-      {
-        "@id": "_:Nd3d662e9ed1e4bc8a59b8e2318005286"
-      },
-      {
-        "@id": "_:N0848bdd97d4045c7a86795f093f07e10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0adb4828d5584b7798dc7adff01989d8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd3d662e9ed1e4bc8a59b8e2318005286",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0848bdd97d4045c7a86795f093f07e10",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has familial relationships"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Relationship"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nccde33a120ec45eb8b5c432ff451d6fa"
-      },
-      {
-        "@id": "_:N0e2fc4cc07c141e8a13bae878113f0d9"
-      },
-      {
-        "@id": "_:N68c907dd018a480684e3dc2964a3fabd"
-      },
-      {
-        "@id": "_:N542b6d64224545b3aaab4418cb148fc1"
-      },
-      {
-        "@id": "_:Na868bde367ab4bd5b98bef5365e502fd"
-      },
-      {
-        "@id": "_:N16146093949843acba2988082ff21453"
-      },
-      {
-        "@id": "_:N336734bf4a7443219583c2ed27816926"
-      },
-      {
-        "@id": "_:N9af64f7b17664315864e47fc23dc89d6"
-      },
-      {
-        "@id": "_:N536607fdfd7442a8b38e2e5987506c3e"
-      },
-      {
-        "@id": "_:Ne00d92f5cada4b47aa075393122a994c"
-      },
-      {
-        "@id": "_:N90adf822661f457e92bebdcd9f7369be"
-      },
-      {
-        "@id": "_:N876d7eefba3940b39cd64f67ce312730"
-      },
-      {
-        "@id": "_:N6cd3c673db4e4d718b5b34943e51be74"
-      },
-      {
-        "@id": "_:Ne6e6a90e495d4be1b1a16baa725d2a1d"
-      },
-      {
-        "@id": "_:N6776334de47e447197d79a5613387c0f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nccde33a120ec45eb8b5c432ff451d6fa",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0e2fc4cc07c141e8a13bae878113f0d9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N68c907dd018a480684e3dc2964a3fabd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N542b6d64224545b3aaab4418cb148fc1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na868bde367ab4bd5b98bef5365e502fd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N16146093949843acba2988082ff21453",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N336734bf4a7443219583c2ed27816926",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9af64f7b17664315864e47fc23dc89d6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N536607fdfd7442a8b38e2e5987506c3e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne00d92f5cada4b47aa075393122a994c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N90adf822661f457e92bebdcd9f7369be",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N876d7eefba3940b39cd64f67ce312730",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6cd3c673db4e4d718b5b34943e51be74",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne6e6a90e495d4be1b1a16baa725d2a1d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6776334de47e447197d79a5613387c0f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "BirthEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:N7b3fd4fb72814ca3b27f1fae4e28bce8"
-      },
-      {
-        "@id": "_:N202f13350e064119ab8150292b78d116"
-      },
-      {
-        "@id": "_:Na0998c078072418ca622bc3ac7f5063e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7b3fd4fb72814ca3b27f1fae4e28bce8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N202f13350e064119ab8150292b78d116",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na0998c078072418ca622bc3ac7f5063e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#LIVING",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "LIVING"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DIRTY"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "test_attribute"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/004",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "TRANSFER"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "transfer internally"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "hateful"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "spiteful"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Ontology"
-    ],
-    "http://purl.org/dc/terms/title": [
-      {
-        "@value": "Kitchen Sink Schema"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
-      {
-        "@id": "https://example.org/"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Kitchen Sink Schema\n\nThis schema does not do anything useful. It exists to test all features of linkml.\n\nThis particular text field exists to demonstrate markdown within a text field:\n\nLists:\n\n   * a\n   * b\n   * c\n\nAnd links, e.g to [Person](Person.md)"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "is current"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Friend",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Friend"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nbc04a6f23f444f14ae16973c18c09752"
-      },
-      {
-        "@id": "_:N46d8f3f0842848c4b6ef240bb102b6ce"
-      },
-      {
-        "@id": "_:N71387ad3157141b58f6fd498a1900b01"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbc04a6f23f444f14ae16973c18c09752",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N46d8f3f0842848c4b6ef240bb102b6ce",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N71387ad3157141b58f6fd498a1900b01",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/used",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "used"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DiagnosisType"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "aliases"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/TubSubClass1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tub sub class 1"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Same depth as Sub sub class 1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/name",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "name"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 2
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/003",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "PROMOTION"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "promotion event"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/life_status",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "life_status"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "diagnosis"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "species name"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "_:N59e4044ebd1b4d7399b2ff024ceabbe9"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N59e4044ebd1b4d7399b2ff024ceabbe9",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N76bc2b3414c444168fac20c8d0da6f99"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N76bc2b3414c444168fac20c8d0da6f99",
-    "http://www.w3.org/2001/XMLSchema#pattern": [
-      {
-        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsString",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EqualsString"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nc3d840c815684d29957d1a052d8697f3"
-      },
-      {
-        "@id": "_:Nc76eb5c67943413a848f519179c3bff0"
-      },
-      {
-        "@id": "_:Nbfe29535b6994e6c816a69ccd3d5bbad"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc3d840c815684d29957d1a052d8697f3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc76eb5c67943413a848f519179c3bff0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbfe29535b6994e6c816a69ccd3d5bbad",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "SIBLING_OF"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/started_at_time",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "started at time"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/agent_set",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "agent set"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/Activity",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "activity"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N01c964fb7b5346cf83a9fa7e2a7bcda3"
-      },
-      {
-        "@id": "_:N090c70cc88a146808b35016d75329205"
-      },
-      {
-        "@id": "_:N235d90f1c50b498fbf905740bf63caa7"
-      },
-      {
-        "@id": "_:Nfb0d679ed2214969915b64c8923a45fc"
-      },
-      {
-        "@id": "_:N239822c07cbd4c25b0c4d41b7390d267"
-      },
-      {
-        "@id": "_:N9dc364e98a704fc3b73844c5827a0e41"
-      },
-      {
-        "@id": "_:Ned9a6ed23dba470d87d8169853307201"
-      },
-      {
-        "@id": "_:Nbb5dc980e9aa4348a73d32c311e83b2f"
-      },
-      {
-        "@id": "_:N390c4f1c923b4dd898a27729e6942feb"
-      },
-      {
-        "@id": "_:Ne063896dad3e4535ba05e0ede3e3f7d1"
-      },
-      {
-        "@id": "_:N734e5cff4c0140c7a8c8bae1946935cc"
-      },
-      {
-        "@id": "_:N602c129f72c84d57adb075c601cbe6f7"
-      },
-      {
-        "@id": "_:N7ff887ec89514a6a858eb5904538640b"
-      },
-      {
-        "@id": "_:N6b09b50765814bd4aa769879e81c1fad"
-      },
-      {
-        "@id": "_:N3aeb07fc792b4a12adda0d9ce5d99f9b"
-      },
-      {
-        "@id": "_:N457deb7185d24995bb1492624f4bedc9"
-      },
-      {
-        "@id": "_:N6866175253b4421588a2256ec845d11d"
-      },
-      {
-        "@id": "_:N940414fe95a14104bf5869a85c1577e1"
-      },
-      {
-        "@id": "_:Nc8afd33a18734619bd6a21a3881aca34"
-      },
-      {
-        "@id": "_:N29600fdefb0e4b97b20771641ad16a6b"
-      },
-      {
-        "@id": "_:N39a8083a0dc0439e831ca7e1053e07d9"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "a provence-generating activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#mappingRelation": [
-      {
-        "@id": "http://www.w3.org/ns/prov#Activity"
-      }
-    ]
-  },
-  {
-    "@id": "_:N01c964fb7b5346cf83a9fa7e2a7bcda3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:N090c70cc88a146808b35016d75329205",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:N235d90f1c50b498fbf905740bf63caa7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfb0d679ed2214969915b64c8923a45fc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N239822c07cbd4c25b0c4d41b7390d267",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9dc364e98a704fc3b73844c5827a0e41",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ned9a6ed23dba470d87d8169853307201",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbb5dc980e9aa4348a73d32c311e83b2f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N390c4f1c923b4dd898a27729e6942feb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne063896dad3e4535ba05e0ede3e3f7d1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N734e5cff4c0140c7a8c8bae1946935cc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N602c129f72c84d57adb075c601cbe6f7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7ff887ec89514a6a858eb5904538640b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6b09b50765814bd4aa769879e81c1fad",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3aeb07fc792b4a12adda0d9ce5d99f9b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:N457deb7185d24995bb1492624f4bedc9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6866175253b4421588a2256ec845d11d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N940414fe95a14104bf5869a85c1577e1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc8afd33a18734619bd6a21a3881aca34",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:N29600fdefb0e4b97b20771641ad16a6b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:N39a8083a0dc0439e831ca7e1053e07d9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute2"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/002",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FIRE"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ],
-    "https://w3id.org/biolink/opposite": [
-      {
-        "@value": "HIRE"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Address"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N24bb14196a04496b8649482da6dfc325"
-      },
-      {
-        "@id": "_:N3a55ee484e214af8b76555b3058bf960"
-      },
-      {
-        "@id": "_:N2685098bbcca4245bfdd1ec93427b222"
-      },
-      {
-        "@id": "_:Nfc192c7b20e54a58a1460360022ccfb8"
-      },
-      {
-        "@id": "_:N42faf5e4bb80415fb698ad8cc5e7f177"
-      },
-      {
-        "@id": "_:Ncc311f278d624322af625da34e2331bf"
-      },
-      {
-        "@id": "_:Nf81788bfe4b848a0b02b1451edb41dca"
-      },
-      {
-        "@id": "_:N47e3d79e858441e5bf16aa25aecf5096"
-      },
-      {
-        "@id": "_:N5bdc0947b21a421dbd4f82f6573d4625"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N24bb14196a04496b8649482da6dfc325",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3a55ee484e214af8b76555b3058bf960",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2685098bbcca4245bfdd1ec93427b222",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfc192c7b20e54a58a1460360022ccfb8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:N42faf5e4bb80415fb698ad8cc5e7f177",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncc311f278d624322af625da34e2331bf",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf81788bfe4b848a0b02b1451edb41dca",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "_:N47e3d79e858441e5bf16aa25aecf5096",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5bdc0947b21a421dbd4f82f6573d4625",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "subclass test"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
-      },
-      {
-        "@id": "_:N1b7da9cf531f49cda31c7ef945da247e"
-      },
-      {
-        "@id": "_:N5bb08cc761774c50b8d68689d70128c0"
-      },
-      {
-        "@id": "_:Nc6f1027a6a1b4781ba79dc2cbcfae462"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1b7da9cf531f49cda31c7ef945da247e",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5bb08cc761774c50b8d68689d70128c0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc6f1027a6a1b4781ba79dc2cbcfae462",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
       }
     ]
   },
@@ -6710,13 +6339,13 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "slot with space 1"
+        "@value": "attribute4"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -6726,68 +6355,27 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/id",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "id"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "PARENT_OF"
+        "@value": "subclass test"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "MarriageEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
       },
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation"
+        "@id": "_:N729601f5f875433d9228a7f6ece4f01f"
       },
       {
-        "@id": "_:Nf0edd5b83e4c46b59897507c36fd150b"
+        "@id": "_:N43899e31d369448db7a1e2f3146480f0"
       },
       {
-        "@id": "_:Nd38062650c644e0aa2add50f14f844d6"
-      },
-      {
-        "@id": "_:N2385bb71aa4b48b2a784fcf92e821921"
+        "@id": "_:N0e42f05150044fc88bd83518f69be164"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -6797,23 +6385,23 @@
     ]
   },
   {
-    "@id": "_:Nf0edd5b83e4c46b59897507c36fd150b",
+    "@id": "_:N729601f5f875433d9228a7f6ece4f01f",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
       }
     ]
   },
   {
-    "@id": "_:Nd38062650c644e0aa2add50f14f844d6",
+    "@id": "_:N43899e31d369448db7a1e2f3146480f0",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -6825,12 +6413,12 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
       }
     ]
   },
   {
-    "@id": "_:N2385bb71aa4b48b2a784fcf92e821921",
+    "@id": "_:N0e42f05150044fc88bd83518f69be164",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -6842,28 +6430,488 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "has birth event"
+        "@value": "MedicalEvent"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:Nb2605928f2594230ab346fc66138cd0e"
+      },
+      {
+        "@id": "_:N5f09b42398454ab089b3025639401fcc"
+      },
+      {
+        "@id": "_:N0979926d819c4e46997b7181a0915afb"
+      },
+      {
+        "@id": "_:N0f56bac7628f4f829378fd17b963d8cd"
+      },
+      {
+        "@id": "_:N3d89b7ba316f441ba2ee2e1c674ee53f"
+      },
+      {
+        "@id": "_:N61ab1fa2b8df401b9acd4314c61e7ecf"
+      },
+      {
+        "@id": "_:N9dbe2e88612d4baaad596c7a5193c092"
+      },
+      {
+        "@id": "_:N4d62e1bfd0c747169422fd9a565b8e8d"
+      },
+      {
+        "@id": "_:Nf395b8d4cf2442708f2e08f8a442d549"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb2605928f2594230ab346fc66138cd0e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5f09b42398454ab089b3025639401fcc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0979926d819c4e46997b7181a0915afb",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0f56bac7628f4f829378fd17b963d8cd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3d89b7ba316f441ba2ee2e1c674ee53f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N61ab1fa2b8df401b9acd4314c61e7ecf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9dbe2e88612d4baaad596c7a5193c092",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4d62e1bfd0c747169422fd9a565b8e8d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf395b8d4cf2442708f2e08f8a442d549",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "is current"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FamilialRelationship"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship"
+      },
+      {
+        "@id": "_:N8480a346e86e4230b38c14b70618c2db"
+      },
+      {
+        "@id": "_:N6a19510d8ad64b4a99137bfb1a2e8eec"
+      },
+      {
+        "@id": "_:N172e61288bf74fd9887a27e5b5cd8cd8"
+      },
+      {
+        "@id": "_:Ne1a55a77fddc460b94e195a2fcf44707"
+      },
+      {
+        "@id": "_:N959779dcba31429192d35a07f5e72b40"
+      },
+      {
+        "@id": "_:N146c4e3d31194d18a401ac9588c69835"
+      },
+      {
+        "@id": "_:N88ac4b049fff40a8aa22c3eca1b002d5"
+      },
+      {
+        "@id": "_:N085aef4392d04db09f392d18aa003c15"
+      },
+      {
+        "@id": "_:Nc12b66c19cff4730aa33a48f9378f050"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 5
+      }
+    ]
+  },
+  {
+    "@id": "_:N8480a346e86e4230b38c14b70618c2db",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6a19510d8ad64b4a99137bfb1a2e8eec",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N172e61288bf74fd9887a27e5b5cd8cd8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne1a55a77fddc460b94e195a2fcf44707",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N959779dcba31429192d35a07f5e72b40",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N146c4e3d31194d18a401ac9588c69835",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N88ac4b049fff40a8aa22c3eca1b002d5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N085aef4392d04db09f392d18aa003c15",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc12b66c19cff4730aa33a48f9378f050",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "companies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "addresses"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/used",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "used"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
       }
     ]
   }

--- a/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl.n3
+++ b/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl.n3
@@ -48,53 +48,53 @@ And links, e.g to [Person](Person.md)""" .
 ks:AnyOfClasses a owl:Class ;
     rdfs:label "AnyOfClasses" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom [ owl:unionOf ( ks:Person ks:Organization ) ] ;
+            owl:onProperty ks:attribute2 ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute2 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute2 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( ks:Person ks:Organization ) ] ;
             owl:onProperty ks:attribute2 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfEnums a owl:Class ;
     rdfs:label "AnyOfEnums" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:attribute3 ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:DiagnosisType ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:attribute3 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute3 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfMix a owl:Class ;
     rdfs:label "AnyOfMix" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute4 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfSimpleType a owl:Class ;
     rdfs:label "AnyOfSimpleType" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:unionOf ( xsd:string xsd:integer ) ] ;
-            owl:onProperty ks:attribute1 ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute1 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:attribute1 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:unionOf ( xsd:string xsd:integer ) ] ;
             owl:onProperty ks:attribute1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -102,10 +102,13 @@ ks:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:persons ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:persons ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:activities ],
@@ -113,66 +116,64 @@ ks:Dataset a owl:Class ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty ks:activities ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:AnyObject ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Company ;
-            owl:onProperty ks:companies ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:code_systems ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
-            owl:onProperty ks:persons ] ;
+            owl:allValuesFrom ks:AnyObject ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Company ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 1 .
 
 ks:EqualsString a owl:Class ;
     rdfs:label "EqualsString" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:oneOf ( "foo" ) ] ;
             owl:onProperty ks:attribute5 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:EqualsStringIn a owl:Class ;
     rdfs:label "EqualsStringIn" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:oneOf ( "foo" "bar" ) ] ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:oneOf ( "foo" "bar" ) ] ;
             owl:onProperty ks:attribute6 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FakeClass a owl:Class ;
     rdfs:label "FakeClass" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:test_attribute ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -226,10 +227,10 @@ ks:MarriageEvent a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:married_to ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:married_to ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:married_to ],
         ks:Event,
         ks:WithLocation ;
@@ -247,14 +248,41 @@ ks:OtherCodes a owl:Class ;
 ks:Relationship a owl:Class ;
     rdfs:label "Relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:related_to ],
@@ -263,46 +291,19 @@ ks:Relationship a owl:Class ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
+            owl:onProperty ks:type ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:WithLocation a owl:Class ;
     rdfs:label "WithLocation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -342,31 +343,31 @@ bizcodes:004 a owl:Class ;
 ks:Address a owl:Class ;
     rdfs:label "Address" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:city ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:street ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:altitude ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:street ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:decimal ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:city ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -376,10 +377,10 @@ ks:BirthEvent a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -387,41 +388,41 @@ ks:BirthEvent a owl:Class ;
 ks:ClassWithSpaces a owl:Class ;
     rdfs:label "class with spaces" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:slot_with_space_1 ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:slot_with_space_1 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Concept a owl:Class ;
     rdfs:label "Concept" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_code_system ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -457,11 +458,8 @@ ks:DiagnosisType a owl:Class ;
 ks:EmploymentEvent a owl:Class ;
     rdfs:label "EmploymentEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:employed_at ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
             owl:onProperty ks:type ],
@@ -469,8 +467,11 @@ ks:EmploymentEvent a owl:Class ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:employed_at ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:type ],
@@ -482,31 +483,31 @@ ks:FamilialRelationship a owl:Class ;
     rdfs:label "FamilialRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty ks:related_to ],
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationshipType ;
-            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationshipType ;
             owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:related_to ],
         ks:Relationship ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 5 .
@@ -554,22 +555,19 @@ ks:MedicalEvent a owl:Class ;
     rdfs:label "MedicalEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:diagnosis ],
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:ProcedureConcept ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:procedure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_location ],
+            owl:allValuesFrom ks:DiagnosisConcept ;
+            owl:onProperty ks:diagnosis ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:procedure ],
@@ -577,7 +575,10 @@ ks:MedicalEvent a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:diagnosis ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:DiagnosisConcept ;
+            owl:allValuesFrom ks:Place ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:diagnosis ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -585,23 +586,23 @@ ks:MedicalEvent a owl:Class ;
 ks:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:definition """An organization.
 
@@ -624,13 +625,13 @@ ks:ProcedureConcept a owl:Class ;
 ks:SubclassTest a owl:Class ;
     rdfs:label "subclass test" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:ClassWithSpaces ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:ClassWithSpaces ;
             owl:onProperty ks:slot_with_space_2 ],
         ks:ClassWithSpaces ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -705,23 +706,23 @@ ks:AnyObject a owl:Class ;
 ks:CodeSystem a owl:Class ;
     rdfs:label "CodeSystem" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Company a owl:Class ;
@@ -730,10 +731,10 @@ ks:Company a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:ceo ],
         ks:Organization ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -866,41 +867,41 @@ ks:test_attribute a owl:DatatypeProperty ;
 ks:Event a owl:Class ;
     rdfs:label "Event" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:is_current ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:boolean ;
             owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_current ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FamilialRelationshipType a owl:Class ;
@@ -914,17 +915,17 @@ ks:FamilialRelationshipType a owl:Class ;
 ks:Place a owl:Class ;
     rdfs:label "Place" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
@@ -937,32 +938,32 @@ ks:Place a owl:Class ;
 <https://w3id.org/linkml/tests/core/Agent> a owl:Class ;
     rdfs:label "agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ] ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:definition "a provence-generating agent" ;
     skos:exactMatch prov:Agent ;
     skos:inScheme <https://w3id.org/linkml/tests/core> .
@@ -1005,17 +1006,35 @@ ks:related_to a owl:DatatypeProperty ;
 <https://w3id.org/linkml/tests/core/Activity> a owl:Class ;
     rdfs:label "activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
@@ -1024,49 +1043,31 @@ ks:related_to a owl:DatatypeProperty ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ] ;
     skos:definition "a provence-generating activity" ;
     skos:inScheme <https://w3id.org/linkml/tests/core> ;
     skos:mappingRelation prov:Activity .
@@ -1087,75 +1088,35 @@ ks:Person a owl:Class ;
     rdfs:seeAlso schema1:Person,
         <https://en.wikipedia.org/wiki/Person> ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:BirthEvent ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( [ a rdfs:Datatype ;
+                                owl:oneOf ( "human" ) ] [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:string ;
+                                owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ) ] ;
+            owl:onProperty ks:species_name ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_medical_history ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Address ;
-            owl:onProperty ks:addresses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+                    owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:EmploymentEvent ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:addresses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationship ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 1 ] ) ] [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:maxInclusive 1 ] ) ] ) ] ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:LifeStatusEnum ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1165,28 +1126,70 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
             owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:BirthEvent ;
-            owl:onProperty ks:has_birth_event ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:stomach_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationship ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:EmploymentEvent ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:has_birth_event ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:stomach_count ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:MedicalEvent ;
             owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Address ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:stomach_count ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:species_name ],
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:minInclusive 1 ] ) ] [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:integer ;
+                                owl:withRestrictions ( [ xsd:maxInclusive 1 ] ) ] ) ] ;
+            owl:onProperty ks:stomach_count ],
         ks:HasAliases ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;

--- a/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl.ttl
+++ b/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl.ttl
@@ -61,10 +61,10 @@ ks:AnyOfClasses a owl:Class ;
 ks:AnyOfEnums a owl:Class ;
     rdfs:label "AnyOfEnums" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:DiagnosisType ks:EmploymentEventType ) ] ;
@@ -77,10 +77,10 @@ ks:AnyOfMix a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute4 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -90,31 +90,19 @@ ks:AnyOfSimpleType a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute1 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute1 ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:unionOf ( xsd:string xsd:integer ) ] ;
+            owl:onProperty ks:attribute1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
-            owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:persons ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:companies ],
@@ -122,70 +110,83 @@ ks:Dataset a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:activities ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty ks:activities ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:AnyObject ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:persons ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
-            owl:onProperty ks:persons ] ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:persons ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:CodeSystem ;
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty ks:activities ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 1 .
 
 ks:EqualsString a owl:Class ;
     rdfs:label "EqualsString" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:attribute5 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:oneOf ( "foo" ) ] ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute5 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:attribute5 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:EqualsStringIn a owl:Class ;
     rdfs:label "EqualsStringIn" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute6 ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:oneOf ( "foo" "bar" ) ] ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:attribute6 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute6 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FakeClass a owl:Class ;
     rdfs:label "FakeClass" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:test_attribute ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:test_attribute ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:test_attribute ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Friend a owl:Class ;
     rdfs:label "Friend" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -223,13 +224,13 @@ ks:tree_slot_C a owl:DatatypeProperty ;
 ks:MarriageEvent a owl:Class ;
     rdfs:label "MarriageEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:married_to ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:married_to ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:married_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:married_to ],
         ks:Event,
         ks:WithLocation ;
@@ -248,58 +249,58 @@ ks:Relationship a owl:Class ;
     rdfs:label "Relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CordialnessEnum ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:type ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:WithLocation a owl:Class ;
     rdfs:label "WithLocation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -342,8 +343,17 @@ bizcodes:004 a owl:Class ;
 ks:Address a owl:Class ;
     rdfs:label "Address" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:city ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:city ],
@@ -351,23 +361,14 @@ ks:Address a owl:Class ;
             owl:allValuesFrom xsd:decimal ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:altitude ] ;
+            owl:onProperty ks:street ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:BirthEvent a owl:Class ;
@@ -376,10 +377,10 @@ ks:BirthEvent a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -387,45 +388,45 @@ ks:BirthEvent a owl:Class ;
 ks:ClassWithSpaces a owl:Class ;
     rdfs:label "class with spaces" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:slot_with_space_1 ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:slot_with_space_1 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Concept a owl:Class ;
     rdfs:label "Concept" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_code_system ] ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 <https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful> a owl:Class ;
@@ -457,23 +458,23 @@ ks:DiagnosisType a owl:Class ;
 ks:EmploymentEvent a owl:Class ;
     rdfs:label "EmploymentEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:employed_at ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:employed_at ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Company ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
+            owl:allValuesFrom ks:Company ;
+            owl:onProperty ks:employed_at ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 6 .
@@ -487,26 +488,26 @@ ks:FamilialRelationship a owl:Class ;
             owl:minCardinality 1 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationshipType ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
+            owl:allValuesFrom ks:FamilialRelationshipType ;
+            owl:onProperty ks:type ],
         ks:Relationship ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 5 .
@@ -554,31 +555,31 @@ ks:MedicalEvent a owl:Class ;
     rdfs:label "MedicalEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_location ],
+            owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:procedure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:procedure ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:DiagnosisConcept ;
             owl:onProperty ks:diagnosis ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:procedure ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ks:ProcedureConcept ;
             owl:onProperty ks:procedure ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:diagnosis ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -586,18 +587,18 @@ ks:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
@@ -624,13 +625,13 @@ ks:ProcedureConcept a owl:Class ;
 ks:SubclassTest a owl:Class ;
     rdfs:label "subclass test" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:ClassWithSpaces ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:ClassWithSpaces ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_2 ],
         ks:ClassWithSpaces ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -705,22 +706,22 @@ ks:AnyObject a owl:Class ;
 ks:CodeSystem a owl:Class ;
     rdfs:label "CodeSystem" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -866,40 +867,40 @@ ks:test_attribute a owl:DatatypeProperty ;
 ks:Event a owl:Class ;
     rdfs:label "Event" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:is_current ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:boolean ;
             owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -914,22 +915,22 @@ ks:FamilialRelationshipType a owl:Class ;
 ks:Place a owl:Class ;
     rdfs:label "Place" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         ks:HasAliases ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -938,31 +939,31 @@ ks:Place a owl:Class ;
     rdfs:label "agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:definition "a provence-generating agent" ;
     skos:exactMatch prov:Agent ;
     skos:inScheme <https://w3id.org/linkml/tests/core> .
@@ -1005,68 +1006,68 @@ ks:related_to a owl:DatatypeProperty ;
 <https://w3id.org/linkml/tests/core/Activity> a owl:Class ;
     rdfs:label "activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ] ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:definition "a provence-generating activity" ;
     skos:inScheme <https://w3id.org/linkml/tests/core> ;
     skos:mappingRelation prov:Activity .
@@ -1087,14 +1088,64 @@ ks:Person a owl:Class ;
     rdfs:seeAlso schema1:Person,
         <https://en.wikipedia.org/wiki/Person> ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_medical_history ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationship ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:EmploymentEvent ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:onDatatype xsd:string ;
+                    owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Address ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:BirthEvent ;
             owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_familial_relationships ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1104,72 +1155,8 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 1 ] ) ] ) ] ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:MedicalEvent ;
-            owl:onProperty ks:has_medical_history ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:EmploymentEvent ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_medical_history ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:LifeStatusEnum ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationship ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:addresses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1179,14 +1166,30 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
             owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:has_birth_event ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:stomach_count ],
+            owl:allValuesFrom ks:MedicalEvent ;
+            owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Address ;
-            owl:onProperty ks:addresses ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( [ a rdfs:Datatype ;
+                                owl:oneOf ( "human" ) ] [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:string ;
+                                owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ) ] ;
+            owl:onProperty ks:species_name ],
         ks:HasAliases ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;

--- a/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.jsonld
+++ b/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.jsonld
@@ -1,38 +1,12 @@
 [
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/type",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "heartfelt"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "warm and hearty friendliness"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+        "@value": "type"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -42,18 +16,34 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DEAD"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "employed at"
+        "@value": "in code system"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -63,53 +53,39 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Dataset",
+    "@id": "https://w3id.org/linkml/tests/core/started_at_time",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Dataset"
+        "@value": "started at time"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "_:N2b73d5309e734e11903900da0f690575"
-      },
-      {
-        "@id": "_:N6cc717f50edf4da68892cb7aa6ce43c1"
-      },
-      {
-        "@id": "_:N3df87046ee05401cb13e6dfa37baac2d"
-      },
-      {
-        "@id": "_:N2e701e3d28d04e15959d7f2a13f3b457"
-      },
-      {
-        "@id": "_:N42d31ae84e384f0da9a3e57313addb2a"
-      },
-      {
-        "@id": "_:N71857d445ea0480d93c5dd538e2513de"
-      },
-      {
-        "@id": "_:N00d1d49f4b484842b638a0bcce1669e8"
-      },
-      {
-        "@id": "_:Nf1035d7918ca42d2bac089d33cadc2b0"
-      },
-      {
-        "@id": "_:N42ddea0dd2404e179ac1ba5651d5439c"
-      },
-      {
-        "@id": "_:Ne890c10f52d14884bf3948e04271d101"
-      },
-      {
-        "@id": "_:Nbcb17e7071f843e0b2f5c0bc59f8a850"
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/id",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "id"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
       }
     ],
     "http://www.w3.org/ns/shacl#order": [
@@ -120,206 +96,24 @@
     ]
   },
   {
-    "@id": "_:N2b73d5309e734e11903900da0f690575",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6cc717f50edf4da68892cb7aa6ce43c1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3df87046ee05401cb13e6dfa37baac2d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2e701e3d28d04e15959d7f2a13f3b457",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
-      }
-    ]
-  },
-  {
-    "@id": "_:N42d31ae84e384f0da9a3e57313addb2a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
-      }
-    ]
-  },
-  {
-    "@id": "_:N71857d445ea0480d93c5dd538e2513de",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
-      }
-    ]
-  },
-  {
-    "@id": "_:N00d1d49f4b484842b638a0bcce1669e8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf1035d7918ca42d2bac089d33cadc2b0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:N42ddea0dd2404e179ac1ba5651d5439c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne890c10f52d14884bf3948e04271d101",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbcb17e7071f843e0b2f5c0bc59f8a850",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FakeClass",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "WithLocation"
+        "@value": "FakeClass"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N005b090038f847399cfd04f7eec46641"
+        "@id": "_:N78ee88959e08433fa0b194b5d4b73eac"
       },
       {
-        "@id": "_:Nc5191c8a342a452a8066b36e3710b43f"
+        "@id": "_:N7e055aff65c049678d66cabc9395b155"
       },
       {
-        "@id": "_:N2c70d214022f40aa9efbb7e8b0146ced"
+        "@id": "_:Nf4b34c2c24f84de4bdc61dea1584d841"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -329,23 +123,23 @@
     ]
   },
   {
-    "@id": "_:N005b090038f847399cfd04f7eec46641",
+    "@id": "_:N78ee88959e08433fa0b194b5d4b73eac",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
       }
     ]
   },
   {
-    "@id": "_:Nc5191c8a342a452a8066b36e3710b43f",
+    "@id": "_:N7e055aff65c049678d66cabc9395b155",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -357,12 +151,12 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
       }
     ]
   },
   {
-    "@id": "_:N2c70d214022f40aa9efbb7e8b0146ced",
+    "@id": "_:Nf4b34c2c24f84de4bdc61dea1584d841",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -374,28 +168,124 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "acted on behalf of"
+        "@value": "has medical history"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
-        "@id": "https://w3id.org/linkml/tests/core"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 5
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "other codes"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "hateful"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "spiteful"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "mixin_slot_I"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "cordialness"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ceo"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -406,12 +296,12 @@
     ],
     "http://www.w3.org/2002/07/owl#equivalentClass": [
       {
-        "@id": "_:N255f89ce799b4d47b45f87102dfc53e0"
+        "@id": "_:N2cbbe78bf10d4fc2b60649d47ee38f20"
       }
     ]
   },
   {
-    "@id": "_:N255f89ce799b4d47b45f87102dfc53e0",
+    "@id": "_:N2cbbe78bf10d4fc2b60649d47ee38f20",
     "@type": [
       "http://www.w3.org/2000/01/rdf-schema#Datatype"
     ],
@@ -424,17 +314,1260 @@
       {
         "@list": [
           {
-            "@id": "_:N4acffdc9e6ae45668f167f49fa904c18"
+            "@id": "_:N3f917d21a8a248709dd13fe44db093ea"
           }
         ]
       }
     ]
   },
   {
-    "@id": "_:N4acffdc9e6ae45668f167f49fa904c18",
+    "@id": "_:N3f917d21a8a248709dd13fe44db093ea",
     "http://www.w3.org/2001/XMLSchema#pattern": [
       {
         "@value": "^[\\\\+\\\\d+ +][\\\\d\\\\- ]+$"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_C",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_C"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/was_generated_by",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was generated by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "aliases"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/was_informed_by",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was informed by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Person"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+      {
+        "@id": "https://en.wikipedia.org/wiki/Person"
+      },
+      {
+        "@id": "http://schema.org/Person"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:Naa7564f36f544412af6cb4bf282c2f01"
+      },
+      {
+        "@id": "_:Nb760b761d4ed43e594c37e28d8e3a0a0"
+      },
+      {
+        "@id": "_:N57ae1c61c8704b09b1bf0e1a21b2db77"
+      },
+      {
+        "@id": "_:Nb35065c18a1648eaaa71f02e3bf34cae"
+      },
+      {
+        "@id": "_:N256b52cc11364aeca7eae1e9ac1251ba"
+      },
+      {
+        "@id": "_:N023f4562f29a43bd9f5c3c21320ecca1"
+      },
+      {
+        "@id": "_:Nd40eff9144424d33b3dee1f69eb01722"
+      },
+      {
+        "@id": "_:Ncc353b3bb83041869213dfd1a97178b1"
+      },
+      {
+        "@id": "_:N6de87f527e844f69ae5611bf8cf516bc"
+      },
+      {
+        "@id": "_:N62eda5633ffc437582980a9358758146"
+      },
+      {
+        "@id": "_:Na170a89c9a8f4810adc2b0c182f53d96"
+      },
+      {
+        "@id": "_:Ne47f7f3a778644b4baafb92ef00fe4ba"
+      },
+      {
+        "@id": "_:Nb3303b2bc3aa477196b34e4e4bc4f821"
+      },
+      {
+        "@id": "_:Nb1498e466588419f911b68c782ffdfad"
+      },
+      {
+        "@id": "_:N433956c4316f4d8d9fd473dce39df7fe"
+      },
+      {
+        "@id": "_:Nbfc7048e62cb425280bee4239a6f5ad9"
+      },
+      {
+        "@id": "_:N275c31bf49a14b84b9269dd27da288ef"
+      },
+      {
+        "@id": "_:Neac6019ff6a240c99ed641ae815ac2e5"
+      },
+      {
+        "@id": "_:N3792130989204793b29d159e93ba2299"
+      },
+      {
+        "@id": "_:Nb120d6fecdef417ea7395c0163b5a649"
+      },
+      {
+        "@id": "_:Nb0957745de5447ada5f16048bbec0bf9"
+      },
+      {
+        "@id": "_:N6dc3e538d9b34f02864d6ff61995954d"
+      },
+      {
+        "@id": "_:N585884a3d6834d2d8011579a0f7e2328"
+      },
+      {
+        "@id": "_:N6a6a95ad7b1645288bd5f334b00a36e2"
+      },
+      {
+        "@id": "_:N32605c413f514e8a855caf967a48aad4"
+      },
+      {
+        "@id": "_:N1d66fc207ab24c5589e9e1ad1fade30e"
+      },
+      {
+        "@id": "_:Nbc20d3701c2a4c588cc8480da2f9fa56"
+      },
+      {
+        "@id": "_:Nf8aad7a9aa4a4cb69a97ce720624786e"
+      },
+      {
+        "@id": "_:N4c3d087b4d64479a9e0eddb403f9cd42"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A person, living or dead"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#exactMatch": [
+      {
+        "@id": "http://schema.org/Person"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 2
+      }
+    ],
+    "https://w3id.org/linkml/tests/kitchen_sink/fallible": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": true
+      }
+    ],
+    "https://w3id.org/linkml/tests/kitchen_sink/opinions": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1000
+      }
+    ],
+    "https://w3id.org/linkml/tests/kitchen_sink/resting": [
+      {
+        "@value": "supine"
+      }
+    ],
+    "https://w3id.org/linkml/tests/kitchen_sink/viewer": [
+      {
+        "@value": "ks:PersonViewer"
+      }
+    ]
+  },
+  {
+    "@id": "_:Naa7564f36f544412af6cb4bf282c2f01",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb760b761d4ed43e594c37e28d8e3a0a0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses"
+      }
+    ]
+  },
+  {
+    "@id": "_:N57ae1c61c8704b09b1bf0e1a21b2db77",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N453e02499c4e4aa3912c4b14075cdaef"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
+      }
+    ]
+  },
+  {
+    "@id": "_:N453e02499c4e4aa3912c4b14075cdaef",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#intersectionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "_:N437e3bc442d24a5ba7f5f5ff2d8b35b7"
+          },
+          {
+            "@id": "_:Nbc05fa40bd4142038a43f61854d81191"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N437e3bc442d24a5ba7f5f5ff2d8b35b7",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N432914d129fa4f69bf2c81dbb1121df6"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N432914d129fa4f69bf2c81dbb1121df6",
+    "http://www.w3.org/2001/XMLSchema#minInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbc05fa40bd4142038a43f61854d81191",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N52594f09ddd94ba0b3df0a0579a72933"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N52594f09ddd94ba0b3df0a0579a72933",
+    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 999
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb35065c18a1648eaaa71f02e3bf34cae",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
+      }
+    ]
+  },
+  {
+    "@id": "_:N256b52cc11364aeca7eae1e9ac1251ba",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
+      }
+    ]
+  },
+  {
+    "@id": "_:N023f4562f29a43bd9f5c3c21320ecca1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd40eff9144424d33b3dee1f69eb01722",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncc353b3bb83041869213dfd1a97178b1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6de87f527e844f69ae5611bf8cf516bc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history"
+      }
+    ]
+  },
+  {
+    "@id": "_:N62eda5633ffc437582980a9358758146",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na170a89c9a8f4810adc2b0c182f53d96",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne47f7f3a778644b4baafb92ef00fe4ba",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb3303b2bc3aa477196b34e4e4bc4f821",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb1498e466588419f911b68c782ffdfad",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history"
+      }
+    ]
+  },
+  {
+    "@id": "_:N433956c4316f4d8d9fd473dce39df7fe",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbfc7048e62cb425280bee4239a6f5ad9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N275c31bf49a14b84b9269dd27da288ef",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Neac6019ff6a240c99ed641ae815ac2e5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3792130989204793b29d159e93ba2299",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb120d6fecdef417ea7395c0163b5a649",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb0957745de5447ada5f16048bbec0bf9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nbeee0e9c88d340b19793150265393104"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbeee0e9c88d340b19793150265393104",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:Neb82331b9eef44c58d75a62f742dae93"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Neb82331b9eef44c58d75a62f742dae93",
+    "http://www.w3.org/2001/XMLSchema#pattern": [
+      {
+        "@value": "^\\S+ \\S+$"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6dc3e538d9b34f02864d6ff61995954d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N585884a3d6834d2d8011579a0f7e2328",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6a6a95ad7b1645288bd5f334b00a36e2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nfb9581cab0ea4901ba63d972a1663925"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfb9581cab0ea4901ba63d972a1663925",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#intersectionOf": [
+      {
+        "@list": [
+          {
+            "@id": "_:N6e7c9b640f004d1f8536e96cc30e8bf6"
+          },
+          {
+            "@id": "_:N521e02c0fc7d43e9846571f7b6b87eda"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N6e7c9b640f004d1f8536e96cc30e8bf6",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#oneOf": [
+      {
+        "@list": [
+          {
+            "@value": "human"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N521e02c0fc7d43e9846571f7b6b87eda",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N3af4b4c46d7c42f7b68f7d6308af43ba"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N3af4b4c46d7c42f7b68f7d6308af43ba",
+    "http://www.w3.org/2001/XMLSchema#pattern": [
+      {
+        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
+      }
+    ]
+  },
+  {
+    "@id": "_:N32605c413f514e8a855caf967a48aad4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1d66fc207ab24c5589e9e1ad1fade30e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbc20d3701c2a4c588cc8480da2f9fa56",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N3349f23a58a74339bb680d6589628925"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3349f23a58a74339bb680d6589628925",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#intersectionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "_:N7ae9f1a2518449c9b5b04e8c50ad9760"
+          },
+          {
+            "@id": "_:Ne1b7568b908a44209b2f9bfe54468029"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N7ae9f1a2518449c9b5b04e8c50ad9760",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N0ec0b6416381447699ca705f59b2e9bc"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N0ec0b6416381447699ca705f59b2e9bc",
+    "http://www.w3.org/2001/XMLSchema#minInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne1b7568b908a44209b2f9bfe54468029",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:N78e313e3acb84d0cb3d7cb5a589cd183"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N78e313e3acb84d0cb3d7cb5a589cd183",
+    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf8aad7a9aa4a4cb69a97ce720624786e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4c3d087b4d64479a9e0eddb403f9cd42",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "KitchenStatus"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+          }
+        ]
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
+      },
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/002",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FIRE"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ],
+    "https://w3id.org/biolink/opposite": [
+      {
+        "@value": "HIRE"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/Agent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "agent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N5e11fdddae064d46a37f99259d2807e2"
+      },
+      {
+        "@id": "_:N831eb2b0afbd4deb963ba953d45ef57d"
+      },
+      {
+        "@id": "_:Na05e5d50fa2046108fa3047e25acbc17"
+      },
+      {
+        "@id": "_:N4aff9d5652e744ccb3b393f05136e819"
+      },
+      {
+        "@id": "_:N12b78f1bb59e4b268533fc81dce624f4"
+      },
+      {
+        "@id": "_:N9e4752ac9c3940288fd8dcae567e66e4"
+      },
+      {
+        "@id": "_:N910d64eb15e34b18a2c18157c194fd9f"
+      },
+      {
+        "@id": "_:N7845eb771c3f470080ebe0223efeef72"
+      },
+      {
+        "@id": "_:Nb9c600d5f5144507a9ff4f7a2aeda8af"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "a provence-generating agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#exactMatch": [
+      {
+        "@id": "http://www.w3.org/ns/prov#Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5e11fdddae064d46a37f99259d2807e2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:N831eb2b0afbd4deb963ba953d45ef57d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na05e5d50fa2046108fa3047e25acbc17",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4aff9d5652e744ccb3b393f05136e819",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N12b78f1bb59e4b268533fc81dce624f4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9e4752ac9c3940288fd8dcae567e66e4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N910d64eb15e34b18a2c18157c194fd9f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7845eb771c3f470080ebe0223efeef72",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb9c600d5f5144507a9ff4f7a2aeda8af",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "persons"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
@@ -497,430 +1630,18 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship"
-      },
-      {
-        "@id": "_:N0610632bb50543d19418061ed6fb8dce"
-      },
-      {
-        "@id": "_:N9edf74df67b045b7bfda40fa5dbb7a03"
-      },
-      {
-        "@id": "_:N3cbfb66a2b814ff4a65791773296b07d"
-      },
-      {
-        "@id": "_:Ne78e03bb53aa4da5a2a8d6fbde30cc08"
-      },
-      {
-        "@id": "_:N8b576cf628cb4fde81ad69570b09bcae"
-      },
-      {
-        "@id": "_:N1aaf9e2537844ae0a1c7263563baf288"
-      },
-      {
-        "@id": "_:Nd3275121b6a242e197188f63eae85baa"
-      },
-      {
-        "@id": "_:Na521528741db43ffb71d6e8b3dd36aef"
-      },
-      {
-        "@id": "_:N8f4d555c603247508f0fd4ef4e1e664b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 5
-      }
-    ]
-  },
-  {
-    "@id": "_:N0610632bb50543d19418061ed6fb8dce",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9edf74df67b045b7bfda40fa5dbb7a03",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3cbfb66a2b814ff4a65791773296b07d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne78e03bb53aa4da5a2a8d6fbde30cc08",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8b576cf628cb4fde81ad69570b09bcae",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1aaf9e2537844ae0a1c7263563baf288",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd3275121b6a242e197188f63eae85baa",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na521528741db43ffb71d6e8b3dd36aef",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8f4d555c603247508f0fd4ef4e1e664b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/description",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "description"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_B"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:N546e2679f0fa474a91233df8be81e71a"
-      },
-      {
-        "@id": "_:N93dd266351f44f3cb7e229f76844e701"
-      },
-      {
-        "@id": "_:Nc06d7c73141646b5818109b8a210ddb5"
-      },
-      {
-        "@id": "_:N1984e2dda04f4ba2aa3037e93ff43bd5"
-      },
-      {
-        "@id": "_:N7c47f6b6222f43a2bc769878e5f24376"
-      },
-      {
-        "@id": "_:Nae86bab04d1c44808204adb19a8982ff"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 6
-      }
-    ]
-  },
-  {
-    "@id": "_:N546e2679f0fa474a91233df8be81e71a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:N93dd266351f44f3cb7e229f76844e701",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc06d7c73141646b5818109b8a210ddb5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1984e2dda04f4ba2aa3037e93ff43bd5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N6556a35404844a6792c6273e1ef9eaf2"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6556a35404844a6792c6273e1ef9eaf2",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N7c47f6b6222f43a2bc769878e5f24376",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nae86bab04d1c44808204adb19a8982ff",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "companies"
+        "@value": "diagnosis"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -930,112 +1651,141 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/Agent",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "agent"
+        "@value": "SIBLING_OF"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N542e81da3ebe4f209d7b4f0350fb2f13"
-      },
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@id": "_:N0a4df3545d344279825cc7ecf9f077b8"
-      },
-      {
-        "@id": "_:N8c737908887741c68a47492faff5e07f"
-      },
-      {
-        "@id": "_:N0ef4a8d5ae5f4bf3887564b215038f0b"
-      },
-      {
-        "@id": "_:Nacabb537e6c2449a983f422168fc94fd"
-      },
-      {
-        "@id": "_:N38e25c6b7d0c463a834fdb942580673e"
-      },
-      {
-        "@id": "_:Nc936f79505704dab99464fde13bf906b"
-      },
-      {
-        "@id": "_:N18be8bd55ea74179a7ad9f0d26b115d5"
-      },
-      {
-        "@id": "_:N7b5031c1f332410ca0cc8abe9bff72ba"
+        "@value": "AnyObject"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "a provence-generating agent"
+        "@value": "Example of unconstrained class"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#exactMatch": [
       {
-        "@id": "http://www.w3.org/ns/prov#Agent"
+        "@id": "https://w3id.org/linkml/Any"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
-        "@id": "https://w3id.org/linkml/tests/core"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ]
   },
   {
-    "@id": "_:N542e81da3ebe4f209d7b4f0350fb2f13",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+    "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
+        "@value": "DIRTY"
       }
     ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
       }
     ]
   },
   {
-    "@id": "_:N0a4df3545d344279825cc7ecf9f077b8",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "https://w3id.org/biolink/Disease"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Organization"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:Nb6c00893f4974ad39c0f81ba12974280"
+      },
+      {
+        "@id": "_:N28c8dc7a1a4f406d87455dc8b73dd748"
+      },
+      {
+        "@id": "_:N3ed8ec524cd84a82a6d42a29f8ac2e51"
+      },
+      {
+        "@id": "_:Nba93d60a7de340fa8c360507b30290e9"
+      },
+      {
+        "@id": "_:Nb4cf3d7516b848fc88a772d56e4a6d9f"
+      },
+      {
+        "@id": "_:Nd11c4917160144b1893f9abe8620c6bc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
+        "@value": 3
       }
     ]
   },
   {
-    "@id": "_:N8c737908887741c68a47492faff5e07f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0ef4a8d5ae5f4bf3887564b215038f0b",
+    "@id": "_:Nb6c00893f4974ad39c0f81ba12974280",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1051,7 +1801,7 @@
     ]
   },
   {
-    "@id": "_:Nacabb537e6c2449a983f422168fc94fd",
+    "@id": "_:N28c8dc7a1a4f406d87455dc8b73dd748",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1068,7 +1818,7 @@
     ]
   },
   {
-    "@id": "_:N38e25c6b7d0c463a834fdb942580673e",
+    "@id": "_:N3ed8ec524cd84a82a6d42a29f8ac2e51",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1085,23 +1835,23 @@
     ]
   },
   {
-    "@id": "_:Nc936f79505704dab99464fde13bf906b",
+    "@id": "_:Nba93d60a7de340fa8c360507b30290e9",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+        "@id": "https://w3id.org/linkml/tests/core/name"
       }
     ]
   },
   {
-    "@id": "_:N18be8bd55ea74179a7ad9f0d26b115d5",
+    "@id": "_:Nb4cf3d7516b848fc88a772d56e4a6d9f",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1113,12 +1863,12 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+        "@id": "https://w3id.org/linkml/tests/core/name"
       }
     ]
   },
   {
-    "@id": "_:N7b5031c1f332410ca0cc8abe9bff72ba",
+    "@id": "_:Nd11c4917160144b1893f9abe8620c6bc",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1130,44 +1880,23 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
+        "@id": "https://w3id.org/linkml/tests/core/name"
       }
     ]
   },
   {
-    "@id": "https://example.org/bizcodes/001",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "HIRE"
+        "@value": "CHILD_OF"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "event for a new employee"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/city",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "city"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
       }
     ]
   },
@@ -1188,37 +1917,24 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "mixin_slot_I"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "HasAliases"
+        "@value": "WithLocation"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N1549944a3e494c9884769fb3a6840305"
+        "@id": "_:N358b9f0a28f7437888d5f10d07a004aa"
       },
       {
-        "@id": "_:N6eb7061914c44a33be014eba98cb419f"
+        "@id": "_:N04c73bc53b394ee2847332f663f04c90"
+      },
+      {
+        "@id": "_:N01a0560c5503481588548a82f030a914"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1228,23 +1944,23 @@
     ]
   },
   {
-    "@id": "_:N1549944a3e494c9884769fb3a6840305",
+    "@id": "_:N358b9f0a28f7437888d5f10d07a004aa",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
       }
     ]
   },
   {
-    "@id": "_:N6eb7061914c44a33be014eba98cb419f",
+    "@id": "_:N04c73bc53b394ee2847332f663f04c90",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1256,7 +1972,809 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N01a0560c5503481588548a82f030a914",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "slot with space 1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/name",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "name"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 2
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/life_status",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "life_status"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfMix",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfMix"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N266d6bdf439e4a449b61f766578bf5a3"
+      },
+      {
+        "@id": "_:N00017e8859654b67a52d0da6ace664f5"
+      },
+      {
+        "@id": "_:Ne320d438501e45c98bc549f815f28298"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N266d6bdf439e4a449b61f766578bf5a3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N67f4944ecf244cb0a395a3caf98321d8"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "_:N67f4944ecf244cb0a395a3caf98321d8",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N00017e8859654b67a52d0da6ace664f5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne320d438501e45c98bc549f815f28298",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "procedure"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/acted_on_behalf_of",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "acted on behalf of"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has familial relationships"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfEnums",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfEnums"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N0b87fd02d63f4f88a00f5c03f7a5e871"
+      },
+      {
+        "@id": "_:N2daee827284d41ab8491600021e565f2"
+      },
+      {
+        "@id": "_:N2fcc2cfabcc5432ca73c911bf3c1ae0a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0b87fd02d63f4f88a00f5c03f7a5e871",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:N7b733e559fec463a95bf61d2b24f83ff"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7b733e559fec463a95bf61d2b24f83ff",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N2daee827284d41ab8491600021e565f2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2fcc2cfabcc5432ca73c911bf3c1ae0a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "a b"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/004",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "TRANSFER"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "transfer internally"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/ended_at_time",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ended at time"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Ontology"
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@value": "Kitchen Sink Schema"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+      {
+        "@id": "https://example.org/"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Kitchen Sink Schema\n\nThis schema does not do anything useful. It exists to test all features of linkml.\n\nThis particular text field exists to demonstrate markdown within a text field:\n\nLists:\n\n   * a\n   * b\n   * c\n\nAnd links, e.g to [Person](Person.md)"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Relationship"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nc9ab1ceb1ff94392bbdeefcf86cef7b9"
+      },
+      {
+        "@id": "_:N5732f001f04549cfaac06640160e84b7"
+      },
+      {
+        "@id": "_:Nce51073d53e942f7a945e1946aaf4130"
+      },
+      {
+        "@id": "_:N3570c9fa20b8414d8a363fce6e9e3bcc"
+      },
+      {
+        "@id": "_:N0978445c19994a7f91dac3248a952716"
+      },
+      {
+        "@id": "_:N435ca06e342f47fb93f8451c776ee936"
+      },
+      {
+        "@id": "_:N97505945ede34119bd7dc6da8a6eac25"
+      },
+      {
+        "@id": "_:Nb806a098e8484ac280dc651e08fd78a8"
+      },
+      {
+        "@id": "_:N7e6f04c7842d426da962f97a7736d95a"
+      },
+      {
+        "@id": "_:Nf3410f39ca7f42f3a3823609cd832a80"
+      },
+      {
+        "@id": "_:N10ff442501f84af198f3d4a5e684382d"
+      },
+      {
+        "@id": "_:N81c07a6722dc470094ad59da1c0a2911"
+      },
+      {
+        "@id": "_:N4739e51a60794ed49a923d31722fa579"
+      },
+      {
+        "@id": "_:N49da023aa3df4e7a950b7c567b78aef5"
+      },
+      {
+        "@id": "_:N0e2ff638e71f4fb2a05881feb34b2e7b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc9ab1ceb1ff94392bbdeefcf86cef7b9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5732f001f04549cfaac06640160e84b7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nce51073d53e942f7a945e1946aaf4130",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3570c9fa20b8414d8a363fce6e9e3bcc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0978445c19994a7f91dac3248a952716",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N435ca06e342f47fb93f8451c776ee936",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N97505945ede34119bd7dc6da8a6eac25",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb806a098e8484ac280dc651e08fd78a8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7e6f04c7842d426da962f97a7736d95a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf3410f39ca7f42f3a3823609cd832a80",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N10ff442501f84af198f3d4a5e684382d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N81c07a6722dc470094ad59da1c0a2911",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4739e51a60794ed49a923d31722fa579",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N49da023aa3df4e7a950b7c567b78aef5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0e2ff638e71f4fb2a05881feb34b2e7b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#UNKNOWN",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "UNKNOWN"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/city",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "city"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "in location"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "https://w3id.org/biolink/opposite": [
+      {
+        "@value": "location_of"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "DiagnosisType"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "https://w3id.org/linkml/permissible_values": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO"
       }
     ]
   },
@@ -1282,272 +2800,83 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsStringIn",
+    "@id": "https://w3id.org/linkml/tests/core/Activity",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "EqualsStringIn"
+        "@value": "activity"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:Nf8d4da998c574513b87c9ef1629e49ef"
+        "@id": "_:N833a15407bec460a8284736369f4414e"
       },
       {
-        "@id": "_:Na18a799ed3c247b5b00b188839e407ce"
+        "@id": "_:Nc6ef2d67c17d499c9b885ab7ab97f02c"
       },
       {
-        "@id": "_:N5f705c2b20bf47aab53e01ba0bfbe31d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf8d4da998c574513b87c9ef1629e49ef",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nc834d57960734fa6a16d43f1b50c6e3d"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc834d57960734fa6a16d43f1b50c6e3d",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#oneOf": [
-      {
-        "@list": [
-          {
-            "@value": "foo"
-          },
-          {
-            "@value": "bar"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Na18a799ed3c247b5b00b188839e407ce",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5f705c2b20bf47aab53e01ba0bfbe31d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "related to"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nec9c58f3e09449e1a88058e65bb88590"
+        "@id": "_:N1d7845b688464b19b64bcad2f6f5beda"
       },
       {
-        "@id": "_:Ne01dd18448ba4dcf8f44f3abad2f63fb"
+        "@id": "_:Nefb40957c91d43a48ae39dee06300aa0"
       },
       {
-        "@id": "_:Nb8f2008b751240de8586f7fa6e2f5df8"
+        "@id": "_:N4b5ac0052a3a4e798dd7e6f05e4285ff"
       },
       {
-        "@id": "_:N83f4ef6687f74353b5ded5cebb317607"
+        "@id": "_:Nc95d07c68db445afa1c6a0bec95722fa"
       },
       {
-        "@id": "_:N4e98efec656144b486bc3f8e81a80bc2"
+        "@id": "_:N8bfbf4eff20949289eb6bd78d8c4b7a3"
       },
       {
-        "@id": "_:N2551c944540c4b329a5a351e957c0cf6"
+        "@id": "_:N77b6f747256c4a4f8b4a8178cec64fcf"
+      },
+      {
+        "@id": "_:N0b202fa806ac4dc785df4d0271b5c023"
+      },
+      {
+        "@id": "_:N6712ab34bfef4d3ea15612c3eda42bc2"
+      },
+      {
+        "@id": "_:N5be21598378b4673b692a59e3fb0a846"
+      },
+      {
+        "@id": "_:N2435c88a84e24c13a5e584a6d1842b09"
+      },
+      {
+        "@id": "_:Nb5d3879bbaf74685b5b9063178e51ca3"
+      },
+      {
+        "@id": "_:N0106f0525b4841cb898e98f8b1f8f334"
+      },
+      {
+        "@id": "_:Ncce0ae2885894b7784b3112818f0dffc"
+      },
+      {
+        "@id": "_:Nf24687fc6496475a8f390d2f5d89a302"
+      },
+      {
+        "@id": "_:Na5f187c5a2214bb887dce8b5182dee78"
+      },
+      {
+        "@id": "_:N1734761fbf4f4228a50c419b58087fc0"
+      },
+      {
+        "@id": "_:N251b40d2dcd84dcfac8b1da10e7e68a8"
+      },
+      {
+        "@id": "_:N4f65b4aa5f554899adf6e3f020d93061"
+      },
+      {
+        "@id": "_:N83a1c13c357d4469becf7adbc1610e70"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
+    "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nec9c58f3e09449e1a88058e65bb88590",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne01dd18448ba4dcf8f44f3abad2f63fb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb8f2008b751240de8586f7fa6e2f5df8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N83f4ef6687f74353b5ded5cebb317607",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4e98efec656144b486bc3f8e81a80bc2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2551c944540c4b329a5a351e957c0cf6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "KitchenStatus"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
-          }
-        ]
+        "@value": "a provence-generating activity"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1555,120 +2884,330 @@
         "@id": "https://w3id.org/linkml/tests/core"
       }
     ],
-    "https://w3id.org/linkml/permissible_values": [
+    "http://www.w3.org/2004/02/skos/core#mappingRelation": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN"
+        "@id": "http://www.w3.org/ns/prov#Activity"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/was_generated_by",
+    "@id": "_:N833a15407bec460a8284736369f4414e",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@value": "was generated by"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc6ef2d67c17d499c9b885ab7ab97f02c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1d7845b688464b19b64bcad2f6f5beda",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/description"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nefb40957c91d43a48ae39dee06300aa0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4b5ac0052a3a4e798dd7e6f05e4285ff",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc95d07c68db445afa1c6a0bec95722fa",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8bfbf4eff20949289eb6bd78d8c4b7a3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N77b6f747256c4a4f8b4a8178cec64fcf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0b202fa806ac4dc785df4d0271b5c023",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N6712ab34bfef4d3ea15612c3eda42bc2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N5be21598378b4673b692a59e3fb0a846",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2435c88a84e24c13a5e584a6d1842b09",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb5d3879bbaf74685b5b9063178e51ca3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0106f0525b4841cb898e98f8b1f8f334",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncce0ae2885894b7784b3112818f0dffc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/used"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf24687fc6496475a8f390d2f5d89a302",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na5f187c5a2214bb887dce8b5182dee78",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1734761fbf4f4228a50c419b58087fc0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
+      }
+    ]
+  },
+  {
+    "@id": "_:N251b40d2dcd84dcfac8b1da10e7e68a8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
         "@id": "https://w3id.org/linkml/tests/core/Activity"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "other codes"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfSimpleType",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfSimpleType"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nd16f20d9d42f4c7892594241476004f6"
-      },
-      {
-        "@id": "_:N049b8497f98a49e990fee3b6c2edcc08"
-      },
-      {
-        "@id": "_:N8ada14a3a70742f4bdae7919bcbe23e7"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd16f20d9d42f4c7892594241476004f6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nbb3ef8cf091b4740b3f0449aa535eded"
-      }
-    ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
       }
     ]
   },
   {
-    "@id": "_:Nbb3ef8cf091b4740b3f0449aa535eded",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#string"
-          },
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N049b8497f98a49e990fee3b6c2edcc08",
+    "@id": "_:N4f65b4aa5f554899adf6e3f020d93061",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1680,12 +3219,12 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
       }
     ]
   },
   {
-    "@id": "_:N8ada14a3a70742f4bdae7919bcbe23e7",
+    "@id": "_:N83a1c13c357d4469becf7adbc1610e70",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -1697,71 +3236,7 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has medical history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 5
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "activities"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "altitude"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
       }
     ]
   },
@@ -1808,60 +3283,1865 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/type",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "type"
+        "@value": "age in years"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes#a%20b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "a b"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/OtherCodes"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyObject"
+        "@id": "_:N9c0e474347b04b2ea4881fb3c9776a85"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
-        "@value": "Example of unconstrained class"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#exactMatch": [
-      {
-        "@id": "https://w3id.org/linkml/Any"
+        "@value": "number of years since birth"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9c0e474347b04b2ea4881fb3c9776a85",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#intersectionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          },
+          {
+            "@id": "_:N359a1ae8f5474247a6b0b389ab027d44"
+          },
+          {
+            "@id": "_:N9fd1636088af466985740abe5bfd4b19"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N359a1ae8f5474247a6b0b389ab027d44",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:Ne01cc059759c41789299ec9907b22538"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne01cc059759c41789299ec9907b22538",
+    "http://www.w3.org/2001/XMLSchema#minInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ]
+  },
+  {
+    "@id": "_:N9fd1636088af466985740abe5bfd4b19",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:Nedb630427c4d4c09bdf2dff2ccd268cb"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nedb630427c4d4c09bdf2dff2ccd268cb",
+    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 999
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_marriage_history",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has marriage history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#LIVING",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "LIVING"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "test_attribute"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N3eb17cfff43c4a2db989ce5ee6bf601c"
+      },
+      {
+        "@id": "_:N4c524536974c4c398fa479a78a0139f7"
+      },
+      {
+        "@id": "_:N391d4d69256340e48c2356229d04ba39"
+      },
+      {
+        "@id": "_:N9dfc81992c1744d580c5cd63cd852b9b"
+      },
+      {
+        "@id": "_:Nb7b4cc0d5bbc49039ed2fc42121dff7b"
+      },
+      {
+        "@id": "_:Nb1d5d3d6728446f9aa44a38e10873f9c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3eb17cfff43c4a2db989ce5ee6bf601c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4c524536974c4c398fa479a78a0139f7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N391d4d69256340e48c2356229d04ba39",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9dfc81992c1744d580c5cd63cd852b9b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb7b4cc0d5bbc49039ed2fc42121dff7b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb1d5d3d6728446f9aa44a38e10873f9c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:N559241c8ccbc480e882cb1fe62979a7e"
+      },
+      {
+        "@id": "_:Nb1ef080966d942ffa5825029217af91d"
+      },
+      {
+        "@id": "_:N161b1a8068f7465482cc45e2ee8db83b"
+      },
+      {
+        "@id": "_:Nb37c5069c1884b63a55e09a3fcf04ee1"
+      },
+      {
+        "@id": "_:Ndff23778c700468aa51f62261758957a"
+      },
+      {
+        "@id": "_:N18d12d19a4cd4e0d99acf5bc6ce2ba81"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 6
+      }
+    ]
+  },
+  {
+    "@id": "_:N559241c8ccbc480e882cb1fe62979a7e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb1ef080966d942ffa5825029217af91d",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:N161b1a8068f7465482cc45e2ee8db83b",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb37c5069c1884b63a55e09a3fcf04ee1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nd99398f203c24b7aa25d94055deebce3"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd99398f203c24b7aa25d94055deebce3",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndff23778c700468aa51f62261758957a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N18d12d19a4cd4e0d99acf5bc6ce2ba81",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Friend",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Friend"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N095577f6fe5a4492b5d53acaf72544b1"
+      },
+      {
+        "@id": "_:N9ce1127d7038409daf98eeb6a9fcd7ee"
+      },
+      {
+        "@id": "_:N8f992d145eaf4659933038e4d03b7018"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N095577f6fe5a4492b5d53acaf72544b1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9ce1127d7038409daf98eeb6a9fcd7ee",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8f992d145eaf4659933038e4d03b7018",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "TODO"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfClasses",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfClasses"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N25eb87fc66dd4b0d98486208f89d0428"
+      },
+      {
+        "@id": "_:Nb4100352e1604ddb9f57d8332a1b1f79"
+      },
+      {
+        "@id": "_:N8f85a1783b51400f8813a5a3185031ff"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N25eb87fc66dd4b0d98486208f89d0428",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nd434a9f3e1aa4caab23b8c0f46ffd49f"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd434a9f3e1aa4caab23b8c0f46ffd49f",
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+          },
+          {
+            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb4100352e1604ddb9f57d8332a1b1f79",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8f85a1783b51400f8813a5a3185031ff",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "has employment history"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 7
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsStringIn",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EqualsStringIn"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nf687455713de49919b583653df91a912"
+      },
+      {
+        "@id": "_:Nbbdb3045d932482cb3af84b69288d24e"
+      },
+      {
+        "@id": "_:N8c2ff3162e4749c890f9f4684b292897"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf687455713de49919b583653df91a912",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nde1afcc28eef4d17859dc57a83e166bb"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nde1afcc28eef4d17859dc57a83e166bb",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#oneOf": [
+      {
+        "@list": [
+          {
+            "@value": "foo"
+          },
+          {
+            "@value": "bar"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbbdb3045d932482cb3af84b69288d24e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8c2ff3162e4749c890f9f4684b292897",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Company"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
+      },
+      {
+        "@id": "_:Nb1d545a4874f401cbbf00d588bc829a9"
+      },
+      {
+        "@id": "_:N427623df020c4a1a9244c96602de4923"
+      },
+      {
+        "@id": "_:N58cfb18e74494e8da9e23f00d9ec46f9"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb1d545a4874f401cbbf00d588bc829a9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "_:N427623df020c4a1a9244c96602de4923",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "_:N58cfb18e74494e8da9e23f00d9ec46f9",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "CLEAN"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/activity_set",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "activity set"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "related to"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "married to"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "slot with space 2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfSimpleType",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "AnyOfSimpleType"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nf65f641285974dd8bec3ab0100883cb1"
+      },
+      {
+        "@id": "_:N790b2dffde85440ea6b46aa2c119ccdd"
+      },
+      {
+        "@id": "_:Na881c173a51a40cf9aa9a1dfd3317a29"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nf65f641285974dd8bec3ab0100883cb1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Nb4fa729d66634612aad03a0957399777"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb4fa729d66634612aad03a0957399777",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#unionOf": [
+      {
+        "@list": [
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#string"
+          },
+          {
+            "@id": "http://www.w3.org/2001/XMLSchema#integer"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N790b2dffde85440ea6b46aa2c119ccdd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na881c173a51a40cf9aa9a1dfd3317a29",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute3"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "class with spaces"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N0f88b984964b4672b4cb14851ba118ba"
+      },
+      {
+        "@id": "_:N3833fa6001b44616a5bfbb139616614e"
+      },
+      {
+        "@id": "_:N33595fec394c46619b5abb84de7d3ede"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N0f88b984964b4672b4cb14851ba118ba",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N3833fa6001b44616a5bfbb139616614e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "_:N33595fec394c46619b5abb84de7d3ede",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/001",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "HIRE"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "event for a new employee"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Place"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
+      },
+      {
+        "@id": "_:N58e36a356b1c4e418c9257fc1afd193a"
+      },
+      {
+        "@id": "_:N4bb351030ca546559a8e3ea343aaf663"
+      },
+      {
+        "@id": "_:N554596cdda794314842c3739eb4a4197"
+      },
+      {
+        "@id": "_:Nb0398be4b4c143a2a5313c1425032d41"
+      },
+      {
+        "@id": "_:N18f1174608004ec1a8ed08ac4befe8d8"
+      },
+      {
+        "@id": "_:Ncc8e8b51c5f14c14afdbb5d27940ac9e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N58e36a356b1c4e418c9257fc1afd193a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N4bb351030ca546559a8e3ea343aaf663",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:N554596cdda794314842c3739eb4a4197",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/id"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb0398be4b4c143a2a5313c1425032d41",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N18f1174608004ec1a8ed08ac4befe8d8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncc8e8b51c5f14c14afdbb5d27940ac9e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_B"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "stomach count"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tree_slot_A"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "altitude"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "metadata"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Example of a slot that has an unconstrained range"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/description",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "description"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "attribute5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/agent_set",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "agent set"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://example.org/bizcodes/003",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "PROMOTION"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "promotion event"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "activities"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "species name"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "_:N7f994b878d1f4a5e890207958efd62d7"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7f994b878d1f4a5e890207958efd62d7",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#onDatatype": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#withRestrictions": [
+      {
+        "@list": [
+          {
+            "@id": "_:Na804f5659654446a9d95a9b44dad923c"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:Na804f5659654446a9d95a9b44dad923c",
+    "http://www.w3.org/2001/XMLSchema#pattern": [
+      {
+        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "PARENT_OF"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsString",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "EqualsString"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:Nc58041f407ac4ecd8e232f1446827f68"
+      },
+      {
+        "@id": "_:N3f9b55969fea4ffcb31529500a554024"
+      },
+      {
+        "@id": "_:Nacd4c873a88c47e59a9cb5fae0087e94"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc58041f407ac4ecd8e232f1446827f68",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "_:Ned283d845fe947b68472404f275bbb4c"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ned283d845fe947b68472404f275bbb4c",
+    "@type": [
+      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+    ],
+    "http://www.w3.org/2002/07/owl#oneOf": [
+      {
+        "@list": [
+          {
+            "@value": "foo"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:N3f9b55969fea4ffcb31529500a554024",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nacd4c873a88c47e59a9cb5fae0087e94",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "HasAliases"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N42c79e66dde647249be565f090e73b3f"
+      },
+      {
+        "@id": "_:Nac9a276702e249a8b5bebef3a126f1bc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N42c79e66dde647249be565f090e73b3f",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nac9a276702e249a8b5bebef3a126f1bc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/TubSubClass1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "tub sub class 1"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Same depth as Sub sub class 1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "BirthEvent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:N13c4d2c26c034c909b8405c5d693e2ec"
+      },
+      {
+        "@id": "_:Na055a5f8911d46b6884f2c94e86f8303"
+      },
+      {
+        "@id": "_:Ndcedee2fc14046c9819d5703c41de1b1"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N13c4d2c26c034c909b8405c5d693e2ec",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na055a5f8911d46b6884f2c94e86f8303",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ndcedee2fc14046c9819d5703c41de1b1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
       }
     ]
   },
@@ -1882,34 +5162,69 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#CHILD_OF",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#heartfelt",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "CHILD_OF"
+        "@value": "heartfelt"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "warm and hearty friendliness"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Dataset",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "in location"
+        "@value": "Dataset"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+        "@id": "_:N0bbfc50486fc40348833c655825ebcd6"
+      },
+      {
+        "@id": "_:N4fdf527a63b8432496cc55a0649e7fcf"
+      },
+      {
+        "@id": "_:N68d97f58d8b84c16aa50528345ce83e9"
+      },
+      {
+        "@id": "_:Ne9c37519a3d24caea737e584099ac02b"
+      },
+      {
+        "@id": "_:Ncd77a7d26a31431399ca0004217a4a07"
+      },
+      {
+        "@id": "_:N861c008184d54125835abd3204ab6fa8"
+      },
+      {
+        "@id": "_:Ncf5b0ceb9a6c478d9807913a00b967a2"
+      },
+      {
+        "@id": "_:N1f68d81727494e9a9d9ad12f0c8961fa"
+      },
+      {
+        "@id": "_:Na6ccfed810954347ab9d4e1c24ecffc0"
+      },
+      {
+        "@id": "_:Nafafd09c592042dcb89f1d93c7997efd"
+      },
+      {
+        "@id": "_:N97977319445147509314e4d8127d27f4"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1917,119 +5232,31 @@
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
       }
     ],
-    "https://w3id.org/biolink/opposite": [
+    "http://www.w3.org/ns/shacl#order": [
       {
-        "@value": "location_of"
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Place"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
-      },
-      {
-        "@id": "_:N7744847b112c4fe393aeff32891dd817"
-      },
-      {
-        "@id": "_:N422ff3558bf64fa18c5ae5e96bf3ece2"
-      },
-      {
-        "@id": "_:N91d2028b964045c8a2131b2bb45c70f9"
-      },
-      {
-        "@id": "_:N80d175f0c2524fc58b1656197d925859"
-      },
-      {
-        "@id": "_:Ne43b09086cf84831ad1867b83eecfc39"
-      },
-      {
-        "@id": "_:Nd99989abefd9498ab9b37697b93cbeb8"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7744847b112c4fe393aeff32891dd817",
+    "@id": "_:N0bbfc50486fc40348833c655825ebcd6",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/id"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
       }
     ]
   },
   {
-    "@id": "_:N422ff3558bf64fa18c5ae5e96bf3ece2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N91d2028b964045c8a2131b2bb45c70f9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N80d175f0c2524fc58b1656197d925859",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne43b09086cf84831ad1867b83eecfc39",
+    "@id": "_:N4fdf527a63b8432496cc55a0649e7fcf",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -2041,243 +5268,177 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/core/name"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/activities"
       }
     ]
   },
   {
-    "@id": "_:Nd99989abefd9498ab9b37697b93cbeb8",
+    "@id": "_:N68d97f58d8b84c16aa50528345ce83e9",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "in code system"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
+    "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent",
+    "@id": "_:Ne9c37519a3d24caea737e584099ac02b",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/code_systems"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncd77a7d26a31431399ca0004217a4a07",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
+      }
+    ]
+  },
+  {
+    "@id": "_:N861c008184d54125835abd3204ab6fa8",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ncf5b0ceb9a6c478d9807913a00b967a2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1f68d81727494e9a9d9ad12f0c8961fa",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na6ccfed810954347ab9d4e1c24ecffc0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nafafd09c592042dcb89f1d93c7997efd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
+      }
+    ]
+  },
+  {
+    "@id": "_:N97977319445147509314e4d8127d27f4",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "MedicalEvent"
+        "@value": "has birth event"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:N843e8941e2b24589941e1b96f5d0e589"
-      },
-      {
-        "@id": "_:N7e11182d460f4f509ec417440ad3072b"
-      },
-      {
-        "@id": "_:Na34efa7665c042d0a74bd628f3853011"
-      },
-      {
-        "@id": "_:Ncab8b5d4cabd4c34a3fb45b03f67329a"
-      },
-      {
-        "@id": "_:N16f003aaccc14d329ae81b06a13ca386"
-      },
-      {
-        "@id": "_:N1e1966cbf6bb46cebb8f100d19d0a999"
-      },
-      {
-        "@id": "_:Nd35cac4689524229927b45e2290ccbe9"
-      },
-      {
-        "@id": "_:N12ada2cc070d482d9da6e7991571ef79"
-      },
-      {
-        "@id": "_:N091f5ab009f74d05a647d6e783f6ecee"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N843e8941e2b24589941e1b96f5d0e589",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7e11182d460f4f509ec417440ad3072b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na34efa7665c042d0a74bd628f3853011",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncab8b5d4cabd4c34a3fb45b03f67329a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N16f003aaccc14d329ae81b06a13ca386",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1e1966cbf6bb46cebb8f100d19d0a999",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd35cac4689524229927b45e2290ccbe9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "_:N12ada2cc070d482d9da6e7991571ef79",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
-      }
-    ]
-  },
-  {
-    "@id": "_:N091f5ab009f74d05a647d6e783f6ecee",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
       }
     ]
   },
@@ -2288,24 +5449,39 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfClasses",
+    "@id": "https://w3id.org/linkml/tests/core/was_associated_with",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "was associated with"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Agent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubSubClass2",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "AnyOfClasses"
+        "@value": "Sub sub class 2"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N98c382371a0d4d919d95e56254955843"
-      },
-      {
-        "@id": "_:N36c3399e86f64bf2bd34082c17951187"
-      },
-      {
-        "@id": "_:N20de8d89703b4a46bbca0f42327aeedf"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2315,55 +5491,85 @@
     ]
   },
   {
-    "@id": "_:N98c382371a0d4d919d95e56254955843",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Concept"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N8bdf4d61991049fa8a6e522301b9f913"
+      },
+      {
+        "@id": "_:N6c8b8bfbfb184f6dbfc59083f37e9c13"
+      },
+      {
+        "@id": "_:N7fea98de390f496abed5d144c7635507"
+      },
+      {
+        "@id": "_:N018976858a6743afae84c1a95ae95059"
+      },
+      {
+        "@id": "_:N33e9c5911510495b9b2ee249714f44ef"
+      },
+      {
+        "@id": "_:Na25c24bf097b4155b418aaf71ac2760a"
+      },
+      {
+        "@id": "_:N2d978d95ab69445f9501157354a791fc"
+      },
+      {
+        "@id": "_:N489a63643ac9452a8520da6861fcaf61"
+      },
+      {
+        "@id": "_:Nb63aba92cf064197ad66be469a230feb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N8bdf4d61991049fa8a6e522301b9f913",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "_:N51b0f7889c7c49d189ae57e2f0cacfc2"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+        "@id": "https://w3id.org/linkml/tests/core/id"
       }
     ]
   },
   {
-    "@id": "_:N51b0f7889c7c49d189ae57e2f0cacfc2",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N36c3399e86f64bf2bd34082c17951187",
+    "@id": "_:N6c8b8bfbfb184f6dbfc59083f37e9c13",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#minCardinality": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
+        "@value": 1
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+        "@id": "https://w3id.org/linkml/tests/core/id"
       }
     ]
   },
   {
-    "@id": "_:N20de8d89703b4a46bbca0f42327aeedf",
+    "@id": "_:N7fea98de390f496abed5d144c7635507",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -2375,28 +5581,135 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2"
+        "@id": "https://w3id.org/linkml/tests/core/id"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years",
+    "@id": "_:N018976858a6743afae84c1a95ae95059",
     "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:N33e9c5911510495b9b2ee249714f44ef",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na25c24bf097b4155b418aaf71ac2760a",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2d978d95ab69445f9501157354a791fc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:N489a63643ac9452a8520da6861fcaf61",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb63aba92cf064197ad66be469a230feb",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/name"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "age in years"
+        "@value": "MarriageEvent"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:Ncce7e96be82f44c59e03fc5ad2571f2c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
       {
-        "@value": "number of years since birth"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation"
+      },
+      {
+        "@id": "_:Nf438b5d7eb504615ac49dfe1f8ffc590"
+      },
+      {
+        "@id": "_:N80fdebb2d3644f63af1e77ef2574e0bd"
+      },
+      {
+        "@id": "_:Na7c8565839c64aa3b4be227ba029bba0"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2406,92 +5719,263 @@
     ]
   },
   {
-    "@id": "_:Ncce7e96be82f44c59e03fc5ad2571f2c",
+    "@id": "_:Nf438b5d7eb504615ac49dfe1f8ffc590",
     "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2002/07/owl#intersectionOf": [
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "_:N8c718e059f234e23800e5fab88b8068d"
-          },
-          {
-            "@id": "_:N2061adfc83964a6a9d5b32e6f7bd9676"
-          }
-        ]
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
       }
     ]
   },
   {
-    "@id": "_:N8c718e059f234e23800e5fab88b8068d",
+    "@id": "_:N80fdebb2d3644f63af1e77ef2574e0bd",
     "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Nb964ad880a1743c986027ba95d9f40c8"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb964ad880a1743c986027ba95d9f40c8",
-    "http://www.w3.org/2001/XMLSchema#minInclusive": [
+    "http://www.w3.org/2002/07/owl#minCardinality": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
         "@value": 0
       }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+      }
     ]
   },
   {
-    "@id": "_:N2061adfc83964a6a9d5b32e6f7bd9676",
+    "@id": "_:Na7c8565839c64aa3b4be227ba029bba0",
     "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
+      "http://www.w3.org/2002/07/owl#Restriction"
     ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N968b9b82a1e1486188b3bb7289babd14"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N968b9b82a1e1486188b3bb7289babd14",
-    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 999
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Address"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "_:N004942d288334e79a8fc2b0c0c1d5fa1"
+      },
+      {
+        "@id": "_:Nb7a817d9adde48f3b50cb143f79c99ba"
+      },
+      {
+        "@id": "_:N87be5a0a20f9403eab6b4202ebb48943"
+      },
+      {
+        "@id": "_:Nd4f265b427354ab18f21d53eb5e9bb8c"
+      },
+      {
+        "@id": "_:Na76e664fd8d245cfb0f9de8b78785ca2"
+      },
+      {
+        "@id": "_:Nbb19d1a3f5bd44a58681c21fdaeee8ba"
+      },
+      {
+        "@id": "_:N58f9cdbb103c4b52a393d1b11eebc108"
+      },
+      {
+        "@id": "_:Nda9906b87506408aa21b9147c595e8cc"
+      },
+      {
+        "@id": "_:N7d9e3a36230f496d8fda74f48ecf0ca7"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N004942d288334e79a8fc2b0c0c1d5fa1",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nb7a817d9adde48f3b50cb143f79c99ba",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:N87be5a0a20f9403eab6b4202ebb48943",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd4f265b427354ab18f21d53eb5e9bb8c",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na76e664fd8d245cfb0f9de8b78785ca2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nbb19d1a3f5bd44a58681c21fdaeee8ba",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
+      }
+    ]
+  },
+  {
+    "@id": "_:N58f9cdbb103c4b52a393d1b11eebc108",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nda9906b87506408aa21b9147c595e8cc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "_:N7d9e3a36230f496d8fda74f48ecf0ca7",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/employed_at",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "ceo"
+        "@value": "employed at"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2543,149 +6027,6 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "cordialness"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_marriage_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has marriage history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "slot with space 2"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "married to"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/was_associated_with",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "was associated with"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "TODO"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
-      }
-    ]
-  },
-  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/street",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
@@ -2702,811 +6043,6 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FakeClass",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FakeClass"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Ncd41110115b14648bce5ecb546d5703f"
-      },
-      {
-        "@id": "_:N9eb2c8409f9e4ca9b62146084fbab85f"
-      },
-      {
-        "@id": "_:N595a9df991e04cb088d9c94651871065"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncd41110115b14648bce5ecb546d5703f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9eb2c8409f9e4ca9b62146084fbab85f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "_:N595a9df991e04cb088d9c94651871065",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "procedure"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/persons",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "persons"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/metadata",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "metadata"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyObject"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Example of a slot that has an unconstrained range"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Concept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nef164ae0a6334ac9a18c59168de9d830"
-      },
-      {
-        "@id": "_:Ncce0c3bdd61e4ec9bf6b9fda6254c754"
-      },
-      {
-        "@id": "_:N42a3c13e643f4c6aac687d8008bd1a07"
-      },
-      {
-        "@id": "_:N75e12cbcccad46829c94d98e04ca2bf5"
-      },
-      {
-        "@id": "_:Nbe1b53bc5aa6475da7f1f65220fb0a1d"
-      },
-      {
-        "@id": "_:N25c7c1d873194e7eb8aec9234967e34b"
-      },
-      {
-        "@id": "_:N2d26f6d92fbb46f194248a009fcead67"
-      },
-      {
-        "@id": "_:Nde4881363db14c2e9cacfb5433d31db5"
-      },
-      {
-        "@id": "_:Nb7949b35608a487fb47f065ced6458f6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nef164ae0a6334ac9a18c59168de9d830",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncce0c3bdd61e4ec9bf6b9fda6254c754",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N42a3c13e643f4c6aac687d8008bd1a07",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N75e12cbcccad46829c94d98e04ca2bf5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CodeSystem"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nbe1b53bc5aa6475da7f1f65220fb0a1d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N25c7c1d873194e7eb8aec9234967e34b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_code_system"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2d26f6d92fbb46f194248a009fcead67",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nde4881363db14c2e9cacfb5433d31db5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb7949b35608a487fb47f065ced6458f6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Organization"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
-      },
-      {
-        "@id": "_:N160a1217aca741269d59fe18b267163d"
-      },
-      {
-        "@id": "_:N2a4ab465a8234ba9bdb6c8d8c271e200"
-      },
-      {
-        "@id": "_:Ne55084457ecc43ab88906a2dc69f3ac6"
-      },
-      {
-        "@id": "_:N5abd6093fd944b1e985f99a0e05227e1"
-      },
-      {
-        "@id": "_:Na0772e3f10404bc2a074c1f85e912d39"
-      },
-      {
-        "@id": "_:N0e7ba6e9468a4c7b9ca35c0e831a4293"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 3
-      }
-    ]
-  },
-  {
-    "@id": "_:N160a1217aca741269d59fe18b267163d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2a4ab465a8234ba9bdb6c8d8c271e200",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne55084457ecc43ab88906a2dc69f3ac6",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5abd6093fd944b1e985f99a0e05227e1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na0772e3f10404bc2a074c1f85e912d39",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0e7ba6e9468a4c7b9ca35c0e831a4293",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/activity_set",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "activity set"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#DEAD",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DEAD"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfMix",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfMix"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N6bb24a4ffa2f4b53a0b4721ec114065b"
-      },
-      {
-        "@id": "_:N9bb1068f6d1140b68a04ec77b3b6d3a4"
-      },
-      {
-        "@id": "_:Nedb78a8433b741a4962c23858819fc7b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N6bb24a4ffa2f4b53a0b4721ec114065b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N0c22a1c23e354facae311b4f589a6144"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0c22a1c23e354facae311b4f589a6144",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N9bb1068f6d1140b68a04ec77b3b6d3a4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nedb78a8433b741a4962c23858819fc7b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/ended_at_time",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ended at time"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/AnyOfEnums",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AnyOfEnums"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N3d5ac6fc6d7c4f92b391805a8a081119"
-      },
-      {
-        "@id": "_:Ndf187f44f91448ceac1322925fd90cc8"
-      },
-      {
-        "@id": "_:Nad4a7c5d00fc4508a63c2d58a62aa9aa"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3d5ac6fc6d7c4f92b391805a8a081119",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N81f0b1fbff84464b83fd27091fce9de2"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "_:N81f0b1fbff84464b83fd27091fce9de2",
-    "http://www.w3.org/2002/07/owl#unionOf": [
-      {
-        "@list": [
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType"
-          },
-          {
-            "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndf187f44f91448ceac1322925fd90cc8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nad4a7c5d00fc4508a63c2d58a62aa9aa",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute3"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#CLEAN",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "CLEAN"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_A",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_A"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has employment history"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 7
-      }
-    ]
-  },
-  {
     "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -3518,40 +6054,40 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "_:N972af170e78e4492bea8c373d6bb2c0d"
+        "@id": "_:Nd2a977ebfac24fdda22da65a8d3afa60"
       },
       {
-        "@id": "_:N48aced2e1c9c405491ff50ac8a143323"
+        "@id": "_:Ndc4f8b93d00e4cf8a6b7a15106192280"
       },
       {
-        "@id": "_:N1c2954bea0e04fbbaf4fd8e8211cf865"
+        "@id": "_:N602cd6400ee3416b84e7bf0bc21fbc97"
       },
       {
-        "@id": "_:N40b9d730840147dfbab224f0106f8679"
+        "@id": "_:Nba743e5d0e7645d78ce143610aae2047"
       },
       {
-        "@id": "_:N187c7c1786db4ccd8e4d0f6cf84ec1b1"
+        "@id": "_:Nf53665191da44d9fb5ed308a623472aa"
       },
       {
-        "@id": "_:N8f920fa1d0cc4abe9d76dc5370c8720a"
+        "@id": "_:N23b844b7948e431cb892c47642fe8b37"
       },
       {
-        "@id": "_:Ncb9cbaafd0724f34b2922f128deee080"
+        "@id": "_:Nbb66dd6a1442466998d758e63e293cb8"
       },
       {
-        "@id": "_:N3a5b3fe4f8e44ee18a27d29f4a9cb559"
+        "@id": "_:N2c9b0706de144490b8687d8bb52e19cd"
       },
       {
-        "@id": "_:N5b9194fc2846445c84a586bed91a9cfe"
+        "@id": "_:N3edccfbf62844c15a57af2db455493ce"
       },
       {
-        "@id": "_:Neafd1f23e7bf40bb980ab1dbef825107"
+        "@id": "_:Nc3f876523788410f990b6f62a768fd14"
       },
       {
-        "@id": "_:Nad64cf6147844f409baa43ad8db897fd"
+        "@id": "_:Ne37726766a104351b10699aa05c5f9ef"
       },
       {
-        "@id": "_:N7cab41a4436545b493eae22114d4692d"
+        "@id": "_:Nd9ef1e61461e49e89383d821ec973d80"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3561,7 +6097,7 @@
     ]
   },
   {
-    "@id": "_:N972af170e78e4492bea8c373d6bb2c0d",
+    "@id": "_:Nd2a977ebfac24fdda22da65a8d3afa60",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3577,7 +6113,7 @@
     ]
   },
   {
-    "@id": "_:N48aced2e1c9c405491ff50ac8a143323",
+    "@id": "_:Ndc4f8b93d00e4cf8a6b7a15106192280",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3594,7 +6130,7 @@
     ]
   },
   {
-    "@id": "_:N1c2954bea0e04fbbaf4fd8e8211cf865",
+    "@id": "_:N602cd6400ee3416b84e7bf0bc21fbc97",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3611,7 +6147,7 @@
     ]
   },
   {
-    "@id": "_:N40b9d730840147dfbab224f0106f8679",
+    "@id": "_:Nba743e5d0e7645d78ce143610aae2047",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3627,7 +6163,7 @@
     ]
   },
   {
-    "@id": "_:N187c7c1786db4ccd8e4d0f6cf84ec1b1",
+    "@id": "_:Nf53665191da44d9fb5ed308a623472aa",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3644,7 +6180,7 @@
     ]
   },
   {
-    "@id": "_:N8f920fa1d0cc4abe9d76dc5370c8720a",
+    "@id": "_:N23b844b7948e431cb892c47642fe8b37",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3661,7 +6197,7 @@
     ]
   },
   {
-    "@id": "_:Ncb9cbaafd0724f34b2922f128deee080",
+    "@id": "_:Nbb66dd6a1442466998d758e63e293cb8",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3677,7 +6213,7 @@
     ]
   },
   {
-    "@id": "_:N3a5b3fe4f8e44ee18a27d29f4a9cb559",
+    "@id": "_:N2c9b0706de144490b8687d8bb52e19cd",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3694,7 +6230,7 @@
     ]
   },
   {
-    "@id": "_:N5b9194fc2846445c84a586bed91a9cfe",
+    "@id": "_:N3edccfbf62844c15a57af2db455493ce",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3711,7 +6247,7 @@
     ]
   },
   {
-    "@id": "_:Neafd1f23e7bf40bb980ab1dbef825107",
+    "@id": "_:Nc3f876523788410f990b6f62a768fd14",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3727,7 +6263,7 @@
     ]
   },
   {
-    "@id": "_:Nad64cf6147844f409baa43ad8db897fd",
+    "@id": "_:Ne37726766a104351b10699aa05c5f9ef",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3744,7 +6280,7 @@
     ]
   },
   {
-    "@id": "_:N7cab41a4436545b493eae22114d4692d",
+    "@id": "_:Nd9ef1e61461e49e89383d821ec973d80",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -3757,2913 +6293,6 @@
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
         "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubSubClass2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Sub sub class 2"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Person"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
-      {
-        "@id": "https://en.wikipedia.org/wiki/Person"
-      },
-      {
-        "@id": "http://schema.org/Person"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/HasAliases"
-      },
-      {
-        "@id": "_:N00b683b78ad24c489b19204d04d8e400"
-      },
-      {
-        "@id": "_:Ne9c1a464bf934e9bb1addf132c46232d"
-      },
-      {
-        "@id": "_:Nf8eafd59feab4cf48e2e10c2c21f1c77"
-      },
-      {
-        "@id": "_:Nff83d93c745c419c95a2c1176fd3fd39"
-      },
-      {
-        "@id": "_:Nd6dac4920c5a45bd90077c29eccfd42c"
-      },
-      {
-        "@id": "_:N3a768396deaa4efba210841837ce846a"
-      },
-      {
-        "@id": "_:N053c6324b4dd40fb966c4434189b88eb"
-      },
-      {
-        "@id": "_:N948de1353ffe466c8cf206680d1888b4"
-      },
-      {
-        "@id": "_:N8fbb1b5d44f44875ba39f954eb36ddac"
-      },
-      {
-        "@id": "_:Nd07cd1cba0b34b28b4fc94a74e0e7783"
-      },
-      {
-        "@id": "_:Neb01f0a143e1478d929b91aec28b9c98"
-      },
-      {
-        "@id": "_:Na19ae1ab262548aa9c01a44f76073718"
-      },
-      {
-        "@id": "_:N8be38c763df84e9cb85ccf2687990852"
-      },
-      {
-        "@id": "_:N2eb73c31c2eb4698916b7e6a65ac9dfc"
-      },
-      {
-        "@id": "_:Ncf3d1663294f4a0295845a02152605cd"
-      },
-      {
-        "@id": "_:N96315503cab3441a927a47c638ed5eef"
-      },
-      {
-        "@id": "_:N8421f1f548c24831b231aa80cdd05729"
-      },
-      {
-        "@id": "_:N82ac28c253e140cbba2f5918e3b01373"
-      },
-      {
-        "@id": "_:N96a39e37a25e497b8f50ae71b1368261"
-      },
-      {
-        "@id": "_:N1aa64918f20b4684b7b9b74236d3355d"
-      },
-      {
-        "@id": "_:N70b9d987ff2740038b83d06fb0bd4f7f"
-      },
-      {
-        "@id": "_:Necfa51ebfe184a1e94690de185d4b135"
-      },
-      {
-        "@id": "_:N07161fb8d6e54f7b8023577ab740bc85"
-      },
-      {
-        "@id": "_:N3bf21a0a14854490ab968ea0b8ef5796"
-      },
-      {
-        "@id": "_:N34f3516a446548f395ba4b9262f1aa95"
-      },
-      {
-        "@id": "_:N97da6c81e894425b95f8d73ea7300b85"
-      },
-      {
-        "@id": "_:Ndeff4db09aee4a1f94a9dc3938bc5c76"
-      },
-      {
-        "@id": "_:N6d61d5f5cf8c4706822753c47b1cc265"
-      },
-      {
-        "@id": "_:N7216df8f525c4b21bccca4930aec66e3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "A person, living or dead"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#exactMatch": [
-      {
-        "@id": "http://schema.org/Person"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 2
-      }
-    ],
-    "https://w3id.org/linkml/tests/kitchen_sink/fallible": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-        "@value": true
-      }
-    ],
-    "https://w3id.org/linkml/tests/kitchen_sink/opinions": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1000
-      }
-    ],
-    "https://w3id.org/linkml/tests/kitchen_sink/resting": [
-      {
-        "@value": "supine"
-      }
-    ],
-    "https://w3id.org/linkml/tests/kitchen_sink/viewer": [
-      {
-        "@value": "ks:PersonViewer"
-      }
-    ]
-  },
-  {
-    "@id": "_:N00b683b78ad24c489b19204d04d8e400",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne9c1a464bf934e9bb1addf132c46232d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf8eafd59feab4cf48e2e10c2c21f1c77",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Na998a1d96a034cb882a7a222ea0ec3ac"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na998a1d96a034cb882a7a222ea0ec3ac",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#intersectionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "_:Ne82eae01797240a888d6e641ac3dd4b7"
-          },
-          {
-            "@id": "_:N91199361d60b4bc9b925481fc0e56fe2"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne82eae01797240a888d6e641ac3dd4b7",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Nf8d31050758943b4a2e3b2625f35ac5e"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf8d31050758943b4a2e3b2625f35ac5e",
-    "http://www.w3.org/2001/XMLSchema#minInclusive": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ]
-  },
-  {
-    "@id": "_:N91199361d60b4bc9b925481fc0e56fe2",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N4d9c17bee17f4d35984f891967e61df4"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N4d9c17bee17f4d35984f891967e61df4",
-    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 999
-      }
-    ]
-  },
-  {
-    "@id": "_:Nff83d93c745c419c95a2c1176fd3fd39",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd6dac4920c5a45bd90077c29eccfd42c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/age_in_years"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3a768396deaa4efba210841837ce846a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
-      }
-    ]
-  },
-  {
-    "@id": "_:N053c6324b4dd40fb966c4434189b88eb",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
-      }
-    ]
-  },
-  {
-    "@id": "_:N948de1353ffe466c8cf206680d1888b4",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8fbb1b5d44f44875ba39f954eb36ddac",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEvent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nd07cd1cba0b34b28b4fc94a74e0e7783",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_employment_history"
-      }
-    ]
-  },
-  {
-    "@id": "_:Neb01f0a143e1478d929b91aec28b9c98",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na19ae1ab262548aa9c01a44f76073718",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8be38c763df84e9cb85ccf2687990852",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2eb73c31c2eb4698916b7e6a65ac9dfc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_medical_history"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncf3d1663294f4a0295845a02152605cd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N96315503cab3441a927a47c638ed5eef",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8421f1f548c24831b231aa80cdd05729",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N82ac28c253e140cbba2f5918e3b01373",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
-      }
-    ]
-  },
-  {
-    "@id": "_:N96a39e37a25e497b8f50ae71b1368261",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1aa64918f20b4684b7b9b74236d3355d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_living"
-      }
-    ]
-  },
-  {
-    "@id": "_:N70b9d987ff2740038b83d06fb0bd4f7f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Na35642b96b0c4fe79940f8284944ccdd"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na35642b96b0c4fe79940f8284944ccdd",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Nb20c42307f794c0d9a7849145cab1428"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb20c42307f794c0d9a7849145cab1428",
-    "http://www.w3.org/2001/XMLSchema#pattern": [
-      {
-        "@value": "^\\S+ \\S+$"
-      }
-    ]
-  },
-  {
-    "@id": "_:Necfa51ebfe184a1e94690de185d4b135",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N07161fb8d6e54f7b8023577ab740bc85",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3bf21a0a14854490ab968ea0b8ef5796",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:Nffacc65d42d7475e9f9a54824aa87197"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nffacc65d42d7475e9f9a54824aa87197",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N86ac6bf84c784c8e99a6f09c6fdf72ae"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N86ac6bf84c784c8e99a6f09c6fdf72ae",
-    "http://www.w3.org/2001/XMLSchema#pattern": [
-      {
-        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
-      }
-    ]
-  },
-  {
-    "@id": "_:N34f3516a446548f395ba4b9262f1aa95",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N97da6c81e894425b95f8d73ea7300b85",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndeff4db09aee4a1f94a9dc3938bc5c76",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "_:N703236c2b3e74c148d1cfcb0d385b4b5"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
-      }
-    ]
-  },
-  {
-    "@id": "_:N703236c2b3e74c148d1cfcb0d385b4b5",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#intersectionOf": [
-      {
-        "@list": [
-          {
-            "@id": "http://www.w3.org/2001/XMLSchema#integer"
-          },
-          {
-            "@id": "_:N011e1ffbb9a445b69f16e7787a97df99"
-          },
-          {
-            "@id": "_:N8f9b1af70f604b05835c599bb05c2e44"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N011e1ffbb9a445b69f16e7787a97df99",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:N3a2110fb6f2142fc953d6364cbce3a8c"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:N3a2110fb6f2142fc953d6364cbce3a8c",
-    "http://www.w3.org/2001/XMLSchema#minInclusive": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "_:N8f9b1af70f604b05835c599bb05c2e44",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Ne4d3578ac7eb4364bcb487c3eb0e16f1"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne4d3578ac7eb4364bcb487c3eb0e16f1",
-    "http://www.w3.org/2001/XMLSchema#maxInclusive": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "_:N6d61d5f5cf8c4706822753c47b1cc265",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7216df8f525c4b21bccca4930aec66e3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/was_informed_by",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "was informed by"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Concept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#closeMatch": [
-      {
-        "@id": "https://w3id.org/biolink/Disease"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "class with spaces"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N9defc9c6ee5e4c33bd903fb23163871d"
-      },
-      {
-        "@id": "_:N2d0f0f6396eb447480d4ede69f743674"
-      },
-      {
-        "@id": "_:N2953ec6b8cab46978a5f8acb24ffd3e8"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9defc9c6ee5e4c33bd903fb23163871d",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2d0f0f6396eb447480d4ede69f743674",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2953ec6b8cab46978a5f8acb24ffd3e8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/stomach_count",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "stomach count"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "addresses"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#UNKNOWN",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "UNKNOWN"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_C",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tree_slot_C"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/tree_slot_B"
-      },
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/mixin_slot_I"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Company",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Company"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Organization"
-      },
-      {
-        "@id": "_:N2895f8b93da646d485e9cdb27d42a96b"
-      },
-      {
-        "@id": "_:N18fa69c170b04f2d8eca885da4725569"
-      },
-      {
-        "@id": "_:N5b1b08d47fe5438a8874b4037922444c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2895f8b93da646d485e9cdb27d42a96b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "_:N18fa69c170b04f2d8eca885da4725569",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5b1b08d47fe5438a8874b4037922444c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ceo"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_familial_relationships",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "has familial relationships"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Relationship"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N009a845dacaf4b79baa8fdc8da1f744c"
-      },
-      {
-        "@id": "_:N241e200ab06543edb63a51a751bf43dc"
-      },
-      {
-        "@id": "_:N34c80daec8b24b5aab8bb2e6420b17c2"
-      },
-      {
-        "@id": "_:Nf58bd96663734edb91bb4fe1f1781096"
-      },
-      {
-        "@id": "_:Na15bde55f8b9448ea98ce3e0d49160c1"
-      },
-      {
-        "@id": "_:N651a7aa872b54b19a3c212ceacfa26ba"
-      },
-      {
-        "@id": "_:N07762825bba74c40b45f33cd1d5663ef"
-      },
-      {
-        "@id": "_:Ncb25b8a79f5847f49968f494631448e1"
-      },
-      {
-        "@id": "_:N1dbaaa29f7a64cce9d0d0fc77607f893"
-      },
-      {
-        "@id": "_:Nf5596dabff8649eb9d55c5ffd062b33c"
-      },
-      {
-        "@id": "_:N686e9714eaee49a8b790946af4697fd9"
-      },
-      {
-        "@id": "_:N9e3b2911c1884897aadd413d35569847"
-      },
-      {
-        "@id": "_:N679a23465ade47fe81b274819ba0f013"
-      },
-      {
-        "@id": "_:N809b6112f7d84a098bee1da0dc658820"
-      },
-      {
-        "@id": "_:N664c93eb8a0d4ac98c050243dafdfa61"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N009a845dacaf4b79baa8fdc8da1f744c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N241e200ab06543edb63a51a751bf43dc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:N34c80daec8b24b5aab8bb2e6420b17c2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf58bd96663734edb91bb4fe1f1781096",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na15bde55f8b9448ea98ce3e0d49160c1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N651a7aa872b54b19a3c212ceacfa26ba",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N07762825bba74c40b45f33cd1d5663ef",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ncb25b8a79f5847f49968f494631448e1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:N1dbaaa29f7a64cce9d0d0fc77607f893",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf5596dabff8649eb9d55c5ffd062b33c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N686e9714eaee49a8b790946af4697fd9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N9e3b2911c1884897aadd413d35569847",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N679a23465ade47fe81b274819ba0f013",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N809b6112f7d84a098bee1da0dc658820",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "_:N664c93eb8a0d4ac98c050243dafdfa61",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "BirthEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
-      },
-      {
-        "@id": "_:Ndb6438cae5cc415181fe9bb65fe03c0a"
-      },
-      {
-        "@id": "_:N66a4e725de7547db90e6c0848f476886"
-      },
-      {
-        "@id": "_:Nc56c25f74036421d807a3cf250ef3475"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndb6438cae5cc415181fe9bb65fe03c0a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:N66a4e725de7547db90e6c0848f476886",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nc56c25f74036421d807a3cf250ef3475",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum#LIVING",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "LIVING"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus#DIRTY",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DIRTY"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/KitchenStatus"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/test_attribute",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "test_attribute"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/004",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "TRANSFER"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "transfer internally"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "hateful"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "spiteful"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink.owl.ttl",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Ontology"
-    ],
-    "http://purl.org/dc/terms/title": [
-      {
-        "@value": "Kitchen Sink Schema"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "kitchen_sink"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
-      {
-        "@id": "https://example.org/"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Kitchen Sink Schema\n\nThis schema does not do anything useful. It exists to test all features of linkml.\n\nThis particular text field exists to demonstrate markdown within a text field:\n\nLists:\n\n   * a\n   * b\n   * c\n\nAnd links, e.g to [Person](Person.md)"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "is current"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Friend",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Friend"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:Nb0341acccd6f4247a0fb7fcb1f14e2e9"
-      },
-      {
-        "@id": "_:N3d0687de3add44c1bf0676f673c1cbb7"
-      },
-      {
-        "@id": "_:Nf3adcf3780bc43a1807404d84dd55d1a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb0341acccd6f4247a0fb7fcb1f14e2e9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:N3d0687de3add44c1bf0676f673c1cbb7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf3adcf3780bc43a1807404d84dd55d1a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/name"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/used",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "used"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "DiagnosisType"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ],
-    "https://w3id.org/linkml/permissible_values": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisType#TODO"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/aliases",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "aliases"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/TubSubClass1",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "tub sub class 1"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Same depth as Sub sub class 1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/name",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "name"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 2
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/003",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "PROMOTION"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "promotion event"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/life_status",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "life_status"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/LifeStatusEnum"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "diagnosis"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/species_name",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "species name"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "_:N0b8e39f9c55a4f6eb63c7b9e081bf6bd"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0b8e39f9c55a4f6eb63c7b9e081bf6bd",
-    "@type": [
-      "http://www.w3.org/2000/01/rdf-schema#Datatype"
-    ],
-    "http://www.w3.org/2002/07/owl#onDatatype": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#withRestrictions": [
-      {
-        "@list": [
-          {
-            "@id": "_:Ndac87a5c64fa4c8380f741be9c26c35e"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "@id": "_:Ndac87a5c64fa4c8380f741be9c26c35e",
-    "http://www.w3.org/2001/XMLSchema#pattern": [
-      {
-        "@value": "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/EqualsString",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "EqualsString"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N5a73d29b598a472c82272c628bfc01fd"
-      },
-      {
-        "@id": "_:N67f9fc6a0e0f41c0a1fa56df132a6419"
-      },
-      {
-        "@id": "_:N642b42b5a56045d3a48f9ee77d89e538"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5a73d29b598a472c82272c628bfc01fd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "_:N67f9fc6a0e0f41c0a1fa56df132a6419",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "_:N642b42b5a56045d3a48f9ee77d89e538",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute5"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#SIBLING_OF",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "SIBLING_OF"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/started_at_time",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "started at time"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/agent_set",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "agent set"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/core/Activity",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "activity"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N26b39349871d4caf98e4bd5a43c6a99f"
-      },
-      {
-        "@id": "_:N44af79301c584bca996a57f9389905d5"
-      },
-      {
-        "@id": "_:Na217529fa68a48d0a80c6c79a932e441"
-      },
-      {
-        "@id": "_:Nfeffdee952994940a547390c60ceb855"
-      },
-      {
-        "@id": "_:Ne7e10ea184264b1fa9591f6944211578"
-      },
-      {
-        "@id": "_:N8b5424ae391948d4b5357aa6793f41e9"
-      },
-      {
-        "@id": "_:N839cca0b3f52403c897b68fef7e0f821"
-      },
-      {
-        "@id": "_:N59a1d86e27654caf82c76b207786094c"
-      },
-      {
-        "@id": "_:N7ba7eedf62154f2398b33dabd475c1dd"
-      },
-      {
-        "@id": "_:Na91229f173e3473fa99a55a13337ecd7"
-      },
-      {
-        "@id": "_:N2d4f9a5f04b94c91b03f95169059aa6b"
-      },
-      {
-        "@id": "_:N40add8c84132401baade7aaa3cb6fdd3"
-      },
-      {
-        "@id": "_:N5f1c99909626477582a38415351da7cd"
-      },
-      {
-        "@id": "_:Nf93f338bf85e4558bdc9cbe7d0ec4fea"
-      },
-      {
-        "@id": "_:N605d3817c1c44999b28904423106a0cc"
-      },
-      {
-        "@id": "_:Nf33020b69641437b83c283acb304393a"
-      },
-      {
-        "@id": "_:N039e0e961c884670ab9c69907d6b07d3"
-      },
-      {
-        "@id": "_:N8ccc2c91424a41c3a4b6b5d0d921cfe7"
-      },
-      {
-        "@id": "_:N7dd615146c5b4aab8d7dd826c400de24"
-      },
-      {
-        "@id": "_:N7697c68954154b35b10e086bbeadead3"
-      },
-      {
-        "@id": "_:N257ecef4f697450288cbef66bec5d52a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "a provence-generating activity"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#mappingRelation": [
-      {
-        "@id": "http://www.w3.org/ns/prov#Activity"
-      }
-    ]
-  },
-  {
-    "@id": "_:N26b39349871d4caf98e4bd5a43c6a99f",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:N44af79301c584bca996a57f9389905d5",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na217529fa68a48d0a80c6c79a932e441",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/description"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfeffdee952994940a547390c60ceb855",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:Ne7e10ea184264b1fa9591f6944211578",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8b5424ae391948d4b5357aa6793f41e9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/ended_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N839cca0b3f52403c897b68fef7e0f821",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N59a1d86e27654caf82c76b207786094c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7ba7eedf62154f2398b33dabd475c1dd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/id"
-      }
-    ]
-  },
-  {
-    "@id": "_:Na91229f173e3473fa99a55a13337ecd7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#date"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2d4f9a5f04b94c91b03f95169059aa6b",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N40add8c84132401baade7aaa3cb6fdd3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/started_at_time"
-      }
-    ]
-  },
-  {
-    "@id": "_:N5f1c99909626477582a38415351da7cd",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf93f338bf85e4558bdc9cbe7d0ec4fea",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:N605d3817c1c44999b28904423106a0cc",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/used"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nf33020b69641437b83c283acb304393a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Agent"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N039e0e961c884670ab9c69907d6b07d3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8ccc2c91424a41c3a4b6b5d0d921cfe7",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_associated_with"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7dd615146c5b4aab8d7dd826c400de24",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/Activity"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7697c68954154b35b10e086bbeadead3",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "_:N257ecef4f697450288cbef66bec5d52a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core/was_informed_by"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute2",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "attribute2"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "https://example.org/bizcodes/002",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "FIRE"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/EmploymentEventType"
-      }
-    ],
-    "https://w3id.org/biolink/opposite": [
-      {
-        "@value": "HIRE"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Address"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "_:N66ae9e94318a4837ae3e03367f0ad667"
-      },
-      {
-        "@id": "_:N0aac6dfc5cda4bc3b89c41e678f8be62"
-      },
-      {
-        "@id": "_:N8c2f46492e84485d855652c3c9cf30b9"
-      },
-      {
-        "@id": "_:N7e5c729396a1429fa156e414ba5e9698"
-      },
-      {
-        "@id": "_:Nb0b61652852745fb812d83625e86a0c0"
-      },
-      {
-        "@id": "_:N4d9b85ab125541b7b48ea31b91dff727"
-      },
-      {
-        "@id": "_:N2732de7ac5d74934bef8f52996135123"
-      },
-      {
-        "@id": "_:N43a2257393a4414fa5df1eff4906a45a"
-      },
-      {
-        "@id": "_:Nfa7a4c4dc5cb4f76ae7619c17ad4284c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N66ae9e94318a4837ae3e03367f0ad667",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#decimal"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N0aac6dfc5cda4bc3b89c41e678f8be62",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N8c2f46492e84485d855652c3c9cf30b9",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/altitude"
-      }
-    ]
-  },
-  {
-    "@id": "_:N7e5c729396a1429fa156e414ba5e9698",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nb0b61652852745fb812d83625e86a0c0",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:N4d9b85ab125541b7b48ea31b91dff727",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/city"
-      }
-    ]
-  },
-  {
-    "@id": "_:N2732de7ac5d74934bef8f52996135123",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "_:N43a2257393a4414fa5df1eff4906a45a",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "_:Nfa7a4c4dc5cb4f76ae7619c17ad4284c",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/street"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "subclass test"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
-      },
-      {
-        "@id": "_:N49fef6868fcb4e6998549b400cf3ccd8"
-      },
-      {
-        "@id": "_:N585c426ae8b84ab4a798d053e87df455"
-      },
-      {
-        "@id": "_:N87b7381b984c43a5b32144f78e3a2067"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
-      }
-    ]
-  },
-  {
-    "@id": "_:N49fef6868fcb4e6998549b400cf3ccd8",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#allValuesFrom": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "_:N585c426ae8b84ab4a798d053e87df455",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#minCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 0
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
-      }
-    ]
-  },
-  {
-    "@id": "_:N87b7381b984c43a5b32144f78e3a2067",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Restriction"
-    ],
-    "http://www.w3.org/2002/07/owl#maxCardinality": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#onProperty": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
       }
     ]
   },
@@ -6710,13 +6339,13 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_1",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/attribute4",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "slot with space 1"
+        "@value": "attribute4"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -6726,68 +6355,27 @@
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/core/id",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "id"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://w3id.org/linkml/tests/core"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#order": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#integer",
-        "@value": 1
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType#PARENT_OF",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/SubclassTest",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "PARENT_OF"
+        "@value": "subclass test"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MarriageEvent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "MarriageEvent"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
       },
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/WithLocation"
+        "@id": "_:Nd77320659cb94ce3b61c508957614faa"
       },
       {
-        "@id": "_:N6718e5972acd4e27af2b28777cef126b"
+        "@id": "_:N0185a2dace6e4948a3a8bd1e8e5a7cb6"
       },
       {
-        "@id": "_:Naff40925f1f245f7a81824c2262e10cd"
-      },
-      {
-        "@id": "_:N84b9b27653224ee8a077073c97be69be"
+        "@id": "_:N1cb1b24463c849f8adcd1dff9c93f445"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -6797,23 +6385,23 @@
     ]
   },
   {
-    "@id": "_:N6718e5972acd4e27af2b28777cef126b",
+    "@id": "_:Nd77320659cb94ce3b61c508957614faa",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
     "http://www.w3.org/2002/07/owl#allValuesFrom": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ClassWithSpaces"
       }
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
       }
     ]
   },
   {
-    "@id": "_:Naff40925f1f245f7a81824c2262e10cd",
+    "@id": "_:N0185a2dace6e4948a3a8bd1e8e5a7cb6",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -6825,12 +6413,12 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
       }
     ]
   },
   {
-    "@id": "_:N84b9b27653224ee8a077073c97be69be",
+    "@id": "_:N1cb1b24463c849f8adcd1dff9c93f445",
     "@type": [
       "http://www.w3.org/2002/07/owl#Restriction"
     ],
@@ -6842,28 +6430,488 @@
     ],
     "http://www.w3.org/2002/07/owl#onProperty": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/married_to"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/slot_with_space_2"
       }
     ]
   },
   {
-    "@id": "https://w3id.org/linkml/tests/kitchen_sink/has_birth_event",
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/MedicalEvent",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "has birth event"
+        "@value": "MedicalEvent"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://w3id.org/linkml/tests/kitchen_sink/BirthEvent"
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Event"
+      },
+      {
+        "@id": "_:N69387c08c0774987a7bc3336b28fa3fa"
+      },
+      {
+        "@id": "_:N322df292d37c4ed99f76f270843d5b33"
+      },
+      {
+        "@id": "_:Ne9400c0983ab4957be5c8aa59c0ad888"
+      },
+      {
+        "@id": "_:Nfe4dbbcccc5343b18ffd9fea38214207"
+      },
+      {
+        "@id": "_:N1663a2b37e104b23a44543da62c0fd48"
+      },
+      {
+        "@id": "_:N1f06d679c9cf4ac9a7c4dccb8042f4a0"
+      },
+      {
+        "@id": "_:N15afa2b8aa5a4d90b6051a4c9f7c2229"
+      },
+      {
+        "@id": "_:Nca8b6c513b684f5896f59a09ecff83b0"
+      },
+      {
+        "@id": "_:Nd0f0e18a4ba246f4ba9751ee99968edc"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
         "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "_:N69387c08c0774987a7bc3336b28fa3fa",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/DiagnosisConcept"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:N322df292d37c4ed99f76f270843d5b33",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne9400c0983ab4957be5c8aa59c0ad888",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/diagnosis"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nfe4dbbcccc5343b18ffd9fea38214207",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Place"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1663a2b37e104b23a44543da62c0fd48",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1f06d679c9cf4ac9a7c4dccb8042f4a0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/in_location"
+      }
+    ]
+  },
+  {
+    "@id": "_:N15afa2b8aa5a4d90b6051a4c9f7c2229",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/ProcedureConcept"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nca8b6c513b684f5896f59a09ecff83b0",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nd0f0e18a4ba246f4ba9751ee99968edc",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/procedure"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/is_current",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "is current"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationship",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "FamilialRelationship"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Relationship"
+      },
+      {
+        "@id": "_:Na3c12c8d73564496ad345c0b2d5ac04e"
+      },
+      {
+        "@id": "_:N9a205ce1503d49cca0d988511bc5aa12"
+      },
+      {
+        "@id": "_:Na40233b7991544a590a2bb5aa9235e29"
+      },
+      {
+        "@id": "_:Ne9a09e44dc0041a5939a9db28e1d0525"
+      },
+      {
+        "@id": "_:N143010b4519f4fc689d0e96c7008e4bd"
+      },
+      {
+        "@id": "_:N2b4487db99c441eb8cf8620639b66f8e"
+      },
+      {
+        "@id": "_:N57ca91e8958b430fb9c4d1c73cd93406"
+      },
+      {
+        "@id": "_:Nc53f714b3235463d843923fb217583ba"
+      },
+      {
+        "@id": "_:N1fde789fd79442bba4768a931f9493b2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#order": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 5
+      }
+    ]
+  },
+  {
+    "@id": "_:Na3c12c8d73564496ad345c0b2d5ac04e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:N9a205ce1503d49cca0d988511bc5aa12",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 0
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Na40233b7991544a590a2bb5aa9235e29",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/cordialness"
+      }
+    ]
+  },
+  {
+    "@id": "_:Ne9a09e44dc0041a5939a9db28e1d0525",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Person"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N143010b4519f4fc689d0e96c7008e4bd",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N2b4487db99c441eb8cf8620639b66f8e",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/related_to"
+      }
+    ]
+  },
+  {
+    "@id": "_:N57ca91e8958b430fb9c4d1c73cd93406",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#allValuesFrom": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/FamilialRelationshipType"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:Nc53f714b3235463d843923fb217583ba",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#minCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "_:N1fde789fd79442bba4768a931f9493b2",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Restriction"
+    ],
+    "http://www.w3.org/2002/07/owl#maxCardinality": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": 1
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#onProperty": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/type"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/companies",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "companies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/kitchen_sink/addresses",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "addresses"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink/Address"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/kitchen_sink"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/linkml/tests/core/used",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core/Activity"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "used"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/linkml/tests/core"
       }
     ]
   }

--- a/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.n3
+++ b/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.n3
@@ -48,144 +48,145 @@ And links, e.g to [Person](Person.md)""" .
 ks:AnyOfClasses a owl:Class ;
     rdfs:label "AnyOfClasses" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute2 ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:Person ks:Organization ) ] ;
             owl:onProperty ks:attribute2 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:attribute2 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute2 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfEnums a owl:Class ;
     rdfs:label "AnyOfEnums" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:attribute3 ],
+        [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:DiagnosisType ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:attribute3 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute3 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfMix a owl:Class ;
     rdfs:label "AnyOfMix" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute4 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfSimpleType a owl:Class ;
     rdfs:label "AnyOfSimpleType" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:unionOf ( xsd:string xsd:integer ) ] ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute1 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute1 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:unionOf ( xsd:string xsd:integer ) ] ;
             owl:onProperty ks:attribute1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:activities ],
+            owl:onProperty ks:companies ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:activities ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:persons ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:code_systems ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Person ;
             owl:onProperty ks:persons ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:companies ],
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty ks:activities ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:companies ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
-            owl:onProperty ks:code_systems ] ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:persons ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 1 .
 
 ks:EqualsString a owl:Class ;
     rdfs:label "EqualsString" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:attribute5 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:oneOf ( "foo" ) ] ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:attribute5 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute5 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:EqualsStringIn a owl:Class ;
     rdfs:label "EqualsStringIn" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:attribute6 ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:oneOf ( "foo" "bar" ) ] ;
-            owl:onProperty ks:attribute6 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute6 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FakeClass a owl:Class ;
     rdfs:label "FakeClass" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:test_attribute ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:test_attribute ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:test_attribute ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Friend a owl:Class ;
     rdfs:label "Friend" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -247,50 +248,50 @@ ks:OtherCodes a owl:Class ;
 ks:Relationship a owl:Class ;
     rdfs:label "Relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CordialnessEnum ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:related_to ] ;
+            owl:onProperty ks:type ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:WithLocation a owl:Class ;
@@ -342,31 +343,31 @@ bizcodes:004 a owl:Class ;
 ks:Address a owl:Class ;
     rdfs:label "Address" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:city ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:decimal ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:altitude ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:altitude ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -387,10 +388,10 @@ ks:BirthEvent a owl:Class ;
 ks:ClassWithSpaces a owl:Class ;
     rdfs:label "class with spaces" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -400,32 +401,32 @@ ks:ClassWithSpaces a owl:Class ;
 ks:Concept a owl:Class ;
     rdfs:label "Concept" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_code_system ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_code_system ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CodeSystem ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_code_system ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:in_code_system ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 <https://w3id.org/linkml/tests/kitchen_sink/CordialnessEnum#hateful> a owl:Class ;
@@ -457,22 +458,22 @@ ks:DiagnosisType a owl:Class ;
 ks:EmploymentEvent a owl:Class ;
     rdfs:label "EmploymentEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:employed_at ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
             owl:onProperty ks:employed_at ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:employed_at ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
             owl:onProperty ks:type ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
@@ -481,32 +482,32 @@ ks:EmploymentEvent a owl:Class ;
 ks:FamilialRelationship a owl:Class ;
     rdfs:label "FamilialRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:type ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:FamilialRelationshipType ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
-            owl:onProperty ks:related_to ],
         ks:Relationship ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 5 .
@@ -553,43 +554,46 @@ ks:KitchenStatus a owl:Class ;
 ks:MedicalEvent a owl:Class ;
     rdfs:label "MedicalEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom ks:DiagnosisConcept ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
             owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:procedure ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:ProcedureConcept ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:DiagnosisConcept ;
-            owl:onProperty ks:diagnosis ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:procedure ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
@@ -598,10 +602,7 @@ ks:Organization a owl:Class ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         ks:HasAliases ;
     skos:definition """An organization.
 
@@ -624,10 +625,10 @@ ks:ProcedureConcept a owl:Class ;
 ks:SubclassTest a owl:Class ;
     rdfs:label "subclass test" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:ClassWithSpaces ;
@@ -708,6 +709,9 @@ ks:CodeSystem a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
@@ -715,12 +719,9 @@ ks:CodeSystem a owl:Class ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -730,10 +731,10 @@ ks:Company a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:ceo ],
         ks:Organization ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -866,41 +867,41 @@ ks:test_attribute a owl:DatatypeProperty ;
 ks:Event a owl:Class ;
     rdfs:label "Event" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:boolean ;
             owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:is_current ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FamilialRelationshipType a owl:Class ;
@@ -914,22 +915,22 @@ ks:FamilialRelationshipType a owl:Class ;
 ks:Place a owl:Class ;
     rdfs:label "Place" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -937,32 +938,32 @@ ks:Place a owl:Class ;
 <https://w3id.org/linkml/tests/core/Agent> a owl:Class ;
     rdfs:label "agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ] ;
     skos:definition "a provence-generating agent" ;
     skos:exactMatch prov:Agent ;
     skos:inScheme <https://w3id.org/linkml/tests/core> .
@@ -1006,37 +1007,43 @@ ks:related_to a owl:DatatypeProperty ;
     rdfs:label "activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
@@ -1044,29 +1051,23 @@ ks:related_to a owl:DatatypeProperty ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:date ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ] ;
     skos:definition "a provence-generating activity" ;
     skos:inScheme <https://w3id.org/linkml/tests/core> ;
     skos:mappingRelation prov:Activity .
@@ -1088,68 +1089,88 @@ ks:Person a owl:Class ;
         <https://en.wikipedia.org/wiki/Person> ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:has_birth_event ],
+            owl:onProperty ks:has_medical_history ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:EmploymentEvent ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Address ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:MedicalEvent ;
             owl:onProperty ks:has_medical_history ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:BirthEvent ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:FamilialRelationship ;
             owl:onProperty ks:has_familial_relationships ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:EmploymentEvent ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Address ;
-            owl:onProperty ks:addresses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:addresses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:LifeStatusEnum ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
+                    owl:intersectionOf ( [ a rdfs:Datatype ;
+                                owl:oneOf ( "human" ) ] [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:string ;
+                                owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ) ] ;
             owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:BirthEvent ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_employment_history ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_employment_history ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1159,18 +1180,6 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 1 ] ) ] ) ] ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:MedicalEvent ;
-            owl:onProperty ks:has_medical_history ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:integer ;
@@ -1179,14 +1188,8 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
             owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:age_in_years ],
+            owl:onProperty ks:has_familial_relationships ],
         ks:HasAliases ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;

--- a/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.ttl
+++ b/tests/linkml/test_scripts/__snapshots__/genowl/meta_owl_custom_enum_separator.ttl
@@ -64,10 +64,10 @@ ks:AnyOfEnums a owl:Class ;
             owl:allValuesFrom [ owl:unionOf ( ks:DiagnosisType ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute3 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute3 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -77,53 +77,35 @@ ks:AnyOfMix a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
             owl:onProperty ks:attribute4 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( xsd:integer ks:Person ks:EmploymentEventType ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute4 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:AnyOfSimpleType a owl:Class ;
     rdfs:label "AnyOfSimpleType" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:attribute1 ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute1 ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:unionOf ( xsd:string xsd:integer ) ] ;
-            owl:onProperty ks:attribute1 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
-            owl:onProperty ks:code_systems ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:persons ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
-            owl:onProperty ks:persons ],
-        [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty ks:activities ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Company ;
-            owl:onProperty ks:companies ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:code_systems ],
+            owl:onProperty ks:persons ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
@@ -131,8 +113,26 @@ ks:Dataset a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
+            owl:allValuesFrom ks:CodeSystem ;
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Person ;
+            owl:onProperty ks:persons ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:activities ] ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:activities ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:code_systems ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Company ;
+            owl:onProperty ks:companies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:companies ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
     sh:order 1 .
 
@@ -142,50 +142,51 @@ ks:EqualsString a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:oneOf ( "foo" ) ] ;
             owl:onProperty ks:attribute5 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:attribute5 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:EqualsStringIn a owl:Class ;
     rdfs:label "EqualsStringIn" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:oneOf ( "foo" "bar" ) ] ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:attribute6 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:oneOf ( "foo" "bar" ) ] ;
             owl:onProperty ks:attribute6 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FakeClass a owl:Class ;
     rdfs:label "FakeClass" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:test_attribute ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:test_attribute ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Friend a owl:Class ;
     rdfs:label "Friend" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -247,14 +248,29 @@ ks:OtherCodes a owl:Class ;
 ks:Relationship a owl:Class ;
     rdfs:label "Relationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:related_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:type ],
@@ -262,35 +278,20 @@ ks:Relationship a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:CordialnessEnum ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:related_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ] ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:WithLocation a owl:Class ;
@@ -299,10 +300,10 @@ ks:WithLocation a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -342,28 +343,28 @@ bizcodes:004 a owl:Class ;
 ks:Address a owl:Class ;
     rdfs:label "Address" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:altitude ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:street ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:city ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:decimal ;
             owl:onProperty ks:altitude ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:city ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:street ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:altitude ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:city ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -373,13 +374,13 @@ ks:Address a owl:Class ;
 ks:BirthEvent a owl:Class ;
     rdfs:label "BirthEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Place ;
             owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_location ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -387,42 +388,42 @@ ks:BirthEvent a owl:Class ;
 ks:ClassWithSpaces a owl:Class ;
     rdfs:label "class with spaces" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:slot_with_space_1 ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty ks:slot_with_space_1 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:slot_with_space_1 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_1 ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Concept a owl:Class ;
     rdfs:label "Concept" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:allValuesFrom ks:CodeSystem ;
+            owl:onProperty ks:in_code_system ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:CodeSystem ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:in_code_system ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_code_system ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ] ;
@@ -458,21 +459,21 @@ ks:EmploymentEvent a owl:Class ;
     rdfs:label "EmploymentEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:employed_at ],
+            owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:employed_at ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:employed_at ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ owl:unionOf ( ks:CordialnessEnum ks:EmploymentEventType ) ] ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
             owl:allValuesFrom ks:Company ;
-            owl:onProperty ks:employed_at ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty ks:employed_at ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> ;
@@ -482,28 +483,28 @@ ks:FamilialRelationship a owl:Class ;
     rdfs:label "FamilialRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty ks:type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty ks:cordialness ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationshipType ;
             owl:onProperty ks:type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty ks:type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:related_to ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationshipType ;
-            owl:onProperty ks:type ],
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:cordialness ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty ks:cordialness ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:Person ;
             owl:onProperty ks:related_to ],
@@ -553,6 +554,18 @@ ks:KitchenStatus a owl:Class ;
 ks:MedicalEvent a owl:Class ;
     rdfs:label "MedicalEvent" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:diagnosis ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:Place ;
+            owl:onProperty ks:in_location ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
@@ -560,47 +573,35 @@ ks:MedicalEvent a owl:Class ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:diagnosis ],
+            owl:onProperty ks:in_location ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:ProcedureConcept ;
             owl:onProperty ks:procedure ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:DiagnosisConcept ;
             owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Place ;
-            owl:onProperty ks:in_location ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:diagnosis ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:in_location ],
         ks:Event ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         ks:HasAliases ;
     skos:definition """An organization.
@@ -627,10 +628,10 @@ ks:SubclassTest a owl:Class ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom ks:ClassWithSpaces ;
             owl:onProperty ks:slot_with_space_2 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:ClassWithSpaces ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:slot_with_space_2 ],
         ks:ClassWithSpaces ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -712,10 +713,10 @@ ks:CodeSystem a owl:Class ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
@@ -727,13 +728,13 @@ ks:CodeSystem a owl:Class ;
 ks:Company a owl:Class ;
     rdfs:label "Company" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom ks:Person ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:ceo ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:Person ;
+            owl:maxCardinality 1 ;
             owl:onProperty ks:ceo ],
         ks:Organization ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
@@ -741,10 +742,10 @@ ks:Company a owl:Class ;
 ks:HasAliases a owl:Class ;
     rdfs:label "HasAliases" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty ks:aliases ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:minCardinality 0 ;
             owl:onProperty ks:aliases ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -867,40 +868,40 @@ ks:Event a owl:Class ;
     rdfs:label "Event" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:metadata ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom ks:AnyObject ;
             owl:onProperty ks:metadata ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:is_current ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:metadata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:boolean ;
-            owl:onProperty ks:is_current ] ;
+            owl:onProperty ks:is_current ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:metadata ] ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
 ks:FamilialRelationshipType a owl:Class ;
@@ -917,20 +918,20 @@ ks:Place a owl:Class ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         ks:HasAliases ;
     skos:inScheme <https://w3id.org/linkml/tests/kitchen_sink> .
 
@@ -940,29 +941,29 @@ ks:Place a owl:Class ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/acted_on_behalf_of> ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ] ;
     skos:definition "a provence-generating agent" ;
     skos:exactMatch prov:Agent ;
     skos:inScheme <https://w3id.org/linkml/tests/core> .
@@ -1005,41 +1006,23 @@ ks:related_to a owl:DatatypeProperty ;
 <https://w3id.org/linkml/tests/core/Activity> a owl:Class ;
     rdfs:label "activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
@@ -1047,26 +1030,44 @@ ks:related_to a owl:DatatypeProperty ;
             owl:allValuesFrom <https://w3id.org/linkml/tests/core/Activity> ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
+            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:date ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/started_at_time> ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/linkml/tests/core/Agent> ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/was_associated_with> ] ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/used> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/was_informed_by> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:date ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/ended_at_time> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/description> ] ;
     skos:definition "a provence-generating activity" ;
     skos:inScheme <https://w3id.org/linkml/tests/core> ;
     skos:mappingRelation prov:Activity .
@@ -1088,39 +1089,10 @@ ks:Person a owl:Class ;
         <https://en.wikipedia.org/wiki/Person> ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:has_employment_history ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:has_familial_relationships ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:LifeStatusEnum ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:Address ;
             owl:onProperty ks:addresses ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:MedicalEvent ;
-            owl:onProperty ks:has_medical_history ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ks:BirthEvent ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty ks:has_birth_event ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:stomach_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:species_name ],
+            owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
@@ -1128,14 +1100,19 @@ ks:Person a owl:Class ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:EmploymentEvent ;
-            owl:onProperty ks:has_employment_history ],
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:onDatatype xsd:string ;
+                    owl:withRestrictions ( [ xsd:pattern "^\\S+ \\S+$" ] ) ] ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ks:age_in_years ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:species_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:has_medical_history ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1145,31 +1122,32 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 1 ] ) ] ) ] ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ;
-            owl:onProperty ks:species_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:is_living ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:addresses ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty ks:has_birth_event ],
         [ a owl:Restriction ;
-            owl:allValuesFrom ks:FamilialRelationship ;
-            owl:onProperty ks:has_familial_relationships ],
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:is_living ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:age_in_years ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty ks:species_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ks:age_in_years ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:allValuesFrom ks:LifeStatusEnum ;
+            owl:onProperty ks:is_living ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
@@ -1179,14 +1157,39 @@ ks:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 999 ] ) ] ) ] ;
             owl:onProperty ks:age_in_years ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/linkml/tests/core/id> ],
+            owl:allValuesFrom ks:Address ;
+            owl:onProperty ks:addresses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:intersectionOf ( [ a rdfs:Datatype ;
+                                owl:oneOf ( "human" ) ] [ a rdfs:Datatype ;
+                                owl:onDatatype xsd:string ;
+                                owl:withRestrictions ( [ xsd:pattern "^[A-Z]+[a-z]+(-[A-Z]+[a-z]+)?\\\\.[A-Z]+(-[0-9]{4})?$" ] ) ] ) ] ;
+            owl:onProperty ks:species_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:FamilialRelationship ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_employment_history ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty ks:is_living ],
+            owl:onProperty ks:stomach_count ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/linkml/tests/core/name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty ks:has_familial_relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:BirthEvent ;
+            owl:onProperty ks:has_birth_event ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:EmploymentEvent ;
+            owl:onProperty ks:has_employment_history ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom ks:MedicalEvent ;
+            owl:onProperty ks:has_medical_history ],
         ks:HasAliases ;
     skos:definition "A person, living or dead" ;
     skos:exactMatch schema1:Person ;


### PR DESCRIPTION
Wait for #3362

## Summary

Fixes #3432

1. When `is_literal` is `None` (*enum-ranged slots*), follow same `owl:oneOf` / `Literal` path that `equals_string_in`  uses.
2. Even after fix 1, the `_complement_of_union_of` should defensively filter `None` values (same path `_boolean_expression` already does) to prevent crashes from any other source of unsolvable constraint expressions.

Fix #3433

3. Iterate over `slot_definition` (the argument), so no slot constraints are silently lost  (any_of / all_of / none_of).

## How was this tested?

- Tested on large schema
- Tested locally and new unit tests

## Areas of uncertainty

I'm not overly familiar with owl.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

Assisted by:  LLM, diagnosis and unit tests
