### PR TITLE
feat(gen-shacl): add --message-template for sh:message on property shapes

### DIFF
--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import string
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -21,6 +22,41 @@ from linkml_runtime.utils.rdf_canonicalize import canonicalize_rdf_graph
 from linkml_runtime.utils.yamlutils import TypedNode, extended_float, extended_int, extended_str
 
 logger = logging.getLogger(__name__)
+
+
+MESSAGE_TEMPLATE_FIELDS = ("name", "title", "description", "comments", "class", "path")
+"""Placeholders permitted in ``--message-template`` (see :attr:`ShaclGenerator.message_template`)."""
+
+
+def _validate_message_template(template: str) -> None:
+    """Validate a ``--message-template`` string, failing fast with a helpful error.
+
+    Only the bare placeholders in :data:`MESSAGE_TEMPLATE_FIELDS` are permitted.
+    Attribute access (``{name.foo}``), indexing (``{name[0]}``), positional fields
+    (``{0}`` / ``{}``), conversions (``{name!r}``) and format specs (``{name:>5}``)
+    are all rejected, as are unbalanced braces. Validation runs once, up front, so a
+    malformed template is caught even for schemas that contain no slots.
+
+    :param template: the raw template string.
+    :raises ValueError: if the template contains an unsupported placeholder or is
+        otherwise malformed.
+    """
+    allowed = frozenset(MESSAGE_TEMPLATE_FIELDS)
+    hint = "Allowed placeholders: " + ", ".join(f"{{{name}}}" for name in MESSAGE_TEMPLATE_FIELDS)
+    try:
+        parsed = list(string.Formatter().parse(template))
+    except ValueError as exc:
+        raise ValueError(f"Invalid placeholder in --message-template ({exc}). {hint}") from None
+    for _literal_text, field_name, format_spec, conversion in parsed:
+        if field_name is None:
+            continue
+        if field_name not in allowed:
+            raise ValueError(f"Invalid placeholder '{{{field_name}}}' in --message-template. {hint}")
+        if conversion is not None or format_spec:
+            raise ValueError(
+                f"Invalid placeholder '{{{field_name}}}' in --message-template: "
+                f"conversions and format specs are not supported. {hint}"
+            )
 
 
 @dataclass
@@ -85,6 +121,27 @@ class ShaclGenerator(Generator):
     Conforms to :rfc:`5646` (BCP 47).
     """
 
+    message_template: str | None = None
+    """Template for ``sh:message`` on property shapes.
+
+    When set, each property shape receives an ``sh:message`` literal built from
+    this template.  The following placeholders are expanded:
+
+    * ``{name}`` — the slot's LinkML name, exactly as written in the schema
+    * ``{title}`` — the slot title (human-readable), falls back to *name*
+    * ``{description}`` — the slot description, falls back to empty string
+    * ``{comments}`` — the slot comments joined with ``; ``, falls back to empty string
+    * ``{class}`` — the enclosing class name
+    * ``{path}``  — the fully-expanded property IRI
+
+    Example: ``"Validation of {name} failed!"`` →
+    ``sh:message "Validation of has_speed failed!"``
+
+    If ``default_language`` is set the literal is tagged with it. The message text
+    is a single template, so it deliberately follows ``default_language`` only and
+    ignores any per-slot ``in_language``.
+    """
+
     generatorname = os.path.basename(__file__)
     generatorversion = "0.0.1"
     valid_formats = ["ttl"]
@@ -109,6 +166,9 @@ class ShaclGenerator(Generator):
         # warning per distinct malformed tag.
         self._language_resolver = LanguageTagResolver(self.default_language)
         super().__post_init__()
+        self.message_template = (self.message_template or "").strip() or None
+        if self.message_template is not None:
+            _validate_message_template(self.message_template)
         self.generate_header()
 
     def generate_header(self) -> str:
@@ -198,6 +258,22 @@ class ShaclGenerator(Generator):
                 order += 1
                 prop_pv_text(SH.name, s.title)
                 prop_pv_text(SH.description, s.description)
+
+                # sh:message from a user template. The template is validated once in
+                # __post_init__, so expansion here cannot raise. The message is a single
+                # template string, so it is tagged with the generator default language
+                # only (via _resolve_language(None)) and ignores per-slot in_language.
+                if self.message_template is not None:
+                    msg_text = self.message_template.format(
+                        name=s.name,
+                        title=s.title or s.name,
+                        description=s.description or "",
+                        comments="; ".join(s.comments) if s.comments else "",
+                        **{"class": c.name},
+                        path=str(slot_uri),
+                    ).strip()
+                    if msg_text:
+                        g.add((pnode, SH.message, Literal(msg_text, lang=self._resolve_language(None))))
                 # minCount
                 if s.minimum_cardinality:
                     prop_pv_literal(SH.minCount, s.minimum_cardinality)
@@ -570,6 +646,18 @@ def add_simple_data_type(func: Callable, r: ElementName) -> None:
         "(e.g. en, de, zh-Hans).  When set, sh:name, sh:description, "
         "rdfs:label and rdfs:comment are emitted with the specified "
         "language tag."
+    ),
+)
+@click.option(
+    "--message-template",
+    default=None,
+    show_default=True,
+    help=(
+        "Template string for sh:message on each property shape. "
+        "Placeholders: {name} (slot name), {title} (slot title or name), "
+        "{description} (slot description), {comments} (slot comments joined with '; '), "
+        "{class} (class name), {path} (fully-expanded property IRI). "
+        'Example: "{name} ({class}): {description} [{comments}]"'
     ),
 )
 @click.version_option(__version__, "-V", "--version")

--- a/tests/linkml/test_generators/test_shaclgen.py
+++ b/tests/linkml/test_generators/test_shaclgen.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from typing import Any
 
+import pytest
 import rdflib
 from rdflib import RDF, RDFS, SH, Literal, URIRef
 from rdflib.collection import Collection
@@ -1221,6 +1222,34 @@ def _build_shacl_lang_schema():
     return sb.schema
 
 
+def _build_message_test_schema():
+    """Build a schema for sh:message testing (includes a second slot without title)."""
+    sb = SchemaBuilder()
+    sb.add_slot(
+        SlotDefinition(
+            "vehicle_name",
+            range="string",
+            description="The vehicle name.",
+            title="Name",
+            required=True,
+        )
+    )
+    sb.add_slot(
+        SlotDefinition(
+            "speed",
+            range="integer",
+            description="Speed in km/h.",
+        )
+    )
+    sb.add_class(
+        "Vehicle",
+        slots=["vehicle_name", "speed"],
+        description="A road vehicle.",
+    )
+    sb.add_defaults()
+    return sb.schema
+
+
 def _parse_shacl(schema, **kwargs):
     shacl = ShaclGenerator(schema, mergeimports=False, **kwargs).serialize()
     g = rdflib.Graph()
@@ -1442,3 +1471,276 @@ def test_shacl_default_language_bcp47_warning_is_deduplicated(caplog):
         f"expected exactly 1 in_language warning for 'toolongtag', got {len(in_language_warnings)}"
     )
     assert len(default_warnings) == 1, f"expected exactly 1 default-language warning, got {len(default_warnings)}"
+
+
+# ---------------------------------------------------------------------------
+# --message-template tests
+# ---------------------------------------------------------------------------
+
+
+def test_message_template_basic():
+    """--message-template emits sh:message on every property shape."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(schema, message_template="Validation of {name} failed!")
+
+    vehicle_shape = EX.Vehicle
+
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert Literal("Validation of vehicle_name failed!") in msgs
+
+    msgs = _get_prop_objects(g, vehicle_shape, EX.speed, SH.message)
+    assert Literal("Validation of speed failed!") in msgs
+
+
+def test_message_template_title_placeholder():
+    """{title} expands to slot title, falling back to slot name."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(schema, message_template="{title} is invalid")
+
+    vehicle_shape = EX.Vehicle
+
+    # vehicle_name has title="Name"
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert Literal("Name is invalid") in msgs
+
+    # speed has no title → falls back to slot name
+    msgs = _get_prop_objects(g, vehicle_shape, EX.speed, SH.message)
+    assert Literal("speed is invalid") in msgs
+
+
+def test_message_template_class_placeholder():
+    """{class} expands to the enclosing class name."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(schema, message_template="{class}.{name} constraint violated")
+
+    vehicle_shape = EX.Vehicle
+
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert Literal("Vehicle.vehicle_name constraint violated") in msgs
+
+
+def test_message_template_description_placeholder():
+    """{description} expands to the slot description, empty string when absent."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(schema, message_template="{name} ({class}): {description}")
+
+    vehicle_shape = EX.Vehicle
+
+    # vehicle_name has description="The vehicle name."
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert Literal("vehicle_name (Vehicle): The vehicle name.") in msgs
+
+    # speed has description="Speed in km/h."
+    msgs = _get_prop_objects(g, vehicle_shape, EX.speed, SH.message)
+    assert Literal("speed (Vehicle): Speed in km/h.") in msgs
+
+
+def test_message_template_description_fallback_empty():
+    """{description} falls back to empty string when slot has no description."""
+    sb = SchemaBuilder()
+    sb.add_slot(SlotDefinition("bare_slot", range="string"))
+    sb.add_class("Thing", slots=["bare_slot"])
+    sb.add_defaults()
+    g = _parse_shacl(sb.schema, message_template="{name}: {description}")
+
+    msgs = _get_prop_objects(g, EX.Thing, EX.bare_slot, SH.message)
+    assert Literal("bare_slot:") in msgs
+
+
+def test_message_template_comments_placeholder():
+    """{comments} expands to slot comments joined with '; '."""
+    sb = SchemaBuilder()
+    sb.add_slot(
+        SlotDefinition(
+            "wind_speed",
+            range="float",
+            description="Wind speed in metres per second.",
+            comments=["ISO 34503:2023, Section 10.2.3"],
+        )
+    )
+    sb.add_class("Weather", slots=["wind_speed"])
+    sb.add_defaults()
+    g = _parse_shacl(sb.schema, message_template="{name} ({class}): {description} [{comments}]")
+
+    msgs = _get_prop_objects(g, EX.Weather, EX.wind_speed, SH.message)
+    assert Literal("wind_speed (Weather): Wind speed in metres per second. [ISO 34503:2023, Section 10.2.3]") in msgs
+
+
+def test_message_template_comments_multiple():
+    """{comments} joins multiple comments with '; '."""
+    sb = SchemaBuilder()
+    sb.add_slot(
+        SlotDefinition(
+            "temperature",
+            range="float",
+            comments=["ISO 34503:2023, Section 10.2", "Unit: Celsius"],
+        )
+    )
+    sb.add_class("Weather", slots=["temperature"])
+    sb.add_defaults()
+    g = _parse_shacl(sb.schema, message_template="{comments}")
+
+    msgs = _get_prop_objects(g, EX.Weather, EX.temperature, SH.message)
+    assert Literal("ISO 34503:2023, Section 10.2; Unit: Celsius") in msgs
+
+
+def test_message_template_comments_fallback_empty():
+    """{comments} falls back to empty string when slot has no comments."""
+    sb = SchemaBuilder()
+    sb.add_slot(SlotDefinition("bare_slot", range="string"))
+    sb.add_class("Thing", slots=["bare_slot"])
+    sb.add_defaults()
+    g = _parse_shacl(sb.schema, message_template="{name}: {comments}")
+
+    msgs = _get_prop_objects(g, EX.Thing, EX.bare_slot, SH.message)
+    assert Literal("bare_slot:") in msgs
+
+
+def test_no_message_template_no_sh_message():
+    """Without --message-template, no sh:message is emitted (backward-compat)."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(schema)
+
+    vehicle_shape = EX.Vehicle
+
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert msgs == []
+
+    msgs = _get_prop_objects(g, vehicle_shape, EX.speed, SH.message)
+    assert msgs == []
+
+
+def test_message_template_invalid_placeholder_raises():
+    """An invalid placeholder in --message-template raises ValueError."""
+    schema = _build_message_test_schema()
+    with pytest.raises(ValueError, match="Invalid placeholder"):
+        _parse_shacl(schema, message_template="Error: {invalid}")
+
+
+def test_message_template_positional_placeholder_raises():
+    """Positional placeholders like {0} raise ValueError."""
+    schema = _build_message_test_schema()
+    with pytest.raises(ValueError, match="Invalid placeholder"):
+        _parse_shacl(schema, message_template="Error: {0}")
+
+
+def test_message_template_format_spec_raises():
+    """Format specs like {name:d} raise ValueError."""
+    schema = _build_message_test_schema()
+    with pytest.raises(ValueError, match="Invalid placeholder"):
+        _parse_shacl(schema, message_template="Error: {name:d}")
+
+
+def test_message_template_empty_string_treated_as_none():
+    """An empty message_template is normalised to None (no sh:message)."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(schema, message_template="")
+
+    vehicle_shape = EX.Vehicle
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert msgs == []
+
+
+def test_message_template_whitespace_only_treated_as_none():
+    """A whitespace-only message_template is normalised to None (no sh:message)."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(schema, message_template="   ")
+
+    vehicle_shape = EX.Vehicle
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert msgs == []
+
+
+def test_message_template_with_default_language():
+    """sh:message is language-tagged when both --message-template and --default-language are set."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(
+        schema,
+        message_template="Validation of {name} failed!",
+        default_language="en",
+    )
+
+    vehicle_shape = EX.Vehicle
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert Literal("Validation of vehicle_name failed!", lang="en") in msgs
+
+    # Verify the message is NOT a plain literal
+    assert Literal("Validation of vehicle_name failed!") not in msgs
+
+
+def test_message_template_path_placeholder():
+    """{path} expands to the fully-expanded property IRI."""
+    schema = _build_message_test_schema()
+    g = _parse_shacl(schema, message_template="{path}")
+
+    vehicle_shape = EX.Vehicle
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    assert Literal(str(EX.vehicle_name)) in msgs
+
+
+def test_message_template_expands_to_empty_no_message():
+    """A template that expands to an empty string emits no sh:message."""
+    sb = SchemaBuilder()
+    sb.add_slot(SlotDefinition("bare_slot", range="string"))
+    sb.add_class("Thing", slots=["bare_slot"])
+    sb.add_defaults()
+    # bare_slot has no description, so "{description}" -> "" -> no sh:message.
+    g = _parse_shacl(sb.schema, message_template="{description}")
+
+    msgs = _get_prop_objects(g, EX.Thing, EX.bare_slot, SH.message)
+    assert msgs == []
+
+
+def test_message_template_attribute_access_raises():
+    """Attribute access in a placeholder (e.g. {name.upper}) raises a friendly ValueError."""
+    schema = _build_message_test_schema()
+    with pytest.raises(ValueError, match="Invalid placeholder"):
+        _parse_shacl(schema, message_template="{name.upper}")
+
+
+def test_message_template_index_access_raises():
+    """Index access in a placeholder (e.g. {name[0]}) raises a friendly ValueError."""
+    schema = _build_message_test_schema()
+    with pytest.raises(ValueError, match="Invalid placeholder"):
+        _parse_shacl(schema, message_template="{name[0]}")
+
+
+def test_message_template_unbalanced_brace_raises():
+    """A malformed template (unbalanced brace) raises a friendly ValueError."""
+    schema = _build_message_test_schema()
+    with pytest.raises(ValueError, match="Invalid placeholder"):
+        _parse_shacl(schema, message_template="Broken {name")
+
+
+def test_message_template_validated_up_front_on_slotless_schema():
+    """An invalid template is rejected up-front, even when no slots are iterated."""
+    sb = SchemaBuilder()
+    sb.add_class("Empty")  # no slots -> the per-slot loop never runs
+    sb.add_defaults()
+    with pytest.raises(ValueError, match="Invalid placeholder"):
+        ShaclGenerator(sb.schema, mergeimports=False, message_template="{bogus}")
+
+
+def test_message_template_ignores_per_slot_in_language():
+    """sh:message follows default_language only, ignoring a slot's in_language.
+
+    The message text is a single global template (one language), so unlike
+    sh:name / sh:description it must not be tagged with the slot's in_language.
+    """
+    schema = _build_message_test_schema()
+    schema.slots["vehicle_name"].in_language = "de"
+    g = _parse_shacl(
+        schema,
+        message_template="Validation of {name} failed!",
+        default_language="en",
+    )
+
+    vehicle_shape = EX.Vehicle
+    msgs = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.message)
+    # Message uses the generator default ("en"), NOT the slot's in_language ("de").
+    assert Literal("Validation of vehicle_name failed!", lang="en") in msgs
+    assert Literal("Validation of vehicle_name failed!", lang="de") not in msgs
+
+    # Contrast: sh:name DOES follow the slot's in_language ("de").
+    names = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.name)
+    assert Literal("Name", lang="de") in names


### PR DESCRIPTION
## Summary

Adds a `--message-template` CLI option to `gen-shacl` that generates `sh:message` literals on every SHACL property shape from a user-supplied template string. This enables SHACL validators (e.g. pyshacl) to produce human-friendly error messages identifying the specific constraint that was violated, rather than generic technical reports.

> **Rebased 2026-07-02:** #3449 (`--default-language`) is now merged into `main`, so its code and tests were dropped from this branch. This PR is now a **single commit** containing only the `--message-template` delta (`shaclgen.py` + `test_shaclgen.py`).

## Problem

LinkML's SHACL generator produces property shapes without `sh:message`. When SHACL validation fails (e.g. via pyshacl), the error report contains only technical identifiers:

```
Constraint Violation in MinCountConstraintComponent:
  Severity: sh:Violation
  Source Shape: [ sh:path <http://example.org/hasName> ; ... ]
  Focus Node: <http://example.org/instance1>
  Result Path: <http://example.org/hasName>
```

For ontologies with hundreds of shapes (our production ENVITED-X ontology has 164,646 SHACL triples), tracing violations back to their source requires manual cross-referencing. The SHACL specification (§2.4.1) explicitly provides `sh:message` for human-readable error context:

> *"Values of sh:message are either xsd:string literals or literals with a language tag. [...] The values of sh:message of a shape are produced as values of sh:resultMessage in the validation results."*

## Usage

```bash
# Basic usage - slot name in error messages:
gen-shacl --message-template 'Validation of {name} failed!' schema.yaml

# Rich messages with class context and description:
gen-shacl --message-template '{name} ({class}): {description}' schema.yaml

# Include standard references from comments field:
gen-shacl --message-template '{name} ({class}): {description} [{comments}]' schema.yaml

# Combined with --default-language for multilingual messages:
gen-shacl --message-template '{name} ({class}): {description}' --default-language en schema.yaml
```

### Supported placeholders

| Placeholder | Description | Example value |
|-------------|-------------|---------------|
| `{name}` | Slot name (underscore-separated) | `has_speed` |
| `{title}` | Slot title (human-readable), falls back to `name` | `Has Speed` |
| `{description}` | Slot description, falls back to empty string | `Speed in km/h.` |
| `{comments}` | Slot comments joined with `; `, falls back to empty string | `ISO 34503:2023, Section 10.2` |
| `{class}` | Enclosing class name | `Vehicle` |
| `{path}` | Full property IRI | `http://example.org/hasSpeed` |

### Example output

```turtle
ex:VehicleShape-has_speed a sh:PropertyShape ;
    sh:path ex:hasSpeed ;
    sh:name "Has Speed" ;
    sh:message "has_speed (Vehicle): Speed in km/h. [ISO 34503:2023, Section 10.2]" ;
    sh:datatype xsd:float .
```

With `--default-language en`:

```turtle
    sh:message "has_speed (Vehicle): Speed in km/h. [ISO 34503:2023, Section 10.2]"@en ;
```

pyshacl then produces:

```
Constraint Violation:
  Message: has_speed (Vehicle): Speed in km/h. [ISO 34503:2023, Section 10.2]
  Source Shape: ex:VehicleShape-has_speed
```

## Design decisions

### 1. Template-based, not per-shape

A single template applies to all property shapes. This is intentional:
- **Consistency**: all violations use the same message format
- **Simplicity**: one CLI flag vs. per-slot metamodel extension
- **Sufficient**: the 6 placeholders provide enough context to identify any shape and its semantics

Per-shape messages would require extending the LinkML metamodel (new metaslot), which is a much larger change. The template approach covers the 90% use case.

### 2. Separation of concerns with {comments}

The `{comments}` placeholder enables a clean separation between:
- **{description}**: semantic meaning of the slot (what it IS)
- **{comments}**: provenance/traceability metadata (WHERE it comes from)

This allows schemas to keep descriptions pure while still surfacing standard references (e.g. ISO clause numbers) in validation error messages via the template.

### 3. Language tag support via --default-language

When combined with `--default-language`, `sh:message` literals get the language tag. This is compliant with SHACL §2.4.1 and verified with pyshacl (which preserves the `@lang` tag on `sh:resultMessage` in validation reports).

Because the message text comes from a single template (one language), `sh:message` follows `--default-language` **only** and deliberately ignores any per-slot `in_language` — unlike `sh:name`/`sh:description`, whose text is the slot's own content.

### 4. Strict, up-front placeholder validation

The template is validated **once**, in `__post_init__` (before any slot is processed), by a restricted parser that accepts only the six bare placeholders. Every malformed template raises a single, helpful `ValueError` naming the allowed placeholders — even for a schema that has no slots to iterate:

- unknown field: `{invalid}`
- positional field: `{0}` / `{}`
- attribute access: `{name.foo}`
- index access: `{name[0]}`
- conversion: `{name!r}`
- format spec: `{name:>5}`
- unbalanced braces: `Broken {name`

Attribute/index access is **rejected** rather than silently traversing the object graph (e.g. `{class.__class__}`), so a template can never leak internals into a message nor crash the generator with a raw `AttributeError`/`TypeError`.

### 5. Whitespace normalisation

Empty and whitespace-only templates are normalised to `None` in `__post_init__`, preventing emission of empty `sh:message` values.

## Changes

### gen-shacl (`shaclgen.py`)
- New `message_template: str | None` field, normalised and validated in `__post_init__`
- New module-level `MESSAGE_TEMPLATE_FIELDS` + `_validate_message_template()`: a restricted, up-front parser permitting only the six bare placeholders
- Template expansion via `str.format()` with 6 placeholders: `{name}`, `{title}`, `{description}`, `{comments}`, `{class}`, `{path}`
- `{comments}` expands to `'; '.join(s.comments)` or empty string
- `sh:message` is tagged with `--default-language` only (ignores per-slot `in_language`)
- Any invalid template raises a single descriptive `ValueError` (attribute/index/positional/conversion/format/unbalanced), even on slot-less schemas
- New `--message-template` Click CLI option

### Tests (22 new tests)
1. **Basic** - template with `{name}` produces `sh:message`
2. **Title placeholder** - `{title}` expands correctly
3. **Class placeholder** - `{class}` expands correctly
4. **Description placeholder** - `{description}` expands correctly
5. **Description fallback** - missing description falls back to empty string
6. **Comments placeholder** - single comment expands correctly
7. **Comments multiple** - multiple comments joined with `; `
8. **Comments fallback** - missing comments falls back to empty string
9. **Backward compatibility** - no template = no `sh:message`
10. **Invalid placeholder** - `{invalid}` raises `ValueError`
11. **Positional placeholder** - `{0}` raises `ValueError`
12. **Format spec** - `{name:d}` raises `ValueError`
13. **Empty string** - normalised to no emission
14. **Whitespace-only** - normalised to no emission
15. **Combined with --default-language** - `sh:message` gets `@en` tag
16. **Path placeholder** - `{path}` expands to the fully-expanded IRI
17. **Empty expansion** - a template expanding to `""` emits no `sh:message`
18. **Attribute access** - `{name.upper}` raises `ValueError`
19. **Index access** - `{name[0]}` raises `ValueError`
20. **Unbalanced brace** - `Broken {name` raises `ValueError`
21. **Up-front validation** - invalid template on a slot-less schema still raises
22. **Ignores per-slot in_language** - `sh:message` uses `--default-language`, not the slot's `in_language`

## Standards compliance

| Standard | Requirement | Status |
|----------|-------------|--------|
| **SHACL §2.4.1** | `sh:message` accepts `xsd:string` or `rdf:langString` | ✅ |
| **SHACL Core** | `sh:message` is non-validating metadata for error reports | ✅ |
| **pyshacl** | Preserves `@lang` tag on `sh:resultMessage` in reports | ✅ Verified |

## Backward compatibility

- Default is `None` - **existing behaviour is completely unchanged**
- All pre-existing SHACL tests continue to pass
- Empty strings and whitespace-only values normalised to `None` (safe no-op)

## Testing

- Rebased onto current `main` (post #3449 merge); branch is a **single, signed commit** with only the `--message-template` delta.
- **All `gen-shacl` tests pass** on current `main`: 57 passed (existing `--default-language` tests now in `main` + 22 new `--message-template` tests), 0 skipped.
- Verified end-to-end with `gen-shacl --message-template '{name} ({class}): {description} [{comments}]' --default-language en`, which emits `sh:message "has_speed (Vehicle): Speed in km/h. [ISO 34503:2023, Section 10.2]"@en`.
- Validated against a real production schema (ENVITED-X `openlabel-v2`): all 1,226 property-shape `sh:message` values match the previously generated artifact.

## Related

- Builds on #3449 (`--default-language`, now **merged**) for language-tag support on `sh:message`.
- Complements #3295 (`--deterministic`) for reproducible SHACL output.
