### PR TITLE
Trigger CI on merge_group events to unblock the merge queue

### DIFF
--- a/.github/workflows/check-external-links.yaml
+++ b/.github/workflows/check-external-links.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - "main"
+  merge_group:
 
 jobs:
   docker:

--- a/.github/workflows/docs-test.yaml
+++ b/.github/workflows/docs-test.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rustgen.yaml
+++ b/.github/workflows/rustgen.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   test-rustgen:


### PR DESCRIPTION
I turned on the GitHub merge queue and PR #3460 was rejected from it three times in a row, each time about an hour after being enqueued. The cause is that when a PR enters the queue, GitHub fires a merge_group event against a temporary gh-readonly-queue branch and waits for the same required checks to report there. None of our workflows listened for merge_group, so no checks ever ran on the temp branch and the queue gave up after its timeout. Running `gh run list --event merge_group` confirmed zero runs across the repo.

This PR adds the merge_group trigger to every workflow that produces a required status check: main.yaml (quality-checks, test matrix, slow tests, test build package), docs-test.yaml (test_docs), rustgen.yaml (test-rustgen), check-external-links.yaml, and docker-build.yaml. No job logic changes, just the trigger.

The merge queue has already been disabled. Once this is in, we can re-enable the merge queue on main if we want.