### PR TITLE
fix(pythongen): dedupe domain_slots by python field name (alias)

### DIFF
--- a/packages/linkml/src/linkml/generators/pythongen.py
+++ b/packages/linkml/src/linkml/generators/pythongen.py
@@ -798,12 +798,35 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
                     post_inits.append(self.gen_postinit(cls, slot))
         else:
             pkeys = []
+
+        # De-duplicate domain_slots by Python field name to prevent emitting two
+        # cast blocks for the same attribute.  This can happen when an ancestor
+        # leaves an orphan bare slot in cls.slots alongside the class-scoped
+        # mangled slot (#3506).  Both resolve to the same Python field name via
+        # slot_name() / alias.  When two slots share a field name, the required
+        # one (i.e. the class-scoped slot_usage refinement) takes priority over
+        # the optional orphan so we keep the most-specific cast.
+        best_slot_for_field: dict[str, object] = {}
         for slot in self.domain_slots(cls):
+            field_name = self.slot_name(slot.name)
+            existing = best_slot_for_field.get(field_name)
+            if existing is None or (slot.required and not existing.required):
+                best_slot_for_field[field_name] = slot
+        # Preserve the original order (first occurrence of each field name).
+        seen_field_names: set[str] = set()
+        deduped_domain_slots: list = []
+        for slot in self.domain_slots(cls):
+            field_name = self.slot_name(slot.name)
+            if field_name not in seen_field_names and slot is best_slot_for_field[field_name]:
+                seen_field_names.add(field_name)
+                deduped_domain_slots.append(slot)
+
+        for slot in deduped_domain_slots:
             if slot.required:
                 # TODO: Remove the bypass whenever we get default_range fixed
                 if slot.name not in pkeys and (not slot.ifabsent or True):
                     post_inits.append(self.gen_postinit(cls, slot))
-        for slot in self.domain_slots(cls):
+        for slot in deduped_domain_slots:
             if not slot.required:
                 # TODO: Remove the bypass whenever we get default_range fixed
                 if slot.name not in pkeys and (not slot.ifabsent or True):

--- a/tests/linkml/test_generators/test_pythongen.py
+++ b/tests/linkml/test_generators/test_pythongen.py
@@ -405,3 +405,85 @@ def test_gen_references_cycle_safety_raises_value_error(monkeypatch):
 
     with pytest.raises(ValueError, match="Cyclic wrapper inheritance"):
         generator.gen_references()
+
+
+def test_gen_postinits_no_duplicate_cast_blocks():
+    """Regression test: a deep slot_usage chain must not emit two cast blocks for the same attribute.
+
+    When an orphan bare slot survives alongside the class-scoped mangled slot (#3507),
+    both map to the same Python field name via their alias.  Before the Bug B fix,
+    gen_postinits emitted one cast block per slot, so the same attribute received two
+    casts — the second of which could crash at runtime.
+
+    We use a 3-level chain (Animal -> Canine -> Dog) where Dog refines the ``sound``
+    slot via slot_usage.  We verify that the generated ``__post_init__`` contains
+    exactly one cast block referencing ``self.sound``.
+    """
+    schema = """
+id: https://example.org/test_no_dup_cast
+name: test_no_dup_cast
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/
+
+default_prefix: ex
+default_range: string
+
+imports:
+  - linkml:types
+
+enums:
+  AnimalSoundEnum:
+    permissible_values:
+      WOOF:
+      MEOW:
+  DogSoundEnum:
+    permissible_values:
+      WOOF:
+      BARK:
+
+slots:
+  sound:
+    range: AnimalSoundEnum
+
+classes:
+  Animal:
+    slots:
+      - sound
+
+  Canine:
+    is_a: Animal
+    slot_usage:
+      sound:
+        range: AnimalSoundEnum
+
+  Dog:
+    is_a: Canine
+    slots:
+      - sound
+    slot_usage:
+      sound:
+        range: DogSoundEnum
+        required: true
+"""
+    python = PythonGenerator(schema, mergeimports=True).serialize()
+
+    # Extract only the Dog class body so we don't count Animal's and Canine's
+    # legitimate self.sound checks as duplicates.  Match the @dataclass decorator
+    # that is immediately followed by "class Dog" (no intervening lines).
+    dog_class_match = re.search(
+        r"^@dataclass[^\n]*\nclass Dog\b.*?(?=^@dataclass|\Z)", python, re.MULTILINE | re.DOTALL
+    )
+    assert dog_class_match, "Could not locate class Dog in generated Python"
+    dog_class_src = dog_class_match.group(0)
+
+    # Count isinstance checks for self.sound within Dog only.
+    cast_lines = [line.strip() for line in dog_class_src.splitlines() if "self.sound" in line and "isinstance" in line]
+    assert len(cast_lines) == 1, (
+        f"Expected exactly 1 isinstance check for self.sound in Dog.__post_init__, "
+        f"got {len(cast_lines)}:\n" + "\n".join(cast_lines)
+    )
+
+    # Also confirm the surviving cast uses the correct (most-specific) enum type
+    assert "DogSoundEnum" in cast_lines[0], f"Expected DogSoundEnum in the surviving cast, got: {cast_lines[0]}"


### PR DESCRIPTION
## Summary

Fixes #3508

- As a defence-in-depth measure, `gen_postinits` can de-duplicate by aliased Python field name before emitting.
- The full list from "domain_slots(cls)" is now de-duplicated by Python field name (self.slot_name(slot.name), resolving alias.

## How was this tested?

New unit tests

## Areas of uncertainty

This PR may be overkill - #3507 may be enough.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance
LLM assistance
