### PR TITLE
fix(shaclgen): emit sh:pattern for pattern constraints inside any_of

### DIFF
--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -343,6 +343,11 @@ class ShaclGenerator(Generator):
 
                             add_simple_data_type(st_node_pv, r)
                             range_list.append(st_node)
+                        # Propagate pattern constraint to the branch node.
+                        # A branch may combine range + pattern (e.g. range: string
+                        # with pattern: "^...") or specify pattern alone (no range).
+                        if any.pattern:
+                            g.add((range_list[-1], SH.pattern, Literal(any.pattern)))
                     Collection(g, or_node, range_list)
                 else:
                     prop_pv_literal(SH.hasValue, s.equals_number)

--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -359,6 +359,11 @@ class ShaclGenerator(Generator):
 
                             add_simple_data_type(st_node_pv, r)
                             range_list.append(st_node)
+                        # Propagate pattern constraint to the branch node.
+                        # A branch may combine range + pattern (e.g. range: string
+                        # with pattern: "^...") or specify pattern alone (no range).
+                        if any.pattern:
+                            g.add((range_list[-1], SH.pattern, Literal(any.pattern)))
                     Collection(g, or_node, range_list)
                 else:
                     prop_pv_literal(SH.hasValue, s.equals_number)

--- a/tests/linkml/test_generators/input/shaclgen/any_of_pattern.yaml
+++ b/tests/linkml/test_generators/input/shaclgen/any_of_pattern.yaml
@@ -1,0 +1,59 @@
+id: https://w3id.org/linkml/examples/any_of_pattern
+name: test_any_of_pattern
+description: >-
+  Test schema for pattern constraints inside any_of branches.
+  Exercises three cases: (1) pattern-only branch (no range),
+  (2) range + pattern on the same branch, (3) mixed branches
+  where some have pattern and some do not.
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://w3id.org/linkml/examples/any_of_pattern/
+imports:
+  - linkml:types
+default_range: string
+default_prefix: ex
+
+enums:
+  LicenseEnum:
+    permissible_values:
+      MIT:
+      Apache-2.0:
+      GPL-3.0-only:
+
+classes:
+  PatternOnlyBranch:
+    description: >-
+      A class where one any_of branch specifies only a pattern
+      (no range). The generated SHACL sh:or should contain a
+      node with sh:pattern but no sh:datatype or sh:class.
+    attributes:
+      license:
+        any_of:
+          - range: LicenseEnum
+          - range: uri
+          - pattern: "^LicenseRef-[a-zA-Z0-9\\-\\.]+$"
+
+  RangeWithPattern:
+    description: >-
+      A class where an any_of branch combines range + pattern.
+      The generated SHACL sh:or node should have both sh:datatype
+      and sh:pattern.
+    attributes:
+      identifier:
+        any_of:
+          - range: string
+            pattern: "^[A-Z]{2}-[0-9]{4}$"
+          - range: integer
+
+  MixedBranches:
+    description: >-
+      A class with three any_of branches: one with range only,
+      one with pattern only, one with range + pattern. Ensures
+      pattern is emitted only on branches that declare it.
+    attributes:
+      code:
+        any_of:
+          - range: integer
+          - pattern: "^CUSTOM-.*$"
+          - range: string
+            pattern: "^STD-[0-9]+$"

--- a/tests/linkml/test_generators/test_shaclgen.py
+++ b/tests/linkml/test_generators/test_shaclgen.py
@@ -1744,3 +1744,68 @@ def test_message_template_ignores_per_slot_in_language():
     # Contrast: sh:name DOES follow the slot's in_language ("de").
     names = _get_prop_objects(g, vehicle_shape, EX.vehicle_name, SH.name)
     assert Literal("Name", lang="de") in names
+
+
+def test_any_of_with_pattern(input_path):
+    """Test that pattern constraints inside any_of branches emit sh:pattern.
+
+    Exercises three cases:
+    1. PatternOnlyBranch: any_of with a pattern-only branch (no range)
+    2. RangeWithPattern: any_of with range + pattern on the same branch
+    3. MixedBranches: combination of range-only, pattern-only, and range+pattern
+    """
+    shacl = ShaclGenerator(input_path("shaclgen/any_of_pattern.yaml"), mergeimports=True).serialize()
+    g = rdflib.Graph()
+    g.parse(data=shacl)
+
+    def get_or_branch_nodes(class_uri: str, slot_local: str) -> list[rdflib.BNode]:
+        """Return the list of BNodes inside sh:or for a given class property."""
+        class_ref = URIRef(class_uri)
+        for prop_node in g.objects(class_ref, SH.property):
+            paths = list(g.objects(prop_node, SH.path))
+            if any(slot_local in str(p) for p in paths):
+                for or_head in g.objects(prop_node, SH["or"]):
+                    return list(Collection(g, or_head))
+        return []
+
+    prefix = "https://w3id.org/linkml/examples/any_of_pattern/"
+
+    # Case 1: PatternOnlyBranch — license slot has 3 branches:
+    #   [enum sh:in], [sh:nodeKind sh:IRI], [sh:pattern "^LicenseRef-..."]
+    branches = get_or_branch_nodes(f"{prefix}PatternOnlyBranch", "license")
+    assert len(branches) == 3, f"Expected 3 branches, got {len(branches)}"
+    # Find the branch with sh:pattern
+    pattern_branches = [b for b in branches if list(g.objects(b, SH.pattern))]
+    assert len(pattern_branches) == 1, f"Expected 1 pattern branch, got {len(pattern_branches)}"
+    pattern_val = str(list(g.objects(pattern_branches[0], SH.pattern))[0])
+    assert pattern_val == "^LicenseRef-[a-zA-Z0-9\\-\\.]+$"
+    # The pattern-only branch should NOT have sh:datatype or sh:class
+    assert list(g.objects(pattern_branches[0], SH.datatype)) == []
+    assert list(g.objects(pattern_branches[0], SH["class"])) == []
+
+    # Case 2: RangeWithPattern — identifier slot has 2 branches:
+    #   [sh:datatype xsd:string + sh:pattern "^[A-Z]{2}-[0-9]{4}$"], [sh:datatype xsd:integer]
+    branches = get_or_branch_nodes(f"{prefix}RangeWithPattern", "identifier")
+    assert len(branches) == 2, f"Expected 2 branches, got {len(branches)}"
+    # Find branch with both datatype and pattern
+    combo_branches = [b for b in branches if list(g.objects(b, SH.datatype)) and list(g.objects(b, SH.pattern))]
+    assert len(combo_branches) == 1, f"Expected 1 combo branch, got {len(combo_branches)}"
+    assert str(list(g.objects(combo_branches[0], SH.pattern))[0]) == "^[A-Z]{2}-[0-9]{4}$"
+    # The other branch (integer) should NOT have sh:pattern
+    int_branches = [b for b in branches if b not in combo_branches]
+    assert list(g.objects(int_branches[0], SH.pattern)) == []
+
+    # Case 3: MixedBranches — code slot has 3 branches:
+    #   [sh:datatype xsd:integer], [sh:pattern "^CUSTOM-.*$"], [sh:datatype xsd:string + sh:pattern "^STD-[0-9]+$"]
+    branches = get_or_branch_nodes(f"{prefix}MixedBranches", "code")
+    assert len(branches) == 3, f"Expected 3 branches, got {len(branches)}"
+    # Exactly 2 branches should have sh:pattern
+    pattern_branches = [b for b in branches if list(g.objects(b, SH.pattern))]
+    assert len(pattern_branches) == 2, f"Expected 2 pattern branches, got {len(pattern_branches)}"
+    # Collect the patterns
+    patterns = sorted(str(list(g.objects(b, SH.pattern))[0]) for b in pattern_branches)
+    assert patterns == ["^CUSTOM-.*$", "^STD-[0-9]+$"]
+    # The integer-only branch should have no pattern
+    no_pattern = [b for b in branches if not list(g.objects(b, SH.pattern))]
+    assert len(no_pattern) == 1
+    assert list(g.objects(no_pattern[0], SH.datatype)) == [URIRef("http://www.w3.org/2001/XMLSchema#integer")]

--- a/tests/linkml/test_generators/test_shaclgen.py
+++ b/tests/linkml/test_generators/test_shaclgen.py
@@ -2784,3 +2784,124 @@ classes:
     has_boolean = any("BOUND" in q for q in queries)
     assert has_exclusive, "Expected one exclusive-value SPARQL constraint"
     assert has_boolean, "Expected one boolean-guard SPARQL constraint"
+
+
+# ---------------------------------------------------------------------------
+# pattern inside any_of branches
+# ---------------------------------------------------------------------------
+
+
+def test_any_of_with_pattern(input_path):
+    """Test that pattern constraints inside any_of branches emit sh:pattern.
+
+    Exercises three cases:
+    1. PatternOnlyBranch: any_of with a pattern-only branch (no range)
+    2. RangeWithPattern: any_of with range + pattern on the same branch
+    3. MixedBranches: combination of range-only, pattern-only, and range+pattern
+    """
+    shacl = ShaclGenerator(input_path("shaclgen/any_of_pattern.yaml"), mergeimports=True).serialize()
+    g = rdflib.Graph()
+    g.parse(data=shacl)
+
+    def get_or_branch_nodes(class_uri: str, slot_local: str) -> list[rdflib.BNode]:
+        """Return the list of BNodes inside sh:or for a given class property."""
+        class_ref = URIRef(class_uri)
+        for prop_node in g.objects(class_ref, SH.property):
+            paths = list(g.objects(prop_node, SH.path))
+            if any(slot_local in str(p) for p in paths):
+                for or_head in g.objects(prop_node, SH["or"]):
+                    return list(Collection(g, or_head))
+        return []
+
+    prefix = "https://w3id.org/linkml/examples/any_of_pattern/"
+
+    # Case 1: PatternOnlyBranch — license slot has 3 branches:
+    #   [enum sh:in], [sh:nodeKind sh:IRI], [sh:pattern "^LicenseRef-..."]
+    branches = get_or_branch_nodes(f"{prefix}PatternOnlyBranch", "license")
+    assert len(branches) == 3, f"Expected 3 branches, got {len(branches)}"
+    # Find the branch with sh:pattern
+    pattern_branches = [b for b in branches if list(g.objects(b, SH.pattern))]
+    assert len(pattern_branches) == 1, f"Expected 1 pattern branch, got {len(pattern_branches)}"
+    pattern_val = str(list(g.objects(pattern_branches[0], SH.pattern))[0])
+    assert pattern_val == "^LicenseRef-[a-zA-Z0-9\\-\\.]+$"
+    # The pattern-only branch should NOT have sh:datatype or sh:class
+    assert list(g.objects(pattern_branches[0], SH.datatype)) == []
+    assert list(g.objects(pattern_branches[0], SH["class"])) == []
+
+    # Case 2: RangeWithPattern — identifier slot has 2 branches:
+    #   [sh:datatype xsd:string + sh:pattern "^[A-Z]{2}-[0-9]{4}$"], [sh:datatype xsd:integer]
+    branches = get_or_branch_nodes(f"{prefix}RangeWithPattern", "identifier")
+    assert len(branches) == 2, f"Expected 2 branches, got {len(branches)}"
+    # Find branch with both datatype and pattern
+    combo_branches = [b for b in branches if list(g.objects(b, SH.datatype)) and list(g.objects(b, SH.pattern))]
+    assert len(combo_branches) == 1, f"Expected 1 combo branch, got {len(combo_branches)}"
+    assert str(list(g.objects(combo_branches[0], SH.pattern))[0]) == "^[A-Z]{2}-[0-9]{4}$"
+    # The other branch (integer) should NOT have sh:pattern
+    int_branches = [b for b in branches if b not in combo_branches]
+    assert list(g.objects(int_branches[0], SH.pattern)) == []
+
+    # Case 3: MixedBranches — code slot has 3 branches:
+    #   [sh:datatype xsd:integer], [sh:pattern "^CUSTOM-.*$"], [sh:datatype xsd:string + sh:pattern "^STD-[0-9]+$"]
+    branches = get_or_branch_nodes(f"{prefix}MixedBranches", "code")
+    assert len(branches) == 3, f"Expected 3 branches, got {len(branches)}"
+    # Exactly 2 branches should have sh:pattern
+    pattern_branches = [b for b in branches if list(g.objects(b, SH.pattern))]
+    assert len(pattern_branches) == 2, f"Expected 2 pattern branches, got {len(pattern_branches)}"
+    # Collect the patterns
+    patterns = sorted(str(list(g.objects(b, SH.pattern))[0]) for b in pattern_branches)
+    assert patterns == ["^CUSTOM-.*$", "^STD-[0-9]+$"]
+    # The integer-only branch should have no pattern
+    no_pattern = [b for b in branches if not list(g.objects(b, SH.pattern))]
+    assert len(no_pattern) == 1
+    assert list(g.objects(no_pattern[0], SH.datatype)) == [URIRef("http://www.w3.org/2001/XMLSchema#integer")]
+
+
+def test_any_of_with_pattern_pyshacl_end_to_end(input_path):
+    """End-to-end: pyshacl accepts values matching an ``any_of`` pattern branch and rejects others.
+
+    This is the behavioural regression guard for the fix. Without ``sh:pattern`` on the
+    branch node, a pattern-only branch serialises as an empty shape ``[ ]``, which every
+    value node trivially satisfies — so ``sh:or`` would accept *anything* and the
+    non-conforming assertions below would fail.
+    """
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(input_path("shaclgen/any_of_pattern.yaml"), mergeimports=True).serialize()
+
+    def conforms(data_ttl: str) -> tuple[bool, str]:
+        ok, _, text = pyshacl.validate(
+            data_graph=data_ttl,
+            shacl_graph=shacl_ttl,
+            data_graph_format="turtle",
+            shacl_graph_format="turtle",
+        )
+        return ok, text
+
+    prefixes = """
+    @prefix ex: <https://w3id.org/linkml/examples/any_of_pattern/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    """
+
+    # Case 1: pattern-only branch. "MIT" satisfies the enum branch, an IRI satisfies the
+    # uri branch, and "LicenseRef-..." may only satisfy the pattern-only branch.
+    for value in ('"MIT"', "<https://example.org/licenses/custom>", '"LicenseRef-My-Custom.1"'):
+        ok, text = conforms(f"{prefixes}\nex:l1 a ex:PatternOnlyBranch ; ex:license {value} .")
+        assert ok, f"license {value} should conform:\n{text}"
+    # No branch matches: not an enum member, not an IRI, and does not match the pattern.
+    ok, _ = conforms(f'{prefixes}\nex:l2 a ex:PatternOnlyBranch ; ex:license "NotALicenseRef" .')
+    assert not ok, "A value matching no any_of branch must be rejected"
+
+    # Case 2: range + pattern on the same branch — both must hold for that branch.
+    ok, text = conforms(f'{prefixes}\nex:i1 a ex:RangeWithPattern ; ex:identifier "AB-1234" .')
+    assert ok, f"identifier 'AB-1234' should conform:\n{text}"
+    ok, text = conforms(f'{prefixes}\nex:i2 a ex:RangeWithPattern ; ex:identifier "42"^^xsd:integer .')
+    assert ok, f"identifier 42 should conform via the integer branch:\n{text}"
+    ok, _ = conforms(f'{prefixes}\nex:i3 a ex:RangeWithPattern ; ex:identifier "ab-1234" .')
+    assert not ok, "A string violating the branch pattern must be rejected"
+
+    # Case 3: mixed branches — each branch accepts only its own values.
+    for value in ('"7"^^xsd:integer', '"CUSTOM-anything"', '"STD-42"'):
+        ok, text = conforms(f"{prefixes}\nex:c1 a ex:MixedBranches ; ex:code {value} .")
+        assert ok, f"code {value} should conform:\n{text}"
+    ok, _ = conforms(f'{prefixes}\nex:c2 a ex:MixedBranches ; ex:code "STD-xyz" .')
+    assert not ok, "A value matching no any_of branch must be rejected"


### PR DESCRIPTION
> **Dependencies:** None (standalone PR)

## Summary

The SHACL generator (`shaclgen.py`) currently ignores `pattern` constraints specified inside `any_of` branches. When a slot uses `any_of` with a branch that has `pattern:` (with or without `range:`), the generated SHACL produces an empty blank node `[ ]` instead of `[ sh:pattern "..." ]`.

This means any value trivially satisfies the branch (an empty node has no constraints), making the `sh:or` validation too permissive.

## Root Cause

In `shaclgen.py` (the `for any in s.any_of:` loop, ~L325–373), branch translation dispatches solely on `any.range`:
- If range maps to a class → `sh:class`
- If range maps to a type → `sh:datatype`  
- If range maps to an enum → `sh:in`
- Else → empty BNode (via `add_simple_data_type(func, None)`)

The loop **never reads `any.pattern`** from the `AnonymousSlotExpression`, so pattern-only branches (no range) produce empty constraint nodes, and range+pattern branches lose the pattern constraint.

Note: the top-level `s.pattern` check (~L394) sits in the `else:` arm of `if s.any_of:`, so it only runs when `any_of` is absent and cannot cover patterns inside branches.

## Fix

After the if/elif/else dispatch that creates each branch BNode, add:

```python
if any.pattern:
    g.add((range_list[-1], SH.pattern, Literal(any.pattern)))
```

This correctly handles all three cases:
1. **Pattern-only branch** (no range): empty node gets `sh:pattern` → `[ sh:pattern "^..." ]`
2. **Range + pattern**: node gets both `sh:datatype` and `sh:pattern` → `[ sh:datatype xsd:string ; sh:pattern "^..." ]`  
3. **Range-only** (no pattern): no-op — existing behavior preserved

This mirrors the existing top-level handling (`if s.pattern: prop_pv(SH.pattern, Literal(s.pattern))`), so both paths emit `sh:pattern` consistently.

## Test Coverage

A 3-class test schema (`tests/linkml/test_generators/input/shaclgen/any_of_pattern.yaml`) exercises:
- `PatternOnlyBranch`: enum + URI + pattern-only (no range) in `any_of`
- `RangeWithPattern`: `range: string` + `pattern` on same branch
- `MixedBranches`: combination of range-only, pattern-only, and range+pattern branches

Two tests consume it:
- `test_any_of_with_pattern()` — asserts on the generated RDF triples (which branch node carries `sh:pattern`, and that range-only branches do not).
- `test_any_of_with_pattern_pyshacl_end_to_end()` — behavioural guard: runs `pyshacl` over conforming and non-conforming instances for all three classes. Without the fix a pattern-only branch serialises as an empty shape `[ ]`, which every value node trivially satisfies, so `sh:or` accepts anything and the non-conforming assertions fail.

Both tests were verified to fail on `main` without the one-line change and pass with it. All existing tests continue to pass.

## Real-World Use Case

This fix is needed for **SPDX license validation** in the [Gaia-X / ENVITED-X](https://gaia-x.eu/) ecosystem. The `gx:license` slot uses `any_of` to accept:
1. Known SPDX identifiers (enum)
2. Arbitrary URIs (`range: uri`)
3. Custom license refs matching `^LicenseRef-[a-zA-Z0-9\-\.]+$` (pattern-only branch)

Without this fix, branch (3) generates an empty SHACL node that accepts *anything*, making validation meaningless. The corresponding upstream model change is tracked in [service-characteristics fix/spdx-license-ref-pattern](https://gitlab.com/ascs-ev/service-characteristics/-/merge_requests).

## Specification References

- [SHACL W3C Rec §4.6.2 (sh:pattern)](https://www.w3.org/TR/shacl/#PatternConstraintComponent): defines pattern as a string constraint on value nodes
- [LinkML Spec §5.6.4 (pattern)](https://linkml.io/linkml-model/latest/docs/pattern/): `The ordinal string value of the slot must match the given pattern`
- [LinkML Spec §5.6.14 (any_of)](https://linkml.io/linkml-model/latest/docs/any_of/): `holds if at least one of the expressions hold`

`sh:pattern` is a value-node string constraint, so it is legal (and idiomatic) on the branch shapes inside `sh:or`; for literals it matches the lexical form, for IRIs the IRI string.

---

*This fix was developed and validated using the Gaia-X credential model as a real-world test case. AI-assisted development (GitHub Copilot).*

