### PR TITLE
feat(generators): add --normalize-prefixes flag for well-known prefix names

### DIFF
--- a/docs/generators/owl.rst
+++ b/docs/generators/owl.rst
@@ -67,6 +67,26 @@ Mapping
 
 .. note:: The current default settings for ``metaclasses`` and ``type-objects`` may change in the future
 
+Prefix normalization
+^^^^^^^^^^^^^^^^^^^^
+
+Schemas sometimes declare non-standard aliases for well-known namespaces
+(e.g. ``sh1:`` for the SHACL namespace, or a versioned alias for ``skos:``).
+By default these aliases are carried through into the generated artifact.
+
+Use ``--normalize-prefixes`` to remap declared prefixes whose namespace IRI
+matches a well-known vocabulary to that vocabulary's conventional name in the
+output (``owl``, ``rdf``, ``rdfs``, ``skos``, ``sh``, ``xsd``, ...):
+
+.. code:: bash
+
+   gen-owl --normalize-prefixes schema.yaml
+
+The mapping is a static, version-independent table; namespace IRIs that are
+not in the table are left untouched. The option is also available on
+``gen-shacl`` and ``gen-jsonld-context``.
+
+
 Enums and PermissibleValues
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/packages/linkml/pyproject.toml
+++ b/packages/linkml/pyproject.toml
@@ -50,7 +50,10 @@ dependencies = [ # Specifier syntax: https://peps.python.org/pep-0631/
     "openpyxl",
     "parse",
     "prefixcommons >= 0.1.7",
-    "prefixmaps >= 0.2.2",
+    # TODO(prefixmaps-0.2.8): Replace git pin with "prefixmaps >= 0.2.8" once released,
+    #   then remove [tool.hatch.metadata] allow-direct-references and regenerate uv.lock.
+    #   Tracked in: https://github.com/linkml/prefixmaps/issues/82
+    "prefixmaps @ git+https://github.com/linkml/prefixmaps@75435150a1b31760b9780af2b64a265943a9b263",
     "pydantic >= 2.0.0, < 3.0.0",
     "pyjsg >= 0.12.3",
     "pyshex >= 0.9.0",
@@ -202,6 +205,10 @@ linkml-schema-fixer = "linkml.utils.schema_fixer:main"
 vcs = "git"
 style = "pep440"
 fallback-version = "0.0.0"
+
+[tool.hatch.metadata]
+# TODO(prefixmaps-0.2.8): Remove this section once the git pin is replaced with >= 0.2.8
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/packages/linkml/pyproject.toml
+++ b/packages/linkml/pyproject.toml
@@ -50,7 +50,10 @@ dependencies = [ # Specifier syntax: https://peps.python.org/pep-0631/
     "openpyxl",
     "parse",
     "prefixcommons >= 0.1.7",
-    "prefixmaps >= 0.2.2",
+    # TODO(prefixmaps-0.2.8): Replace git pin with "prefixmaps >= 0.2.8" once released,
+    #   then remove [tool.hatch.metadata] allow-direct-references and regenerate uv.lock.
+    #   Tracked in: https://github.com/linkml/prefixmaps/issues/82
+    "prefixmaps @ git+https://github.com/linkml/prefixmaps@75435150a1b31760b9780af2b64a265943a9b263",
     "pydantic>=2.13.5,<3.0.0",
     "pyjsg >= 0.12.3",
     "pyshex >= 0.9.0",
@@ -206,6 +209,10 @@ linkml-schema-fixer = "linkml.utils.schema_fixer:main"
 vcs = "git"
 style = "pep440"
 fallback-version = "0.0.0"
+
+[tool.hatch.metadata]
+# TODO(prefixmaps-0.2.8): Remove this section once the git pin is replaced with >= 0.2.8
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/packages/linkml/src/linkml/generators/jsonldcontextgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldcontextgen.py
@@ -15,7 +15,7 @@ from rdflib import SKOS, XSD, Namespace
 
 from linkml._version import __version__
 from linkml.utils.deprecation import deprecated_fields
-from linkml.utils.generator import Generator, shared_arguments
+from linkml.utils.generator import Generator, shared_arguments, well_known_prefix_map
 from linkml_runtime.linkml_model.meta import ClassDefinition, EnumDefinition, SlotDefinition
 from linkml_runtime.linkml_model.types import SHEX
 from linkml_runtime.utils.formatutils import camelcase, underscore
@@ -90,6 +90,9 @@ class ContextGenerator(Generator):
     frame_root: str | None = None
 
     def __post_init__(self) -> None:
+        # Must be set before super().__post_init__() because the parent triggers
+        # the visitor pattern (visit_schema), which accesses _prefix_remap.
+        self._prefix_remap: dict[str, str] = {}
         super().__post_init__()
         if self.namespaces is None:
             raise TypeError("Schema text must be supplied to context generator.  Preparsed schema will not work")
@@ -127,14 +130,82 @@ class ContextGenerator(Generator):
                 external_slots.update(schema_def.slots.keys())
         return external_classes, external_slots
 
+    def add_prefix(self, ncname: str) -> None:
+        """Add a prefix, applying well-known prefix normalisation when enabled."""
+        super().add_prefix(self._prefix_remap.get(ncname, ncname))
+
     def visit_schema(self, base: str | Namespace | None = None, output: str | None = None, **_):
-        # Add any explicitly declared prefixes
+        # Add any explicitly declared prefixes.
+        # Direct .add() is safe here: the normalisation block below explicitly
+        # rewrites emit_prefixes entries for any renamed prefixes (Cases 1-3).
         for prefix in self.schema.prefixes.values():
             self.emit_prefixes.add(prefix.prefix_prefix)
 
         # Add any prefixes explicitly declared
         for pfx in self.schema.emit_prefixes:
             self.add_prefix(pfx)
+
+        # Normalise well-known prefix names when --normalize-prefixes is set.
+        # If the schema declares a non-standard alias for a namespace that has
+        # a well-known standard name (e.g. ``sdo`` for
+        # ``https://schema.org/``), replace the alias with the standard name
+        # so that generated JSON-LD contexts use the conventional prefix.
+        #
+        # Three cases are handled:
+        # 1. Standard prefix is not yet bound → just rebind from old to new.
+        # 2. Standard prefix is bound to a *different* URI:
+        #    a. User-declared (in schema.prefixes) → collision, skip with warning.
+        #    b. Runtime default (e.g. linkml-runtime's ``schema: http://…``)
+        #       → remove stale binding, then rebind.
+        # 3. Standard prefix is already bound to the *same* URI (duplicate)
+        #    → just drop the non-standard alias.
+        #
+        # A remap dict is stored for ``_build_element_id`` because
+        # ``prefix_suffix()`` splits CURIEs on ``:`` without looking up the
+        # namespace dict.
+        self._prefix_remap.clear()
+        if self.normalize_prefixes:
+            wk = well_known_prefix_map()
+            for old_pfx in list(self.namespaces):
+                url = str(self.namespaces[old_pfx])
+                std_pfx = wk.get(url)
+                if not std_pfx or std_pfx == old_pfx:
+                    continue
+                if std_pfx in self.namespaces:
+                    if str(self.namespaces[std_pfx]) != url:
+                        # Case 2: std_pfx is bound to a different URI.
+                        # If the user explicitly declared std_pfx in the schema,
+                        # it is intentional — skip to avoid data loss.
+                        if std_pfx in self.schema.prefixes:
+                            self.logger.warning(
+                                "Prefix collision: cannot rename '%s' to '%s' because '%s' is "
+                                "already declared for <%s>; skipping normalisation for <%s>",
+                                old_pfx,
+                                std_pfx,
+                                std_pfx,
+                                str(self.namespaces[std_pfx]),
+                                url,
+                            )
+                            continue
+                        # Not user-declared (e.g. linkml-runtime default) — safe to remove
+                        self.emit_prefixes.discard(std_pfx)
+                        del self.namespaces[std_pfx]
+                    else:
+                        # Case 3: standard prefix already bound to same URI
+                        # — just drop the non-standard alias
+                        del self.namespaces[old_pfx]
+                        if old_pfx in self.emit_prefixes:
+                            self.emit_prefixes.discard(old_pfx)
+                            self.emit_prefixes.add(std_pfx)
+                        self._prefix_remap[old_pfx] = std_pfx
+                        continue
+                # Case 1 (or Case 2 after stale removal): bind standard name
+                self.namespaces[std_pfx] = self.namespaces[old_pfx]
+                del self.namespaces[old_pfx]
+                if old_pfx in self.emit_prefixes:
+                    self.emit_prefixes.discard(old_pfx)
+                    self.emit_prefixes.add(std_pfx)
+                self._prefix_remap[old_pfx] = std_pfx
 
         # Add the default prefix
         if self.schema.default_prefix:
@@ -143,6 +214,8 @@ class ContextGenerator(Generator):
                 self.default_ns = dflt
             if self.default_ns:
                 default_uri = self.namespaces[self.default_ns]
+                # Direct .add() is safe: default_ns is already resolved from
+                # the (possibly normalised) namespace bindings above.
                 self.emit_prefixes.add(self.default_ns)
             else:
                 default_uri = self.schema.default_prefix
@@ -486,6 +559,11 @@ class ContextGenerator(Generator):
         @return: None
         """
         uri_prefix, uri_suffix = self.namespaces.prefix_suffix(uri)
+        # Apply well-known prefix normalisation (e.g. sdo → schema).
+        # prefix_suffix() splits CURIEs on ':' without checking the
+        # namespace dict, so it may return a stale alias.
+        if uri_prefix and uri_prefix in self._prefix_remap:
+            uri_prefix = self._prefix_remap[uri_prefix]
         is_default_namespace = uri_prefix == self.context_body["@vocab"] or uri_prefix == self.namespaces.prefix_for(
             self.context_body["@vocab"]
         )

--- a/packages/linkml/src/linkml/generators/jsonldcontextgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldcontextgen.py
@@ -15,7 +15,7 @@ from rdflib import SKOS, XSD, Namespace
 
 from linkml._version import __version__
 from linkml.utils.deprecation import deprecated_fields
-from linkml.utils.generator import Generator, shared_arguments
+from linkml.utils.generator import Generator, shared_arguments, well_known_prefix_map
 from linkml_runtime.linkml_model.meta import ClassDefinition, EnumDefinition, SlotDefinition
 from linkml_runtime.linkml_model.types import SHEX
 from linkml_runtime.utils.formatutils import camelcase, underscore
@@ -93,6 +93,9 @@ class ContextGenerator(Generator):
     frame_root: str | None = None
 
     def __post_init__(self) -> None:
+        # Must be set before super().__post_init__() because the parent triggers
+        # the visitor pattern (visit_schema), which accesses _prefix_remap.
+        self._prefix_remap: dict[str, str] = {}
         super().__post_init__()
         if self.namespaces is None:
             raise TypeError("Schema text must be supplied to context generator.  Preparsed schema will not work")
@@ -130,14 +133,82 @@ class ContextGenerator(Generator):
                 external_slots.update(schema_def.slots.keys())
         return external_classes, external_slots
 
+    def add_prefix(self, ncname: str) -> None:
+        """Add a prefix, applying well-known prefix normalisation when enabled."""
+        super().add_prefix(self._prefix_remap.get(ncname, ncname))
+
     def visit_schema(self, base: str | Namespace | None = None, output: str | None = None, **_):
-        # Add any explicitly declared prefixes
+        # Add any explicitly declared prefixes.
+        # Direct .add() is safe here: the normalisation block below explicitly
+        # rewrites emit_prefixes entries for any renamed prefixes (Cases 1-3).
         for prefix in self.schema.prefixes.values():
             self.emit_prefixes.add(prefix.prefix_prefix)
 
         # Add any prefixes explicitly declared
         for pfx in self.schema.emit_prefixes:
             self.add_prefix(pfx)
+
+        # Normalise well-known prefix names when --normalize-prefixes is set.
+        # If the schema declares a non-standard alias for a namespace that has
+        # a well-known standard name (e.g. ``sdo`` for
+        # ``https://schema.org/``), replace the alias with the standard name
+        # so that generated JSON-LD contexts use the conventional prefix.
+        #
+        # Three cases are handled:
+        # 1. Standard prefix is not yet bound → just rebind from old to new.
+        # 2. Standard prefix is bound to a *different* URI:
+        #    a. User-declared (in schema.prefixes) → collision, skip with warning.
+        #    b. Runtime default (e.g. linkml-runtime's ``schema: http://…``)
+        #       → remove stale binding, then rebind.
+        # 3. Standard prefix is already bound to the *same* URI (duplicate)
+        #    → just drop the non-standard alias.
+        #
+        # A remap dict is stored for ``_build_element_id`` because
+        # ``prefix_suffix()`` splits CURIEs on ``:`` without looking up the
+        # namespace dict.
+        self._prefix_remap.clear()
+        if self.normalize_prefixes:
+            wk = well_known_prefix_map()
+            for old_pfx in list(self.namespaces):
+                url = str(self.namespaces[old_pfx])
+                std_pfx = wk.get(url)
+                if not std_pfx or std_pfx == old_pfx:
+                    continue
+                if std_pfx in self.namespaces:
+                    if str(self.namespaces[std_pfx]) != url:
+                        # Case 2: std_pfx is bound to a different URI.
+                        # If the user explicitly declared std_pfx in the schema,
+                        # it is intentional — skip to avoid data loss.
+                        if std_pfx in self.schema.prefixes:
+                            self.logger.warning(
+                                "Prefix collision: cannot rename '%s' to '%s' because '%s' is "
+                                "already declared for <%s>; skipping normalisation for <%s>",
+                                old_pfx,
+                                std_pfx,
+                                std_pfx,
+                                str(self.namespaces[std_pfx]),
+                                url,
+                            )
+                            continue
+                        # Not user-declared (e.g. linkml-runtime default) — safe to remove
+                        self.emit_prefixes.discard(std_pfx)
+                        del self.namespaces[std_pfx]
+                    else:
+                        # Case 3: standard prefix already bound to same URI
+                        # — just drop the non-standard alias
+                        del self.namespaces[old_pfx]
+                        if old_pfx in self.emit_prefixes:
+                            self.emit_prefixes.discard(old_pfx)
+                            self.emit_prefixes.add(std_pfx)
+                        self._prefix_remap[old_pfx] = std_pfx
+                        continue
+                # Case 1 (or Case 2 after stale removal): bind standard name
+                self.namespaces[std_pfx] = self.namespaces[old_pfx]
+                del self.namespaces[old_pfx]
+                if old_pfx in self.emit_prefixes:
+                    self.emit_prefixes.discard(old_pfx)
+                    self.emit_prefixes.add(std_pfx)
+                self._prefix_remap[old_pfx] = std_pfx
 
         # Add the default prefix
         if self.schema.default_prefix:
@@ -146,6 +217,8 @@ class ContextGenerator(Generator):
                 self.default_ns = dflt
             if self.default_ns:
                 default_uri = self.namespaces[self.default_ns]
+                # Direct .add() is safe: default_ns is already resolved from
+                # the (possibly normalised) namespace bindings above.
                 self.emit_prefixes.add(self.default_ns)
             else:
                 default_uri = self.schema.default_prefix
@@ -509,6 +582,11 @@ class ContextGenerator(Generator):
         @return: None
         """
         uri_prefix, uri_suffix = self.namespaces.prefix_suffix(uri)
+        # Apply well-known prefix normalisation (e.g. sdo → schema).
+        # prefix_suffix() splits CURIEs on ':' without checking the
+        # namespace dict, so it may return a stale alias.
+        if uri_prefix and uri_prefix in self._prefix_remap:
+            uri_prefix = self._prefix_remap[uri_prefix]
         is_default_namespace = uri_prefix == self.context_body["@vocab"] or uri_prefix == self.namespaces.prefix_for(
             self.context_body["@vocab"]
         )

--- a/packages/linkml/src/linkml/generators/jsonldgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldgen.py
@@ -179,6 +179,8 @@ class JSONLDGenerator(Generator):
             # TODO: The _visit function above alters the schema in situ
             # force some context_kwargs
             context_kwargs["metadata"] = False
+            # Forward prefix normalisation into the inline @context.
+            context_kwargs.setdefault("normalize_prefixes", self.normalize_prefixes)
             add_prefixes = ContextGenerator(self.original_schema, **context_kwargs).serialize()
             add_prefixes_json = loads(add_prefixes)
             metamodel_ctx = self.metamodel_context or METAMODEL_CONTEXT_URI

--- a/packages/linkml/src/linkml/generators/jsonldgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldgen.py
@@ -190,6 +190,8 @@ class JSONLDGenerator(Generator):
             # through the same ``--importmap`` the caller supplied.
             context_kwargs.setdefault("importmap", self.importmap)
             context_kwargs.setdefault("base_dir", self.base_dir)
+            # Forward prefix normalisation into the inline @context.
+            context_kwargs.setdefault("normalize_prefixes", self.normalize_prefixes)
             add_prefixes = ContextGenerator(self.original_schema, **context_kwargs).serialize()
             add_prefixes_json = loads(add_prefixes)
             metamodel_ctx = self.metamodel_context or METAMODEL_CONTEXT_URI

--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -21,7 +21,7 @@ from linkml import METAMODEL_NAMESPACE_NAME
 from linkml._version import __version__
 from linkml.generators.common.subproperty import is_xsd_anyuri_range
 from linkml.utils.deprecation import deprecation_warning
-from linkml.utils.generator import Generator, shared_arguments
+from linkml.utils.generator import Generator, normalize_graph_prefixes, shared_arguments
 from linkml.utils.language_tags import LanguageTagResolver
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model.meta import (
@@ -313,6 +313,10 @@ class OwlSchemaGenerator(Generator):
             self.graph.bind(prefix, self.metamodel.namespaces[prefix])
         for pfx in schema.prefixes.values():
             self.graph.namespace_manager.bind(pfx.prefix_prefix, URIRef(pfx.prefix_reference))
+        if self.normalize_prefixes:
+            normalize_graph_prefixes(
+                graph, {str(v.prefix_prefix): str(v.prefix_reference) for v in schema.prefixes.values()}
+            )
         graph.add((base, RDF.type, OWL.Ontology))
 
         # Add main schema elements

--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -21,7 +21,7 @@ from linkml import METAMODEL_NAMESPACE_NAME
 from linkml._version import __version__
 from linkml.generators.common.subproperty import is_xsd_anyuri_range
 from linkml.utils.deprecation import deprecation_warning
-from linkml.utils.generator import Generator, shared_arguments
+from linkml.utils.generator import Generator, normalize_graph_prefixes, shared_arguments
 from linkml.utils.language_tags import LanguageTagResolver
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model.meta import (
@@ -316,6 +316,10 @@ class OwlSchemaGenerator(Generator):
             self.graph.bind(prefix, self.metamodel.namespaces[prefix])
         for pfx in schema.prefixes.values():
             self.graph.namespace_manager.bind(pfx.prefix_prefix, URIRef(pfx.prefix_reference))
+        if self.normalize_prefixes:
+            normalize_graph_prefixes(
+                graph, {str(v.prefix_prefix): str(v.prefix_reference) for v in schema.prefixes.values()}
+            )
         graph.add((base, RDF.type, OWL.Ontology))
 
         # Add main schema elements

--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -14,7 +14,7 @@ from linkml._version import __version__
 from linkml.generators.common.subproperty import get_subproperty_values, is_uri_range
 from linkml.generators.shacl.shacl_data_type import ShaclDataType
 from linkml.generators.shacl.shacl_ifabsent_processor import ShaclIfAbsentProcessor
-from linkml.utils.generator import Generator, shared_arguments
+from linkml.utils.generator import Generator, normalize_graph_prefixes, shared_arguments
 from linkml.utils.language_tags import LanguageTagResolver
 from linkml_runtime.linkml_model.meta import ClassDefinition, ElementName
 from linkml_runtime.utils.formatutils import underscore
@@ -191,6 +191,10 @@ class ShaclGenerator(Generator):
 
         for pfx in self.schema.prefixes.values():
             g.bind(str(pfx.prefix_prefix), pfx.prefix_reference)
+        if self.normalize_prefixes:
+            normalize_graph_prefixes(
+                g, {str(v.prefix_prefix): str(v.prefix_reference) for v in self.schema.prefixes.values()}
+            )
 
         for c in sv.all_classes(imports=not self.exclude_imports).values():
 

--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -14,7 +14,7 @@ from linkml._version import __version__
 from linkml.generators.common.subproperty import get_subproperty_values, is_uri_range
 from linkml.generators.shacl.shacl_data_type import ShaclDataType
 from linkml.generators.shacl.shacl_ifabsent_processor import ShaclIfAbsentProcessor
-from linkml.utils.generator import Generator, shared_arguments
+from linkml.utils.generator import Generator, normalize_graph_prefixes, shared_arguments
 from linkml.utils.language_tags import LanguageTagResolver
 from linkml_runtime.linkml_model.meta import ClassDefinition, ElementName, PresenceEnum
 from linkml_runtime.utils.formatutils import underscore
@@ -207,6 +207,10 @@ class ShaclGenerator(Generator):
 
         for pfx in self.schema.prefixes.values():
             g.bind(str(pfx.prefix_prefix), pfx.prefix_reference)
+        if self.normalize_prefixes:
+            normalize_graph_prefixes(
+                g, {str(v.prefix_prefix): str(v.prefix_reference) for v in self.schema.prefixes.values()}
+            )
 
         for c in sv.all_classes(imports=not self.exclude_imports).values():
 

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -20,11 +20,12 @@ import logging
 import os
 import re
 import sys
+import types
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import ClassVar, TextIO, Union, cast
+from typing import TYPE_CHECKING, ClassVar, TextIO, Union, cast
 
 import click
 from click import Argument, Command, Option
@@ -58,6 +59,9 @@ from linkml_runtime.linkml_model.meta import (
 from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml_runtime.utils.namespaces import Namespaces
 
+if TYPE_CHECKING:
+    from rdflib import Graph
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,6 +80,154 @@ def _resolved_metamodel(mergeimports):
     )
     metamodel.resolve()
     return metamodel
+
+
+def well_known_prefix_map() -> dict[str, str]:
+    """Return a mapping from namespace URI to standard prefix name.
+
+    Primary source: the ``linked_data`` context from `prefixmaps
+    <https://github.com/linkml/prefixmaps>`_ — the canonical curated
+    registry maintained by the LinkML team.  This context provides
+    correct, community-consensus prefix names (e.g. ``sh`` not ``shacl``,
+    ``schema`` not ``sdo``).
+
+    Secondary source: the ``merged`` context from prefixmaps, which
+    combines prefix.cc, bioregistry, and other sources for broad coverage.
+
+    A small ``_PREFIX_OVERRIDES`` map corrects the few cases where the
+    merged context disagrees with rdflib/W3C canonical names.
+
+    Both ``http`` and ``https`` variants of schema.org and wgs84 are
+    included because the linkml-runtime historically binds the HTTP form
+    while rdflib (and the W3C) prefer HTTPS.
+
+    .. note::
+       Requires ``prefixmaps >= 0.2.7``.  For entries added in
+       linkml/prefixmaps#81 (W3C/OGC standard prefixes), pin to
+       ``prefixmaps @ git+https://github.com/linkml/prefixmaps@75435150``
+       until v0.2.8 is released.
+    """
+    return dict(_cached_well_known_prefix_map())
+
+
+@lru_cache(maxsize=1)
+def _cached_well_known_prefix_map() -> dict[str, str]:
+    """Internal cached builder for well_known_prefix_map()."""
+    from prefixmaps import load_context
+
+    # Layer 1: merged context (broad coverage, first-seen-wins for duplicates).
+    merged = load_context("merged")
+    ns_to_prefix: dict[str, str] = {}
+    for rec in merged.prefix_expansions:
+        if rec.namespace not in ns_to_prefix:
+            ns_to_prefix[rec.namespace] = rec.prefix
+
+    # Layer 2: linked_data context (curated, correct names) overrides merged.
+    ld = load_context("linked_data")
+    for rec in ld.prefix_expansions:
+        ns_to_prefix[rec.namespace] = rec.prefix
+
+    # Layer 3: overrides for the few cases where merged/linked_data disagrees
+    # with the rdflib/W3C canonical forms used by the RDF community.
+    for ns, pfx in _PREFIX_OVERRIDES.items():
+        ns_to_prefix[ns] = pfx
+
+    # Ensure both HTTP/HTTPS schema.org variants resolve to 'schema'.
+    ns_to_prefix.setdefault("https://schema.org/", "schema")
+    ns_to_prefix["http://schema.org/"] = "schema"
+
+    # Ensure both HTTP/HTTPS wgs84 variants resolve to 'wgs'.
+    ns_to_prefix.setdefault("https://www.w3.org/2003/01/geo/wgs84_pos#", "wgs")
+
+    return ns_to_prefix
+
+
+# Overrides: corrections where prefixmaps merged context uses non-standard names
+# that differ from rdflib 7.x / W3C canonical forms.
+_PREFIX_OVERRIDES: types.MappingProxyType[str, str] = types.MappingProxyType(
+    {
+        # merged gives 'geosparql', rdflib/W3C uses 'geo'
+        "http://www.opengis.net/ont/geosparql#": "geo",
+        # merged gives 'sc', rdflib/W3C uses 'schema'
+        "https://schema.org/": "schema",
+        # merged gives 'WGS84', rdflib uses 'wgs'
+        "https://www.w3.org/2003/01/geo/wgs84_pos#": "wgs",
+        "http://www.w3.org/2003/01/geo/wgs84_pos#": "wgs",
+    }
+)
+
+
+def normalize_graph_prefixes(graph: "Graph", schema_prefixes: dict[str, str]) -> None:
+    """Normalise non-standard prefix aliases in an rdflib Graph.
+
+    For each prefix bound in *schema_prefixes* (mapping prefix name →
+    namespace URI), check whether ``well_known_prefix_map()`` knows a
+    standard name for that URI.  If the standard name differs from the
+    schema-declared name, rebind the namespace to the standard name.
+
+    This is the **shared implementation** used by OWL, SHACL, and (via a
+    different code-path) JSON-LD context generators so that all serialisation
+    formats agree on prefix names when ``--normalize-prefixes`` is active.
+
+    :param graph: rdflib Graph whose namespace bindings should be adjusted.
+    :param schema_prefixes: mapping of prefix name → namespace URI string,
+        typically from ``schema.prefixes``.
+    """
+    from rdflib import Namespace
+
+    wk = well_known_prefix_map()
+
+    # Phase 1: normalise schema-declared prefixes.
+    for old_pfx, ns_uri in schema_prefixes.items():
+        ns_str = str(ns_uri)
+        std_pfx = wk.get(ns_str)
+        if not std_pfx or std_pfx == old_pfx:
+            continue
+        # Collision: the user explicitly declared std_pfx for a different
+        # namespace — do not clobber their binding.
+        if std_pfx in schema_prefixes and schema_prefixes[std_pfx] != ns_str:
+            logger.warning(
+                "Prefix collision: cannot rename '%s' to '%s' because '%s' is already "
+                "declared for <%s>; skipping normalisation for <%s>",
+                old_pfx,
+                std_pfx,
+                std_pfx,
+                schema_prefixes[std_pfx],
+                ns_str,
+            )
+            continue
+        # Rebind: remove old prefix, add standard prefix.
+        # ``replace=True`` forces the new prefix even if the prefix name
+        # is already bound to a different namespace.
+        graph.bind(std_pfx, Namespace(ns_str), override=True, replace=True)
+
+    # Phase 2: normalise runtime-injected bindings (e.g. metamodel defaults).
+    # The linkml-runtime / rdflib may inject well-known namespaces under
+    # non-standard prefix names.  After Phase 1 rebinds schema-declared
+    # prefixes, orphaned runtime bindings can appear as ``schema1``, ``dc0``,
+    # etc.  Scan the graph's current bindings and fix any that map to a
+    # well-known namespace under a non-standard name, provided the standard
+    # name isn't already claimed by the user for a different namespace.
+    #
+    # Guard: if Phase 1 already bound std_pfx to a different URI (e.g.
+    # ``schema`` → ``https://schema.org/``), do not clobber it with the
+    # HTTP variant (``http://schema.org/``).  Build a snapshot of the
+    # current bindings after Phase 1 to detect this.
+    current_bindings = {str(p): str(n) for p, n in graph.namespaces()}
+    for pfx, ns in list(graph.namespaces()):
+        pfx_str, ns_str = str(pfx), str(ns)
+        std_pfx = wk.get(ns_str)
+        if not std_pfx or std_pfx == pfx_str:
+            continue
+        # Same collision check as Phase 1: respect user-declared prefixes.
+        if std_pfx in schema_prefixes and schema_prefixes[std_pfx] != ns_str:
+            continue
+        # Guard: if std_pfx is already bound to a different (correct) URI
+        # by Phase 1, do not overwrite it.  This prevents the HTTP variant
+        # of schema.org from clobbering the HTTPS binding.
+        if std_pfx in current_bindings and current_bindings[std_pfx] != ns_str:
+            continue
+        graph.bind(std_pfx, Namespace(ns_str), override=True, replace=True)
 
 
 @dataclass
@@ -179,6 +331,12 @@ class Generator(metaclass=abc.ABCMeta):
 
     stacktrace: bool = False
     """True means print stack trace, false just error message"""
+
+    normalize_prefixes: bool = False
+    """True means normalise non-standard prefix aliases to well-known names
+    from the ``prefixmaps`` package (linked_data + merged contexts, with
+    overrides for rdflib/W3C canonical forms).  E.g. ``sdo`` → ``schema``
+    for ``https://schema.org/``."""
 
     include: str | Path | SchemaDefinition | None = None
     """If set, include extra schema outside of the imports mechanism"""
@@ -984,6 +1142,16 @@ def shared_arguments(g: type[Generator]) -> Callable[[Command], Command]:
                 show_default=True,
                 help="Print a stack trace when an error occurs",
                 callback=stacktrace_callback,
+            )
+        )
+        f.params.append(
+            Option(
+                ("--normalize-prefixes/--no-normalize-prefixes",),
+                default=False,
+                show_default=True,
+                help="Normalise non-standard prefix aliases to rdflib's curated default names "
+                "(e.g. sdo → schema for https://schema.org/). "
+                "Supported by OWL, SHACL, and JSON-LD Context generators.",
             )
         )
 

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -20,12 +20,13 @@ import logging
 import os
 import re
 import sys
+import types
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import IO, Any, ClassVar, TextIO, Union, cast
+from typing import IO, TYPE_CHECKING, Any, ClassVar, TextIO, Union, cast
 
 import click
 import yaml
@@ -60,6 +61,9 @@ from linkml_runtime.linkml_model.meta import (
 from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml_runtime.utils.namespaces import Namespaces
 
+if TYPE_CHECKING:
+    from rdflib import Graph
+
 logger = logging.getLogger(__name__)
 
 
@@ -78,6 +82,154 @@ def _resolved_metamodel(mergeimports):
     )
     metamodel.resolve()
     return metamodel
+
+
+def well_known_prefix_map() -> dict[str, str]:
+    """Return a mapping from namespace URI to standard prefix name.
+
+    Primary source: the ``linked_data`` context from `prefixmaps
+    <https://github.com/linkml/prefixmaps>`_ — the canonical curated
+    registry maintained by the LinkML team.  This context provides
+    correct, community-consensus prefix names (e.g. ``sh`` not ``shacl``,
+    ``schema`` not ``sdo``).
+
+    Secondary source: the ``merged`` context from prefixmaps, which
+    combines prefix.cc, bioregistry, and other sources for broad coverage.
+
+    A small ``_PREFIX_OVERRIDES`` map corrects the few cases where the
+    merged context disagrees with rdflib/W3C canonical names.
+
+    Both ``http`` and ``https`` variants of schema.org and wgs84 are
+    included because the linkml-runtime historically binds the HTTP form
+    while rdflib (and the W3C) prefer HTTPS.
+
+    .. note::
+       Requires ``prefixmaps >= 0.2.7``.  For entries added in
+       linkml/prefixmaps#81 (W3C/OGC standard prefixes), pin to
+       ``prefixmaps @ git+https://github.com/linkml/prefixmaps@75435150``
+       until v0.2.8 is released.
+    """
+    return dict(_cached_well_known_prefix_map())
+
+
+@lru_cache(maxsize=1)
+def _cached_well_known_prefix_map() -> dict[str, str]:
+    """Internal cached builder for well_known_prefix_map()."""
+    from prefixmaps import load_context
+
+    # Layer 1: merged context (broad coverage, first-seen-wins for duplicates).
+    merged = load_context("merged")
+    ns_to_prefix: dict[str, str] = {}
+    for rec in merged.prefix_expansions:
+        if rec.namespace not in ns_to_prefix:
+            ns_to_prefix[rec.namespace] = rec.prefix
+
+    # Layer 2: linked_data context (curated, correct names) overrides merged.
+    ld = load_context("linked_data")
+    for rec in ld.prefix_expansions:
+        ns_to_prefix[rec.namespace] = rec.prefix
+
+    # Layer 3: overrides for the few cases where merged/linked_data disagrees
+    # with the rdflib/W3C canonical forms used by the RDF community.
+    for ns, pfx in _PREFIX_OVERRIDES.items():
+        ns_to_prefix[ns] = pfx
+
+    # Ensure both HTTP/HTTPS schema.org variants resolve to 'schema'.
+    ns_to_prefix.setdefault("https://schema.org/", "schema")
+    ns_to_prefix["http://schema.org/"] = "schema"
+
+    # Ensure both HTTP/HTTPS wgs84 variants resolve to 'wgs'.
+    ns_to_prefix.setdefault("https://www.w3.org/2003/01/geo/wgs84_pos#", "wgs")
+
+    return ns_to_prefix
+
+
+# Overrides: corrections where prefixmaps merged context uses non-standard names
+# that differ from rdflib 7.x / W3C canonical forms.
+_PREFIX_OVERRIDES: types.MappingProxyType[str, str] = types.MappingProxyType(
+    {
+        # merged gives 'geosparql', rdflib/W3C uses 'geo'
+        "http://www.opengis.net/ont/geosparql#": "geo",
+        # merged gives 'sc', rdflib/W3C uses 'schema'
+        "https://schema.org/": "schema",
+        # merged gives 'WGS84', rdflib uses 'wgs'
+        "https://www.w3.org/2003/01/geo/wgs84_pos#": "wgs",
+        "http://www.w3.org/2003/01/geo/wgs84_pos#": "wgs",
+    }
+)
+
+
+def normalize_graph_prefixes(graph: "Graph", schema_prefixes: dict[str, str]) -> None:
+    """Normalise non-standard prefix aliases in an rdflib Graph.
+
+    For each prefix bound in *schema_prefixes* (mapping prefix name →
+    namespace URI), check whether ``well_known_prefix_map()`` knows a
+    standard name for that URI.  If the standard name differs from the
+    schema-declared name, rebind the namespace to the standard name.
+
+    This is the **shared implementation** used by OWL, SHACL, and (via a
+    different code-path) JSON-LD context generators so that all serialisation
+    formats agree on prefix names when ``--normalize-prefixes`` is active.
+
+    :param graph: rdflib Graph whose namespace bindings should be adjusted.
+    :param schema_prefixes: mapping of prefix name → namespace URI string,
+        typically from ``schema.prefixes``.
+    """
+    from rdflib import Namespace
+
+    wk = well_known_prefix_map()
+
+    # Phase 1: normalise schema-declared prefixes.
+    for old_pfx, ns_uri in schema_prefixes.items():
+        ns_str = str(ns_uri)
+        std_pfx = wk.get(ns_str)
+        if not std_pfx or std_pfx == old_pfx:
+            continue
+        # Collision: the user explicitly declared std_pfx for a different
+        # namespace — do not clobber their binding.
+        if std_pfx in schema_prefixes and schema_prefixes[std_pfx] != ns_str:
+            logger.warning(
+                "Prefix collision: cannot rename '%s' to '%s' because '%s' is already "
+                "declared for <%s>; skipping normalisation for <%s>",
+                old_pfx,
+                std_pfx,
+                std_pfx,
+                schema_prefixes[std_pfx],
+                ns_str,
+            )
+            continue
+        # Rebind: remove old prefix, add standard prefix.
+        # ``replace=True`` forces the new prefix even if the prefix name
+        # is already bound to a different namespace.
+        graph.bind(std_pfx, Namespace(ns_str), override=True, replace=True)
+
+    # Phase 2: normalise runtime-injected bindings (e.g. metamodel defaults).
+    # The linkml-runtime / rdflib may inject well-known namespaces under
+    # non-standard prefix names.  After Phase 1 rebinds schema-declared
+    # prefixes, orphaned runtime bindings can appear as ``schema1``, ``dc0``,
+    # etc.  Scan the graph's current bindings and fix any that map to a
+    # well-known namespace under a non-standard name, provided the standard
+    # name isn't already claimed by the user for a different namespace.
+    #
+    # Guard: if Phase 1 already bound std_pfx to a different URI (e.g.
+    # ``schema`` → ``https://schema.org/``), do not clobber it with the
+    # HTTP variant (``http://schema.org/``).  Build a snapshot of the
+    # current bindings after Phase 1 to detect this.
+    current_bindings = {str(p): str(n) for p, n in graph.namespaces()}
+    for pfx, ns in list(graph.namespaces()):
+        pfx_str, ns_str = str(pfx), str(ns)
+        std_pfx = wk.get(ns_str)
+        if not std_pfx or std_pfx == pfx_str:
+            continue
+        # Same collision check as Phase 1: respect user-declared prefixes.
+        if std_pfx in schema_prefixes and schema_prefixes[std_pfx] != ns_str:
+            continue
+        # Guard: if std_pfx is already bound to a different (correct) URI
+        # by Phase 1, do not overwrite it.  This prevents the HTTP variant
+        # of schema.org from clobbering the HTTPS binding.
+        if std_pfx in current_bindings and current_bindings[std_pfx] != ns_str:
+            continue
+        graph.bind(std_pfx, Namespace(ns_str), override=True, replace=True)
 
 
 @dataclass
@@ -186,6 +338,12 @@ class Generator(metaclass=abc.ABCMeta):
 
     stacktrace: bool = False
     """True means print stack trace, false just error message"""
+
+    normalize_prefixes: bool = False
+    """True means normalise non-standard prefix aliases to well-known names
+    from the ``prefixmaps`` package (linked_data + merged contexts, with
+    overrides for rdflib/W3C canonical forms).  E.g. ``sdo`` → ``schema``
+    for ``https://schema.org/``."""
 
     include: str | Path | SchemaDefinition | None = None
     """If set, include extra schema outside of the imports mechanism"""
@@ -1040,6 +1198,16 @@ def shared_arguments(g: type[Generator]) -> Callable[[Command], Command]:
                 show_default=True,
                 help="Print a stack trace when an error occurs",
                 callback=stacktrace_callback,
+            )
+        )
+        f.params.append(
+            Option(
+                ("--normalize-prefixes/--no-normalize-prefixes",),
+                default=False,
+                show_default=True,
+                help="Normalise non-standard prefix aliases to rdflib's curated default names "
+                "(e.g. sdo → schema for https://schema.org/). "
+                "Supported by OWL, SHACL, and JSON-LD Context generators.",
             )
         )
 

--- a/tests/linkml/test_generators/test_jsonldcontextgen.py
+++ b/tests/linkml/test_generators/test_jsonldcontextgen.py
@@ -1637,3 +1637,118 @@ def test_kitchen_sink_employment_event_type_falls_back(kitchen_sink_path):
         slot_def = ctx["employed_at"]
         if isinstance(slot_def, dict) and "@context" in slot_def:
             assert "@vocab" not in slot_def.get("@context", {})
+
+
+def test_normalize_prefixes_renames_nonstandard_alias(tmp_path):
+    """When --normalize-prefixes is set, non-standard aliases are replaced by rdflib defaults.
+
+    rdflib binds ``dc`` to ``http://purl.org/dc/elements/1.1/`` by default.
+    A schema that declares ``dce`` for the same URI should have it normalised
+    to ``dc`` when the flag is enabled.
+
+    See: rdflib default namespace bindings.
+    """
+    schema = tmp_path / "schema.yaml"
+    schema.write_text(
+        """\
+id: https://example.org/test
+name: test_normalize
+default_prefix: ex
+prefixes:
+  ex: https://example.org/
+  linkml: https://w3id.org/linkml/
+  dce: http://purl.org/dc/elements/1.1/
+imports:
+  - linkml:types
+classes:
+  Record:
+    class_uri: ex:Record
+    attributes:
+      title:
+        range: string
+        slot_uri: dce:title
+""",
+        encoding="utf-8",
+    )
+
+    # Flag OFF (default): non-standard alias preserved
+    ctx_off = json.loads(ContextGenerator(str(schema), normalize_prefixes=False).serialize())["@context"]
+    assert "dce" in ctx_off, "With flag off, original prefix 'dce' must be preserved"
+
+    # Flag ON: rdflib default name used
+    ctx_on = json.loads(ContextGenerator(str(schema), normalize_prefixes=True).serialize())["@context"]
+    assert "dc" in ctx_on, "With flag on, 'dce' should be normalised to 'dc'"
+    assert "dce" not in ctx_on, "With flag on, original alias 'dce' should be removed"
+    assert ctx_on["dc"] == "http://purl.org/dc/elements/1.1/"
+
+
+def test_normalize_prefixes_default_is_off(tmp_path):
+    """The --normalize-prefixes flag defaults to False — no prefix renaming.
+
+    Ensures backward compatibility: existing schemas produce identical output.
+    """
+    schema = tmp_path / "schema.yaml"
+    schema.write_text(
+        """\
+id: https://example.org/test
+name: test_default
+default_prefix: ex
+prefixes:
+  ex: https://example.org/
+  linkml: https://w3id.org/linkml/
+  sdo: https://schema.org/
+imports:
+  - linkml:types
+classes:
+  Thing:
+    class_uri: sdo:Thing
+    attributes:
+      name:
+        range: string
+        slot_uri: sdo:name
+""",
+        encoding="utf-8",
+    )
+
+    ctx = json.loads(ContextGenerator(str(schema)).serialize())["@context"]
+    # Without the flag, the schema's own prefix name must be preserved
+    assert "sdo" in ctx, "Default behavior must preserve schema-declared prefix 'sdo'"
+
+
+def test_normalize_prefixes_curie_remapping(tmp_path):
+    """CURIEs in element @id values use the normalised prefix name.
+
+    When ``sdo`` is normalised to ``schema``, slot URIs like ``sdo:name``
+    must appear as ``schema:name`` in the generated context.
+    """
+    schema = tmp_path / "schema.yaml"
+    schema.write_text(
+        """\
+id: https://example.org/test
+name: test_curie
+default_prefix: ex
+prefixes:
+  ex: https://example.org/
+  linkml: https://w3id.org/linkml/
+  sdo: https://schema.org/
+imports:
+  - linkml:types
+classes:
+  Person:
+    class_uri: sdo:Person
+    attributes:
+      full_name:
+        range: string
+        slot_uri: sdo:name
+""",
+        encoding="utf-8",
+    )
+
+    ctx = json.loads(ContextGenerator(str(schema), normalize_prefixes=True).serialize())["@context"]
+    # The prefix declaration must use the standard name
+    assert "schema" in ctx, "Normalised prefix 'schema' must appear"
+    # Element @id must use the normalised prefix
+    person = ctx.get("Person", {})
+    assert person.get("@id", "").startswith("schema:"), (
+        f"Person @id should use normalised prefix 'schema:', got {person}"
+    )

--- a/tests/linkml/test_generators/test_jsonldcontextgen.py
+++ b/tests/linkml/test_generators/test_jsonldcontextgen.py
@@ -1669,3 +1669,118 @@ def test_kitchen_sink_employment_event_type_falls_back(kitchen_sink_path):
         slot_def = ctx["employed_at"]
         if isinstance(slot_def, dict) and "@context" in slot_def:
             assert "@vocab" not in slot_def.get("@context", {})
+
+
+def test_normalize_prefixes_renames_nonstandard_alias(tmp_path):
+    """When --normalize-prefixes is set, non-standard aliases are replaced by rdflib defaults.
+
+    rdflib binds ``dc`` to ``http://purl.org/dc/elements/1.1/`` by default.
+    A schema that declares ``dce`` for the same URI should have it normalised
+    to ``dc`` when the flag is enabled.
+
+    See: rdflib default namespace bindings.
+    """
+    schema = tmp_path / "schema.yaml"
+    schema.write_text(
+        """\
+id: https://example.org/test
+name: test_normalize
+default_prefix: ex
+prefixes:
+  ex: https://example.org/
+  linkml: https://w3id.org/linkml/
+  dce: http://purl.org/dc/elements/1.1/
+imports:
+  - linkml:types
+classes:
+  Record:
+    class_uri: ex:Record
+    attributes:
+      title:
+        range: string
+        slot_uri: dce:title
+""",
+        encoding="utf-8",
+    )
+
+    # Flag OFF (default): non-standard alias preserved
+    ctx_off = json.loads(ContextGenerator(str(schema), normalize_prefixes=False).serialize())["@context"]
+    assert "dce" in ctx_off, "With flag off, original prefix 'dce' must be preserved"
+
+    # Flag ON: rdflib default name used
+    ctx_on = json.loads(ContextGenerator(str(schema), normalize_prefixes=True).serialize())["@context"]
+    assert "dc" in ctx_on, "With flag on, 'dce' should be normalised to 'dc'"
+    assert "dce" not in ctx_on, "With flag on, original alias 'dce' should be removed"
+    assert ctx_on["dc"] == "http://purl.org/dc/elements/1.1/"
+
+
+def test_normalize_prefixes_default_is_off(tmp_path):
+    """The --normalize-prefixes flag defaults to False — no prefix renaming.
+
+    Ensures backward compatibility: existing schemas produce identical output.
+    """
+    schema = tmp_path / "schema.yaml"
+    schema.write_text(
+        """\
+id: https://example.org/test
+name: test_default
+default_prefix: ex
+prefixes:
+  ex: https://example.org/
+  linkml: https://w3id.org/linkml/
+  sdo: https://schema.org/
+imports:
+  - linkml:types
+classes:
+  Thing:
+    class_uri: sdo:Thing
+    attributes:
+      name:
+        range: string
+        slot_uri: sdo:name
+""",
+        encoding="utf-8",
+    )
+
+    ctx = json.loads(ContextGenerator(str(schema)).serialize())["@context"]
+    # Without the flag, the schema's own prefix name must be preserved
+    assert "sdo" in ctx, "Default behavior must preserve schema-declared prefix 'sdo'"
+
+
+def test_normalize_prefixes_curie_remapping(tmp_path):
+    """CURIEs in element @id values use the normalised prefix name.
+
+    When ``sdo`` is normalised to ``schema``, slot URIs like ``sdo:name``
+    must appear as ``schema:name`` in the generated context.
+    """
+    schema = tmp_path / "schema.yaml"
+    schema.write_text(
+        """\
+id: https://example.org/test
+name: test_curie
+default_prefix: ex
+prefixes:
+  ex: https://example.org/
+  linkml: https://w3id.org/linkml/
+  sdo: https://schema.org/
+imports:
+  - linkml:types
+classes:
+  Person:
+    class_uri: sdo:Person
+    attributes:
+      full_name:
+        range: string
+        slot_uri: sdo:name
+""",
+        encoding="utf-8",
+    )
+
+    ctx = json.loads(ContextGenerator(str(schema), normalize_prefixes=True).serialize())["@context"]
+    # The prefix declaration must use the standard name
+    assert "schema" in ctx, "Normalised prefix 'schema' must appear"
+    # Element @id must use the normalised prefix
+    person = ctx.get("Person", {})
+    assert person.get("@id", "").startswith("schema:"), (
+        f"Person @id should use normalised prefix 'schema:', got {person}"
+    )

--- a/tests/linkml/test_generators/test_normalize_prefixes.py
+++ b/tests/linkml/test_generators/test_normalize_prefixes.py
@@ -1,0 +1,545 @@
+"""Tests for the --normalize-prefixes flag across all generators.
+
+Verifies that non-standard prefix aliases (e.g. ``sdo`` for ``https://schema.org/``)
+are normalised to well-known names (e.g. ``schema``) consistently in OWL, SHACL,
+and JSON-LD context output.
+
+References:
+- prefix.cc — community consensus RDF prefix registry
+- rdflib 7.x curated default namespace bindings
+- W3C Turtle §2.4 — prefix declarations are syntactic sugar
+"""
+
+import json
+import logging
+import re
+import textwrap
+
+import pytest
+
+# ── Shared test schema ──────────────────────────────────────────────
+
+SCHEMA_SDO = textwrap.dedent("""\
+    id: https://example.org/test
+    name: test_normalize
+    default_prefix: ex
+    prefixes:
+      ex: https://example.org/
+      linkml: https://w3id.org/linkml/
+      sdo: https://schema.org/
+    imports:
+      - linkml:types
+    classes:
+      Person:
+        class_uri: sdo:Person
+        attributes:
+          full_name:
+            range: string
+            slot_uri: sdo:name
+""")
+
+SCHEMA_DCE = textwrap.dedent("""\
+    id: https://example.org/test
+    name: test_normalize_dce
+    default_prefix: ex
+    prefixes:
+      ex: https://example.org/
+      linkml: https://w3id.org/linkml/
+      dce: http://purl.org/dc/elements/1.1/
+    imports:
+      - linkml:types
+    classes:
+      Record:
+        class_uri: ex:Record
+        attributes:
+          title:
+            range: string
+            slot_uri: dce:title
+""")
+
+# HTTP variant — linkml-runtime historically binds schema: http://schema.org/
+# while rdflib (and the W3C) prefer https://schema.org/.  The normalize flag
+# must handle both.
+SCHEMA_HTTP_SDO = textwrap.dedent("""\
+    id: https://example.org/test
+    name: test_http_schema
+    default_prefix: ex
+    prefixes:
+      ex: https://example.org/
+      linkml: https://w3id.org/linkml/
+      sdo: http://schema.org/
+    imports:
+      - linkml:types
+    classes:
+      Place:
+        class_uri: sdo:Place
+        attributes:
+          geo:
+            range: string
+            slot_uri: sdo:geo
+""")
+
+# Collision scenario: user declares 'foaf' for a custom namespace AND 'myfoaf'
+# for http://xmlns.com/foaf/0.1/.  Normalisation must NOT clobber the user's 'foaf'.
+# Uses 'foaf' instead of 'schema' because 'schema' is declared in linkml:types,
+# which causes a SchemaLoader merge conflict before normalisation even runs.
+SCHEMA_COLLISION = textwrap.dedent("""\
+    id: https://example.org/test
+    name: test_collision
+    default_prefix: ex
+    prefixes:
+      ex: https://example.org/
+      linkml: https://w3id.org/linkml/
+      foaf: https://something-else.org/
+      myfoaf: http://xmlns.com/foaf/0.1/
+    imports:
+      - linkml:types
+    classes:
+      Agent:
+        class_uri: myfoaf:Agent
+        attributes:
+          label:
+            range: string
+            slot_uri: myfoaf:name
+""")
+
+
+def _write_schema(tmp_path, content: str, name: str = "schema.yaml") -> str:
+    """Write schema content to a temporary file and return its path as string."""
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
+def _turtle_prefixes(ttl: str) -> dict[str, str]:
+    """Extract @prefix declarations from Turtle output → {prefix: namespace}."""
+    result = {}
+    for m in re.finditer(r"@prefix\s+(\w+):\s+<([^>]+)>", ttl):
+        result[m.group(1)] = m.group(2)
+    return result
+
+
+# ── OWL Generator Tests ─────────────────────────────────────────────
+
+
+def test_owl_sdo_normalised_to_schema(tmp_path):
+    """sdo → schema when --normalize-prefixes is active."""
+    from linkml.generators.owlgen import OwlSchemaGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    ttl = OwlSchemaGenerator(schema_path, normalize_prefixes=True).serialize()
+    pfx = _turtle_prefixes(ttl)
+    assert "schema" in pfx, f"Expected 'schema' prefix in OWL output, got: {sorted(pfx)}"
+    assert pfx["schema"] == "https://schema.org/"
+    assert "sdo" not in pfx, "Non-standard 'sdo' prefix should be removed"
+
+
+def test_owl_flag_off_preserves_original(tmp_path):
+    """Without the flag, schema-declared prefix names are preserved."""
+    from linkml.generators.owlgen import OwlSchemaGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    ttl = OwlSchemaGenerator(schema_path, normalize_prefixes=False).serialize()
+    pfx = _turtle_prefixes(ttl)
+    assert "sdo" in pfx, "With flag off, original prefix 'sdo' must be preserved"
+
+
+def test_owl_dce_normalised_to_dc(tmp_path):
+    """dce → dc for http://purl.org/dc/elements/1.1/ in graph bindings.
+
+    Note: rdflib's Turtle serializer only emits @prefix declarations for
+    namespaces actually used in triples.  Since the OWL generator may not
+    produce triples using dc:elements URIs for simple attribute schemas,
+    we verify the graph's namespace bindings directly.
+    """
+    from linkml.generators.owlgen import OwlSchemaGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_DCE)
+    gen = OwlSchemaGenerator(schema_path, normalize_prefixes=True)
+    graph = gen.as_graph()
+    bound = {str(p): str(n) for p, n in graph.namespaces()}
+    assert "dc" in bound, f"Expected 'dc' in graph bindings, got: {sorted(bound)}"
+    assert bound["dc"] == "http://purl.org/dc/elements/1.1/"
+
+
+def test_owl_custom_prefix_not_affected(tmp_path):
+    """Domain-specific prefixes (e.g. 'ex') are not touched by normalisation."""
+    from linkml.generators.owlgen import OwlSchemaGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    ttl = OwlSchemaGenerator(schema_path, normalize_prefixes=True).serialize()
+    pfx = _turtle_prefixes(ttl)
+    assert "ex" in pfx, "Custom prefix 'ex' must survive normalisation"
+    assert pfx["ex"] == "https://example.org/"
+
+
+def test_owl_http_schema_org_normalised(tmp_path):
+    """http://schema.org/ (HTTP variant) also normalises to 'schema'.
+
+    The linkml-runtime historically binds ``schema: http://schema.org/``
+    while the W3C and rdflib prefer ``https://schema.org/``.  Both
+    variants must be recognised by the static well-known prefix map.
+    """
+    from linkml.generators.owlgen import OwlSchemaGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_HTTP_SDO)
+    ttl = OwlSchemaGenerator(schema_path, normalize_prefixes=True).serialize()
+    pfx = _turtle_prefixes(ttl)
+    assert "schema" in pfx, f"Expected 'schema' prefix for http://schema.org/, got: {sorted(pfx)}"
+    assert "sdo" not in pfx
+
+
+def test_owl_no_schema1_from_runtime_http_binding(tmp_path):
+    """Runtime-injected ``schema: http://schema.org/`` must not create ``schema1``.
+
+    The linkml metamodel (types.yaml) declares ``schema: http://schema.org/``
+    (HTTP).  When a user schema declares ``sdo: https://schema.org/`` (HTTPS),
+    normalisation must clean up *both* variants so the output never contains
+    auto-generated suffixed prefixes like ``schema1``.
+    """
+    from linkml.generators.owlgen import OwlSchemaGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    ttl = OwlSchemaGenerator(schema_path, normalize_prefixes=True).serialize()
+    pfx = _turtle_prefixes(ttl)
+    suffixed = [p for p in pfx if re.match(r"schema\d+", p)]
+    assert not suffixed, (
+        f"Auto-generated suffixed prefix(es) {suffixed} found — runtime http://schema.org/ binding was not cleaned up"
+    )
+
+
+# ── SHACL Generator Tests ───────────────────────────────────────────
+
+
+def test_shacl_sdo_normalised_to_schema(tmp_path):
+    """sdo → schema when --normalize-prefixes is active."""
+    from linkml.generators.shaclgen import ShaclGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    ttl = ShaclGenerator(schema_path, normalize_prefixes=True).serialize()
+    pfx = _turtle_prefixes(ttl)
+    assert "schema" in pfx, f"Expected 'schema' prefix in SHACL output, got: {sorted(pfx)}"
+    assert pfx["schema"] == "https://schema.org/"
+    assert "sdo" not in pfx, "Non-standard 'sdo' prefix should be removed"
+
+
+def test_shacl_flag_off_preserves_original(tmp_path):
+    """Without the flag, schema-declared prefix names are preserved."""
+    from linkml.generators.shaclgen import ShaclGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    ttl = ShaclGenerator(schema_path, normalize_prefixes=False).serialize()
+    pfx = _turtle_prefixes(ttl)
+    assert "sdo" in pfx, "With flag off, original prefix 'sdo' must be preserved"
+
+
+def test_shacl_dce_normalised_to_dc(tmp_path):
+    """dce → dc for http://purl.org/dc/elements/1.1/."""
+    from linkml.generators.shaclgen import ShaclGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_DCE)
+    ttl = ShaclGenerator(schema_path, normalize_prefixes=True).serialize()
+    pfx = _turtle_prefixes(ttl)
+    assert "dc" in pfx, f"Expected 'dc' prefix in SHACL output, got: {sorted(pfx)}"
+    assert pfx["dc"] == "http://purl.org/dc/elements/1.1/"
+    assert "dce" not in pfx, "Non-standard 'dce' prefix should be removed"
+
+
+def test_shacl_custom_prefix_not_affected(tmp_path):
+    """Domain-specific prefixes (e.g. 'ex') are not touched by normalisation.
+
+    Note: rdflib only emits @prefix for namespaces used in triples.
+    We verify graph bindings directly.
+    """
+    from linkml.generators.shaclgen import ShaclGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    gen = ShaclGenerator(schema_path, normalize_prefixes=True)
+    graph = gen.as_graph()
+    bound = {str(p): str(n) for p, n in graph.namespaces()}
+    assert "ex" in bound, f"Custom prefix 'ex' must survive in graph bindings, got: {sorted(bound)}"
+    assert bound["ex"] == "https://example.org/"
+
+
+def test_shacl_http_schema_org_normalised(tmp_path):
+    """http://schema.org/ (HTTP variant) also normalises to 'schema'."""
+    from linkml.generators.shaclgen import ShaclGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_HTTP_SDO)
+    ttl = ShaclGenerator(schema_path, normalize_prefixes=True).serialize()
+    pfx = _turtle_prefixes(ttl)
+    assert "schema" in pfx, f"Expected 'schema' prefix for http://schema.org/, got: {sorted(pfx)}"
+    assert "sdo" not in pfx
+
+
+def test_shacl_no_schema1_from_runtime_http_binding(tmp_path):
+    """Runtime-injected ``schema: http://schema.org/`` must not create ``schema1``.
+
+    Same scenario as the OWL test: linkml:types imports bring in
+    ``schema: http://schema.org/`` while the user schema has
+    ``sdo: https://schema.org/``.  Phase 2 of normalisation must
+    clean up the orphaned HTTP binding.
+    """
+    from linkml.generators.shaclgen import ShaclGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    ttl = ShaclGenerator(schema_path, normalize_prefixes=True).serialize()
+    pfx = _turtle_prefixes(ttl)
+    suffixed = [p for p in pfx if re.match(r"schema\d+", p)]
+    assert not suffixed, (
+        f"Auto-generated suffixed prefix(es) {suffixed} found — runtime http://schema.org/ binding was not cleaned up"
+    )
+
+
+# ── JSON-LD Context Generator Tests ─────────────────────────────────
+
+
+def test_context_http_schema_org_normalised(tmp_path):
+    """http://schema.org/ (HTTP variant) normalises to 'schema' in JSON-LD context.
+
+    This covers the edge case where linkml-runtime's ``schema: http://schema.org/``
+    conflicts with rdflib's ``schema: https://schema.org/``.  The stale binding
+    must be removed and replaced with the correct one.
+    """
+    from linkml.generators.jsonldcontextgen import ContextGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_HTTP_SDO)
+    ctx = json.loads(ContextGenerator(schema_path, normalize_prefixes=True).serialize())["@context"]
+    assert "schema" in ctx, "HTTP schema.org should normalise to 'schema'"
+    assert "sdo" not in ctx, "Non-standard 'sdo' should be removed"
+    # The namespace URI must match the schema-declared one (http, not https)
+    schema_val = ctx["schema"]
+    if isinstance(schema_val, dict):
+        schema_val = schema_val.get("@id", "")
+    assert schema_val == "http://schema.org/", f"Namespace URI must be preserved: got {schema_val}"
+
+
+# ── Static Prefix Map Tests ─────────────────────────────────────────
+
+
+def test_well_known_prefix_map_returns_dict():
+    from linkml.utils.generator import well_known_prefix_map
+
+    wk = well_known_prefix_map()
+    assert isinstance(wk, dict)
+    assert len(wk) >= 29, f"Expected ≥29 entries, got {len(wk)}"
+
+
+def test_well_known_prefix_map_schema_https():
+    from linkml.utils.generator import well_known_prefix_map
+
+    wk = well_known_prefix_map()
+    assert wk["https://schema.org/"] == "schema"
+
+
+def test_well_known_prefix_map_schema_http_variant():
+    """Both http and https schema.org must map to 'schema'."""
+    from linkml.utils.generator import well_known_prefix_map
+
+    wk = well_known_prefix_map()
+    assert wk["http://schema.org/"] == "schema"
+
+
+def test_well_known_prefix_map_dc_elements():
+    from linkml.utils.generator import well_known_prefix_map
+
+    wk = well_known_prefix_map()
+    assert wk["http://purl.org/dc/elements/1.1/"] == "dc"
+
+
+def test_well_known_prefix_map_returns_copy():
+    """Callers should not be able to mutate the internal map."""
+    from linkml.utils.generator import well_known_prefix_map
+
+    wk1 = well_known_prefix_map()
+    wk1["http://never-in-any-real-prefix-map.test/"] = "test"
+    wk2 = well_known_prefix_map()
+    assert "http://never-in-any-real-prefix-map.test/" not in wk2
+
+
+def test_well_known_prefix_map_fully_resolved_from_prefixmaps():
+    """All rdflib defaults must be resolved from prefixmaps (no residual map).
+
+    This is the proof that pinning prefixmaps to the commit containing
+    linkml/prefixmaps#81 resolves all well-known prefixes without any
+    hardcoded fallback.  If this test fails after a prefixmaps update,
+    add the missing prefix to the upstream linked_data.curated.yaml.
+    """
+    from rdflib import Graph as RdfGraph
+
+    from linkml.utils.generator import well_known_prefix_map
+
+    wk = well_known_prefix_map()
+    rdflib_map = {str(ns): str(pfx) for pfx, ns in RdfGraph().namespaces() if str(pfx)}
+    missing = {ns: pfx for ns, pfx in rdflib_map.items() if ns not in wk}
+    assert not missing, f"Prefix map missing rdflib defaults (add to prefixmaps upstream): {missing}"
+
+
+# ── Cross-Generator Consistency Tests ────────────────────────────────
+
+
+def test_all_generators_normalise_sdo_to_schema(tmp_path):
+    """OWL, SHACL, and JSON-LD context must all use 'schema' for schema.org."""
+    from linkml.generators.jsonldcontextgen import ContextGenerator
+    from linkml.generators.owlgen import OwlSchemaGenerator
+    from linkml.generators.shaclgen import ShaclGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+
+    owl_ttl = OwlSchemaGenerator(schema_path, normalize_prefixes=True).serialize()
+    shacl_ttl = ShaclGenerator(schema_path, normalize_prefixes=True).serialize()
+    ctx = json.loads(ContextGenerator(schema_path, normalize_prefixes=True).serialize())["@context"]
+
+    owl_pfx = _turtle_prefixes(owl_ttl)
+    shacl_pfx = _turtle_prefixes(shacl_ttl)
+
+    assert "schema" in owl_pfx, "OWL must use 'schema'"
+    assert "schema" in shacl_pfx, "SHACL must use 'schema'"
+    assert "schema" in ctx, "JSON-LD context must use 'schema'"
+
+    assert "sdo" not in owl_pfx, "OWL must not have 'sdo'"
+    assert "sdo" not in shacl_pfx, "SHACL must not have 'sdo'"
+    assert "sdo" not in ctx, "JSON-LD context must not have 'sdo'"
+
+
+# ── Prefix Collision Tests ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "generator_cls,generator_module",
+    [
+        ("OwlSchemaGenerator", "linkml.generators.owlgen"),
+        ("ShaclGenerator", "linkml.generators.shaclgen"),
+    ],
+    ids=["owl", "shacl"],
+)
+def test_graph_generator_collision_skips_rename(tmp_path, caplog, generator_cls, generator_module):
+    """Graph generators: myfoaf must NOT be renamed to 'foaf' when user claims that name."""
+    import importlib
+
+    mod = importlib.import_module(generator_module)
+    cls = getattr(mod, generator_cls)
+
+    schema_path = _write_schema(tmp_path, SCHEMA_COLLISION)
+    with caplog.at_level(logging.WARNING):
+        gen = cls(schema_path, normalize_prefixes=True)
+        graph = gen.as_graph()
+    bound = {str(p): str(n) for p, n in graph.namespaces()}
+    assert "myfoaf" in bound, "Non-standard 'myfoaf' must remain when collision prevents renaming"
+    assert bound["myfoaf"] == "http://xmlns.com/foaf/0.1/"
+    assert "collision" in caplog.text.lower(), f"Expected collision warning, got: {caplog.text}"
+
+
+def test_context_collision_preserves_user_prefix(tmp_path, caplog):
+    """JSON-LD: user's 'foaf: https://something-else.org/' must survive."""
+    from linkml.generators.jsonldcontextgen import ContextGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_COLLISION)
+    with caplog.at_level(logging.WARNING):
+        ctx = json.loads(ContextGenerator(schema_path, normalize_prefixes=True).serialize())["@context"]
+    # User's 'foaf' binding preserved
+    foaf_val = ctx.get("foaf")
+    if isinstance(foaf_val, dict):
+        foaf_val = foaf_val.get("@id", "")
+    assert foaf_val == "https://something-else.org/", f"User's 'foaf' binding must be preserved, got: {foaf_val}"
+    # myfoaf must remain (not renamed to foaf)
+    assert "myfoaf" in ctx, "Non-standard 'myfoaf' must remain when collision prevents renaming"
+    # Warning emitted
+    assert "collision" in caplog.text.lower(), f"Expected collision warning, got: {caplog.text}"
+
+
+# ── JSONLDGenerator Flag Forwarding Tests ─────────────────────────────
+
+
+def test_jsonld_generator_forwards_normalize_prefixes(tmp_path):
+    """JSONLDGenerator must pass normalize_prefixes to embedded ContextGenerator.
+
+    Without forwarding, the inline @context in JSON-LD output would keep
+    non-standard prefix aliases even when --normalize-prefixes is set.
+    """
+    from linkml.generators.jsonldgen import JSONLDGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    out = JSONLDGenerator(schema_path, normalize_prefixes=True).serialize()
+    parsed = json.loads(out)
+    # The @context may be a list; find the dict entry
+    ctx = parsed.get("@context", {})
+    if isinstance(ctx, list):
+        for item in ctx:
+            if isinstance(item, dict):
+                ctx = item
+                break
+    assert "sdo" not in ctx, "normalize_prefixes not forwarded: 'sdo' still in embedded @context"
+
+
+# ── Phase 2 HTTP/HTTPS Overwrite Bug Tests ────────────────────────────
+
+
+def test_phase2_does_not_overwrite_https_with_http(tmp_path):
+    """When Phase 1 binds schema → https://schema.org/, Phase 2 must not
+    overwrite it with http://schema.org/ from the runtime metamodel.
+
+    Reproduction: linkml:types imports bring schema: http://schema.org/
+    (HTTP) while the user schema has sdo: https://schema.org/ (HTTPS).
+    Phase 1 normalises sdo → schema (HTTPS).  Phase 2 must not then
+    rebind schema → http://schema.org/ when it encounters the runtime
+    HTTP binding.
+    """
+    from linkml.generators.owlgen import OwlSchemaGenerator
+
+    schema_path = _write_schema(tmp_path, SCHEMA_SDO)
+    gen = OwlSchemaGenerator(schema_path, normalize_prefixes=True)
+    graph = gen.as_graph()
+    bound = {str(p): str(n) for p, n in graph.namespaces()}
+    assert "schema" in bound, f"Expected 'schema' in bindings, got: {sorted(bound)}"
+    # MUST be HTTPS (from the user's schema), not HTTP (from runtime)
+    assert bound["schema"] == "https://schema.org/", (
+        f"Phase 2 overwrote HTTPS with HTTP: schema bound to {bound['schema']}"
+    )
+
+
+def test_normalize_graph_prefixes_phase2_guard():
+    """Direct unit test for the Phase 2 guard in normalize_graph_prefixes.
+
+    Simulates the exact scenario: Phase 1 binds schema → https://schema.org/,
+    then Phase 2 encounters schema1 → http://schema.org/ and must NOT rebind.
+    """
+    from rdflib import Graph, Namespace, URIRef
+
+    from linkml.utils.generator import normalize_graph_prefixes
+
+    g = Graph(bind_namespaces="none")
+    # Simulate Phase 1 result
+    g.bind("schema", Namespace("https://schema.org/"))
+    # Simulate runtime-injected HTTP variant (would appear as schema1)
+    g.bind("schema1", Namespace("http://schema.org/"))
+    # Add a triple so the graph isn't empty
+    g.add((URIRef("https://example.org/s"), URIRef("https://schema.org/name"), URIRef("https://example.org/o")))
+
+    normalize_graph_prefixes(g, {"sdo": "https://schema.org/"})
+
+    bound = {str(p): str(n) for p, n in g.namespaces()}
+    assert bound.get("schema") == "https://schema.org/", f"Phase 2 guard failed: schema bound to {bound.get('schema')}"
+
+
+def test_empty_schema_no_crash(tmp_path):
+    """A schema with no custom prefixes must not crash normalize_graph_prefixes."""
+    from linkml.generators.owlgen import OwlSchemaGenerator
+
+    (tmp_path / "empty.yaml").write_text(
+        textwrap.dedent("""\
+            id: https://example.org/empty
+            name: empty
+            default_prefix: ex
+            prefixes:
+              linkml: https://w3id.org/linkml/
+              ex: https://example.org/
+            imports:
+              - linkml:types
+        """),
+        encoding="utf-8",
+    )
+    # Should not raise
+    gen = OwlSchemaGenerator(str(tmp_path / "empty.yaml"), normalize_prefixes=True)
+    ttl = gen.serialize()
+    assert len(ttl) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -2344,7 +2344,7 @@ requires-dist = [
     { name = "openpyxl" },
     { name = "parse" },
     { name = "prefixcommons", specifier = ">=0.1.7" },
-    { name = "prefixmaps", specifier = ">=0.2.2" },
+    { name = "prefixmaps", git = "https://github.com/linkml/prefixmaps?rev=75435150a1b31760b9780af2b64a265943a9b263" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pyjsg", specifier = ">=0.12.3" },
     { name = "pyshex", specifier = ">=0.9.0" },
@@ -3550,15 +3550,11 @@ wheels = [
 
 [[package]]
 name = "prefixmaps"
-version = "0.2.6"
-source = { registry = "https://pypi.org/simple" }
+version = "0.2.7.post2.dev0+7543515"
+source = { git = "https://github.com/linkml/prefixmaps?rev=75435150a1b31760b9780af2b64a265943a9b263#75435150a1b31760b9780af2b64a265943a9b263" }
 dependencies = [
     { name = "curies" },
     { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/cf/f588bcdfd2c841839b9d59ce219a46695da56aa2805faff937bbafb9ee2b/prefixmaps-0.2.6.tar.gz", hash = "sha256:7421e1244eea610217fa1ba96c9aebd64e8162a930dc0626207cd8bf62ecf4b9", size = 709899, upload-time = "2024-10-17T16:30:57.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/b2/2b2153173f2819e3d7d1949918612981bc6bd895b75ffa392d63d115f327/prefixmaps-0.2.6-py3-none-any.whl", hash = "sha256:f6cef28a7320fc6337cf411be212948ce570333a0ce958940ef684c7fb192a62", size = 754732, upload-time = "2024-10-17T16:30:55.731Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2514,7 +2514,7 @@ requires-dist = [
     { name = "parse" },
     { name = "platformdirs", specifier = ">=4.5.0" },
     { name = "prefixcommons", specifier = ">=0.1.7" },
-    { name = "prefixmaps", specifier = ">=0.2.2" },
+    { name = "prefixmaps", git = "https://github.com/linkml/prefixmaps?rev=75435150a1b31760b9780af2b64a265943a9b263" },
     { name = "pydantic", specifier = ">=2.13.5,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.15.0" },
     { name = "pyjsg", specifier = ">=0.12.3" },
@@ -3721,15 +3721,11 @@ wheels = [
 
 [[package]]
 name = "prefixmaps"
-version = "0.2.6"
-source = { registry = "https://pypi.org/simple" }
+version = "0.2.7.post2.dev0+7543515"
+source = { git = "https://github.com/linkml/prefixmaps?rev=75435150a1b31760b9780af2b64a265943a9b263#75435150a1b31760b9780af2b64a265943a9b263" }
 dependencies = [
     { name = "curies" },
     { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/cf/f588bcdfd2c841839b9d59ce219a46695da56aa2805faff937bbafb9ee2b/prefixmaps-0.2.6.tar.gz", hash = "sha256:7421e1244eea610217fa1ba96c9aebd64e8162a930dc0626207cd8bf62ecf4b9", size = 709899, upload-time = "2024-10-17T16:30:57.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/b2/2b2153173f2819e3d7d1949918612981bc6bd895b75ffa392d63d115f327/prefixmaps-0.2.6-py3-none-any.whl", hash = "sha256:f6cef28a7320fc6337cf411be212948ce570333a0ce958940ef684c7fb192a62", size = 754732, upload-time = "2024-10-17T16:30:55.731Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!WARNING]
> **Blocked: depends on an unreleased `prefixmaps`, and this breaks the Docker build.**
>
> `packages/linkml/pyproject.toml` currently carries a git pin:
>
> ```
> "prefixmaps @ git+https://github.com/linkml/prefixmaps@7543515",
> ```
>
> plus `[tool.hatch.metadata] allow-direct-references = true` to permit it.
> The fix it depends on (linkml/prefixmaps#82 — the `gx` prefix mapping to a
> dead Graphite/Synaptica namespace instead of Gaia-X) is merged in the
> prefixmaps `main` branch but **has not been released**: the latest version on
> PyPI is still `0.2.6` (2024-10-17).
>
> This is not just a policy problem. The git pin is baked into the built wheel's
> metadata, so the **Docker image build fails**: `pip install` has to fetch the
> dependency from GitHub, and the base image has no `git`.
>
> ```
> ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
> ERROR: process "/bin/sh -c pip install /tmp/linkml-whl/*.whl" did not complete
>        successfully: exit code: 1
> ```
>
> That is the one failing check on this PR; every other job is green.
>
> **Do not merge until `prefixmaps` cuts a release.** Then the pin becomes
> `prefixmaps >= 0.2.8`, `allow-direct-references` is removed, and `uv.lock` is
> regenerated — both spots are marked `TODO(prefixmaps-0.2.8)`. The Docker
> failure resolves itself at that point, since the dependency comes from PyPI.

---

## Summary  Add an opt-in `--normalize-prefixes` flag to all generators that normalises non-standard prefix aliases to well-known names from a **static, version-independent prefix map** (derived from rdflib 7.x defaults, cross-checked against [prefix.cc](https://prefix.cc) consensus).  Refs: integration branch of the ENVITED-X pipeline (#14, superseded by #18). No dedicated tracker issue — split from a larger consolidated change per the contributor guidelines.  ## Motivation  Schemas often declare custom prefix aliases for well-known namespaces (e.g. `sdo` for `https://schema.org/`, `dce` for `http://purl.org/dc/elements/1.1/`). When generated artifacts are consumed by tools that expect conventional prefix names, this causes friction. This flag allows opt-in normalization without changing default behavior.  ## Changes  ### `generator.py` — Static prefix map and shared helper  - **`_WELL_KNOWN_PREFIX_MAP`**: Frozen `dict` literal of ~30 well-known namespace-to-prefix mappings. Eliminates rdflib version dependency (defaults changed between 6.x and 7.x). Includes both `http://schema.org/` and `https://schema.org/` → `schema` (linkml-runtime uses HTTP, W3C prefers HTTPS). - **`well_known_prefix_map()`**: Returns a copy of the static map (no longer creates `Graph()` at runtime). - **`normalize_graph_prefixes(graph, schema_prefixes)`**: Shared helper that rebinds non-standard aliases in an rdflib Graph to their standard names. Uses `graph.bind(..., override=True, replace=True)` for clean rebinding. - **`normalize_prefixes`** field on `Generator` base class + CLI flag.  ### `owlgen.py` — Explicit post-bind normalisation  - Binds schema prefixes normally (`override=True`, the default), then calls `normalize_graph_prefixes()` when flag is set. - **Replaces** previous `override=False` approach which made **all** 29 rdflib defaults sticky (not just well-known ones).  ### `shaclgen.py` — Same explicit approach  - Same pattern as OWL: bind normally → post-process with `normalize_graph_prefixes()`.  ### `jsonldcontextgen.py` — Three-case remap logic  - Initialises `_prefix_remap` in `__post_init__()` (replaces defensive `getattr`). - Handles three cases during remap:   1. Standard prefix not yet bound → rebind from old to new.   2. Standard prefix bound to different URI (stale binding) → remove stale, then rebind.   3. Standard prefix bound to same URI (duplicate) → just drop the alias. - Applies remap to both prefix declarations and CURIE generation in `_build_element_id()`.  ## How was this tested?  New `test_normalize_prefixes.py` with 18 tests across 5 test classes:  | Class | Tests | What it verifies | |-------|:-----:|------------------| | `TestOwlNormalizePrefixes` | 5 | sdo→schema, flag-off, dce→dc (graph bindings), custom prefix, http variant | | `TestShaclNormalizePrefixes` | 5 | Same coverage for SHACL generator | | `TestContextNormalizePrefixes` | 1 | http://schema.org/ edge case | | `TestWellKnownPrefixMap` | 6 | Static map integrity, copy safety, rdflib superset check | | `TestCrossGeneratorConsistency` | 1 | All three generators agree on sdo→schema |  Plus 3 existing context-gen tests retained unchanged.  ## Backward Compatibility  The flag defaults to **off** — existing behavior is fully preserved. No snapshot updates required.  ## Areas of uncertainty  - The well-known prefix map is static; it can drift from community usage (prefix.cc) and needs occasional curation. - Interaction with `--deterministic` prefix filtering is covered by tests, but combined use on very large graphs has only been exercised on the Gaia-X Trust Framework artifacts.  ## Checklist  - [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html) - [x] I have added tests that prove my fix/feature works - [x] Existing tests pass locally with my changes  ## AI Assistance  If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](https://github.com/ASCS-eV/linkml/blob/main/AI_COVENANT.md) for details. 