### PR TITLE
fix(excel): class names longer than 31 chars

### DIFF
--- a/packages/linkml/src/linkml/generators/excelgen.py
+++ b/packages/linkml/src/linkml/generators/excelgen.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -55,14 +56,21 @@ class ExcelGenerator(Generator):
         # Compute enum lookup before next inner loop
         enum_set = set(sv.all_enums(imports=self.mergeimports).keys())
 
+        used_titles: set[str] = set()
         for cls_name in classes:
-            workbook.create_sheet(cls_name)
+            title = self._safe_sheet_title(cls_name, used_titles)
+            if title != cls_name:
+                self.logger.warning(
+                    f"Class name '{cls_name}' exceeds Excel's 31-character sheet title limit; "
+                    f"using '{title}' as the worksheet name."
+                )
+            workbook.create_sheet(title)
 
             # Add columns to the worksheet for the current class
             # (call class_induced_slots, reuse for heading/enum validation)
             induced_slots = list(sv.class_induced_slots(cls_name, self.mergeimports))
             slot_names = [s.name for s in induced_slots]
-            self.add_columns_to_worksheet(workbook, cls_name, slot_names)
+            self.add_columns_to_worksheet(workbook, title, slot_names)
 
             # Add enum validation for columns with enum types
             for s in induced_slots:
@@ -77,7 +85,7 @@ class ExcelGenerator(Generator):
                     # including the separators is <= 255 characters
                     enum_length = len(dv_formula)
                     if enum_length <= 255:
-                        self.column_enum_validation(workbook, cls_name, s.name, dv_formula)
+                        self.column_enum_validation(workbook, title, s.name, dv_formula)
                     else:
                         self.logger.warning(
                             f"'{s.range}' has permissible values with total "
@@ -88,6 +96,31 @@ class ExcelGenerator(Generator):
         workbook.save(output_path)
         if self.split_workbook_by_class:
             self.logger.info(f"The Excel workbooks have been written to {output_path}")
+
+    @staticmethod
+    def _safe_sheet_title(cls_name: str, used: set) -> str:
+        """Return a valid Excel sheet title for *cls_name* (≤ 31 chars, unique).
+
+        Excel limits worksheet titles to 31 characters.  When *cls_name* is
+        longer, a deterministic 6-hex-char SHA-1 suffix is appended so the
+        title is still traceable to the class name.
+
+        :param cls_name: The LinkML class name.
+        :param used: Set of already-allocated titles; updated in place.
+        :return: A deterministic, collision-free sheet title ≤ 31 characters.
+        """
+        if len(cls_name) <= 31:
+            title = cls_name
+        else:
+            h = hashlib.sha1(cls_name.encode("utf-8")).hexdigest()[:6]
+            title = f"{cls_name[:24]}_{h}"  # 24 + 1 + 6 = 31
+        base, n = title, 1
+        while title in used:
+            suffix = f"~{n}"
+            title = base[: 31 - len(suffix)] + suffix
+            n += 1
+        used.add(title)
+        return title
 
     @staticmethod
     def add_columns_to_worksheet(workbook: Workbook, worksheet_name: str, sheet_headings: list[str]) -> None:

--- a/tests/linkml/test_generators/test_excelgen.py
+++ b/tests/linkml/test_generators/test_excelgen.py
@@ -1,10 +1,12 @@
+import hashlib
 import logging
 import os
 
 import pytest
+from click.testing import CliRunner
 from openpyxl import load_workbook
 
-from linkml.generators.excelgen import ExcelGenerator
+from linkml.generators.excelgen import ExcelGenerator, cli
 
 
 def test_excel_generation(input_path, tmp_path):
@@ -364,3 +366,148 @@ def test_enum_values_exceed_255_chars_logs_warning(input_path, tmp_path, caplog)
 
     # Assert a warning was logged about enum values exceeding 255 characters
     assert any("255" in record.message and "LongEnum" in record.message for record in caplog.records)
+
+
+##### tests for long class names (> 31 chars)
+
+LONG_NAME_SCHEMA = """\
+id: https://example.org/excelgen-longname
+name: excelgen_longname
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/
+default_prefix: ex
+imports:
+  - linkml:types
+
+classes:
+  AClassNameThatIsDefinitelyLongerThan31Chars:
+    description: 43-char class name to overflow Excel 31-char sheet title limit.
+    attributes:
+      id:
+        identifier: true
+        range: string
+      label:
+        range: string
+  ShortName:
+    attributes:
+      id:
+        identifier: true
+        range: string
+"""
+
+
+def test_long_class_name_does_not_crash(tmp_path):
+    """gen-excel must not raise KeyError when a class name exceeds 31 characters."""
+    schema_path = tmp_path / "long_name.yaml"
+    schema_path.write_text(LONG_NAME_SCHEMA)
+    xlsx_path = tmp_path / "out.xlsx"
+
+    ExcelGenerator(str(schema_path), output=str(xlsx_path)).serialize()
+
+    wb = load_workbook(xlsx_path)
+
+    # All sheet titles must be at most 31 characters
+    assert all(len(name) <= 31 for name in wb.sheetnames)
+
+    # ShortName fits unchanged
+    assert "ShortName" in wb.sheetnames
+
+    # The long class sheet title must be a deterministic 31-char truncation
+    long_cls = "AClassNameThatIsDefinitelyLongerThan31Chars"
+    h = hashlib.sha1(long_cls.encode("utf-8")).hexdigest()[:6]
+    expected_title = f"{long_cls[:24]}_{h}"
+    assert expected_title in wb.sheetnames
+
+    # The truncated sheet must carry the expected column headers
+    ws = wb[expected_title]
+    headers = [ws.cell(row=1, column=i).value for i in range(1, ws.max_column + 1)]
+    assert "id" in headers
+    assert "label" in headers
+
+
+def test_long_class_name_logs_warning(tmp_path, caplog):
+    """A warning must be emitted when a class name is truncated."""
+    schema_path = tmp_path / "long_name.yaml"
+    schema_path.write_text(LONG_NAME_SCHEMA)
+    xlsx_path = tmp_path / "out.xlsx"
+
+    with caplog.at_level(logging.WARNING, logger="linkml.generators.excelgen"):
+        ExcelGenerator(str(schema_path), output=str(xlsx_path)).serialize()
+
+    long_cls = "AClassNameThatIsDefinitelyLongerThan31Chars"
+    assert any(long_cls in record.message for record in caplog.records)
+
+
+def test_safe_sheet_title_short_name():
+    """Names ≤ 31 chars pass through unchanged."""
+    used: set = set()
+    assert ExcelGenerator._safe_sheet_title("ShortName", used) == "ShortName"
+    assert "ShortName" in used
+
+
+def test_safe_sheet_title_long_name():
+    """Names > 31 chars are truncated to exactly 31 chars."""
+    used: set = set()
+    long_cls = "AClassNameThatIsDefinitelyLongerThan31Chars"
+    title = ExcelGenerator._safe_sheet_title(long_cls, used)
+    assert len(title) == 31
+    h = hashlib.sha1(long_cls.encode("utf-8")).hexdigest()[:6]
+    assert title == f"{long_cls[:24]}_{h}"
+
+
+def test_safe_sheet_title_collision_disambiguation():
+    """Collisions after truncation are resolved deterministically."""
+    used: set = set()
+
+    # Two distinct long names sharing same 24-char prefix have different titles.
+    cls_a = "AClassNameThatIsDefinitelyLongerThan31Chars"
+    cls_b = "AClassNameThatIsDefinitelyLongerThan31CharsB"
+    title_a = ExcelGenerator._safe_sheet_title(cls_a, used)
+    title_b = ExcelGenerator._safe_sheet_title(cls_b, used)
+    assert title_a != title_b
+    assert len(title_a) <= 31
+    assert len(title_b) <= 31
+
+
+def test_safe_sheet_title_collision_loop_executes():
+    """The while-loop inside _safe_sheet_title fires when the candidate title
+    is already occupied."""
+    used: set = {"ShortName"}  # pre-populate so the first candidate collides
+    title = ExcelGenerator._safe_sheet_title("ShortName", used)
+    # The loop must have run: result differs from the original and stays ≤ 31
+    assert title != "ShortName"
+    assert len(title) <= 31
+    # The disambiguated title must now be in used
+    assert title in used
+    assert "ShortName" in used  # original still present
+
+
+def test_split_workbook_creates_output_dir(input_path, tmp_path):
+    """serialize() with split_workbook_by_class=True must create the output
+    directory when it does not yet exist."""
+    organization_schema = str(input_path("organization.yaml"))
+    new_dir = tmp_path / "new_subdir" / "sheets"  # does not exist
+
+    ExcelGenerator(
+        organization_schema,
+        split_workbook_by_class=True,
+        output=str(new_dir),
+    ).serialize()
+
+    assert new_dir.is_dir()
+    xlsx_files = list(new_dir.glob("*.xlsx"))
+    assert len(xlsx_files) > 0
+
+
+def test_cli_entry_point(input_path, tmp_path):
+    """The cli() Click command must produce a workbook without errors."""
+    organization_schema = str(input_path("organization.yaml"))
+    xlsx_path = str(tmp_path / "cli_out.xlsx")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [organization_schema, "-o", xlsx_path])
+
+    assert result.exit_code == 0, result.output
+    wb = load_workbook(xlsx_path)
+    assert len(wb.sheetnames) > 0


### PR DESCRIPTION
## Summary

Fixes #3526

Compute a deterministic, collision-free sheet title once per class and use it for **both** `create_sheet` and the subsequent lookup. 

Keep a`cls_name -> sheet_title` map.

## How was this tested?

<!-- Describe how you verified your changes (e.g. new tests, existing test suite, manual testing). -->

## Areas of uncertainty

<!-- Are there parts of this change you'd like reviewers to look at more closely? -->

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

LLM assisted unit tests
