### PR TITLE
feat(contextgen): add @type: @vocab coercion for eligible enums

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonldcontextgen.py
+++ b/packages/linkml/src/linkml/generators/jsonldcontextgen.py
@@ -16,7 +16,7 @@ from rdflib import SKOS, XSD, Namespace
 from linkml._version import __version__
 from linkml.utils.deprecation import deprecated_fields
 from linkml.utils.generator import Generator, shared_arguments
-from linkml_runtime.linkml_model.meta import ClassDefinition, SlotDefinition
+from linkml_runtime.linkml_model.meta import ClassDefinition, EnumDefinition, SlotDefinition
 from linkml_runtime.linkml_model.types import SHEX
 from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml_runtime.utils.schemaview import SchemaView
@@ -300,6 +300,57 @@ class ContextGenerator(Generator):
             return True, next(iter(coercions))
         return False, None
 
+    def _vocab_eligible_enum(self, enum: EnumDefinition) -> tuple[bool, str | None]:
+        """Check if an enum qualifies for ``@type: @vocab`` context generation.
+
+        An enum is eligible when:
+
+        1. Every permissible value defines a ``meaning`` IRI.
+        2. All meaning IRIs share a single namespace prefix.
+        3. Each value's ``text`` equals the local part of its ``meaning`` CURIE.
+
+        When eligible, the generated context can use ``@type: @vocab`` with a
+        scoped ``@vocab`` set to the common namespace.  This lets bare string
+        values (e.g. ``"RoadTypeMotorway"``) expand to full IRIs — a JSON-LD
+        1.1 §4.2.3 / §4.1.8 compliant approach.
+
+        Returns ``(True, namespace_str)`` or ``(False, None)``.
+        """
+        if not enum.permissible_values:
+            return False, None
+
+        prefixes: set[str] = set()
+        for pv_text, pv in enum.permissible_values.items():
+            if not pv or not pv.meaning:
+                return False, None
+
+            meaning = str(pv.meaning)
+            if ":" not in meaning:
+                return False, None
+
+            prefix, local = meaning.split(":", 1)
+            prefixes.add(prefix)
+
+            if local != pv_text:
+                self.logger.debug(
+                    "Enum %s value '%s' text does not match meaning local name '%s'; falling back to ENUM_CONTEXT.",
+                    enum.name,
+                    pv_text,
+                    local,
+                )
+                return False, None
+
+        if len(prefixes) != 1:
+            return False, None
+
+        # Resolve the single prefix to a namespace URI
+        prefix = next(iter(prefixes))
+        namespace = self.namespaces.get(prefix)
+        if not namespace:
+            return False, None
+
+        return True, str(namespace)
+
     def visit_slot(self, aliased_slot_name: str, slot: SlotDefinition) -> None:
         if self.exclude_imports and slot.name not in self._local_slots:
             return
@@ -325,7 +376,17 @@ class ContextGenerator(Generator):
                 elif has_class_range:
                     slot_def["@type"] = "@id"
                 elif slot.range in self.schema.enums:
-                    slot_def["@context"] = ENUM_CONTEXT
+                    enum = self.schema.enums[slot.range]
+                    eligible, vocab_ns = self._vocab_eligible_enum(enum)
+                    if eligible:
+                        # JSON-LD 1.1 §4.2.3 + §4.1.8: scoped @vocab coercion.
+                        # Bare string values expand via @vocab; structured
+                        # {text, description, meaning} objects still work via
+                        # the SKOS mappings in the scoped context.
+                        slot_def["@type"] = "@vocab"
+                        slot_def["@context"] = {**ENUM_CONTEXT, "@vocab": vocab_ns}
+                    else:
+                        slot_def["@context"] = ENUM_CONTEXT
                     # Add the necessary prefixes to the namespace
                     skos = self.namespaces.prefix_for(SKOS)
                     if not skos:

--- a/tests/linkml/test_generators/test_jsonldcontextgen.py
+++ b/tests/linkml/test_generators/test_jsonldcontextgen.py
@@ -1387,3 +1387,253 @@ classes:
         assert result_iri.exit_code == 0, result_iri.output
         ctx_iri = json.loads(result_iri.output)["@context"]
         assert ctx_iri["homepage"]["@type"] == "@id"
+
+
+# Enum @type: @vocab context generation (JSON-LD 1.1 §4.2.3 + §4.1.8)
+# ---------------------------------------------------------------------------
+
+
+def _ctx_for_yaml(yaml_text: str, tmp_path, **kwargs) -> dict:
+    """Generate a context from inline YAML and return the @context dict."""
+    schema_path = tmp_path / "schema.yaml"
+    schema_path.write_text(textwrap.dedent(yaml_text), encoding="utf-8")
+    ctx_text = ContextGenerator(str(schema_path), **kwargs).serialize()
+    return json.loads(ctx_text)["@context"]
+
+
+ELIGIBLE_ENUM_SCHEMA = """\
+    id: https://example.org/test
+    name: test
+    default_prefix: test
+    prefixes:
+      linkml: https://w3id.org/linkml/
+      test: https://example.org/test/
+      myns: https://example.org/myns/
+    imports:
+      - linkml:types
+    enums:
+      ColorEnum:
+        enum_uri: myns:Color
+        permissible_values:
+          Red:
+            meaning: myns:Red
+          Green:
+            meaning: myns:Green
+          Blue:
+            meaning: myns:Blue
+    slots:
+      favorite_color:
+        slot_uri: test:favoriteColor
+        range: ColorEnum
+    classes:
+      Thing:
+        class_uri: test:Thing
+        slots:
+          - favorite_color
+"""
+
+
+def test_eligible_enum_gets_vocab_coercion(tmp_path):
+    """Enum where all values have meanings with matching text gets @type: @vocab."""
+    ctx = _ctx_for_yaml(ELIGIBLE_ENUM_SCHEMA, tmp_path)
+
+    slot_ctx = ctx["favorite_color"]
+    assert slot_ctx["@type"] == "@vocab", "Eligible enum slot should have @type: @vocab"
+    assert "@context" in slot_ctx
+    scoped = slot_ctx["@context"]
+    assert scoped["@vocab"] == "https://example.org/myns/"
+    # SKOS mappings preserved for backward compat with structured values
+    assert scoped["meaning"] == "@id"
+    assert scoped["text"] == "skos:notation"
+    assert scoped["description"] == "skos:prefLabel"
+
+
+INELIGIBLE_TEXT_MISMATCH_SCHEMA = """\
+    id: https://example.org/test
+    name: test
+    default_prefix: test
+    prefixes:
+      linkml: https://w3id.org/linkml/
+      test: https://example.org/test/
+      codes: https://example.org/codes/
+    imports:
+      - linkml:types
+    enums:
+      EventType:
+        permissible_values:
+          HIRE:
+            meaning: codes:001
+          FIRE:
+            meaning: codes:002
+    slots:
+      event_type:
+        slot_uri: test:eventType
+        range: EventType
+    classes:
+      Event:
+        class_uri: test:Event
+        slots:
+          - event_type
+"""
+
+
+def test_text_mismatch_falls_back_to_enum_context(tmp_path):
+    """Enum where text != meaning local name falls back to ENUM_CONTEXT only."""
+    ctx = _ctx_for_yaml(INELIGIBLE_TEXT_MISMATCH_SCHEMA, tmp_path)
+
+    slot_ctx = ctx["event_type"]
+    assert "@type" not in slot_ctx, "Ineligible enum should not get @type"
+    scoped = slot_ctx["@context"]
+    assert "@vocab" not in scoped, "Ineligible enum should not get scoped @vocab"
+    assert scoped["meaning"] == "@id"
+
+
+INELIGIBLE_NO_MEANING_SCHEMA = """\
+    id: https://example.org/test
+    name: test
+    default_prefix: test
+    prefixes:
+      linkml: https://w3id.org/linkml/
+      test: https://example.org/test/
+    imports:
+      - linkml:types
+    enums:
+      MoodEnum:
+        permissible_values:
+          happy:
+            description: feeling happy
+          sad:
+            description: feeling sad
+    slots:
+      mood:
+        slot_uri: test:mood
+        range: MoodEnum
+    classes:
+      Person:
+        class_uri: test:Person
+        slots:
+          - mood
+"""
+
+
+def test_no_meaning_falls_back_to_enum_context(tmp_path):
+    """Enum where some values lack meaning falls back to ENUM_CONTEXT."""
+    ctx = _ctx_for_yaml(INELIGIBLE_NO_MEANING_SCHEMA, tmp_path)
+
+    slot_ctx = ctx["mood"]
+    assert "@type" not in slot_ctx
+    scoped = slot_ctx["@context"]
+    assert "@vocab" not in scoped
+
+
+INELIGIBLE_MIXED_NS_SCHEMA = """\
+    id: https://example.org/test
+    name: test
+    default_prefix: test
+    prefixes:
+      linkml: https://w3id.org/linkml/
+      test: https://example.org/test/
+      ns1: https://example.org/ns1/
+      ns2: https://example.org/ns2/
+    imports:
+      - linkml:types
+    enums:
+      MixedEnum:
+        permissible_values:
+          Foo:
+            meaning: ns1:Foo
+          Bar:
+            meaning: ns2:Bar
+    slots:
+      mixed:
+        slot_uri: test:mixed
+        range: MixedEnum
+    classes:
+      Container:
+        class_uri: test:Container
+        slots:
+          - mixed
+"""
+
+
+def test_mixed_namespaces_falls_back_to_enum_context(tmp_path):
+    """Enum with values from different namespaces falls back to ENUM_CONTEXT."""
+    ctx = _ctx_for_yaml(INELIGIBLE_MIXED_NS_SCHEMA, tmp_path)
+
+    slot_ctx = ctx["mixed"]
+    assert "@type" not in slot_ctx
+    scoped = slot_ctx["@context"]
+    assert "@vocab" not in scoped
+
+
+def test_eligible_enum_bare_string_expands_to_iri(tmp_path):
+    """End-to-end: bare string enum value expands to the correct IRI.
+
+    Verifies the generated context enables the JSON-LD 1.1 expansion
+    described in §4.2.3 (type coercion via @vocab).
+
+    Uses rdflib's JSON-LD parser for expansion verification.
+    """
+    from rdflib import Graph, URIRef
+
+    ctx = _ctx_for_yaml(ELIGIBLE_ENUM_SCHEMA, tmp_path)
+
+    doc = {
+        "@context": ctx,
+        "@id": "urn:test:instance",
+        "favorite_color": "Red",
+    }
+
+    g = Graph()
+    g.parse(data=json.dumps(doc), format="json-ld")
+
+    pred = URIRef("https://example.org/test/favoriteColor")
+    objects = list(g.objects(URIRef("urn:test:instance"), pred))
+    assert len(objects) == 1
+    assert isinstance(objects[0], URIRef), f"Expected URIRef, got {type(objects[0]).__name__}: {objects[0]}"
+    assert str(objects[0]) == "https://example.org/myns/Red"
+
+
+def test_eligible_enum_structured_value_still_works(tmp_path):
+    """Structured enum value {text, meaning} still expands correctly.
+
+    The combined context (@type: @vocab + SKOS mappings) supports both
+    bare strings and structured objects simultaneously.
+
+    Uses rdflib's JSON-LD parser for expansion verification.
+    """
+    from rdflib import Graph, URIRef
+
+    ctx = _ctx_for_yaml(ELIGIBLE_ENUM_SCHEMA, tmp_path)
+
+    doc = {
+        "@context": ctx,
+        "@id": "urn:test:instance",
+        "favorite_color": {
+            "text": "Red",
+            "meaning": "https://example.org/myns/Red",
+        },
+    }
+
+    g = Graph()
+    g.parse(data=json.dumps(doc), format="json-ld")
+
+    pred = URIRef("https://example.org/test/favoriteColor")
+    subjects = list(g.objects(URIRef("urn:test:instance"), pred))
+    assert len(subjects) == 1
+    # The meaning → @id mapping makes the structured value a node with @id
+    assert isinstance(subjects[0], URIRef), f"Expected URIRef, got {type(subjects[0]).__name__}: {subjects[0]}"
+    assert str(subjects[0]) == "https://example.org/myns/Red"
+
+
+def test_kitchen_sink_employment_event_type_falls_back(kitchen_sink_path):
+    """Kitchen sink EmploymentEventType (HIRE→bizcodes:001) must fall back."""
+    ctx_text = ContextGenerator(kitchen_sink_path).serialize()
+    ctx = json.loads(ctx_text)["@context"]
+
+    # EmploymentEventType has text!=local (HIRE vs 001)
+    # Slots using this enum should not get @type: @vocab
+    if "employed_at" in ctx:
+        slot_def = ctx["employed_at"]
+        if isinstance(slot_def, dict) and "@context" in slot_def:
+            assert "@vocab" not in slot_def.get("@context", {})


### PR DESCRIPTION
> **Dependencies:** None (standalone PR)

## Summary

Adds JSON-LD 1.1 `@type: @vocab` coercion for enum-ranged slots whose permissible values are eligible (all have meanings, single namespace, text matches local name).

**Closes linkml/linkml#2497**

## Problem

LinkML's `visit_enum` is a no-op ÔÇö enum permissible values are not emitted in the generated JSON-LD context. Slots with enum ranges only get a structural `ENUM_CONTEXT` mapping (`{text: skos:notation, description: skos:prefLabel, meaning: @id}`), which requires structured object values.

In practice, JSON data files use **bare string** enum values (e.g. `"DrivableAreaType": "RoadTypeMotorway"`). Without context support, these remain plain strings and don't expand to IRIs.

## Approach

Uses JSON-LD 1.1 ┬º4.2.3 (type coercion via `@vocab`) combined with ┬º4.1.8 (scoped contexts):

```json
"DrivableAreaType": {
  "@id": "openlabel_v2:DrivableAreaType",
  "@type": "@vocab",
  "@context": {
    "@vocab": "https://w3id.org/ascs-ev/envited-x/openlabel/v2/",
    "text": "skos:notation",
    "description": "skos:prefLabel",
    "meaning": "@id"
  }
}
```

This supports **both** value forms simultaneously:

- **Bare string**: `"RoadTypeMotorway"` ÔåÆ expands to IRI via scoped `@vocab`
- **Structured object**: `{text, description, meaning}` ÔåÆ SKOS mappings still work

### Eligibility Criteria

An enum qualifies for `@type: @vocab` only when ALL conditions are met:

1. Every permissible value has a `meaning` IRI
2. All meaning IRIs share the same namespace prefix
3. Each value's `text` matches the local part of its `meaning` CURIE

Ineligible enums fall back to the existing `ENUM_CONTEXT` behavior unchanged.

### Collision handling

When many enum-typed slots share identical scoped `@context` blocks, the `pyld` JSON-LD processor has a scoped context cache pollution bug that causes `@type: @vocab` coercion to silently fail for all but the first term. We root-caused this to a stale `_uuid` cache key in `pyld`'s `_process_context()` and submitted a minimal fix upstream:

- **digitalbazaar/pyld#249**: fix: prevent scoped context cache pollution during context processing

Note that `rdflib`'s JSON-LD implementation is **not** affected ÔÇö the generated contexts are spec-compliant and work correctly with rdflib. The pyld bug only impacts consumers using the pyld library directly.

## Changes

| File | Change |
|------|--------|
| `packages/linkml/src/linkml/generators/jsonldcontextgen.py` | Added `_vocab_eligible_enum()` method (3-check eligibility) + modified `visit_slot` enum branch to emit `@type: @vocab` with scoped `@context` for eligible enums |
| `tests/linkml/test_generators/test_jsonldcontextgen.py` | 7 new tests: eligible enum (positive), 3 ineligible variants (text mismatch, no meaning, mixed namespaces), rdflib expansion verification (bare string + structured), kitchen_sink fallback |

## Testing

- **35 tests pass** in `test_jsonldcontextgen.py` (+ 3 xfailed for unrelated HTTPS schema.org issues)
- All existing context generator tests continue to pass ÔÇö ineligible enums fall back to `ENUM_CONTEXT` unchanged
- End-to-end rdflib expansion tests verify correct IRI expansion for both bare strings and structured objects
- Kitchen sink schema correctly falls back (`EmploymentEventType` has text Ôëá local: `HIRE` ÔåÆ `bizcodes:001`)

## Backward Compatibility

- Enums that don't meet the eligibility criteria produce **identical** output to before
- Eligible enums get strictly **more** information (`@type: @vocab` + scoped `@vocab`) ÔÇö the existing SKOS mappings are preserved in the scoped context
- No CLI flag required ÔÇö the feature activates automatically for qualifying enums

## References

- [JSON-LD 1.1 ┬º4.2.3: Type Coercion](https://www.w3.org/TR/json-ld11/#type-coercion) (`@type: @vocab`)
- [JSON-LD 1.1 ┬º4.1.8: Scoped Contexts](https://www.w3.org/TR/json-ld11/#scoped-contexts)
- linkml/linkml#2497: Enums not serialised to JSON-LD as anticipated
- digitalbazaar/pyld#249: pyld scoped context cache pollution fix (discovered while testing this feature)

