### PR TITLE
DEMO — DO NOT MERGE — diff stability for #3407

### DIFF
--- a/examples/PersonSchema/personinfo.yaml
+++ b/examples/PersonSchema/personinfo.yaml
@@ -80,6 +80,7 @@ classes:
       - has_familial_relationships
       - has_interpersonal_relationships
       - has_medical_history
+      - person_comment
     slot_usage:
       primary_email:
         pattern: "^\\S+@[\\S+\\.]+\\S+"
@@ -278,6 +279,9 @@ slots:
 
   primary_email:
     slot_uri: schema:email
+  person_comment:
+    description: Free-text comment about the person.
+    range: string
   birth_date:
     slot_uri: schema:birthDate
   employed_at:

--- a/examples/PersonSchema/personinfo/owl/personinfo.owl.ttl
+++ b/examples/PersonSchema/personinfo/owl/personinfo.owl.ttl
@@ -85,20 +85,20 @@ linkml:examples\/personinfo.owl.ttl dcterms:license "https://creativecommons.org
 	skos:definition "Information about people, based on [schema.org](http://schema.org)" .
 personinfo:Address a owl:Class ;
 	rdfs:label "Address" ;
-	rdfs:subClassOf _:c14n130 , _:c14n156 , _:c14n157 , _:c14n35 , _:c14n52 , _:c14n57 , _:c14n74 , _:c14n93 , _:c14n97 ;
+	rdfs:subClassOf _:c14n133 , _:c14n159 , _:c14n160 , _:c14n35 , _:c14n52 , _:c14n57 , _:c14n74 , _:c14n95 , _:c14n99 ;
 	skos:exactMatch schema1:PostalAddress ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:CodeSystem a owl:Class ;
 	rdfs:label "code system" ;
-	rdfs:subClassOf _:c14n132 , _:c14n175 , _:c14n185 , _:c14n27 , _:c14n66 , _:c14n84 ;
+	rdfs:subClassOf _:c14n135 , _:c14n178 , _:c14n188 , _:c14n27 , _:c14n66 , _:c14n85 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:Concept a owl:Class ;
 	rdfs:label "Concept" ;
-	rdfs:subClassOf personinfo:NamedThing , _:c14n1 , _:c14n141 , _:c14n165 , _:c14n41 , _:c14n86 ;
+	rdfs:subClassOf personinfo:NamedThing , _:c14n1 , _:c14n144 , _:c14n168 , _:c14n41 , _:c14n87 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:Container a owl:Class ;
 	rdfs:label "Container" ;
-	rdfs:subClassOf _:c14n10 , _:c14n137 , _:c14n146 , _:c14n149 , _:c14n21 , _:c14n61 ;
+	rdfs:subClassOf _:c14n10 , _:c14n140 , _:c14n149 , _:c14n152 , _:c14n21 , _:c14n61 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:DiagnosisConcept a owl:Class ;
 	rdfs:label "DiagnosisConcept" ;
@@ -113,16 +113,16 @@ personinfo:DiagnosisType a owl:Class ;
 	linkml:permissible_values personinfo:DiagnosisType\#todo .
 personinfo:EmploymentEvent a owl:Class ;
 	rdfs:label "EmploymentEvent" ;
-	rdfs:subClassOf personinfo:Event , _:c14n101 , _:c14n120 , _:c14n153 , _:c14n166 , _:c14n46 , _:c14n51 ;
+	rdfs:subClassOf personinfo:Event , _:c14n103 , _:c14n123 , _:c14n156 , _:c14n169 , _:c14n46 , _:c14n51 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:Event a owl:Class ;
 	rdfs:label "Event" ;
-	rdfs:subClassOf _:c14n0 , _:c14n116 , _:c14n134 , _:c14n139 , _:c14n162 , _:c14n170 , _:c14n26 , _:c14n38 , _:c14n49 , _:c14n58 , _:c14n68 , _:c14n75 ;
+	rdfs:subClassOf _:c14n0 , _:c14n119 , _:c14n137 , _:c14n142 , _:c14n165 , _:c14n173 , _:c14n26 , _:c14n38 , _:c14n49 , _:c14n58 , _:c14n68 , _:c14n75 ;
 	skos:closeMatch schema1:Event ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:FamilialRelationship a owl:Class ;
 	rdfs:label "FamilialRelationship" ;
-	rdfs:subClassOf personinfo:Relationship , _:c14n114 , _:c14n155 , _:c14n2 , _:c14n5 , _:c14n56 , _:c14n8 ;
+	rdfs:subClassOf personinfo:Relationship , _:c14n117 , _:c14n158 , _:c14n2 , _:c14n5 , _:c14n56 , _:c14n8 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:FamilialRelationshipType a owl:Class ;
 	rdfs:label "FamilialRelationshipType" ;
@@ -131,17 +131,17 @@ personinfo:FamilialRelationshipType a owl:Class ;
 	linkml:permissible_values famrel:01 , famrel:02 , famrel:03 .
 personinfo:GenderType a owl:Class ;
 	rdfs:label "GenderType" ;
-	owl:unionOf _:c14n107 ;
+	owl:unionOf _:c14n109 ;
 	skos:inScheme linkml:examples\/personinfo ;
 	linkml:permissible_values GSSO:000371 , GSSO:000372 , GSSO:000384 , GSSO:000385 , GSSO:009253 , GSSO:009254 .
 personinfo:HasAliases a owl:Class ;
 	rdfs:label "HasAliases" ;
-	rdfs:subClassOf _:c14n123 , _:c14n22 ;
+	rdfs:subClassOf _:c14n126 , _:c14n22 ;
 	skos:definition "A mixin applied to any class that can have aliases/alternateNames" ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:HasNewsEvents a owl:Class ;
 	rdfs:label "HasNewsEvents" ;
-	rdfs:subClassOf _:c14n100 , _:c14n144 ;
+	rdfs:subClassOf _:c14n102 , _:c14n147 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:ImagingProcedureConcept a owl:Class ;
 	rdfs:label "ImagingProcedureConcept" ;
@@ -149,25 +149,25 @@ personinfo:ImagingProcedureConcept a owl:Class ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:IntegerPrimaryKeyObject a owl:Class ;
 	rdfs:label "IntegerPrimaryKeyObject" ;
-	rdfs:subClassOf _:c14n103 , _:c14n168 , _:c14n4 ;
+	rdfs:subClassOf _:c14n105 , _:c14n171 , _:c14n4 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:InterPersonalRelationship a owl:Class ;
 	rdfs:label "InterPersonalRelationship" ;
-	rdfs:subClassOf personinfo:Relationship , _:c14n13 , _:c14n145 , _:c14n183 , _:c14n39 , _:c14n54 , _:c14n65 ;
+	rdfs:subClassOf personinfo:Relationship , _:c14n13 , _:c14n148 , _:c14n186 , _:c14n39 , _:c14n54 , _:c14n65 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:MedicalEvent a owl:Class ;
 	rdfs:label "MedicalEvent" ;
-	rdfs:subClassOf personinfo:Event , personinfo:WithLocation , _:c14n119 , _:c14n14 , _:c14n152 , _:c14n164 , _:c14n17 , _:c14n44 ;
+	rdfs:subClassOf personinfo:Event , personinfo:WithLocation , _:c14n122 , _:c14n14 , _:c14n155 , _:c14n167 , _:c14n17 , _:c14n44 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:NamedThing a owl:Class ;
 	rdfs:label "NamedThing" ;
-	rdfs:subClassOf _:c14n105 , _:c14n128 , _:c14n143 , _:c14n151 , _:c14n158 , _:c14n167 , _:c14n184 , _:c14n42 , _:c14n48 , _:c14n59 , _:c14n79 , _:c14n90 ;
+	rdfs:subClassOf _:c14n107 , _:c14n131 , _:c14n146 , _:c14n154 , _:c14n161 , _:c14n170 , _:c14n187 , _:c14n42 , _:c14n48 , _:c14n59 , _:c14n79 , _:c14n92 ;
 	skos:closeMatch schema1:Thing ;
 	skos:definition "A generic grouping for any identifiable entity" ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:NewsEvent a owl:Class ;
 	rdfs:label "NewsEvent" ;
-	rdfs:subClassOf personinfo:Event , _:c14n172 , _:c14n55 , _:c14n76 ;
+	rdfs:subClassOf personinfo:Event , _:c14n175 , _:c14n55 , _:c14n76 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:NonFamilialRelationshipType\#BEST_FRIEND_OF a owl:Class ;
 	rdfs:label "BEST_FRIEND_OF" ;
@@ -177,7 +177,7 @@ personinfo:NonFamilialRelationshipType\#MORTAL_ENEMY_OF a owl:Class ;
 	rdfs:subClassOf personinfo:NonFamilialRelationshipType .
 personinfo:NonFamilialRelationshipType a owl:Class ;
 	rdfs:label "NonFamilialRelationshipType" ;
-	owl:unionOf _:c14n138 ;
+	owl:unionOf _:c14n141 ;
 	skos:inScheme linkml:examples\/personinfo ;
 	linkml:permissible_values famrel:70 , famrel:71 , personinfo:NonFamilialRelationshipType\#BEST_FRIEND_OF , personinfo:NonFamilialRelationshipType\#MORTAL_ENEMY_OF .
 personinfo:OperationProcedureConcept a owl:Class ;
@@ -186,7 +186,7 @@ personinfo:OperationProcedureConcept a owl:Class ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:Organization a owl:Class ;
 	rdfs:label "Organization" ;
-	rdfs:subClassOf personinfo:HasAliases , personinfo:HasNewsEvents , personinfo:NamedThing , _:c14n104 , _:c14n112 , _:c14n124 , _:c14n131 , _:c14n150 , _:c14n161 , _:c14n169 , _:c14n176 , _:c14n25 , _:c14n33 , _:c14n60 , _:c14n62 , _:c14n73 , _:c14n82 , _:c14n9 , _:c14n91 , _:c14n99 ;
+	rdfs:subClassOf personinfo:HasAliases , personinfo:HasNewsEvents , personinfo:NamedThing , _:c14n101 , _:c14n106 , _:c14n115 , _:c14n127 , _:c14n134 , _:c14n153 , _:c14n164 , _:c14n172 , _:c14n179 , _:c14n25 , _:c14n33 , _:c14n60 , _:c14n62 , _:c14n73 , _:c14n83 , _:c14n9 , _:c14n93 ;
 	skos:definition "An organization such as a company or university" ;
 	skos:exactMatch schema1:Organization ;
 	skos:inScheme linkml:examples\/personinfo .
@@ -207,18 +207,18 @@ personinfo:OrganizationType\#shell\%20company a owl:Class ;
 	rdfs:subClassOf personinfo:OrganizationType .
 personinfo:OrganizationType a owl:Class ;
 	rdfs:label "OrganizationType" ;
-	owl:unionOf _:c14n111 ;
+	owl:unionOf _:c14n114 ;
 	skos:inScheme linkml:examples\/personinfo ;
 	linkml:permissible_values bizcodes:001 , personinfo:OrganizationType\#for\%20profit , personinfo:OrganizationType\#loose\%20organization , personinfo:OrganizationType\#non\%20profit , personinfo:OrganizationType\#offshore , personinfo:OrganizationType\#shell\%20company .
 personinfo:Person a owl:Class ;
 	rdfs:label "Person" ;
-	rdfs:subClassOf personinfo:HasAliases , personinfo:HasNewsEvents , personinfo:NamedThing , _:c14n109 , _:c14n113 , _:c14n125 , _:c14n127 , _:c14n129 , _:c14n133 , _:c14n147 , _:c14n15 , _:c14n154 , _:c14n160 , _:c14n171 , _:c14n180 , _:c14n181 , _:c14n20 , _:c14n28 , _:c14n3 , _:c14n40 , _:c14n47 , _:c14n6 , _:c14n64 , _:c14n67 , _:c14n7 , _:c14n70 , _:c14n78 , _:c14n87 , _:c14n89 ;
+	rdfs:subClassOf personinfo:HasAliases , personinfo:HasNewsEvents , personinfo:NamedThing , _:c14n111 , _:c14n112 , _:c14n116 , _:c14n128 , _:c14n130 , _:c14n132 , _:c14n136 , _:c14n15 , _:c14n150 , _:c14n157 , _:c14n163 , _:c14n174 , _:c14n183 , _:c14n184 , _:c14n20 , _:c14n28 , _:c14n3 , _:c14n40 , _:c14n47 , _:c14n6 , _:c14n64 , _:c14n67 , _:c14n7 , _:c14n70 , _:c14n78 , _:c14n80 , _:c14n88 , _:c14n90 , _:c14n91 ;
 	skos:definition "A person (alive, dead, undead, or fictional)." ;
 	skos:exactMatch schema1:Person ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:Place a owl:Class ;
 	rdfs:label "Place" ;
-	rdfs:subClassOf personinfo:HasAliases , _:c14n108 , _:c14n12 , _:c14n121 , _:c14n173 , _:c14n177 , _:c14n179 , _:c14n29 , _:c14n77 , _:c14n81 ;
+	rdfs:subClassOf personinfo:HasAliases , _:c14n110 , _:c14n12 , _:c14n124 , _:c14n176 , _:c14n180 , _:c14n182 , _:c14n29 , _:c14n77 , _:c14n82 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:ProcedureConcept a owl:Class ;
 	rdfs:label "ProcedureConcept" ;
@@ -226,13 +226,13 @@ personinfo:ProcedureConcept a owl:Class ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:Relationship a owl:Class ;
 	rdfs:label "Relationship" ;
-	rdfs:subClassOf _:c14n110 , _:c14n118 , _:c14n135 , _:c14n159 , _:c14n16 , _:c14n174 , _:c14n178 , _:c14n24 , _:c14n31 , _:c14n36 , _:c14n50 , _:c14n88 ;
+	rdfs:subClassOf _:c14n113 , _:c14n121 , _:c14n138 , _:c14n16 , _:c14n162 , _:c14n177 , _:c14n181 , _:c14n24 , _:c14n31 , _:c14n36 , _:c14n50 , _:c14n89 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:SalaryType a rdfs:Datatype ;
 	owl:equivalentClass xsd:decimal .
 personinfo:WithLocation a owl:Class ;
 	rdfs:label "WithLocation" ;
-	rdfs:subClassOf _:c14n102 , _:c14n23 , _:c14n43 ;
+	rdfs:subClassOf _:c14n104 , _:c14n23 , _:c14n43 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:age_in_years a owl:DatatypeProperty ;
 	rdfs:label "age_in_years" ;
@@ -352,6 +352,11 @@ personinfo:organizations a owl:ObjectProperty ;
 	rdfs:label "organizations" ;
 	rdfs:range personinfo:Organization ;
 	skos:inScheme linkml:examples\/personinfo .
+personinfo:person_comment a owl:DatatypeProperty ;
+	rdfs:label "person_comment" ;
+	rdfs:range xsd:string ;
+	skos:definition "Free-text comment about the person." ;
+	skos:inScheme linkml:examples\/personinfo .
 personinfo:persons a owl:ObjectProperty ;
 	rdfs:label "persons" ;
 	rdfs:range personinfo:Person ;
@@ -381,7 +386,7 @@ personinfo:salary a owl:DatatypeProperty ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:score a owl:DatatypeProperty ;
 	rdfs:label "score" ;
-	rdfs:range _:c14n83 ;
+	rdfs:range _:c14n84 ;
 	skos:definition "A score between 0 and 5, represented as a decimal" ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:started_at_time a owl:DatatypeProperty ;
@@ -393,7 +398,7 @@ personinfo:street a owl:DatatypeProperty ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:telephone a owl:DatatypeProperty ;
 	rdfs:label "telephone" ;
-	rdfs:range _:c14n85 ;
+	rdfs:range _:c14n86 ;
 	skos:inScheme linkml:examples\/personinfo .
 personinfo:type a owl:DatatypeProperty ;
 	rdfs:label "type" ;
@@ -407,301 +412,302 @@ _:c14n1 a owl:Restriction ;
 _:c14n10 a owl:Restriction ;
 	owl:allValuesFrom personinfo:Organization ;
 	owl:onProperty personinfo:organizations .
-_:c14n100 a owl:Restriction ;
+_:c14n100 rdf:first GSSO:009253 ;
+	rdf:rest _:c14n143 .
+_:c14n101 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:mission_statement .
+_:c14n102 a owl:Restriction ;
 	owl:allValuesFrom personinfo:NewsEvent ;
 	owl:onProperty personinfo:has_news_events .
-_:c14n101 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:salary .
-_:c14n102 a owl:Restriction ;
-	owl:allValuesFrom personinfo:Place ;
-	owl:onProperty personinfo:in_location .
 _:c14n103 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:int_id .
+	owl:onProperty personinfo:salary .
 _:c14n104 a owl:Restriction ;
-	owl:allValuesFrom _:c14n192 ;
-	owl:onProperty personinfo:score .
+	owl:allValuesFrom personinfo:Place ;
+	owl:onProperty personinfo:in_location .
 _:c14n105 a owl:Restriction ;
 	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:int_id .
+_:c14n106 a owl:Restriction ;
+	owl:allValuesFrom _:c14n204 ;
+	owl:onProperty personinfo:score .
+_:c14n107 a owl:Restriction ;
+	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:name .
-_:c14n106 rdf:first personinfo:NonFamilialRelationshipType\#MORTAL_ENEMY_OF ;
+_:c14n108 rdf:first personinfo:NonFamilialRelationshipType\#MORTAL_ENEMY_OF ;
 	rdf:rest rdf:nil .
-_:c14n107 rdf:first GSSO:009254 ;
-	rdf:rest _:c14n98 .
-_:c14n108 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty personinfo:id .
-_:c14n109 a owl:Restriction ;
-	owl:allValuesFrom _:c14n224 ;
-	owl:onProperty personinfo:telephone .
+_:c14n109 rdf:first GSSO:009254 ;
+	rdf:rest _:c14n100 .
 _:c14n11 rdf:first GSSO:000371 ;
 	rdf:rest _:c14n45 .
 _:c14n110 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty personinfo:id .
+_:c14n111 a owl:Restriction ;
+	owl:allValuesFrom xsd:string ;
+	owl:onProperty personinfo:person_comment .
+_:c14n112 a owl:Restriction ;
+	owl:allValuesFrom _:c14n227 ;
+	owl:onProperty personinfo:telephone .
+_:c14n113 a owl:Restriction ;
 	owl:allValuesFrom personinfo:Person ;
 	owl:onProperty personinfo:related_to .
-_:c14n111 rdf:first personinfo:OrganizationType\#non\%20profit ;
-	rdf:rest _:c14n115 .
-_:c14n112 a owl:Restriction ;
+_:c14n114 rdf:first personinfo:OrganizationType\#non\%20profit ;
+	rdf:rest _:c14n118 .
+_:c14n115 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:categories .
-_:c14n113 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:current_address .
-_:c14n114 a owl:Restriction ;
-	owl:allValuesFrom personinfo:FamilialRelationshipType ;
-	owl:onProperty personinfo:type .
-_:c14n115 rdf:first personinfo:OrganizationType\#for\%20profit ;
-	rdf:rest _:c14n63 .
 _:c14n116 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty personinfo:duration .
-_:c14n117 rdf:first personinfo:Organization ;
-	rdf:rest rdf:nil .
-_:c14n118 a owl:Restriction ;
-	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:current_address .
+_:c14n117 a owl:Restriction ;
+	owl:allValuesFrom personinfo:FamilialRelationshipType ;
 	owl:onProperty personinfo:type .
+_:c14n118 rdf:first personinfo:OrganizationType\#for\%20profit ;
+	rdf:rest _:c14n63 .
 _:c14n119 a owl:Restriction ;
-	owl:allValuesFrom personinfo:DiagnosisConcept ;
-	owl:onProperty personinfo:diagnosis .
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:duration .
 _:c14n12 a owl:Restriction ;
 	owl:allValuesFrom xsd:anyURI ;
 	owl:onProperty personinfo:id .
-_:c14n120 a owl:Restriction ;
+_:c14n120 rdf:first personinfo:Organization ;
+	rdf:rest rdf:nil .
+_:c14n121 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:type .
+_:c14n122 a owl:Restriction ;
+	owl:allValuesFrom personinfo:DiagnosisConcept ;
+	owl:onProperty personinfo:diagnosis .
+_:c14n123 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:salary .
-_:c14n121 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:depicted_by .
-_:c14n122 rdf:first famrel:03 ;
-	rdf:rest rdf:nil .
-_:c14n123 a owl:Restriction ;
-	owl:allValuesFrom xsd:string ;
-	owl:onProperty personinfo:aliases .
 _:c14n124 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty personinfo:founding_location .
-_:c14n125 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:has_employment_history .
-_:c14n126 rdfs:subClassOf _:c14n37 ;
-	owl:intersectionOf _:c14n71 .
+	owl:onProperty personinfo:depicted_by .
+_:c14n125 rdf:first famrel:03 ;
+	rdf:rest rdf:nil .
+_:c14n126 a owl:Restriction ;
+	owl:allValuesFrom xsd:string ;
+	owl:onProperty personinfo:aliases .
 _:c14n127 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:current_address .
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:founding_location .
 _:c14n128 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty personinfo:depicted_by .
-_:c14n129 a owl:Restriction ;
-	owl:allValuesFrom _:c14n225 ;
-	owl:onProperty personinfo:primary_email .
+	owl:onProperty personinfo:has_employment_history .
+_:c14n129 rdfs:subClassOf _:c14n37 ;
+	owl:intersectionOf _:c14n71 .
 _:c14n13 a owl:Restriction ;
 	owl:allValuesFrom _:c14n34 ;
 	owl:onProperty personinfo:type .
 _:c14n130 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:current_address .
+_:c14n131 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:depicted_by .
+_:c14n132 a owl:Restriction ;
+	owl:allValuesFrom _:c14n228 ;
+	owl:onProperty personinfo:primary_email .
+_:c14n133 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:street .
-_:c14n131 a owl:Restriction ;
+_:c14n134 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:score .
-_:c14n132 a owl:Restriction ;
+_:c14n135 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty personinfo:id .
-_:c14n133 a owl:Restriction ;
+_:c14n136 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:primary_email .
-_:c14n134 a owl:Restriction ;
+_:c14n137 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:started_at_time .
-_:c14n135 a owl:Restriction ;
+_:c14n138 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:type .
-_:c14n136 xsd:maxInclusive 0 .
-_:c14n137 a owl:Restriction ;
-	owl:allValuesFrom personinfo:Person ;
-	owl:onProperty personinfo:persons .
-_:c14n138 rdf:first famrel:70 ;
-	rdf:rest _:c14n30 .
-_:c14n139 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:started_at_time .
+_:c14n139 xsd:maxInclusive 0 .
 _:c14n14 a owl:Restriction ;
 	owl:allValuesFrom personinfo:ProcedureConcept ;
 	owl:onProperty personinfo:procedure .
-_:c14n140 rdf:first GSSO:000384 ;
-	rdf:rest _:c14n72 .
-_:c14n141 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:code_system .
-_:c14n142 xsd:minInclusive 0 .
-_:c14n143 a owl:Restriction ;
+_:c14n140 a owl:Restriction ;
+	owl:allValuesFrom personinfo:Person ;
+	owl:onProperty personinfo:persons .
+_:c14n141 rdf:first famrel:70 ;
+	rdf:rest _:c14n30 .
+_:c14n142 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:depicted_by .
+	owl:onProperty personinfo:started_at_time .
+_:c14n143 rdf:first GSSO:000384 ;
+	rdf:rest _:c14n72 .
 _:c14n144 a owl:Restriction ;
 	owl:minCardinality 0 ;
+	owl:onProperty personinfo:code_system .
+_:c14n145 xsd:minInclusive 0 .
+_:c14n146 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:depicted_by .
+_:c14n147 a owl:Restriction ;
+	owl:minCardinality 0 ;
 	owl:onProperty personinfo:has_news_events .
-_:c14n145 a owl:Restriction ;
+_:c14n148 a owl:Restriction ;
 	owl:allValuesFrom personinfo:Person ;
 	owl:onProperty personinfo:related_to .
-_:c14n146 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:persons .
-_:c14n147 a owl:Restriction ;
-	owl:allValuesFrom personinfo:Address ;
-	owl:onProperty personinfo:current_address .
-_:c14n148 rdf:first bizcodes:001 ;
-	rdf:rest _:c14n92 .
 _:c14n149 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty personinfo:places .
+	owl:onProperty personinfo:persons .
 _:c14n15 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:gender .
 _:c14n150 a owl:Restriction ;
-	owl:allValuesFrom xsd:string ;
-	owl:onProperty personinfo:mission_statement .
-_:c14n151 a owl:Restriction ;
-	owl:allValuesFrom xsd:string ;
-	owl:onProperty personinfo:description .
+	owl:allValuesFrom personinfo:Address ;
+	owl:onProperty personinfo:current_address .
+_:c14n151 rdf:first bizcodes:001 ;
+	rdf:rest _:c14n94 .
 _:c14n152 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty personinfo:procedure .
+	owl:onProperty personinfo:places .
 _:c14n153 a owl:Restriction ;
+	owl:allValuesFrom xsd:string ;
+	owl:onProperty personinfo:mission_statement .
+_:c14n154 a owl:Restriction ;
+	owl:allValuesFrom xsd:string ;
+	owl:onProperty personinfo:description .
+_:c14n155 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:procedure .
+_:c14n156 a owl:Restriction ;
 	owl:allValuesFrom personinfo:Organization ;
 	owl:onProperty personinfo:employed_at .
-_:c14n154 a owl:Restriction ;
+_:c14n157 a owl:Restriction ;
 	owl:allValuesFrom personinfo:GenderType ;
 	owl:onProperty personinfo:gender .
-_:c14n155 a owl:Restriction ;
+_:c14n158 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty personinfo:type .
-_:c14n156 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:street .
-_:c14n157 a owl:Restriction ;
-	owl:allValuesFrom xsd:string ;
-	owl:onProperty personinfo:street .
-_:c14n158 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:description .
 _:c14n159 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:started_at_time .
+	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:street .
 _:c14n16 a owl:Restriction ;
 	owl:allValuesFrom xsd:string ;
 	owl:onProperty personinfo:type .
 _:c14n160 a owl:Restriction ;
+	owl:allValuesFrom xsd:string ;
+	owl:onProperty personinfo:street .
+_:c14n161 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:description .
+_:c14n162 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:started_at_time .
+_:c14n163 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:age_in_years .
-_:c14n161 a owl:Restriction ;
+_:c14n164 a owl:Restriction ;
 	owl:allValuesFrom xsd:string ;
 	owl:onProperty personinfo:founding_date .
-_:c14n162 a owl:Restriction ;
+_:c14n165 a owl:Restriction ;
 	owl:allValuesFrom xsd:float ;
 	owl:onProperty personinfo:duration .
-_:c14n163 rdf:first personinfo:NonFamilialRelationshipType\#BEST_FRIEND_OF ;
-	rdf:rest _:c14n106 .
-_:c14n164 a owl:Restriction ;
+_:c14n166 rdf:first personinfo:NonFamilialRelationshipType\#BEST_FRIEND_OF ;
+	rdf:rest _:c14n108 .
+_:c14n167 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:diagnosis .
-_:c14n165 a owl:Restriction ;
+_:c14n168 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:code_system .
-_:c14n166 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:employed_at .
-_:c14n167 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:description .
-_:c14n168 a owl:Restriction ;
-	owl:allValuesFrom xsd:integer ;
-	owl:onProperty personinfo:int_id .
 _:c14n169 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty personinfo:min_salary .
+	owl:onProperty personinfo:employed_at .
 _:c14n17 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:procedure .
 _:c14n170 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:ended_at_time .
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:description .
 _:c14n171 a owl:Restriction ;
-	owl:allValuesFrom personinfo:FamilialRelationship ;
-	owl:onProperty personinfo:has_familial_relationships .
+	owl:allValuesFrom xsd:integer ;
+	owl:onProperty personinfo:int_id .
 _:c14n172 a owl:Restriction ;
-	owl:allValuesFrom xsd:string ;
-	owl:onProperty personinfo:headline .
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:min_salary .
 _:c14n173 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:depicted_by .
+	owl:onProperty personinfo:ended_at_time .
 _:c14n174 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:related_to .
+	owl:allValuesFrom personinfo:FamilialRelationship ;
+	owl:onProperty personinfo:has_familial_relationships .
 _:c14n175 a owl:Restriction ;
 	owl:allValuesFrom xsd:string ;
-	owl:onProperty personinfo:name .
+	owl:onProperty personinfo:headline .
 _:c14n176 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:founding_location .
+	owl:onProperty personinfo:depicted_by .
 _:c14n177 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty personinfo:name .
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:related_to .
 _:c14n178 a owl:Restriction ;
-	owl:allValuesFrom xsd:date ;
-	owl:onProperty personinfo:ended_at_time .
-_:c14n179 a owl:Restriction ;
 	owl:allValuesFrom xsd:string ;
 	owl:onProperty personinfo:name .
+_:c14n179 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:founding_location .
 _:c14n18 rdf:first famrel:01 ;
 	rdf:rest _:c14n53 .
 _:c14n180 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:name .
+_:c14n181 a owl:Restriction ;
+	owl:allValuesFrom xsd:date ;
+	owl:onProperty personinfo:ended_at_time .
+_:c14n182 a owl:Restriction ;
+	owl:allValuesFrom xsd:string ;
+	owl:onProperty personinfo:name .
+_:c14n183 a owl:Restriction ;
 	owl:allValuesFrom personinfo:EmploymentEvent ;
 	owl:onProperty personinfo:has_employment_history .
-_:c14n181 a owl:Restriction ;
+_:c14n184 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:telephone .
-_:c14n182 a rdfs:Datatype ;
+_:c14n185 a rdfs:Datatype ;
 	owl:onDatatype xsd:float ;
-	owl:withRestrictions _:c14n228 .
-_:c14n183 a owl:Restriction ;
+	owl:withRestrictions _:c14n231 .
+_:c14n186 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty personinfo:type .
-_:c14n184 a owl:Restriction ;
+_:c14n187 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty personinfo:name .
-_:c14n185 a owl:Restriction ;
+_:c14n188 a owl:Restriction ;
 	owl:allValuesFrom xsd:anyURI ;
 	owl:onProperty personinfo:id .
-_:c14n186 a owl:Restriction ;
+_:c14n189 a owl:Restriction ;
 	owl:onProperty personinfo:min_salary ;
-	owl:someValuesFrom _:c14n182 .
-_:c14n187 xsd:minInclusive "0.0"^^xsd:double .
-_:c14n188 rdf:first _:c14n187 ;
-	rdf:rest rdf:nil .
-_:c14n189 a rdfs:Datatype ;
-	owl:onDatatype xsd:float ;
-	owl:withRestrictions _:c14n188 .
+	owl:someValuesFrom _:c14n185 .
 _:c14n19 xsd:pattern "^\\S+@[\\S+\\.]+\\S+" .
-_:c14n190 rdf:first _:c14n189 ;
-	rdf:rest _:c14n193 .
-_:c14n191 rdf:first xsd:decimal ;
-	rdf:rest _:c14n190 .
-_:c14n192 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n191 .
-_:c14n193 rdf:first _:c14n194 ;
+_:c14n190 xsd:minInclusive "0.0"^^xsd:double .
+_:c14n191 rdf:first _:c14n190 ;
 	rdf:rest rdf:nil .
-_:c14n194 a rdfs:Datatype ;
+_:c14n192 a rdfs:Datatype ;
 	owl:onDatatype xsd:float ;
-	owl:withRestrictions _:c14n195 .
+	owl:withRestrictions _:c14n191 .
+_:c14n193 rdf:first _:c14n192 ;
+	rdf:rest _:c14n195 .
+_:c14n194 rdf:first xsd:decimal ;
+	rdf:rest _:c14n193 .
 _:c14n195 rdf:first _:c14n196 ;
 	rdf:rest rdf:nil .
-_:c14n196 xsd:maxInclusive "5.0"^^xsd:double .
-_:c14n197 xsd:minInclusive "0.0"^^xsd:double .
-_:c14n198 rdf:first _:c14n197 ;
-	rdf:rest rdf:nil .
-_:c14n199 a rdfs:Datatype ;
+_:c14n196 a rdfs:Datatype ;
 	owl:onDatatype xsd:float ;
-	owl:withRestrictions _:c14n198 .
+	owl:withRestrictions _:c14n197 .
+_:c14n197 rdf:first _:c14n198 ;
+	rdf:rest rdf:nil .
+_:c14n198 xsd:maxInclusive "5.0"^^xsd:double .
+_:c14n199 xsd:minInclusive "0.0"^^xsd:double .
 _:c14n2 a owl:Restriction ;
 	owl:allValuesFrom personinfo:Person ;
 	owl:onProperty personinfo:related_to .
@@ -709,73 +715,80 @@ _:c14n20 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:birth_date .
 _:c14n200 rdf:first _:c14n199 ;
-	rdf:rest _:c14n202 .
-_:c14n201 rdf:first xsd:decimal ;
-	rdf:rest _:c14n200 .
-_:c14n202 rdf:first _:c14n203 ;
 	rdf:rest rdf:nil .
-_:c14n203 a rdfs:Datatype ;
+_:c14n201 a rdfs:Datatype ;
 	owl:onDatatype xsd:float ;
-	owl:withRestrictions _:c14n204 .
-_:c14n204 rdf:first _:c14n205 ;
+	owl:withRestrictions _:c14n200 .
+_:c14n202 rdf:first _:c14n201 ;
+	rdf:rest _:c14n205 .
+_:c14n203 rdf:first xsd:decimal ;
+	rdf:rest _:c14n202 .
+_:c14n204 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n203 .
+_:c14n205 rdf:first _:c14n206 ;
 	rdf:rest rdf:nil .
-_:c14n205 xsd:maxInclusive "5.0"^^xsd:double .
 _:c14n206 a rdfs:Datatype ;
-	owl:onDatatype xsd:integer ;
+	owl:onDatatype xsd:float ;
 	owl:withRestrictions _:c14n207 .
-_:c14n207 rdf:first _:c14n142 ;
+_:c14n207 rdf:first _:c14n208 ;
 	rdf:rest rdf:nil .
-_:c14n208 rdf:first _:c14n206 ;
-	rdf:rest _:c14n210 .
-_:c14n209 rdf:first xsd:integer ;
-	rdf:rest _:c14n208 .
+_:c14n208 xsd:maxInclusive "5.0"^^xsd:double .
+_:c14n209 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n210 .
 _:c14n21 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:organizations .
-_:c14n210 rdf:first _:c14n211 ;
+_:c14n210 rdf:first _:c14n145 ;
 	rdf:rest rdf:nil .
-_:c14n211 a rdfs:Datatype ;
-	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n212 .
-_:c14n212 rdf:first _:c14n213 ;
+_:c14n211 rdf:first _:c14n209 ;
+	rdf:rest _:c14n213 .
+_:c14n212 rdf:first xsd:integer ;
+	rdf:rest _:c14n211 .
+_:c14n213 rdf:first _:c14n214 ;
 	rdf:rest rdf:nil .
-_:c14n213 xsd:maxInclusive 999 .
 _:c14n214 a rdfs:Datatype ;
 	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n218 .
-_:c14n215 rdf:first _:c14n214 ;
+	owl:withRestrictions _:c14n215 .
+_:c14n215 rdf:first _:c14n216 ;
 	rdf:rest rdf:nil .
-_:c14n216 rdf:first xsd:integer ;
-	rdf:rest _:c14n215 .
+_:c14n216 xsd:maxInclusive 999 .
 _:c14n217 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n216 .
-_:c14n218 rdf:first _:c14n219 ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n221 .
+_:c14n218 rdf:first _:c14n217 ;
 	rdf:rest rdf:nil .
-_:c14n219 xsd:maxInclusive 999 .
+_:c14n219 rdf:first xsd:integer ;
+	rdf:rest _:c14n218 .
 _:c14n22 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:aliases .
-_:c14n220 xsd:pattern "^[\\d\\(\\)\\-]+$" .
-_:c14n221 rdf:first _:c14n220 ;
+_:c14n220 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n219 .
+_:c14n221 rdf:first _:c14n222 ;
 	rdf:rest rdf:nil .
-_:c14n222 xsd:pattern "^[\\d\\(\\)\\-]+$" .
-_:c14n223 rdf:first _:c14n222 ;
+_:c14n222 xsd:maxInclusive 999 .
+_:c14n223 xsd:pattern "^[\\d\\(\\)\\-]+$" .
+_:c14n224 rdf:first _:c14n223 ;
 	rdf:rest rdf:nil .
-_:c14n224 a rdfs:Datatype ;
-	owl:onDatatype xsd:string ;
-	owl:withRestrictions _:c14n223 .
-_:c14n225 a rdfs:Datatype ;
+_:c14n225 xsd:pattern "^[\\d\\(\\)\\-]+$" .
+_:c14n226 rdf:first _:c14n225 ;
+	rdf:rest rdf:nil .
+_:c14n227 a rdfs:Datatype ;
 	owl:onDatatype xsd:string ;
 	owl:withRestrictions _:c14n226 .
-_:c14n226 rdf:first _:c14n19 ;
-	rdf:rest rdf:nil .
-_:c14n227 rdf:first _:c14n136 ;
-	rdf:rest rdf:nil .
-_:c14n228 rdf:first _:c14n94 ;
+_:c14n228 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n229 .
+_:c14n229 rdf:first _:c14n19 ;
 	rdf:rest rdf:nil .
 _:c14n23 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:in_location .
+_:c14n230 rdf:first _:c14n139 ;
+	rdf:rest rdf:nil .
+_:c14n231 rdf:first _:c14n96 ;
+	rdf:rest rdf:nil .
 _:c14n24 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:related_to .
@@ -798,17 +811,17 @@ _:c14n3 a owl:Restriction ;
 	owl:allValuesFrom xsd:string ;
 	owl:onProperty personinfo:birth_date .
 _:c14n30 rdf:first famrel:71 ;
-	rdf:rest _:c14n163 .
+	rdf:rest _:c14n166 .
 _:c14n31 a owl:Restriction ;
 	owl:allValuesFrom xsd:date ;
 	owl:onProperty personinfo:started_at_time .
 _:c14n32 a rdfs:Datatype ;
 	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n227 .
+	owl:withRestrictions _:c14n230 .
 _:c14n33 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:min_salary .
-_:c14n34 owl:unionOf _:c14n80 .
+_:c14n34 owl:unionOf _:c14n81 .
 _:c14n35 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:postal_code .
@@ -869,7 +882,7 @@ _:c14n52 a owl:Restriction ;
 	owl:allValuesFrom xsd:string ;
 	owl:onProperty personinfo:postal_code .
 _:c14n53 rdf:first famrel:02 ;
-	rdf:rest _:c14n122 .
+	rdf:rest _:c14n125 .
 _:c14n54 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty personinfo:related_to .
@@ -901,7 +914,7 @@ _:c14n62 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:score .
 _:c14n63 rdf:first personinfo:OrganizationType\#offshore ;
-	rdf:rest _:c14n148 .
+	rdf:rest _:c14n151 .
 _:c14n64 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:birth_date .
@@ -918,15 +931,15 @@ _:c14n68 a owl:Restriction ;
 	owl:allValuesFrom xsd:boolean ;
 	owl:onProperty personinfo:is_current .
 _:c14n69 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n209 .
+	owl:intersectionOf _:c14n212 .
 _:c14n7 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:gender .
 _:c14n70 a owl:Restriction ;
-	owl:allValuesFrom _:c14n217 ;
+	owl:allValuesFrom _:c14n220 ;
 	owl:onProperty personinfo:age_in_years .
-_:c14n71 rdf:first _:c14n186 ;
-	rdf:rest _:c14n117 .
+_:c14n71 rdf:first _:c14n189 ;
+	rdf:rest _:c14n120 .
 _:c14n72 rdf:first GSSO:000372 ;
 	rdf:rest _:c14n11 .
 _:c14n73 a owl:Restriction ;
@@ -953,59 +966,60 @@ _:c14n79 a owl:Restriction ;
 _:c14n8 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty personinfo:related_to .
-_:c14n80 rdf:first personinfo:FamilialRelationshipType ;
-	rdf:rest _:c14n95 .
-_:c14n81 a owl:Restriction ;
+_:c14n80 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty personinfo:person_comment .
+_:c14n81 rdf:first personinfo:FamilialRelationshipType ;
+	rdf:rest _:c14n97 .
+_:c14n82 a owl:Restriction ;
 	owl:allValuesFrom xsd:anyURI ;
 	owl:onProperty personinfo:depicted_by .
-_:c14n82 a owl:Restriction ;
+_:c14n83 a owl:Restriction ;
 	owl:allValuesFrom personinfo:OrganizationType ;
 	owl:onProperty personinfo:categories .
-_:c14n83 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n201 .
-_:c14n84 a owl:Restriction ;
+_:c14n84 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n194 .
+_:c14n85 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:name .
-_:c14n85 a rdfs:Datatype ;
+_:c14n86 a rdfs:Datatype ;
 	owl:onDatatype xsd:string ;
-	owl:withRestrictions _:c14n221 .
-_:c14n86 a owl:Restriction ;
+	owl:withRestrictions _:c14n224 .
+_:c14n87 a owl:Restriction ;
 	owl:allValuesFrom rdfs:Resource ;
 	owl:onProperty personinfo:mappings .
-_:c14n87 a owl:Restriction ;
+_:c14n88 a owl:Restriction ;
 	owl:allValuesFrom personinfo:MedicalEvent ;
 	owl:onProperty personinfo:has_medical_history .
-_:c14n88 a owl:Restriction ;
+_:c14n89 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:started_at_time .
-_:c14n89 a owl:Restriction ;
-	owl:allValuesFrom personinfo:InterPersonalRelationship ;
-	owl:onProperty personinfo:has_interpersonal_relationships .
 _:c14n9 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:mission_statement .
 _:c14n90 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty personinfo:person_comment .
+_:c14n91 a owl:Restriction ;
+	owl:allValuesFrom personinfo:InterPersonalRelationship ;
+	owl:onProperty personinfo:has_interpersonal_relationships .
+_:c14n92 a owl:Restriction ;
 	owl:allValuesFrom xsd:string ;
 	owl:onProperty personinfo:name .
-_:c14n91 a owl:Restriction ;
+_:c14n93 a owl:Restriction ;
 	owl:allValuesFrom personinfo:Place ;
 	owl:onProperty personinfo:founding_location .
-_:c14n92 rdf:first personinfo:OrganizationType\#shell\%20company ;
-	rdf:rest _:c14n96 .
-_:c14n93 a owl:Restriction ;
+_:c14n94 rdf:first personinfo:OrganizationType\#shell\%20company ;
+	rdf:rest _:c14n98 .
+_:c14n95 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty personinfo:postal_code .
-_:c14n94 xsd:maxInclusive "80000.0"^^xsd:double .
-_:c14n95 rdf:first personinfo:NonFamilialRelationshipType ;
+_:c14n96 xsd:maxInclusive "80000.0"^^xsd:double .
+_:c14n97 rdf:first personinfo:NonFamilialRelationshipType ;
 	rdf:rest rdf:nil .
-_:c14n96 rdf:first personinfo:OrganizationType\#loose\%20organization ;
+_:c14n98 rdf:first personinfo:OrganizationType\#loose\%20organization ;
 	rdf:rest rdf:nil .
-_:c14n97 a owl:Restriction ;
+_:c14n99 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty personinfo:city .
-_:c14n98 rdf:first GSSO:009253 ;
-	rdf:rest _:c14n140 .
-_:c14n99 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty personinfo:mission_statement .
 

--- a/examples/PersonSchema/personinfo/shacl/personinfo.shacl.ttl
+++ b/examples/PersonSchema/personinfo/shacl/personinfo.shacl.ttl
@@ -40,616 +40,619 @@
 schema1:Organization a sh:NodeShape ;
 	rdfs:comment "An organization such as a company or university" ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n120 ;
-	sh:property _:c14n101 , _:c14n119 , _:c14n158 , _:c14n171 , _:c14n175 , _:c14n37 , _:c14n55 , _:c14n57 , _:c14n69 , _:c14n76 , _:c14n84 , _:c14n91 ;
+	sh:ignoredProperties _:c14n124 ;
+	sh:property _:c14n102 , _:c14n123 , _:c14n161 , _:c14n173 , _:c14n177 , _:c14n35 , _:c14n54 , _:c14n56 , _:c14n69 , _:c14n76 , _:c14n84 , _:c14n92 ;
 	sh:targetClass schema1:Organization .
 schema1:Person a sh:NodeShape ;
 	rdfs:comment "A person (alive, dead, undead, or fictional)." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n176 ;
-	sh:property _:c14n104 , _:c14n111 , _:c14n128 , _:c14n133 , _:c14n139 , _:c14n170 , _:c14n173 , _:c14n24 , _:c14n3 , _:c14n30 , _:c14n34 , _:c14n54 , _:c14n60 , _:c14n9 , _:c14n90 , _:c14n99 ;
+	sh:ignoredProperties _:c14n178 ;
+	sh:property _:c14n100 , _:c14n106 , _:c14n107 , _:c14n111 , _:c14n119 , _:c14n132 , _:c14n137 , _:c14n175 , _:c14n23 , _:c14n32 , _:c14n53 , _:c14n57 , _:c14n59 , _:c14n7 , _:c14n85 , _:c14n91 , _:c14n93 ;
 	sh:targetClass schema1:Person .
 schema1:PostalAddress a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n141 ;
-	sh:property _:c14n112 , _:c14n149 , _:c14n62 ;
+	sh:ignoredProperties _:c14n144 ;
+	sh:property _:c14n115 , _:c14n152 , _:c14n62 ;
 	sh:targetClass schema1:PostalAddress .
 personinfo:CodeSystem a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n59 ;
-	sh:property _:c14n105 , _:c14n122 ;
+	sh:ignoredProperties _:c14n60 ;
+	sh:property _:c14n108 , _:c14n126 ;
 	sh:targetClass personinfo:CodeSystem .
 personinfo:Concept a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n148 ;
-	sh:property _:c14n102 , _:c14n131 , _:c14n146 , _:c14n160 , _:c14n64 , _:c14n68 ;
+	sh:ignoredProperties _:c14n151 ;
+	sh:property _:c14n103 , _:c14n135 , _:c14n149 , _:c14n163 , _:c14n64 , _:c14n68 ;
 	sh:targetClass personinfo:Concept .
 personinfo:Container a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n31 ;
-	sh:property _:c14n151 , _:c14n163 , _:c14n96 ;
+	sh:ignoredProperties _:c14n29 ;
+	sh:property _:c14n154 , _:c14n166 , _:c14n97 ;
 	sh:targetClass personinfo:Container .
 personinfo:DiagnosisConcept a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n44 ;
-	sh:property _:c14n121 , _:c14n164 , _:c14n174 , _:c14n23 , _:c14n35 , _:c14n36 ;
+	sh:ignoredProperties _:c14n42 ;
+	sh:property _:c14n125 , _:c14n167 , _:c14n176 , _:c14n22 , _:c14n33 , _:c14n34 ;
 	sh:targetClass personinfo:DiagnosisConcept .
 personinfo:EmploymentEvent a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n136 ;
-	sh:property _:c14n103 , _:c14n130 , _:c14n169 , _:c14n41 , _:c14n77 , _:c14n81 ;
+	sh:ignoredProperties _:c14n140 ;
+	sh:property _:c14n105 , _:c14n134 , _:c14n172 , _:c14n39 , _:c14n77 , _:c14n81 ;
 	sh:targetClass personinfo:EmploymentEvent .
 personinfo:Event a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n50 ;
-	sh:property _:c14n22 , _:c14n46 , _:c14n56 , _:c14n80 ;
+	sh:ignoredProperties _:c14n51 ;
+	sh:property _:c14n21 , _:c14n44 , _:c14n55 , _:c14n80 ;
 	sh:targetClass personinfo:Event .
 personinfo:FamilialRelationship a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n113 ;
-	sh:property _:c14n11 , _:c14n134 , _:c14n18 , _:c14n66 ;
+	sh:ignoredProperties _:c14n116 ;
+	sh:property _:c14n138 , _:c14n16 , _:c14n66 , _:c14n9 ;
 	sh:targetClass personinfo:FamilialRelationship .
 personinfo:HasAliases a sh:NodeShape ;
 	rdfs:comment "A mixin applied to any class that can have aliases/alternateNames" ;
 	sh:closed false ;
-	sh:ignoredProperties _:c14n2 ;
-	sh:property _:c14n140 ;
+	sh:ignoredProperties _:c14n1 ;
+	sh:property _:c14n143 ;
 	sh:targetClass personinfo:HasAliases .
 personinfo:HasNewsEvents a sh:NodeShape ;
 	sh:closed false ;
-	sh:ignoredProperties _:c14n117 ;
-	sh:property _:c14n107 ;
+	sh:ignoredProperties _:c14n121 ;
+	sh:property _:c14n110 ;
 	sh:targetClass personinfo:HasNewsEvents .
 personinfo:ImagingProcedureConcept a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n14 ;
-	sh:property _:c14n114 , _:c14n12 , _:c14n123 , _:c14n138 , _:c14n144 , _:c14n172 ;
+	sh:ignoredProperties _:c14n12 ;
+	sh:property _:c14n10 , _:c14n117 , _:c14n127 , _:c14n142 , _:c14n147 , _:c14n174 ;
 	sh:targetClass personinfo:ImagingProcedureConcept .
 personinfo:IntegerPrimaryKeyObject a sh:NodeShape ;
 	sh:closed true ;
 	sh:ignoredProperties _:c14n61 ;
-	sh:property _:c14n19 ;
+	sh:property _:c14n18 ;
 	sh:targetClass personinfo:IntegerPrimaryKeyObject .
 personinfo:InterPersonalRelationship a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n118 ;
-	sh:property _:c14n115 , _:c14n155 , _:c14n52 , _:c14n88 ;
+	sh:ignoredProperties _:c14n122 ;
+	sh:property _:c14n118 , _:c14n158 , _:c14n49 , _:c14n89 ;
 	sh:targetClass personinfo:InterPersonalRelationship .
 personinfo:MedicalEvent a sh:NodeShape ;
 	sh:closed true ;
 	sh:ignoredProperties _:c14n74 ;
-	sh:property _:c14n132 , _:c14n135 , _:c14n17 , _:c14n58 , _:c14n73 , _:c14n83 , _:c14n98 ;
+	sh:property _:c14n136 , _:c14n139 , _:c14n15 , _:c14n58 , _:c14n73 , _:c14n83 , _:c14n99 ;
 	sh:targetClass personinfo:MedicalEvent .
 personinfo:NamedThing a sh:NodeShape ;
 	rdfs:comment "A generic grouping for any identifiable entity" ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n0 ;
-	sh:property _:c14n145 , _:c14n152 , _:c14n6 , _:c14n92 ;
+	sh:ignoredProperties _:c14n104 ;
+	sh:property _:c14n148 , _:c14n155 , _:c14n4 , _:c14n94 ;
 	sh:targetClass personinfo:NamedThing .
 personinfo:NewsEvent a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n49 ;
-	sh:property _:c14n162 , _:c14n33 , _:c14n70 , _:c14n82 , _:c14n97 ;
+	sh:ignoredProperties _:c14n47 ;
+	sh:property _:c14n165 , _:c14n31 , _:c14n70 , _:c14n82 , _:c14n98 ;
 	sh:targetClass personinfo:NewsEvent .
 personinfo:OperationProcedureConcept a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n21 ;
-	sh:property _:c14n116 , _:c14n26 , _:c14n38 , _:c14n39 , _:c14n53 , _:c14n7 ;
+	sh:ignoredProperties _:c14n20 ;
+	sh:property _:c14n120 , _:c14n25 , _:c14n36 , _:c14n37 , _:c14n5 , _:c14n52 ;
 	sh:targetClass personinfo:OperationProcedureConcept .
 personinfo:Place a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n51 ;
-	sh:property _:c14n106 , _:c14n110 , _:c14n147 , _:c14n75 ;
+	sh:ignoredProperties _:c14n48 ;
+	sh:property _:c14n109 , _:c14n114 , _:c14n150 , _:c14n75 ;
 	sh:targetClass personinfo:Place .
 personinfo:ProcedureConcept a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n45 ;
-	sh:property _:c14n1 , _:c14n159 , _:c14n161 , _:c14n5 , _:c14n72 , _:c14n79 ;
+	sh:ignoredProperties _:c14n43 ;
+	sh:property _:c14n0 , _:c14n162 , _:c14n164 , _:c14n3 , _:c14n72 , _:c14n79 ;
 	sh:targetClass personinfo:ProcedureConcept .
 personinfo:Relationship a sh:NodeShape ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n100 ;
-	sh:property _:c14n109 , _:c14n43 , _:c14n78 , _:c14n86 ;
+	sh:ignoredProperties _:c14n101 ;
+	sh:property _:c14n113 , _:c14n41 , _:c14n78 , _:c14n87 ;
 	sh:targetClass personinfo:Relationship .
 personinfo:WithLocation a sh:NodeShape ;
 	sh:closed false ;
-	sh:ignoredProperties _:c14n47 ;
-	sh:property _:c14n16 ;
+	sh:ignoredProperties _:c14n45 ;
+	sh:property _:c14n14 ;
 	sh:targetClass personinfo:WithLocation .
-_:c14n0 rdf:first personinfo:CodeSystem ;
-	rdf:rest _:c14n8 .
-_:c14n1 sh:maxCount 1 ;
+_:c14n0 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path schema1:identifier .
-_:c14n10 rdf:first personinfo:aliases ;
-	rdf:rest _:c14n93 .
-_:c14n100 rdf:first rdf:type ;
+_:c14n1 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n101 sh:datatype xsd:string ;
+_:c14n10 sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 5 ;
+	sh:path personinfo:depicted_by .
+_:c14n100 sh:class personinfo:InterPersonalRelationship ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 8 ;
+	sh:path personinfo:has_interpersonal_relationships .
+_:c14n101 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n102 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
 	sh:path personinfo:founding_date .
-_:c14n102 sh:maxCount 1 ;
+_:c14n103 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 5 ;
 	sh:path personinfo:depicted_by .
-_:c14n103 sh:maxCount 1 ;
+_:c14n104 rdf:first personinfo:person_comment ;
+	rdf:rest _:c14n157 .
+_:c14n105 sh:maxCount 1 ;
 	sh:order 1 ;
 	sh:path personinfo:salary .
-_:c14n104 sh:datatype xsd:integer ;
+_:c14n106 sh:datatype xsd:string ;
+	sh:nodeKind sh:Literal ;
+	sh:order 11 ;
+	sh:path personinfo:aliases .
+_:c14n107 sh:datatype xsd:integer ;
 	sh:maxCount 1 ;
 	sh:maxInclusive 999 ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path personinfo:age_in_years .
-_:c14n105 sh:maxCount 1 ;
+_:c14n108 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 0 ;
 	sh:path schema1:identifier .
-_:c14n106 sh:datatype xsd:string ;
+_:c14n109 sh:datatype xsd:string ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path personinfo:aliases .
-_:c14n107 sh:class personinfo:NewsEvent ;
+_:c14n11 rdf:first GSSO:000371 ;
+	rdf:rest _:c14n38 .
+_:c14n110 sh:class personinfo:NewsEvent ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	sh:order 0 ;
 	sh:path personinfo:has_news_events .
-_:c14n108 rdf:first personinfo:procedure ;
-	rdf:rest _:c14n124 .
-_:c14n109 sh:datatype xsd:string ;
+_:c14n111 sh:datatype xsd:string ;
+	sh:maxCount 1 ;
+	sh:minCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 14 ;
+	sh:path schema1:name .
+_:c14n112 rdf:first personinfo:procedure ;
+	rdf:rest _:c14n129 .
+_:c14n113 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path personinfo:type .
-_:c14n11 sh:datatype xsd:date ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 0 ;
-	sh:path prov:startedAtTime .
-_:c14n110 sh:maxCount 1 ;
+_:c14n114 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 0 ;
 	sh:path schema1:identifier .
-_:c14n111 sh:datatype xsd:string ;
-	sh:nodeKind sh:Literal ;
-	sh:order 10 ;
-	sh:path personinfo:aliases .
-_:c14n112 sh:datatype xsd:string ;
+_:c14n115 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path personinfo:street .
-_:c14n113 rdf:first rdf:type ;
+_:c14n116 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n114 sh:maxCount 1 ;
+_:c14n117 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path schema1:identifier .
-_:c14n115 sh:class schema1:Person ;
+_:c14n118 sh:class schema1:Person ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path personinfo:related_to .
-_:c14n116 sh:datatype rdfs:Resource ;
+_:c14n119 sh:datatype xsd:string ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 15 ;
+	sh:path schema1:description .
+_:c14n12 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n120 sh:datatype rdfs:Resource ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
 	sh:path skos:exactMatch .
-_:c14n117 rdf:first rdf:type ;
+_:c14n121 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n118 rdf:first rdf:type ;
+_:c14n122 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n119 sh:datatype xsd:string ;
+_:c14n123 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 10 ;
 	sh:path schema1:description .
-_:c14n12 sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 5 ;
-	sh:path personinfo:depicted_by .
-_:c14n120 rdf:first rdf:type ;
+_:c14n124 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n121 sh:maxCount 1 ;
+_:c14n125 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path schema1:identifier .
-_:c14n122 sh:datatype xsd:string ;
+_:c14n126 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
 	sh:path schema1:name .
-_:c14n123 sh:datatype xsd:string ;
+_:c14n127 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path schema1:name .
-_:c14n124 rdf:first personinfo:employed_at ;
-	rdf:rest _:c14n186 .
-_:c14n125 rdf:first personinfo:salary ;
-	rdf:rest rdf:nil .
-_:c14n126 rdf:first personinfo:min_salary ;
-	rdf:rest _:c14n85 .
-_:c14n127 rdf:first personinfo:categories ;
-	rdf:rest _:c14n15 .
-_:c14n128 sh:in _:c14n167 ;
+_:c14n128 rdf:first personinfo:salary ;
+	rdf:rest _:c14n17 .
+_:c14n129 rdf:first personinfo:employed_at ;
+	rdf:rest _:c14n156 .
+_:c14n13 rdf:first personinfo:score ;
+	rdf:rest _:c14n65 .
+_:c14n130 rdf:first personinfo:min_salary ;
+	rdf:rest _:c14n8 .
+_:c14n131 rdf:first personinfo:categories ;
+	rdf:rest _:c14n71 .
+_:c14n132 sh:in _:c14n170 ;
 	sh:maxCount 1 ;
 	sh:order 3 ;
 	sh:path schema1:gender .
-_:c14n129 rdf:first schema1:birthDate ;
-	rdf:rest _:c14n20 .
-_:c14n13 rdf:first GSSO:000371 ;
-	rdf:rest _:c14n40 .
-_:c14n130 sh:datatype xsd:date ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 3 ;
-	sh:path prov:endedAtTime .
-_:c14n131 sh:datatype xsd:string ;
-	sh:maxCount 1 ;
-	sh:minCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 3 ;
-	sh:path schema1:name .
-_:c14n132 sh:class personinfo:Place ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 2 ;
-	sh:path personinfo:in_location .
-_:c14n133 sh:class personinfo:EmploymentEvent ;
-	sh:nodeKind sh:BlankNodeOrIRI ;
-	sh:order 6 ;
-	sh:path personinfo:has_employment_history .
+_:c14n133 rdf:first schema1:birthDate ;
+	rdf:rest _:c14n6 .
 _:c14n134 sh:datatype xsd:date ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
-	sh:order 1 ;
-	sh:path prov:endedAtTime .
-_:c14n135 sh:datatype xsd:date ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 4 ;
-	sh:path prov:endedAtTime .
-_:c14n136 rdf:first rdf:type ;
-	rdf:rest rdf:nil .
-_:c14n137 rdf:first GSSO:000384 ;
-	rdf:rest _:c14n67 .
-_:c14n138 sh:class personinfo:CodeSystem ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 0 ;
-	sh:path personinfo:code_system .
-_:c14n139 sh:datatype xsd:string ;
-	sh:maxCount 1 ;
-	sh:minCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 13 ;
-	sh:path schema1:name .
-_:c14n14 rdf:first rdf:type ;
-	rdf:rest rdf:nil .
-_:c14n140 sh:datatype xsd:string ;
-	sh:nodeKind sh:Literal ;
-	sh:order 0 ;
-	sh:path personinfo:aliases .
-_:c14n141 rdf:first rdf:type ;
-	rdf:rest rdf:nil .
-_:c14n142 rdf:first bizcodes:001 ;
-	rdf:rest _:c14n4 .
-_:c14n143 rdf:first personinfo:mission_statement ;
-	rdf:rest _:c14n25 .
-_:c14n144 sh:datatype xsd:string ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 4 ;
-	sh:path schema1:description .
-_:c14n145 sh:datatype xsd:string ;
-	sh:maxCount 1 ;
-	sh:minCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 1 ;
-	sh:path schema1:name .
-_:c14n146 sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 2 ;
-	sh:path schema1:identifier .
-_:c14n147 sh:datatype xsd:string ;
-	sh:maxCount 1 ;
-	sh:minCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 1 ;
-	sh:path schema1:name .
-_:c14n148 rdf:first rdf:type ;
-	rdf:rest rdf:nil .
-_:c14n149 sh:datatype xsd:string ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 1 ;
-	sh:path personinfo:city .
-_:c14n15 rdf:first personinfo:score ;
-	rdf:rest _:c14n185 .
-_:c14n150 rdf:first personinfo:founding_date ;
-	rdf:rest _:c14n48 .
-_:c14n151 sh:class schema1:Person ;
-	sh:nodeKind sh:IRI ;
-	sh:order 0 ;
-	sh:path personinfo:persons .
-_:c14n152 sh:datatype xsd:string ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 2 ;
-	sh:path schema1:description .
-_:c14n153 rdf:first personinfo:headline ;
-	rdf:rest _:c14n94 .
-_:c14n154 rdf:first personinfo:has_interpersonal_relationships ;
-	rdf:rest _:c14n129 .
-_:c14n155 sh:maxCount 1 ;
-	sh:minCount 1 ;
-	sh:or _:c14n63 ;
 	sh:order 3 ;
-	sh:path personinfo:type .
-_:c14n156 rdf:first "for profit" ;
-	rdf:rest _:c14n29 .
-_:c14n157 rdf:first famrel:70 ;
-	rdf:rest _:c14n32 .
-_:c14n158 sh:maxCount 1 ;
+	sh:path prov:endedAtTime .
+_:c14n135 sh:datatype xsd:string ;
+	sh:maxCount 1 ;
+	sh:minCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 3 ;
+	sh:path schema1:name .
+_:c14n136 sh:class personinfo:Place ;
+	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
-	sh:order 8 ;
-	sh:path schema1:identifier .
-_:c14n159 sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 5 ;
-	sh:path personinfo:depicted_by .
-_:c14n16 sh:class personinfo:Place ;
+	sh:order 2 ;
+	sh:path personinfo:in_location .
+_:c14n137 sh:class personinfo:EmploymentEvent ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 6 ;
+	sh:path personinfo:has_employment_history .
+_:c14n138 sh:datatype xsd:date ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path prov:endedAtTime .
+_:c14n139 sh:datatype xsd:date ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 4 ;
+	sh:path prov:endedAtTime .
+_:c14n14 sh:class personinfo:Place ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 0 ;
 	sh:path personinfo:in_location .
-_:c14n160 sh:class personinfo:CodeSystem ;
+_:c14n140 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n141 rdf:first GSSO:000384 ;
+	rdf:rest _:c14n67 .
+_:c14n142 sh:class personinfo:CodeSystem ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 0 ;
 	sh:path personinfo:code_system .
-_:c14n161 sh:datatype rdfs:Resource ;
+_:c14n143 sh:datatype xsd:string ;
 	sh:nodeKind sh:Literal ;
-	sh:order 1 ;
-	sh:path skos:exactMatch .
-_:c14n162 sh:datatype xsd:boolean ;
+	sh:order 0 ;
+	sh:path personinfo:aliases .
+_:c14n144 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n145 rdf:first bizcodes:001 ;
+	rdf:rest _:c14n2 .
+_:c14n146 rdf:first personinfo:mission_statement ;
+	rdf:rest _:c14n90 .
+_:c14n147 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 4 ;
-	sh:path personinfo:is_current .
-_:c14n163 sh:class schema1:Organization ;
-	sh:nodeKind sh:IRI ;
-	sh:order 1 ;
-	sh:path personinfo:organizations .
-_:c14n164 sh:class personinfo:CodeSystem ;
+	sh:path schema1:description .
+_:c14n148 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 0 ;
-	sh:path personinfo:code_system .
-_:c14n165 rdf:first "MORTAL_ENEMY_OF" ;
-	rdf:rest rdf:nil .
-_:c14n166 rdf:first schema1:gender ;
-	rdf:rest _:c14n126 .
-_:c14n167 rdf:first GSSO:009254 ;
-	rdf:rest _:c14n87 .
-_:c14n168 rdf:first personinfo:age_in_years ;
-	rdf:rest _:c14n71 .
-_:c14n169 sh:datatype xsd:boolean ;
-	sh:maxCount 1 ;
+	sh:minCount 1 ;
 	sh:nodeKind sh:Literal ;
-	sh:order 5 ;
-	sh:path personinfo:is_current .
-_:c14n17 sh:datatype xsd:float ;
+	sh:order 1 ;
+	sh:path schema1:name .
+_:c14n149 sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 2 ;
+	sh:path schema1:identifier .
+_:c14n15 sh:datatype xsd:float ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 5 ;
 	sh:path personinfo:duration .
-_:c14n170 sh:class personinfo:NewsEvent ;
-	sh:nodeKind sh:BlankNodeOrIRI ;
-	sh:order 11 ;
-	sh:path personinfo:has_news_events .
-_:c14n171 sh:datatype xsd:string ;
-	sh:nodeKind sh:Literal ;
-	sh:order 6 ;
-	sh:path personinfo:aliases .
-_:c14n172 sh:datatype rdfs:Resource ;
+_:c14n150 sh:datatype xsd:string ;
+	sh:maxCount 1 ;
+	sh:minCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
-	sh:path skos:exactMatch .
-_:c14n173 sh:datatype xsd:string ;
+	sh:path schema1:name .
+_:c14n151 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n152 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
-	sh:path schema1:birthDate .
-_:c14n174 sh:datatype rdfs:Resource ;
+	sh:path personinfo:city .
+_:c14n153 rdf:first personinfo:founding_date ;
+	rdf:rest _:c14n86 .
+_:c14n154 sh:class schema1:Person ;
+	sh:nodeKind sh:IRI ;
+	sh:order 0 ;
+	sh:path personinfo:persons .
+_:c14n155 sh:datatype xsd:string ;
+	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
-	sh:order 1 ;
-	sh:path skos:exactMatch .
-_:c14n175 sh:class personinfo:NewsEvent ;
-	sh:nodeKind sh:BlankNodeOrIRI ;
-	sh:order 7 ;
-	sh:path personinfo:has_news_events .
-_:c14n176 rdf:first rdf:type ;
+	sh:order 2 ;
+	sh:path schema1:description .
+_:c14n156 rdf:first personinfo:diagnosis ;
 	rdf:rest rdf:nil .
-_:c14n177 rdf:first famrel:02 ;
-	rdf:rest _:c14n180 .
-_:c14n178 rdf:first famrel:01 ;
-	rdf:rest _:c14n177 .
-_:c14n179 sh:in _:c14n178 .
-_:c14n18 sh:class schema1:Person ;
+_:c14n157 rdf:first personinfo:has_interpersonal_relationships ;
+	rdf:rest _:c14n95 .
+_:c14n158 sh:maxCount 1 ;
+	sh:minCount 1 ;
+	sh:or _:c14n63 ;
+	sh:order 3 ;
+	sh:path personinfo:type .
+_:c14n159 rdf:first "for profit" ;
+	rdf:rest _:c14n28 .
+_:c14n16 sh:class schema1:Person ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path personinfo:related_to .
-_:c14n180 rdf:first famrel:03 ;
+_:c14n160 rdf:first famrel:70 ;
+	rdf:rest _:c14n30 .
+_:c14n161 sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 8 ;
+	sh:path schema1:identifier .
+_:c14n162 sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 5 ;
+	sh:path personinfo:depicted_by .
+_:c14n163 sh:class personinfo:CodeSystem ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 0 ;
+	sh:path personinfo:code_system .
+_:c14n164 sh:datatype rdfs:Resource ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path skos:exactMatch .
+_:c14n165 sh:datatype xsd:boolean ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 4 ;
+	sh:path personinfo:is_current .
+_:c14n166 sh:class schema1:Organization ;
+	sh:nodeKind sh:IRI ;
+	sh:order 1 ;
+	sh:path personinfo:organizations .
+_:c14n167 sh:class personinfo:CodeSystem ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 0 ;
+	sh:path personinfo:code_system .
+_:c14n168 rdf:first "MORTAL_ENEMY_OF" ;
 	rdf:rest rdf:nil .
-_:c14n181 rdf:first famrel:02 ;
-	rdf:rest _:c14n183 .
-_:c14n182 rdf:first famrel:01 ;
-	rdf:rest _:c14n181 .
-_:c14n183 rdf:first famrel:03 ;
+_:c14n169 rdf:first schema1:gender ;
+	rdf:rest _:c14n131 .
+_:c14n17 rdf:first personinfo:in_location ;
+	rdf:rest _:c14n112 .
+_:c14n170 rdf:first GSSO:009254 ;
+	rdf:rest _:c14n88 .
+_:c14n171 rdf:first personinfo:age_in_years ;
+	rdf:rest _:c14n24 .
+_:c14n172 sh:datatype xsd:boolean ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 5 ;
+	sh:path personinfo:is_current .
+_:c14n173 sh:datatype xsd:string ;
+	sh:nodeKind sh:Literal ;
+	sh:order 6 ;
+	sh:path personinfo:aliases .
+_:c14n174 sh:datatype rdfs:Resource ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path skos:exactMatch .
+_:c14n175 sh:datatype xsd:string ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path schema1:birthDate .
+_:c14n176 sh:datatype rdfs:Resource ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path skos:exactMatch .
+_:c14n177 sh:class personinfo:NewsEvent ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 7 ;
+	sh:path personinfo:has_news_events .
+_:c14n178 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n184 sh:in _:c14n157 .
-_:c14n185 rdf:first rdf:type ;
-	rdf:rest _:c14n168 .
-_:c14n186 rdf:first rdf:type ;
-	rdf:rest _:c14n125 .
-_:c14n19 sh:datatype xsd:integer ;
+_:c14n179 rdf:first famrel:02 ;
+	rdf:rest _:c14n182 .
+_:c14n18 sh:datatype xsd:integer ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path schema1:int_identifier .
-_:c14n2 rdf:first rdf:type ;
+_:c14n180 rdf:first famrel:01 ;
+	rdf:rest _:c14n179 .
+_:c14n181 sh:in _:c14n180 .
+_:c14n182 rdf:first famrel:03 ;
 	rdf:rest rdf:nil .
-_:c14n20 rdf:first personinfo:has_medical_history ;
-	rdf:rest _:c14n143 .
-_:c14n21 rdf:first rdf:type ;
+_:c14n183 rdf:first famrel:02 ;
+	rdf:rest _:c14n185 .
+_:c14n184 rdf:first famrel:01 ;
+	rdf:rest _:c14n183 .
+_:c14n185 rdf:first famrel:03 ;
 	rdf:rest rdf:nil .
-_:c14n22 sh:datatype xsd:boolean ;
+_:c14n186 sh:in _:c14n160 .
+_:c14n187 rdf:first rdf:type ;
+	rdf:rest _:c14n128 .
+_:c14n188 rdf:first rdf:type ;
+	rdf:rest _:c14n46 .
+_:c14n19 rdf:first personinfo:has_medical_history ;
+	rdf:rest _:c14n188 .
+_:c14n2 rdf:first "shell company" ;
+	rdf:rest _:c14n27 .
+_:c14n20 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n21 sh:datatype xsd:boolean ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path personinfo:is_current .
-_:c14n23 sh:datatype xsd:string ;
+_:c14n22 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 4 ;
 	sh:path schema1:description .
-_:c14n24 sh:datatype xsd:string ;
+_:c14n23 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 5 ;
 	sh:path schema1:telephone ;
 	sh:pattern "^[\\d\\(\\)\\-]+$" .
-_:c14n25 rdf:first personinfo:has_familial_relationships ;
-	rdf:rest _:c14n65 .
-_:c14n26 sh:datatype xsd:string ;
+_:c14n24 rdf:first personinfo:has_familial_relationships ;
+	rdf:rest _:c14n130 .
+_:c14n25 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path schema1:name .
-_:c14n27 rdf:first "non profit" ;
-	rdf:rest _:c14n156 .
-_:c14n28 rdf:first "loose organization" ;
+_:c14n26 rdf:first "non profit" ;
+	rdf:rest _:c14n159 .
+_:c14n27 rdf:first "loose organization" ;
 	rdf:rest rdf:nil .
-_:c14n29 rdf:first "offshore" ;
-	rdf:rest _:c14n142 .
-_:c14n3 sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 12 ;
-	sh:path schema1:identifier .
-_:c14n30 sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 15 ;
-	sh:path personinfo:depicted_by .
-_:c14n31 rdf:first rdf:type ;
+_:c14n28 rdf:first "offshore" ;
+	rdf:rest _:c14n145 .
+_:c14n29 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n32 rdf:first famrel:71 ;
-	rdf:rest _:c14n42 .
-_:c14n33 sh:datatype xsd:string ;
+_:c14n3 sh:class personinfo:CodeSystem ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 0 ;
+	sh:path personinfo:code_system .
+_:c14n30 rdf:first famrel:71 ;
+	rdf:rest _:c14n40 .
+_:c14n31 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path personinfo:headline .
-_:c14n34 sh:datatype xsd:string ;
+_:c14n32 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path schema1:email ;
 	sh:pattern "^\\S+@[\\S+\\.]+\\S+" .
-_:c14n35 sh:maxCount 1 ;
+_:c14n33 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 5 ;
 	sh:path personinfo:depicted_by .
-_:c14n36 sh:datatype xsd:string ;
+_:c14n34 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path schema1:name .
-_:c14n37 sh:maxCount 1 ;
+_:c14n35 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 11 ;
 	sh:path personinfo:depicted_by .
-_:c14n38 sh:maxCount 1 ;
+_:c14n36 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 5 ;
 	sh:path personinfo:depicted_by .
-_:c14n39 sh:datatype xsd:string ;
+_:c14n37 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 4 ;
 	sh:path schema1:description .
-_:c14n4 rdf:first "shell company" ;
-	rdf:rest _:c14n28 .
-_:c14n40 rdf:first GSSO:000385 ;
+_:c14n38 rdf:first GSSO:000385 ;
 	rdf:rest rdf:nil .
-_:c14n41 sh:class schema1:Organization ;
+_:c14n39 sh:class schema1:Organization ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 0 ;
 	sh:path personinfo:employed_at .
-_:c14n42 rdf:first "BEST_FRIEND_OF" ;
-	rdf:rest _:c14n165 .
-_:c14n43 sh:class schema1:Person ;
+_:c14n4 sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 3 ;
+	sh:path personinfo:depicted_by .
+_:c14n40 rdf:first "BEST_FRIEND_OF" ;
+	rdf:rest _:c14n168 .
+_:c14n41 sh:class schema1:Person ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path personinfo:related_to .
-_:c14n44 rdf:first rdf:type ;
+_:c14n42 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n45 rdf:first rdf:type ;
+_:c14n43 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n46 sh:datatype xsd:float ;
+_:c14n44 sh:datatype xsd:float ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path personinfo:duration .
+_:c14n45 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n46 rdf:first skos:exactMatch ;
+	rdf:rest _:c14n153 .
 _:c14n47 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n48 rdf:first skos:exactMatch ;
-	rdf:rest _:c14n154 .
-_:c14n49 rdf:first rdf:type ;
+_:c14n48 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
+_:c14n49 sh:datatype xsd:date ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path prov:endedAtTime .
 _:c14n5 sh:class personinfo:CodeSystem ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 0 ;
 	sh:path personinfo:code_system .
-_:c14n50 rdf:first personinfo:in_location ;
-	rdf:rest _:c14n153 .
-_:c14n51 rdf:first rdf:type ;
-	rdf:rest rdf:nil .
-_:c14n52 sh:datatype xsd:date ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 1 ;
-	sh:path prov:endedAtTime .
-_:c14n53 sh:maxCount 1 ;
+_:c14n50 rdf:first personinfo:CodeSystem ;
+	rdf:rest _:c14n13 .
+_:c14n51 rdf:first personinfo:headline ;
+	rdf:rest _:c14n187 .
+_:c14n52 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path schema1:identifier .
-_:c14n54 sh:class personinfo:FamilialRelationship ;
+_:c14n53 sh:class personinfo:FamilialRelationship ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	sh:order 7 ;
 	sh:path personinfo:has_familial_relationships .
-_:c14n55 sh:datatype xsd:string ;
+_:c14n54 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path personinfo:mission_statement .
-_:c14n56 sh:datatype xsd:date ;
+_:c14n55 sh:datatype xsd:date ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
 	sh:path prov:endedAtTime .
-_:c14n57 sh:datatype xsd:decimal ;
+_:c14n56 sh:datatype xsd:decimal ;
 	sh:description "A score between 0 and 5, represented as a decimal" ;
 	sh:maxCount 1 ;
 	sh:maxInclusive "5.0"^^xsd:double ;
@@ -657,22 +660,23 @@ _:c14n57 sh:datatype xsd:decimal ;
 	sh:nodeKind sh:Literal ;
 	sh:order 4 ;
 	sh:path personinfo:score .
+_:c14n57 sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 16 ;
+	sh:path personinfo:depicted_by .
 _:c14n58 sh:class personinfo:DiagnosisConcept ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 0 ;
 	sh:path personinfo:diagnosis .
-_:c14n59 rdf:first rdf:type ;
+_:c14n59 sh:class personinfo:NewsEvent ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 12 ;
+	sh:path personinfo:has_news_events .
+_:c14n6 rdf:first personinfo:has_employment_history ;
+	rdf:rest _:c14n171 .
+_:c14n60 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n6 sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 3 ;
-	sh:path personinfo:depicted_by .
-_:c14n60 sh:datatype xsd:string ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 14 ;
-	sh:path schema1:description .
 _:c14n61 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
 _:c14n62 sh:datatype xsd:string ;
@@ -680,8 +684,8 @@ _:c14n62 sh:datatype xsd:string ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path personinfo:postal_code .
-_:c14n63 rdf:first _:c14n179 ;
-	rdf:rest _:c14n95 .
+_:c14n63 rdf:first _:c14n181 ;
+	rdf:rest _:c14n96 .
 _:c14n64 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
@@ -689,32 +693,33 @@ _:c14n64 sh:datatype xsd:string ;
 	sh:path schema1:description .
 _:c14n65 rdf:first personinfo:has_news_events ;
 	rdf:rest rdf:nil .
-_:c14n66 sh:in _:c14n182 ;
+_:c14n66 sh:in _:c14n184 ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:order 3 ;
 	sh:path personinfo:type .
 _:c14n67 rdf:first GSSO:000372 ;
-	rdf:rest _:c14n13 .
+	rdf:rest _:c14n11 .
 _:c14n68 sh:datatype rdfs:Resource ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
 	sh:path skos:exactMatch .
-_:c14n69 sh:in _:c14n27 ;
+_:c14n69 sh:in _:c14n26 ;
 	sh:order 3 ;
 	sh:path personinfo:categories .
-_:c14n7 sh:class personinfo:CodeSystem ;
+_:c14n7 sh:class schema1:PostalAddress ;
+	sh:description "The address at which a person currently lives" ;
 	sh:maxCount 1 ;
-	sh:nodeKind sh:IRI ;
-	sh:order 0 ;
-	sh:path personinfo:code_system .
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 4 ;
+	sh:path personinfo:current_address .
 _:c14n70 sh:datatype xsd:date ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
 	sh:path prov:startedAtTime .
 _:c14n71 rdf:first personinfo:current_address ;
-	rdf:rest _:c14n166 .
+	rdf:rest _:c14n19 .
 _:c14n72 sh:datatype xsd:string ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
@@ -750,8 +755,8 @@ _:c14n79 sh:datatype xsd:string ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path schema1:name .
-_:c14n8 rdf:first personinfo:has_employment_history ;
-	rdf:rest _:c14n89 .
+_:c14n8 rdf:first personinfo:aliases ;
+	rdf:rest _:c14n169 .
 _:c14n80 sh:datatype xsd:date ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
@@ -778,63 +783,66 @@ _:c14n84 sh:datatype xsd:string ;
 	sh:nodeKind sh:Literal ;
 	sh:order 9 ;
 	sh:path schema1:name .
-_:c14n85 rdf:first personinfo:founding_location ;
-	rdf:rest _:c14n10 .
-_:c14n86 sh:datatype xsd:date ;
+_:c14n85 sh:datatype xsd:string ;
+	sh:description "Free-text comment about the person." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 10 ;
+	sh:path personinfo:person_comment .
+_:c14n86 rdf:first personinfo:founding_location ;
+	rdf:rest _:c14n50 .
+_:c14n87 sh:datatype xsd:date ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path prov:startedAtTime .
-_:c14n87 rdf:first GSSO:009253 ;
-	rdf:rest _:c14n137 .
-_:c14n88 sh:datatype xsd:date ;
+_:c14n88 rdf:first GSSO:009253 ;
+	rdf:rest _:c14n141 .
+_:c14n89 sh:datatype xsd:date ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path prov:startedAtTime .
-_:c14n89 rdf:first schema1:email ;
-	rdf:rest _:c14n127 .
-_:c14n9 sh:class schema1:PostalAddress ;
-	sh:description "The address at which a person currently lives" ;
+_:c14n9 sh:datatype xsd:date ;
 	sh:maxCount 1 ;
-	sh:nodeKind sh:BlankNodeOrIRI ;
-	sh:order 4 ;
-	sh:path personinfo:current_address .
-_:c14n90 sh:class personinfo:MedicalEvent ;
+	sh:nodeKind sh:Literal ;
+	sh:order 0 ;
+	sh:path prov:startedAtTime .
+_:c14n90 rdf:first schema1:email ;
+	rdf:rest _:c14n133 .
+_:c14n91 sh:class personinfo:MedicalEvent ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	sh:order 9 ;
 	sh:path personinfo:has_medical_history .
-_:c14n91 sh:class personinfo:Place ;
+_:c14n92 sh:class personinfo:Place ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path personinfo:founding_location .
-_:c14n92 sh:maxCount 1 ;
+_:c14n93 sh:maxCount 1 ;
+	sh:nodeKind sh:IRI ;
+	sh:order 13 ;
+	sh:path schema1:identifier .
+_:c14n94 sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 0 ;
 	sh:path schema1:identifier .
-_:c14n93 rdf:first schema1:telephone ;
-	rdf:rest _:c14n150 .
-_:c14n94 rdf:first personinfo:diagnosis ;
-	rdf:rest _:c14n108 .
-_:c14n95 rdf:first _:c14n184 ;
+_:c14n95 rdf:first schema1:telephone ;
+	rdf:rest _:c14n146 .
+_:c14n96 rdf:first _:c14n186 ;
 	rdf:rest rdf:nil .
-_:c14n96 sh:class personinfo:Place ;
+_:c14n97 sh:class personinfo:Place ;
 	sh:nodeKind sh:IRI ;
 	sh:order 2 ;
 	sh:path personinfo:places .
-_:c14n97 sh:datatype xsd:date ;
+_:c14n98 sh:datatype xsd:date ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path prov:endedAtTime .
-_:c14n98 sh:class personinfo:ProcedureConcept ;
+_:c14n99 sh:class personinfo:ProcedureConcept ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:IRI ;
 	sh:order 1 ;
 	sh:path personinfo:procedure .
-_:c14n99 sh:class personinfo:InterPersonalRelationship ;
-	sh:nodeKind sh:BlankNodeOrIRI ;
-	sh:order 8 ;
-	sh:path personinfo:has_interpersonal_relationships .
 


### PR DESCRIPTION
**This is a demonstration PR. It must not be merged.** It exists to give #3407 reviewers a concrete view of how a small schema change diffs against generated RDF artifacts when RDFC-1.0 canonicalization is the only stability mechanism.

## Setup

- Both branches are off `pyoxygraph-rdf` (the head of #3407).
- Base (`demo-3407-baseline`): one commit that regenerates the committed PersonInfo OWL + SHACL artifacts under RDFC-1.0, with no schema change. This commit absorbs the one-time \"convert to RDFC\" diff that @sneakers-the-rat asked us to factor out (see his [May 5 comment](https://github.com/linkml/linkml/pull/3407#issuecomment-4382363519)).
- Head (`demo-3407-change`): one commit on top that adds **a single optional string slot** (`person_comment`) to the `Person` class in `examples/PersonSchema/personinfo.yaml`, then regenerates the same two artifacts.
- The diff in this PR is therefore: \"once everything is in RDFC form, what does adding one slot look like?\"

## YAML change (+6 lines)

\`\`\`yaml
# classes.Person.slots
+      - person_comment

# top-level slots
+  person_comment:
+    description: Free-text comment about the person.
+    range: string
\`\`\`

## Artifact diff

| File | Total changed lines | Lines mentioning \`person_comment\` | Signal |
|---|---:|---:|---:|
| \`personinfo.owl.ttl\` | 494 (+254 / −240) | 5 | ~1.0% |
| \`personinfo.shacl.ttl\` | 632 (+320 / −312) | 2 | ~0.3% |
| **Total** | **1126** | **7** | **~0.6%** |

The non-signal portion is almost entirely sequential blank-node renumbering (e.g. \`_:c14n130\` → \`_:c14n133\`) downstream of the insertion point. Classes structurally unrelated to \`person_comment\` (e.g. \`personinfo:Address\`) have multiple blank-node IDs in their \`rdfs:subClassOf\` rewritten.

## Relation to other discussions

- Reproduces, on a LinkML-controlled schema, the diff-stability concern @jdsika raised in [#3407 (comment)](https://github.com/linkml/linkml/pull/3407#issuecomment-4319593847) and demonstrated in [ASCS-eV/ontology-management-base#67 vs #68](https://github.com/ASCS-eV/ontology-management-base/pull/67).
- Does **not** propose a fix here. This PR is purely diagnostic.

## What to look at

Open the **Files changed** tab and skim either file. Most changed lines are blank-node ID renumberings, not anything to do with the new slot.