### PR TITLE
fix(notebooks): make install cells portable via %pip

### DIFF
--- a/notebooks/DistributedModels.ipynb
+++ b/notebooks/DistributedModels.ipynb
@@ -21,20 +21,35 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T17:16:09.128755Z",
-     "iopub.status.busy": "2026-05-14T17:16:09.128461Z",
-     "iopub.status.idle": "2026-05-14T17:16:10.232068Z",
-     "shell.execute_reply": "2026-05-14T17:16:10.230151Z"
+     "iopub.execute_input": "2026-05-14T18:02:15.402517Z",
+     "iopub.status.busy": "2026-05-14T18:02:15.402204Z",
+     "iopub.status.idle": "2026-05-14T18:02:16.558489Z",
+     "shell.execute_reply": "2026-05-14T18:02:16.557530Z"
     },
     "pycharm": {
      "is_executing": false,
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
-    "!pip install -q --disable-pip-version-check yamlmagic\n",
-    "!pip install linkml --upgrade --disable-pip-version-check -q"
+    "%pip install -q --disable-pip-version-check yamlmagic\n",
+    "%pip install linkml --upgrade --disable-pip-version-check -q"
    ]
   },
   {
@@ -42,10 +57,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T17:16:10.236504Z",
-     "iopub.status.busy": "2026-05-14T17:16:10.236191Z",
-     "iopub.status.idle": "2026-05-14T17:16:10.260635Z",
-     "shell.execute_reply": "2026-05-14T17:16:10.259529Z"
+     "iopub.execute_input": "2026-05-14T18:02:16.560549Z",
+     "iopub.status.busy": "2026-05-14T18:02:16.560393Z",
+     "iopub.status.idle": "2026-05-14T18:02:16.575687Z",
+     "shell.execute_reply": "2026-05-14T18:02:16.574819Z"
     }
    },
    "outputs": [],
@@ -58,10 +73,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T17:16:10.263844Z",
-     "iopub.status.busy": "2026-05-14T17:16:10.263601Z",
-     "iopub.status.idle": "2026-05-14T17:16:10.275811Z",
-     "shell.execute_reply": "2026-05-14T17:16:10.275184Z"
+     "iopub.execute_input": "2026-05-14T18:02:16.577314Z",
+     "iopub.status.busy": "2026-05-14T18:02:16.577035Z",
+     "iopub.status.idle": "2026-05-14T18:02:16.583409Z",
+     "shell.execute_reply": "2026-05-14T18:02:16.582901Z"
     },
     "pycharm": {
      "is_executing": false,
@@ -184,10 +199,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T17:16:10.299928Z",
-     "iopub.status.busy": "2026-05-14T17:16:10.299800Z",
-     "iopub.status.idle": "2026-05-14T17:16:15.546964Z",
-     "shell.execute_reply": "2026-05-14T17:16:15.546527Z"
+     "iopub.execute_input": "2026-05-14T18:02:16.584629Z",
+     "iopub.status.busy": "2026-05-14T18:02:16.584544Z",
+     "iopub.status.idle": "2026-05-14T18:02:21.520581Z",
+     "shell.execute_reply": "2026-05-14T18:02:21.520162Z"
     }
    },
    "outputs": [
@@ -204,7 +219,7 @@
      "output_type": "stream",
      "text": [
       "# Auto generated from None by pythongen.py version: 0.0.1\n",
-      "# Generation date: 2026-05-14T12:16:11\n",
+      "# Generation date: 2026-05-14T13:02:17\n",
       "# Schema: dist1\n",
       "#\n",
       "# id: http://example.org/examples/distributeExample\n",

--- a/notebooks/DistributedModels.ipynb
+++ b/notebooks/DistributedModels.ipynb
@@ -21,47 +21,20 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:23.620771Z",
-     "iopub.status.busy": "2026-05-08T15:54:23.620614Z",
-     "iopub.status.idle": "2026-05-08T15:54:26.047355Z",
-     "shell.execute_reply": "2026-05-08T15:54:26.046362Z"
+     "iopub.execute_input": "2026-05-14T17:16:09.128755Z",
+     "iopub.status.busy": "2026-05-14T17:16:09.128461Z",
+     "iopub.status.idle": "2026-05-14T17:16:10.232068Z",
+     "shell.execute_reply": "2026-05-14T17:16:10.230151Z"
     },
     "pycharm": {
      "is_executing": false,
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1m\u001b[31merror\u001b[39m\u001b[0m: The build backend returned an error\r\n",
-      "  \u001b[1m\u001b[31mCaused by\u001b[39m\u001b[0m: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)\r\n",
-      "\r\n",
-      "\u001b[31m[stderr]\u001b[39m\r\n",
-      "error: Multiple top-level packages discovered in a flat-layout: ['images', 'packages', 'notebooks'].\r\n",
-      "\r\n",
-      "To avoid accidental inclusion of unwanted files or directories,\r\n",
-      "setuptools will not proceed with this build.\r\n",
-      "\r\n",
-      "If you are trying to create a single distribution with multiple packages\r\n",
-      "on purpose, you should not rely on automatic discovery.\r\n",
-      "Instead, consider the following options:\r\n",
-      "\r\n",
-      "1. set up custom discovery (`find` directive with `include` or `exclude`)\r\n",
-      "2. use a `src-layout`\r\n",
-      "3. explicitly set `py_modules` or `packages` with a list of names\r\n",
-      "\r\n",
-      "To find more information, look for \"package discovery\" on setuptools docs.\r\n",
-      "\r\n",
-      "\u001b[36m\u001b[1mhint\u001b[0m\u001b[39m\u001b[1m:\u001b[0m This usually indicates a problem with the package or the build environment.\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!uv pip install -q --disable-pip-version-check yamlmagic\n",
-    "!uv pip install -q --disable-pip-version-check .."
+    "!pip install -q --disable-pip-version-check yamlmagic\n",
+    "!pip install linkml --upgrade --disable-pip-version-check -q"
    ]
   },
   {
@@ -69,10 +42,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:26.049948Z",
-     "iopub.status.busy": "2026-05-08T15:54:26.049754Z",
-     "iopub.status.idle": "2026-05-08T15:54:26.129612Z",
-     "shell.execute_reply": "2026-05-08T15:54:26.128571Z"
+     "iopub.execute_input": "2026-05-14T17:16:10.236504Z",
+     "iopub.status.busy": "2026-05-14T17:16:10.236191Z",
+     "iopub.status.idle": "2026-05-14T17:16:10.260635Z",
+     "shell.execute_reply": "2026-05-14T17:16:10.259529Z"
     }
    },
    "outputs": [],
@@ -85,10 +58,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:26.131549Z",
-     "iopub.status.busy": "2026-05-08T15:54:26.131388Z",
-     "iopub.status.idle": "2026-05-08T15:54:26.139972Z",
-     "shell.execute_reply": "2026-05-08T15:54:26.138777Z"
+     "iopub.execute_input": "2026-05-14T17:16:10.263844Z",
+     "iopub.status.busy": "2026-05-14T17:16:10.263601Z",
+     "iopub.status.idle": "2026-05-14T17:16:10.275811Z",
+     "shell.execute_reply": "2026-05-14T17:16:10.275184Z"
     },
     "pycharm": {
      "is_executing": false,
@@ -211,10 +184,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:26.141502Z",
-     "iopub.status.busy": "2026-05-08T15:54:26.141371Z",
-     "iopub.status.idle": "2026-05-08T15:54:41.341165Z",
-     "shell.execute_reply": "2026-05-08T15:54:41.340088Z"
+     "iopub.execute_input": "2026-05-14T17:16:10.299928Z",
+     "iopub.status.busy": "2026-05-14T17:16:10.299800Z",
+     "iopub.status.idle": "2026-05-14T17:16:15.546964Z",
+     "shell.execute_reply": "2026-05-14T17:16:15.546527Z"
     }
    },
    "outputs": [
@@ -222,7 +195,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/mnt/c/Users/Yuyao/PycharmProjects/PythonProject/linkml/.venv/lib/python3.13/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.3)/charset_normalizer (3.4.4) doesn't match a supported version!\n",
+      "/home/corey/Code/linkml/.wt/fix-notebook-installs/.venv/lib/python3.13/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.3)/charset_normalizer (3.4.4) doesn't match a supported version!\n",
       "  warnings.warn(\n"
      ]
     },
@@ -231,7 +204,7 @@
      "output_type": "stream",
      "text": [
       "# Auto generated from None by pythongen.py version: 0.0.1\n",
-      "# Generation date: 2026-05-08T16:54:33\n",
+      "# Generation date: 2026-05-14T12:16:11\n",
       "# Schema: dist1\n",
       "#\n",
       "# id: http://example.org/examples/distributeExample\n",
@@ -291,7 +264,7 @@
       "from linkml_runtime.linkml_model.types import Boolean, Date, Double, Float, Integer, String, Time, Uriorcurie\n",
       "from linkml_runtime.utils.metamodelcore import Bool, URIorCURIE, XSDDate, XSDTime\n",
       "\n",
-      "metamodel_version = \"1.7.0\"\n",
+      "metamodel_version = \"1.11.0\"\n",
       "version = \"0.0.1\"\n",
       "\n",
       "# Namespaces\n",
@@ -19091,7 +19064,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/ShExPrimerModel.ipynb
+++ b/notebooks/ShExPrimerModel.ipynb
@@ -14,26 +14,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:55:23.951286Z",
-     "iopub.status.busy": "2026-05-08T15:55:23.951119Z",
-     "iopub.status.idle": "2026-05-08T15:55:38.062149Z",
-     "shell.execute_reply": "2026-05-08T15:55:38.059608Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "!uv pip install linkml --upgrade --disable-pip-version-check -q"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-08T15:55:38.065549Z",
-     "iopub.status.busy": "2026-05-08T15:55:38.065370Z",
-     "iopub.status.idle": "2026-05-08T15:55:50.647804Z",
-     "shell.execute_reply": "2026-05-08T15:55:50.646576Z"
+     "iopub.execute_input": "2026-05-14T18:02:36.014820Z",
+     "iopub.status.busy": "2026-05-14T18:02:36.014545Z",
+     "iopub.status.idle": "2026-05-14T18:02:36.646783Z",
+     "shell.execute_reply": "2026-05-14T18:02:36.646300Z"
     }
    },
    "outputs": [
@@ -41,8 +25,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install linkml --upgrade --disable-pip-version-check -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T18:02:36.648254Z",
+     "iopub.status.busy": "2026-05-14T18:02:36.648150Z",
+     "iopub.status.idle": "2026-05-14T18:02:37.201090Z",
+     "shell.execute_reply": "2026-05-14T18:02:37.200380Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/corey/Code/linkml/.wt/fix-notebook-installs/.venv/lib/python3.13/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.3)/charset_normalizer (3.4.4) doesn't match a supported version!\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "# Auto generated from None by pythongen.py version: 0.0.1\n",
-      "# Generation date: 2026-05-08T16:55:50\n",
+      "# Generation date: 2026-05-14T13:02:37\n",
       "# Schema: issue\n",
       "#\n",
       "# id: http://shex.io/shex-primer/issueshape\n",
@@ -101,7 +117,7 @@
       "\n",
       "\n",
       "\n",
-      "metamodel_version = \"1.7.0\"\n",
+      "metamodel_version = \"1.11.0\"\n",
       "version = \"0.1.0\"\n",
       "\n",
       "# Namespaces\n",
@@ -165,7 +181,7 @@
       "slots.hasGuardian = Slot(uri=ISSUE.hasGuardian, name=\"hasGuardian\", curie=ISSUE.curie('hasGuardian'),\n",
       "                   model_uri=ISSUE.hasGuardian, domain=Enrolee, range=Union[Union[dict, Person], list[Union[dict, Person]]])\n",
       "\n",
-      "# metamodel_version: 1.7.0\n",
+      "# metamodel_version: 1.11.0\n",
       "# version: 0.1.0\n",
       "BASE <http://shex.io/shex-primer/issue/>\n",
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
@@ -275,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/Type-Designators.ipynb
+++ b/notebooks/Type-Designators.ipynb
@@ -6,15 +6,23 @@
    "id": "09841f4a-d785-4fa8-8daf-2906c89007c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:20.867689Z",
-     "iopub.status.busy": "2026-05-08T15:56:20.867508Z",
-     "iopub.status.idle": "2026-05-08T15:56:21.758799Z",
-     "shell.execute_reply": "2026-05-08T15:56:21.757207Z"
+     "iopub.execute_input": "2026-05-14T18:02:38.259261Z",
+     "iopub.status.busy": "2026-05-14T18:02:38.259002Z",
+     "iopub.status.idle": "2026-05-14T18:02:38.801952Z",
+     "shell.execute_reply": "2026-05-14T18:02:38.801423Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
-    "!uv pip install -q --disable-pip-version-check yamlmagic\n",
+    "%pip install -q --disable-pip-version-check yamlmagic\n",
     "%load_ext yamlmagic"
    ]
   },
@@ -24,10 +32,10 @@
    "id": "8327f543",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:21.760626Z",
-     "iopub.status.busy": "2026-05-08T15:56:21.760456Z",
-     "iopub.status.idle": "2026-05-08T15:56:21.767406Z",
-     "shell.execute_reply": "2026-05-08T15:56:21.766547Z"
+     "iopub.execute_input": "2026-05-14T18:02:38.803734Z",
+     "iopub.status.busy": "2026-05-14T18:02:38.803641Z",
+     "iopub.status.idle": "2026-05-14T18:02:38.808227Z",
+     "shell.execute_reply": "2026-05-14T18:02:38.807611Z"
     }
    },
    "outputs": [
@@ -97,10 +105,10 @@
    "id": "25ad3561-ccb0-418b-b9f5-3d17ef13e343",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:21.768936Z",
-     "iopub.status.busy": "2026-05-08T15:56:21.768802Z",
-     "iopub.status.idle": "2026-05-08T15:56:21.772190Z",
-     "shell.execute_reply": "2026-05-08T15:56:21.771255Z"
+     "iopub.execute_input": "2026-05-14T18:02:38.809676Z",
+     "iopub.status.busy": "2026-05-14T18:02:38.809596Z",
+     "iopub.status.idle": "2026-05-14T18:02:38.811663Z",
+     "shell.execute_reply": "2026-05-14T18:02:38.811360Z"
     }
    },
    "outputs": [],
@@ -115,13 +123,22 @@
    "id": "32188102",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:21.773525Z",
-     "iopub.status.busy": "2026-05-08T15:56:21.773399Z",
-     "iopub.status.idle": "2026-05-08T15:56:24.517394Z",
-     "shell.execute_reply": "2026-05-08T15:56:24.516335Z"
+     "iopub.execute_input": "2026-05-14T18:02:38.812992Z",
+     "iopub.status.busy": "2026-05-14T18:02:38.812914Z",
+     "iopub.status.idle": "2026-05-14T18:02:38.988599Z",
+     "shell.execute_reply": "2026-05-14T18:02:38.988062Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/corey/Code/linkml/.wt/fix-notebook-installs/.venv/lib/python3.13/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.3)/charset_normalizer (3.4.4) doesn't match a supported version!\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "from linkml_runtime.utils.schemaview import SchemaView"
    ]
@@ -132,10 +149,10 @@
    "id": "0c7a6094",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:24.519104Z",
-     "iopub.status.busy": "2026-05-08T15:56:24.518945Z",
-     "iopub.status.idle": "2026-05-08T15:56:24.616093Z",
-     "shell.execute_reply": "2026-05-08T15:56:24.614986Z"
+     "iopub.execute_input": "2026-05-14T18:02:38.990047Z",
+     "iopub.status.busy": "2026-05-14T18:02:38.989952Z",
+     "iopub.status.idle": "2026-05-14T18:02:38.996347Z",
+     "shell.execute_reply": "2026-05-14T18:02:38.995865Z"
     }
    },
    "outputs": [],
@@ -150,10 +167,10 @@
    "id": "efdd443a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:24.617743Z",
-     "iopub.status.busy": "2026-05-08T15:56:24.617585Z",
-     "iopub.status.idle": "2026-05-08T15:56:26.759498Z",
-     "shell.execute_reply": "2026-05-08T15:56:26.758373Z"
+     "iopub.execute_input": "2026-05-14T18:02:38.998268Z",
+     "iopub.status.busy": "2026-05-14T18:02:38.998179Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.265690Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.264998Z"
     }
    },
    "outputs": [],
@@ -168,10 +185,10 @@
    "id": "00808b90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:26.761489Z",
-     "iopub.status.busy": "2026-05-08T15:56:26.761238Z",
-     "iopub.status.idle": "2026-05-08T15:56:26.764324Z",
-     "shell.execute_reply": "2026-05-08T15:56:26.763552Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.267759Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.267555Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.269960Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.269466Z"
     }
    },
    "outputs": [],
@@ -186,10 +203,10 @@
    "id": "7acde179",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:26.766010Z",
-     "iopub.status.busy": "2026-05-08T15:56:26.765883Z",
-     "iopub.status.idle": "2026-05-08T15:56:26.928030Z",
-     "shell.execute_reply": "2026-05-08T15:56:26.926971Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.271503Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.271414Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.290769Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.290464Z"
     }
    },
    "outputs": [
@@ -228,7 +245,7 @@
       ")\n",
       "\n",
       "\n",
-      "metamodel_version = \"1.7.0\"\n",
+      "metamodel_version = \"1.11.0\"\n",
       "version = \"None\"\n",
       "\n",
       "\n",
@@ -322,10 +339,10 @@
    "id": "ed4dae50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:26.929920Z",
-     "iopub.status.busy": "2026-05-08T15:56:26.929747Z",
-     "iopub.status.idle": "2026-05-08T15:56:27.061594Z",
-     "shell.execute_reply": "2026-05-08T15:56:27.060666Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.292307Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.292217Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.299416Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.299135Z"
     }
    },
    "outputs": [],
@@ -339,10 +356,10 @@
    "id": "68b8b0c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:27.063339Z",
-     "iopub.status.busy": "2026-05-08T15:56:27.063168Z",
-     "iopub.status.idle": "2026-05-08T15:56:27.068159Z",
-     "shell.execute_reply": "2026-05-08T15:56:27.067287Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.301317Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.301228Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.303178Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.303015Z"
     }
    },
    "outputs": [
@@ -367,10 +384,10 @@
    "id": "edd152f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:27.069775Z",
-     "iopub.status.busy": "2026-05-08T15:56:27.069632Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.175347Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.174389Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.304922Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.304838Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.335549Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.335031Z"
     }
    },
    "outputs": [],
@@ -384,10 +401,10 @@
    "id": "23f2c500",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.176958Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.176803Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.180171Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.179368Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.337271Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.337183Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.339532Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.338838Z"
     }
    },
    "outputs": [],
@@ -402,10 +419,10 @@
    "id": "46081bd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.181642Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.181511Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.185092Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.184300Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.341003Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.340913Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.343042Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.342855Z"
     }
    },
    "outputs": [
@@ -430,10 +447,10 @@
    "id": "3313a7d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.186434Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.186308Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.188929Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.188152Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.344220Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.344143Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.345721Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.345493Z"
     }
    },
    "outputs": [],
@@ -458,10 +475,10 @@
    "id": "5a013aa6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.190566Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.190444Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.440634Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.439514Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.347003Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.346915Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.359163Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.358718Z"
     }
    },
    "outputs": [
@@ -500,7 +517,7 @@
       ")\n",
       "\n",
       "\n",
-      "metamodel_version = \"1.7.0\"\n",
+      "metamodel_version = \"1.11.0\"\n",
       "version = \"None\"\n",
       "\n",
       "\n",
@@ -597,10 +614,10 @@
    "id": "73eacb9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.442246Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.442088Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.446180Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.445269Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.360416Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.360282Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.362746Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.362394Z"
     }
    },
    "outputs": [
@@ -625,10 +642,10 @@
    "id": "161b1224",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.447606Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.447447Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.688557Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.687371Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.363549Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.363459Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.375634Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.375349Z"
     }
    },
    "outputs": [
@@ -667,7 +684,7 @@
       ")\n",
       "\n",
       "\n",
-      "metamodel_version = \"1.7.0\"\n",
+      "metamodel_version = \"1.11.0\"\n",
       "version = \"None\"\n",
       "\n",
       "\n",
@@ -793,10 +810,10 @@
    "id": "5471eebf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.690347Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.690206Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.695736Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.694943Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.376892Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.376790Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.380293Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.380028Z"
     }
    },
    "outputs": [
@@ -878,10 +895,10 @@
    "id": "eb108020",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.697477Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.697349Z",
-     "iopub.status.idle": "2026-05-08T15:56:28.702905Z",
-     "shell.execute_reply": "2026-05-08T15:56:28.702106Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.381265Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.381175Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.385125Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.384818Z"
     }
    },
    "outputs": [],
@@ -897,10 +914,10 @@
    "id": "5125a057",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:28.704459Z",
-     "iopub.status.busy": "2026-05-08T15:56:28.704295Z",
-     "iopub.status.idle": "2026-05-08T15:56:29.041874Z",
-     "shell.execute_reply": "2026-05-08T15:56:29.041007Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.386192Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.386106Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.402341Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.401732Z"
     }
    },
    "outputs": [
@@ -939,7 +956,7 @@
       ")\n",
       "\n",
       "\n",
-      "metamodel_version = \"1.7.0\"\n",
+      "metamodel_version = \"1.11.0\"\n",
       "version = \"None\"\n",
       "\n",
       "\n",
@@ -1054,10 +1071,10 @@
    "id": "2599c367",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:29.043584Z",
-     "iopub.status.busy": "2026-05-08T15:56:29.043435Z",
-     "iopub.status.idle": "2026-05-08T15:56:29.046143Z",
-     "shell.execute_reply": "2026-05-08T15:56:29.045389Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.403528Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.403435Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.404828Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.404572Z"
     }
    },
    "outputs": [],
@@ -1071,10 +1088,10 @@
    "id": "52a742f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:29.047451Z",
-     "iopub.status.busy": "2026-05-08T15:56:29.047314Z",
-     "iopub.status.idle": "2026-05-08T15:56:29.051016Z",
-     "shell.execute_reply": "2026-05-08T15:56:29.050323Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.405998Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.405911Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.407824Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.407589Z"
     }
    },
    "outputs": [
@@ -1099,10 +1116,10 @@
    "id": "23f35fee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:29.052385Z",
-     "iopub.status.busy": "2026-05-08T15:56:29.052249Z",
-     "iopub.status.idle": "2026-05-08T15:56:29.054842Z",
-     "shell.execute_reply": "2026-05-08T15:56:29.054044Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.409087Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.408973Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.410334Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.410095Z"
     }
    },
    "outputs": [],
@@ -1124,10 +1141,10 @@
    "id": "7d897da4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:56:29.056350Z",
-     "iopub.status.busy": "2026-05-08T15:56:29.056209Z",
-     "iopub.status.idle": "2026-05-08T15:56:29.062261Z",
-     "shell.execute_reply": "2026-05-08T15:56:29.061446Z"
+     "iopub.execute_input": "2026-05-14T18:02:39.411443Z",
+     "iopub.status.busy": "2026-05-14T18:02:39.411356Z",
+     "iopub.status.idle": "2026-05-14T18:02:39.414945Z",
+     "shell.execute_reply": "2026-05-14T18:02:39.414669Z"
     }
    },
    "outputs": [
@@ -1220,7 +1237,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/context_issue.ipynb
+++ b/notebooks/context_issue.ipynb
@@ -45,18 +45,47 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:13.951669Z",
-     "iopub.status.busy": "2026-05-08T15:54:13.951357Z",
-     "iopub.status.idle": "2026-05-08T15:54:16.976228Z",
-     "shell.execute_reply": "2026-05-08T15:54:16.975251Z"
+     "iopub.execute_input": "2026-05-14T18:02:22.798150Z",
+     "iopub.status.busy": "2026-05-14T18:02:22.797994Z",
+     "iopub.status.idle": "2026-05-14T18:02:25.146700Z",
+     "shell.execute_reply": "2026-05-14T18:02:25.145776Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
-    "!uv pip install -q --disable-pip-version-check prefixcommons\n",
-    "!uv pip install -q --disable-pip-version-check rdflib\n",
-    "!uv pip install -q --disable-pip-version-check rdflib-jsonld\n",
-    "!uv pip install -q --disable-pip-version-check jsonasobj"
+    "%pip install -q --disable-pip-version-check prefixcommons\n",
+    "%pip install -q --disable-pip-version-check rdflib\n",
+    "%pip install -q --disable-pip-version-check rdflib-jsonld\n",
+    "%pip install -q --disable-pip-version-check jsonasobj"
    ]
   },
   {
@@ -75,10 +104,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:16.978263Z",
-     "iopub.status.busy": "2026-05-08T15:54:16.978012Z",
-     "iopub.status.idle": "2026-05-08T15:54:18.010369Z",
-     "shell.execute_reply": "2026-05-08T15:54:18.009392Z"
+     "iopub.execute_input": "2026-05-14T18:02:25.150048Z",
+     "iopub.status.busy": "2026-05-14T18:02:25.149747Z",
+     "iopub.status.idle": "2026-05-14T18:02:25.227739Z",
+     "shell.execute_reply": "2026-05-14T18:02:25.226878Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -89,7 +118,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/mnt/c/Users/Yuyao/PycharmProjects/PythonProject/linkml/.venv/lib/python3.13/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.3)/charset_normalizer (3.4.4) doesn't match a supported version!\n",
+      "/home/corey/Code/linkml/.wt/fix-notebook-installs/.venv/lib/python3.13/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.3)/charset_normalizer (3.4.4) doesn't match a supported version!\n",
       "  warnings.warn(\n"
      ]
     }
@@ -140,10 +169,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:18.012037Z",
-     "iopub.status.busy": "2026-05-08T15:54:18.011876Z",
-     "iopub.status.idle": "2026-05-08T15:54:18.339056Z",
-     "shell.execute_reply": "2026-05-08T15:54:18.338337Z"
+     "iopub.execute_input": "2026-05-14T18:02:25.229574Z",
+     "iopub.status.busy": "2026-05-14T18:02:25.229384Z",
+     "iopub.status.idle": "2026-05-14T18:02:25.257438Z",
+     "shell.execute_reply": "2026-05-14T18:02:25.256772Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -178,10 +207,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:18.341883Z",
-     "iopub.status.busy": "2026-05-08T15:54:18.341743Z",
-     "iopub.status.idle": "2026-05-08T15:54:18.350906Z",
-     "shell.execute_reply": "2026-05-08T15:54:18.350262Z"
+     "iopub.execute_input": "2026-05-14T18:02:25.258809Z",
+     "iopub.status.busy": "2026-05-14T18:02:25.258645Z",
+     "iopub.status.idle": "2026-05-14T18:02:25.262756Z",
+     "shell.execute_reply": "2026-05-14T18:02:25.261828Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -215,10 +244,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:18.352297Z",
-     "iopub.status.busy": "2026-05-08T15:54:18.352129Z",
-     "iopub.status.idle": "2026-05-08T15:54:18.559033Z",
-     "shell.execute_reply": "2026-05-08T15:54:18.558406Z"
+     "iopub.execute_input": "2026-05-14T18:02:25.264434Z",
+     "iopub.status.busy": "2026-05-14T18:02:25.264245Z",
+     "iopub.status.idle": "2026-05-14T18:02:25.275883Z",
+     "shell.execute_reply": "2026-05-14T18:02:25.275241Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -259,7 +288,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/enumerations.ipynb
+++ b/notebooks/enumerations.ipynb
@@ -22,18 +22,26 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:47.665570Z",
-     "iopub.status.busy": "2026-05-08T15:54:47.665420Z",
-     "iopub.status.idle": "2026-05-08T15:54:48.479120Z",
-     "shell.execute_reply": "2026-05-08T15:54:48.477884Z"
+     "iopub.execute_input": "2026-05-14T18:02:13.366455Z",
+     "iopub.status.busy": "2026-05-14T18:02:13.366195Z",
+     "iopub.status.idle": "2026-05-14T18:02:13.917547Z",
+     "shell.execute_reply": "2026-05-14T18:02:13.916618Z"
     },
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
-    "!uv pip install -q --disable-pip-version-check yamlmagic\n",
+    "%pip install -q --disable-pip-version-check yamlmagic\n",
     "%reload_ext yamlmagic"
    ]
   },
@@ -58,10 +66,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:48.481002Z",
-     "iopub.status.busy": "2026-05-08T15:54:48.480835Z",
-     "iopub.status.idle": "2026-05-08T15:54:53.594185Z",
-     "shell.execute_reply": "2026-05-08T15:54:53.593127Z"
+     "iopub.execute_input": "2026-05-14T18:02:13.938038Z",
+     "iopub.status.busy": "2026-05-14T18:02:13.937826Z",
+     "iopub.status.idle": "2026-05-14T18:02:14.402926Z",
+     "shell.execute_reply": "2026-05-14T18:02:14.401896Z"
     },
     "jupyter": {
      "outputs_hidden": false
@@ -75,7 +83,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/mnt/c/Users/Yuyao/PycharmProjects/PythonProject/linkml/.venv/lib/python3.13/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.3)/charset_normalizer (3.4.4) doesn't match a supported version!\n",
+      "/home/corey/Code/linkml/.wt/fix-notebook-installs/.venv/lib/python3.13/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.3)/charset_normalizer (3.4.4) doesn't match a supported version!\n",
       "  warnings.warn(\n"
      ]
     }
@@ -106,10 +114,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:53.596090Z",
-     "iopub.status.busy": "2026-05-08T15:54:53.595848Z",
-     "iopub.status.idle": "2026-05-08T15:54:53.603439Z",
-     "shell.execute_reply": "2026-05-08T15:54:53.602558Z"
+     "iopub.execute_input": "2026-05-14T18:02:14.404459Z",
+     "iopub.status.busy": "2026-05-14T18:02:14.404281Z",
+     "iopub.status.idle": "2026-05-14T18:02:14.409769Z",
+     "shell.execute_reply": "2026-05-14T18:02:14.409151Z"
     },
     "jupyter": {
      "outputs_hidden": false
@@ -190,10 +198,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:53.604911Z",
-     "iopub.status.busy": "2026-05-08T15:54:53.604779Z",
-     "iopub.status.idle": "2026-05-08T15:54:53.872557Z",
-     "shell.execute_reply": "2026-05-08T15:54:53.871537Z"
+     "iopub.execute_input": "2026-05-14T18:02:14.411011Z",
+     "iopub.status.busy": "2026-05-14T18:02:14.410918Z",
+     "iopub.status.idle": "2026-05-14T18:02:14.507309Z",
+     "shell.execute_reply": "2026-05-14T18:02:14.506851Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -205,7 +213,7 @@
      "output_type": "stream",
      "text": [
       "# Auto generated from None by pythongen.py version: 0.0.1\n",
-      "# Generation date: 2026-05-08T16:54:53\n",
+      "# Generation date: 2026-05-14T13:02:14\n",
       "# Schema: simple\n",
       "#\n",
       "# id: http://example.org/test/simple\n",
@@ -264,7 +272,7 @@
       "\n",
       "from linkml_runtime.linkml_model.types import String\n",
       "\n",
-      "metamodel_version = \"1.7.0\"\n",
+      "metamodel_version = \"1.11.0\"\n",
       "version = None\n",
       "\n",
       "# Namespaces\n",
@@ -371,10 +379,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:53.874258Z",
-     "iopub.status.busy": "2026-05-08T15:54:53.874123Z",
-     "iopub.status.idle": "2026-05-08T15:54:53.879466Z",
-     "shell.execute_reply": "2026-05-08T15:54:53.878351Z"
+     "iopub.execute_input": "2026-05-14T18:02:14.508435Z",
+     "iopub.status.busy": "2026-05-14T18:02:14.508339Z",
+     "iopub.status.idle": "2026-05-14T18:02:14.511619Z",
+     "shell.execute_reply": "2026-05-14T18:02:14.511235Z"
     },
     "jupyter": {
      "outputs_hidden": false
@@ -453,10 +461,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:53.881847Z",
-     "iopub.status.busy": "2026-05-08T15:54:53.881718Z",
-     "iopub.status.idle": "2026-05-08T15:54:53.998782Z",
-     "shell.execute_reply": "2026-05-08T15:54:53.997913Z"
+     "iopub.execute_input": "2026-05-14T18:02:14.513093Z",
+     "iopub.status.busy": "2026-05-14T18:02:14.512997Z",
+     "iopub.status.idle": "2026-05-14T18:02:14.526819Z",
+     "shell.execute_reply": "2026-05-14T18:02:14.525959Z"
     },
     "jupyter": {
      "outputs_hidden": false
@@ -471,7 +479,7 @@
      "output_type": "stream",
      "text": [
       "# Auto generated from None by pythongen.py version: 0.0.1\n",
-      "# Generation date: 2026-05-08T16:54:53\n",
+      "# Generation date: 2026-05-14T13:02:14\n",
       "# Schema: simple\n",
       "#\n",
       "# id: http://example.org/test/simple\n",
@@ -530,7 +538,7 @@
       "\n",
       "from linkml_runtime.linkml_model.types import String\n",
       "\n",
-      "metamodel_version = \"1.7.0\"\n",
+      "metamodel_version = \"1.11.0\"\n",
       "version = None\n",
       "\n",
       "# Namespaces\n",
@@ -636,10 +644,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:54.000683Z",
-     "iopub.status.busy": "2026-05-08T15:54:54.000501Z",
-     "iopub.status.idle": "2026-05-08T15:54:54.006405Z",
-     "shell.execute_reply": "2026-05-08T15:54:54.005619Z"
+     "iopub.execute_input": "2026-05-14T18:02:14.528080Z",
+     "iopub.status.busy": "2026-05-14T18:02:14.527968Z",
+     "iopub.status.idle": "2026-05-14T18:02:14.531793Z",
+     "shell.execute_reply": "2026-05-14T18:02:14.531472Z"
     },
     "jupyter": {
      "outputs_hidden": false
@@ -729,10 +737,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T15:54:54.007785Z",
-     "iopub.status.busy": "2026-05-08T15:54:54.007653Z",
-     "iopub.status.idle": "2026-05-08T15:54:54.121816Z",
-     "shell.execute_reply": "2026-05-08T15:54:54.120830Z"
+     "iopub.execute_input": "2026-05-14T18:02:14.532921Z",
+     "iopub.status.busy": "2026-05-14T18:02:14.532817Z",
+     "iopub.status.idle": "2026-05-14T18:02:14.546908Z",
+     "shell.execute_reply": "2026-05-14T18:02:14.546560Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -814,7 +822,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/packages/linkml/pyproject.toml
+++ b/packages/linkml/pyproject.toml
@@ -75,10 +75,19 @@ typing = [
 shacl = [
     "pyshacl >= 0.25.0",
 ]
+notebooks = [
+  "ipykernel",
+  "ipython-genutils",
+  "jupyter",
+  "nbconvert",
+  "nbformat",
+  "pip",
+]
 tests = [
   { include-group = "lint" },
   { include-group = "typing" },
   { include-group = "shacl" },
+  { include-group = "notebooks" },
   "duckdb>=1.5.2",
 ]
 dev = [
@@ -86,11 +95,6 @@ dev = [
   {include-group = "tests-extra" },
   {include-group = "pandera"},
   "chardet",
-  "ipykernel",
-  "ipython-genutils",
-  "jupyter",
-  "nbconvert",
-  "nbformat",
   "coverage >= 6.4.1",
   "tox >= 4",
   "tox-uv",

--- a/tests/linkml/test_notebooks/test_notebooks.py
+++ b/tests/linkml/test_notebooks/test_notebooks.py
@@ -10,6 +10,40 @@ from tests.environment import env
 # Tests moved to root: tests/linkml/test_notebooks, notebooks at root
 NBBASEDIR = os.path.join(env.cwd, "..", "notebooks")
 
+# Substrings that indicate a real failure leaked into cell output
+# without raising (e.g., shell-magic install errors, post-execution tracebacks).
+# Kept narrow on purpose: must appear at line start so they match tool error
+# prefixes (setuptools, pip, uv) rather than incidental occurrences in strings.
+_ERROR_LINE_PREFIXES = ("error: ", "ERROR: ")
+_ERROR_SUBSTRINGS = (
+    "Traceback (most recent call last):",
+    "No module named",
+)
+
+
+def _collect_output_errors(nb: nbformat.NotebookNode) -> list[str]:
+    """Scan executed notebook for failure indicators that didn't raise.
+
+    Returns a list of human-readable findings; empty list means clean.
+    """
+    findings: list[str] = []
+    for idx, cell in enumerate(nb.cells):
+        if cell.get("cell_type") != "code":
+            continue
+        for output in cell.get("outputs", []):
+            if output.get("output_type") != "stream":
+                continue
+            text = "".join(output.get("text", []))
+            for marker in _ERROR_SUBSTRINGS:
+                if marker in text:
+                    findings.append(f"cell {idx} ({output.get('name')}): contains {marker!r}")
+                    break
+            for line in text.splitlines():
+                if line.startswith(_ERROR_LINE_PREFIXES):
+                    findings.append(f"cell {idx} ({output.get('name')}): {line[:160]}")
+                    break
+    return findings
+
 
 @pytest.fixture
 def ep():
@@ -25,7 +59,11 @@ def ep():
     [filename for filename in os.listdir(NBBASEDIR) if not filename.startswith(".") and filename.endswith(".ipynb")],
 )
 def test_redo_notebook(nbname: str, ep: ExecutePreprocessor) -> None:
-    """Verify the notebook executes end-to-end without raising in any cell."""
+    """Verify the notebook executes end-to-end without raising or surfacing errors in output."""
     with open(os.path.join(NBBASEDIR, nbname), encoding="utf-8") as nbf:
         nb = nbformat.read(nbf, as_version=4)
     ep.preprocess(nb, dict(metadata=dict(path=NBBASEDIR)))
+
+    findings = _collect_output_errors(nb)
+    if findings:
+        pytest.fail(f"{nbname} executed but cell output contains failure markers:\n  " + "\n  ".join(findings))

--- a/tests/linkml/test_notebooks/test_notebooks.py
+++ b/tests/linkml/test_notebooks/test_notebooks.py
@@ -1,16 +1,12 @@
 import os
 import sys
-from io import StringIO
 
 import nbformat
 import pytest
 from nbconvert.preprocessors import ExecutePreprocessor
 
 from tests.environment import env
-from tests.linkml.test_notebooks.environment import nbenv
-from tests.linkml.utils.filters import nb_filter
 
-FORCE_REWRITE = True
 # Tests moved to root: tests/linkml/test_notebooks, notebooks at root
 NBBASEDIR = os.path.join(env.cwd, "..", "notebooks")
 
@@ -18,13 +14,6 @@ NBBASEDIR = os.path.join(env.cwd, "..", "notebooks")
 @pytest.fixture
 def ep():
     return ExecutePreprocessor(timeout=600)
-
-
-def force_rewrite_comparator(expected: str, actual: str) -> str:
-    msg = nbenv.string_comparator(expected, actual)
-    if not msg and FORCE_REWRITE:
-        msg = "Forced rewrite"
-    return msg
 
 
 @pytest.mark.skipif(
@@ -35,21 +24,8 @@ def force_rewrite_comparator(expected: str, actual: str) -> str:
     "nbname",
     [filename for filename in os.listdir(NBBASEDIR) if not filename.startswith(".") and filename.endswith(".ipynb")],
 )
-def test_redo_notebook(nbname, ep):
-    # The information on how to do this comes from: http://tritemio.github.io/smbits/2016/01/02/execute-notebooks/
+def test_redo_notebook(nbname: str, ep: ExecutePreprocessor) -> None:
+    """Verify the notebook executes end-to-end without raising in any cell."""
     with open(os.path.join(NBBASEDIR, nbname), encoding="utf-8") as nbf:
         nb = nbformat.read(nbf, as_version=4)
     ep.preprocess(nb, dict(metadata=dict(path=NBBASEDIR)))
-
-    outf = StringIO()
-    nbformat.write(nb, outf)
-
-    result = nbenv.eval_single_file(
-        os.path.join(NBBASEDIR, nbname),
-        outf.getvalue(),
-        nb_filter,
-        force_rewrite_comparator,
-    )
-    if result and nbenv.fail_on_error:
-        with open(nbenv.temp_file_path(nbname), "w", encoding="utf-8") as actualf:
-            actualf.write(outf.getvalue())

--- a/tests/linkml/utils/filters.py
+++ b/tests/linkml/utils/filters.py
@@ -2,8 +2,6 @@
 
 import re
 
-from jsonasobj2 import as_json, loads
-
 
 def ldcontext_metadata_filter(s: str) -> str:
     """
@@ -55,38 +53,3 @@ def yaml_filter(s: str) -> str:
             re.sub(r"(source_file_size: ).*", r"\1 23600", s),
         ),
     )
-
-
-def nb_filter(s: str) -> str:
-    """Filter for jupyter (ipynb) notebooks"""
-    # It is easier to deal with notebook content in JSON
-    s_json = loads(ldcontext_metadata_filter(s))
-    for cell in s_json.cells:
-        if hasattr(cell, "execution_count"):
-            cell.execution_count = 1
-        if hasattr(cell, "metadata"):
-            delattr(cell, "metadata")
-        if hasattr(cell, "outputs"):
-            del_outputs = []
-            for output in cell.outputs:
-                to_del = []
-                if hasattr(output, "text"):
-                    for line in output.text:
-                        if (
-                            "WARNING: You are using pip" in line
-                            or "You should consider upgrading via" in line
-                            or "Requirement already satisfied:" in line
-                        ):
-                            to_del.append(line)
-                    for del_line in to_del:
-                        output.text.remove(del_line)
-                    if not output.text:
-                        del_outputs.append(output)
-            if del_outputs:
-                for del_output in del_outputs:
-                    cell.outputs.remove(del_output)
-    if hasattr(s_json.metadata, "language_info"):
-        if hasattr(s_json.metadata.language_info, "version"):
-            s_json.metadata.language_info.version = "3"
-
-    return as_json(s_json)

--- a/uv.lock
+++ b/uv.lock
@@ -1995,6 +1995,7 @@ dev = [
     { name = "openapi-spec-validator" },
     { name = "pandas" },
     { name = "pandera" },
+    { name = "pip" },
     { name = "polars-lts-cpu" },
     { name = "pyshacl" },
     { name = "pytest" },
@@ -2023,6 +2024,14 @@ docs = [
 lint = [
     { name = "black" },
 ]
+notebooks = [
+    { name = "ipykernel" },
+    { name = "ipython-genutils" },
+    { name = "jupyter" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "pip" },
+]
 pandera = [
     { name = "pandas" },
     { name = "pandera" },
@@ -2034,7 +2043,13 @@ shacl = [
 tests = [
     { name = "black" },
     { name = "duckdb" },
+    { name = "ipykernel" },
+    { name = "ipython-genutils" },
+    { name = "jupyter" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
     { name = "numpydantic" },
+    { name = "pip" },
     { name = "pyshacl" },
 ]
 tests-extra = [
@@ -2110,6 +2125,7 @@ dev = [
     { name = "openapi-spec-validator", specifier = ">=0.8.4" },
     { name = "pandas" },
     { name = "pandera", specifier = ">=0.19.0" },
+    { name = "pip" },
     { name = "polars-lts-cpu", specifier = ">=1.0.0" },
     { name = "pyshacl", specifier = ">=0.25.0" },
     { name = "pytest", specifier = ">=7.4.0" },
@@ -2135,6 +2151,14 @@ docs = [
     { name = "sphinxcontrib-programoutput", specifier = ">=0.17" },
 ]
 lint = [{ name = "black", specifier = ">=24.0.0" }]
+notebooks = [
+    { name = "ipykernel" },
+    { name = "ipython-genutils" },
+    { name = "jupyter" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "pip" },
+]
 pandera = [
     { name = "pandas" },
     { name = "pandera", specifier = ">=0.19.0" },
@@ -2144,7 +2168,13 @@ shacl = [{ name = "pyshacl", specifier = ">=0.25.0" }]
 tests = [
     { name = "black", specifier = ">=24.0.0" },
     { name = "duckdb", specifier = ">=1.5.2" },
+    { name = "ipykernel" },
+    { name = "ipython-genutils" },
+    { name = "jupyter" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
     { name = "numpydantic", specifier = ">=1.6.1" },
+    { name = "pip" },
     { name = "pyshacl", specifier = ">=0.25.0" },
 ]
 tests-extra = [
@@ -3225,6 +3255,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/2e/3434380e8110b76cd9eb00a363c484b050f949b4bbe84ba770bb8508a02c/pillow-12.0.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f2d0abef9e4e2f349305a4f8cc784a8a6c2f58a8c4892eea13b10a943bd26e", size = 5313505, upload-time = "2025-10-15T18:24:07.137Z" },
     { url = "https://files.pythonhosted.org/packages/57/ca/5a9d38900d9d74785141d6580950fe705de68af735ff6e727cb911b64740/pillow-12.0.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bdee52571a343d721fb2eb3b090a82d959ff37fc631e3f70422e0c2e029f3e76", size = 5963654, upload-time = "2025-10-15T18:24:09.579Z" },
     { url = "https://files.pythonhosted.org/packages/95/7e/f896623c3c635a90537ac093c6a618ebe1a90d87206e42309cb5d98a1b9e/pillow-12.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b290fd8aa38422444d4b50d579de197557f182ef1068b75f5aa8558638b8d0a5", size = 6997850, upload-time = "2025-10-15T18:24:11.495Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The notebooks' install cells (`!pip install ...`) didn't behave the same way across environments:
- In our uv-managed CI venv, `!pip` only worked because shell falls through to mise's pip shim, which happened to land in the active venv's Python. Fragile.
- `notebooks/DistributedModels.ipynb` cell 1 had `!uv pip install ..` (introduced in #3172), which fails because the repo root is no longer an installable Python package after the workspace split (root `pyproject.toml` is a uv workspace declaration with no `[project]` table — setuptools refuses with "Multiple top-level packages discovered in a flat-layout"). The failure was committed into the cell's `outputs`.

This PR makes the notebooks behave the same way for everyone:

1. **Switch all install cells to `%pip install`** across `DistributedModels`, `ShExPrimerModel`, `Type-Designators`, `context_issue`, `enumerations`. `%pip` is the canonical Jupyter idiom: it does `sys.executable -m pip install`, guaranteeing the install targets *this kernel's* Python regardless of what's on `PATH`. Works in Binder, Anaconda, plain `python -m venv`, and our uv venv (after the next change).
2. **Add a `notebooks` dependency group** in `packages/linkml/pyproject.toml` with `ipykernel`, `ipython-genutils`, `jupyter`, `nbconvert`, `nbformat`, `pip` (moved out of `dev` for clarity of purpose). Included from `tests` since `tests/linkml/test_notebooks/` is part of the test suite.
3. Cleared stale install-cell outputs and reset `execution_count` so the next CI run produces fresh, clean output (the install cells now show only the benign "Note: you may need to restart the kernel..." notice).
4. **Stop rewriting source notebooks during test runs.** `tests/linkml/test_notebooks/test_notebooks.py` was passing the *source* `.ipynb` path as the `expected_file_path` to `eval_single_file`, which (with `fail_on_error=False`, the local default) silently overwrites the source on every run. The snapshot-style infrastructure here was vestigial: `FORCE_REWRITE = True` had been set since the 2021 import from biolinkml ("does not pass tests yet"), short-circuiting the comparator. So no real comparison ever ran — the test was de facto "no cell raises." Simplified accordingly; removed the now-dead `nb_filter` from `tests/linkml/utils/filters.py`.
5. **Added a positive output-error check.** After execution, scan cell outputs for failure markers (`Traceback (most recent call last):`, `No module named`, lines starting with `error:`/`ERROR:`). Catches the exact class of regression #3172 introduced — install errors that land in `stdout` without raising — without going down the snapshot path. Notebooks remain demos, not contract tests: we verify they don't embarrass us, not that they produce byte-identical output. Verified the check fires on the original regression and stays quiet on benign output (kernel-restart notices, `RequestsDependencyWarning`).

## Test plan

- [x] `uv run pytest tests/linkml/test_notebooks/test_notebooks.py` — 6 pass, 1 fail (`SQL-examples.ipynb`, pre-existing on `main`, unrelated)
- [x] Verified `git status notebooks/` is clean after a test run (no spurious rewrites)
- [x] Re-injected the original broken install cell — confirmed the new output-error check fails with a clear message pointing at cell 1
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] CI green