### PR TITLE
feat(typedbgen): implement TypeDB CTO's mapping recommendations

### DIFF
--- a/packages/linkml/src/linkml/generators/typedbgen.py
+++ b/packages/linkml/src/linkml/generators/typedbgen.py
@@ -361,6 +361,10 @@ class TypeDBGenerator(Generator):
     def _build_owns_stmt(self, slot_tname: str, induced: SlotDefinition) -> str:
         """Return a TypeQL ``owns`` statement with the appropriate cardinality annotation.
 
+        Uses ``minimum_cardinality`` / ``maximum_cardinality`` / ``exact_cardinality``
+        when set, falling back to the boolean flags (``required``, ``multivalued``,
+        ``identifier``) for backwards compatibility.
+
         :param slot_tname: the safe TypeDB attribute name for the slot
         :param induced: the induced SlotDefinition carrying cardinality/identity metadata
         :return: a TypeQL ``owns`` clause string (without trailing punctuation)
@@ -368,6 +372,12 @@ class TypeDBGenerator(Generator):
         owns = f"owns {slot_tname}"
         if induced.identifier:
             owns += " @key"
+        elif induced.exact_cardinality is not None:
+            owns += f" @card({induced.exact_cardinality}..{induced.exact_cardinality})"
+        elif induced.minimum_cardinality is not None or induced.maximum_cardinality is not None:
+            lo = induced.minimum_cardinality if induced.minimum_cardinality is not None else 0
+            hi = str(induced.maximum_cardinality) if induced.maximum_cardinality is not None else ""
+            owns += f" @card({lo}..{hi})"
         elif induced.required and not induced.multivalued:
             owns += " @card(1..1)"
         elif induced.multivalued:

--- a/packages/linkml/src/linkml/generators/typedbgen.py
+++ b/packages/linkml/src/linkml/generators/typedbgen.py
@@ -330,7 +330,7 @@ class TypeDBGenerator(Generator):
                     continue  # object range → relation, not attribute
                 seen[slot_name] = f"attribute {slot_name}, value {value_type};"
 
-        # Enums used in slot ranges also need attribute declarations with comments
+        # Enums used in slot ranges get @values(...) annotations to enforce permitted values.
         enum_attr_lines: list[str] = []
         enum_slots_seen: set[str] = set()
         for class_name in sv.all_classes():
@@ -340,10 +340,11 @@ class TypeDBGenerator(Generator):
                     enum_slots_seen.add(slot_name)
                     enum_def = sv.get_enum(induced_slot.range)
                     permitted = list(enum_def.permissible_values.keys()) if enum_def else []
-                    comment = f"# Enum: {_typedb_name(induced_slot.range)} (permitted values: {', '.join(permitted)})"
+                    comment = f"# Enum: {_typedb_name(induced_slot.range)}"
                     enum_attr_lines.append(comment)
                     seen.pop(slot_name, None)
-                    enum_attr_lines.append(f"attribute {slot_name}, value string;")
+                    values_str = ", ".join(f'"{v}"' for v in permitted)
+                    enum_attr_lines.append(f"attribute {slot_name}, value string @values({values_str});")
 
         result = list(seen.values()) + enum_attr_lines
         return result

--- a/packages/linkml/src/linkml/generators/typedbgen.py
+++ b/packages/linkml/src/linkml/generators/typedbgen.py
@@ -368,6 +368,19 @@ class TypeDBGenerator(Generator):
                     values_str = ", ".join(f'"{v}"' for v in permitted)
                     enum_attr_lines.append(f"attribute {slot_name}, value string @values({values_str});")
 
+        # Attribute subtyping: slots with is_a pointing to another scalar slot
+        # emit "attribute <child>, sub <parent>;" instead of a flat value declaration.
+        # TypeDB inherits the value type from the parent, so no value clause is needed.
+        all_slots = sv.all_slots()
+        for slot_name_orig, safe_name in attr_names.items():
+            if safe_name not in seen:
+                continue
+            slot_def = all_slots.get(slot_name_orig)
+            if slot_def and slot_def.is_a:
+                parent_safe = attr_names.get(slot_def.is_a)
+                if parent_safe and parent_safe in seen:
+                    seen[safe_name] = f"attribute {safe_name}, sub {parent_safe};"
+
         result = list(seen.values()) + enum_attr_lines
         return result
 

--- a/packages/linkml/src/linkml/generators/typedbgen.py
+++ b/packages/linkml/src/linkml/generators/typedbgen.py
@@ -384,13 +384,20 @@ class TypeDBGenerator(Generator):
         result = list(seen.values()) + enum_attr_lines
         return result
 
-    def _ancestor_slots(self, sv: SchemaView, class_name: str) -> set[str]:
-        """Return the set of slot names inherited from all ancestors (excluding self)."""
+    def _ancestor_slot_names(self, sv: SchemaView, class_name: str) -> set[str]:
+        """Return the set of slot names inherited from non-mixin ancestors (excluding self).
+
+        Mixin ancestors are skipped because TypeDB has single ``sub`` inheritance
+        only — there is no mixin/trait mechanism.  Mixin-contributed slots must be
+        re-declared on each consuming class as ``owns`` / ``plays``.
+        """
         result: set[str] = set()
         for ancestor in sv.class_ancestors(class_name)[1:]:  # skip self
-            ancestor_cls = sv.get_class(ancestor)
-            if ancestor_cls and ancestor_cls.slots:
-                result.update(ancestor_cls.slots)
+            ancestor_def = sv.get_class(ancestor)
+            if ancestor_def and ancestor_def.mixin:
+                continue  # mixin slots must be re-declared; TypeDB has no mixin inheritance
+            for slot in sv.class_induced_slots(ancestor):
+                result.add(slot.name)
         return result
 
     def _build_owns_stmt(self, slot_tname: str, induced: SlotDefinition) -> str:
@@ -433,48 +440,53 @@ class TypeDBGenerator(Generator):
         :param attr_names: slot name → safe TypeDB attribute name
         :param rel_names: slot name → safe TypeDB relation name
         """
-        # Pre-compute ancestor slots for all classes to avoid redundant traversal
-        ancestor_slots_cache: dict[str, set[str]] = {cn: self._ancestor_slots(sv, cn) for cn in sv.all_classes()}
+        # Pre-compute ancestor slot names and direct induced slots for all classes.
+        # ``_ancestor_slot_names`` already skips mixin ancestors, so mixin-contributed
+        # slots appear as "direct" on the consuming class.
+        ancestor_slot_names_cache: dict[str, set[str]] = {
+            cn: self._ancestor_slot_names(sv, cn) for cn in sv.all_classes()
+        }
+        direct_slots_cache: dict[str, list[SlotDefinition]] = {
+            cn: [s for s in sv.class_induced_slots(cn) if s.name not in ancestor_slot_names_cache[cn]]
+            for cn in sv.all_classes()
+        }
+        all_class_names = set(sv.all_classes().keys())
 
         plays_map: dict[str, list[str]] = {cn: [] for cn in sv.all_classes()}
 
         # Populate plays_map for represents_relationship classes first.
         # Object-ranged slots on these classes add plays entries to the range classes.
         for class_name in sv.all_classes():
-            if not sv.get_class(class_name).represents_relationship:
+            class_def = sv.get_class(class_name)
+            if class_def.mixin or not class_def.represents_relationship:
                 continue
-            ancestor_slots = ancestor_slots_cache[class_name]
-            direct_slot_names = [s for s in (sv.get_class(class_name).slots or []) if s not in ancestor_slots]
             rel_tname = _typedb_name(class_name)
-            for slot_name in direct_slot_names:
-                induced = sv.induced_slot(slot_name, class_name)
-                if induced.range not in sv.all_classes():
+            for induced in direct_slots_cache[class_name]:
+                if induced.range not in all_class_names:
                     continue
-                role_name = _typedb_name(slot_name)
-                range_class = induced.range
-                if range_class in plays_map:
-                    plays_map[range_class].append(f"plays {rel_tname}:{role_name}")
+                role_name = _typedb_name(induced.name)
+                if induced.range in plays_map:
+                    plays_map[induced.range].append(f"plays {rel_tname}:{role_name}")
 
         # Populate plays_map for regular entity classes (non-represents_relationship).
         for class_name in sv.all_classes():
-            if sv.get_class(class_name).represents_relationship:
-                continue  # handled above
-            ancestor_slots = ancestor_slots_cache[class_name]
-            direct_slot_names = [s for s in (sv.get_class(class_name).slots or []) if s not in ancestor_slots]
-            for slot_name in direct_slot_names:
-                induced = sv.induced_slot(slot_name, class_name)
-                if induced.range not in sv.all_classes():
+            class_def = sv.get_class(class_name)
+            if class_def.mixin or class_def.represents_relationship:
+                continue  # handled above or skipped
+            for induced in direct_slots_cache[class_name]:
+                if induced.range not in all_class_names:
                     continue
-                slot_tname = rel_names.get(slot_name, _typedb_name(slot_name))
+                slot_tname = rel_names.get(induced.name, _typedb_name(induced.name))
                 domain_role = _typedb_name(class_name)
                 range_role = _typedb_name(induced.range)
                 plays_map[class_name].append(f"plays {slot_tname}:{domain_role}")
-                range_class = induced.range
-                if range_class in plays_map:
-                    plays_map[range_class].append(f"plays {slot_tname}:{range_role}")
+                if induced.range in plays_map:
+                    plays_map[induced.range].append(f"plays {slot_tname}:{range_role}")
 
         lines: list[str] = []
         for class_name, class_def in sv.all_classes().items():
+            if class_def.mixin:
+                continue  # mixins are not emitted as TypeDB types
             tname = _typedb_name(class_name)
             is_rel_class = bool(class_def.represents_relationship)
 
@@ -488,17 +500,15 @@ class TypeDBGenerator(Generator):
                 if class_def.is_a:
                     parts[0] += f", sub {_typedb_name(class_def.is_a)}"
 
-                direct_slot_names = [s for s in (class_def.slots or []) if s not in ancestor_slots_cache[class_name]]
-                for slot_name in direct_slot_names:
-                    induced = sv.induced_slot(slot_name, class_name)
+                for induced in direct_slots_cache[class_name]:
                     value_type = _resolve_typedb_value_type(sv, induced.range)
                     if value_type is None:
                         # Object-ranged slot → becomes a relates role
-                        role_name = _typedb_name(slot_name)
+                        role_name = _typedb_name(induced.name)
                         parts.append(f"relates {role_name}")
                     else:
                         # Scalar slot → owns attribute
-                        slot_tname = attr_names.get(slot_name, _typedb_name(slot_name))
+                        slot_tname = attr_names.get(induced.name, _typedb_name(induced.name))
                         parts.append(self._build_owns_stmt(slot_tname, induced))
             else:
                 # Emit as TypeDB entity type
@@ -509,15 +519,13 @@ class TypeDBGenerator(Generator):
                 if class_def.is_a:
                     parts[0] += f", sub {_typedb_name(class_def.is_a)}"
 
-                # Slots that appear on ANY ancestor are already inherited in TypeDB —
-                # redeclaring them causes [SVL42]. Filter them out here.
-                direct_slot_names = [s for s in (class_def.slots or []) if s not in ancestor_slots_cache[class_name]]
-                for slot_name in direct_slot_names:
-                    induced = sv.induced_slot(slot_name, class_name)
+                # Slots that appear on ANY non-mixin ancestor are already inherited
+                # in TypeDB — redeclaring them causes [SVL42].
+                for induced in direct_slots_cache[class_name]:
                     value_type = _resolve_typedb_value_type(sv, induced.range)
                     if value_type is None:
                         continue  # object range → relation
-                    slot_tname = attr_names.get(slot_name, _typedb_name(slot_name))
+                    slot_tname = attr_names.get(induced.name, _typedb_name(induced.name))
                     parts.append(self._build_owns_stmt(slot_tname, induced))
 
                 for plays_stmt in dict.fromkeys(plays_map.get(class_name, [])):
@@ -547,18 +555,22 @@ class TypeDBGenerator(Generator):
 
         :param rel_names: slot name → safe TypeDB relation name
         """
-        # First pass: collect all (domain_class, range_class) pairs per slot.
-        # Classes with represents_relationship emit 'relates' roles instead of standalone
-        # relation types, so they are skipped here.
+        # First pass: collect all (domain_class, range_class) pairs per slot from
+        # directly-declared slots on each class. Mixin and represents_relationship
+        # classes are skipped.
+        all_class_names = set(sv.all_classes().keys())
         slot_pairs: dict[str, list[tuple[str, str]]] = {}
         for class_name in sv.all_classes():
-            if sv.get_class(class_name).represents_relationship:
-                continue  # object-ranged slots handled as 'relates' in entity/relation defs
-            for slot_name in sv.get_class(class_name).slots or []:
-                induced = sv.induced_slot(slot_name, class_name)
-                if induced.range not in sv.all_classes():
+            class_def = sv.get_class(class_name)
+            if class_def.mixin or class_def.represents_relationship:
+                continue  # mixins not emitted; represents_relationship handled as 'relates'
+            ancestor_slot_names = self._ancestor_slot_names(sv, class_name)
+            for induced in sv.class_induced_slots(class_name):
+                if induced.name in ancestor_slot_names:
                     continue
-                slot_pairs.setdefault(slot_name, []).append((class_name, induced.range))
+                if induced.range not in all_class_names:
+                    continue
+                slot_pairs.setdefault(induced.name, []).append((class_name, induced.range))
 
         lines: list[str] = []
         for slot_name, pairs in slot_pairs.items():

--- a/packages/linkml/src/linkml/generators/typedbgen.py
+++ b/packages/linkml/src/linkml/generators/typedbgen.py
@@ -389,13 +389,13 @@ class TypeDBGenerator(Generator):
 
         Mixin ancestors are skipped because TypeDB has single ``sub`` inheritance
         only — there is no mixin/trait mechanism.  Mixin-contributed slots must be
-        re-declared on each consuming class as ``owns`` / ``plays``.
+        redeclared on each consuming class as ``owns`` / ``plays``.
         """
         result: set[str] = set()
         for ancestor in sv.class_ancestors(class_name)[1:]:  # skip self
             ancestor_def = sv.get_class(ancestor)
             if ancestor_def and ancestor_def.mixin:
-                continue  # mixin slots must be re-declared; TypeDB has no mixin inheritance
+                continue  # mixin slots must be redeclared; TypeDB has no mixin inheritance
             for slot in sv.class_induced_slots(ancestor):
                 result.add(slot.name)
         return result

--- a/packages/linkml/src/linkml/generators/typedbgen.py
+++ b/packages/linkml/src/linkml/generators/typedbgen.py
@@ -198,6 +198,24 @@ def _resolve_typedb_value_type(sv: SchemaView, range_name: str | None) -> str | 
     return _TYPEDB_PRIMITIVE.get(range_name.lower(), "string")
 
 
+def _build_range_annotation(induced: SlotDefinition) -> str | None:
+    """Return a ``@range(min..max)`` annotation string, or ``None`` if no range constraints are set.
+
+    Reads ``minimum_value`` and ``maximum_value`` from the induced slot definition.
+    Supports open-ended ranges (``@range(N..)`` or ``@range(..M)``).
+
+    :param induced: the induced SlotDefinition carrying value range metadata
+    :return: annotation string like ``@range(0..150)`` or ``None``
+    """
+    lo = induced.minimum_value
+    hi = induced.maximum_value
+    if lo is None and hi is None:
+        return None
+    lo_str = str(lo) if lo is not None else ""
+    hi_str = str(hi) if hi is not None else ""
+    return f"@range({lo_str}..{hi_str})"
+
+
 def _build_name_maps(sv: SchemaView) -> tuple[dict[str, str], dict[str, str]]:
     """Build safe TypeDB name mappings for attributes and relations.
 
@@ -328,7 +346,11 @@ class TypeDBGenerator(Generator):
                 value_type = _resolve_typedb_value_type(sv, induced_slot.range)
                 if value_type is None:
                     continue  # object range → relation, not attribute
-                seen[slot_name] = f"attribute {slot_name}, value {value_type};"
+                range_ann = _build_range_annotation(induced_slot)
+                if range_ann:
+                    seen[slot_name] = f"attribute {slot_name}, value {value_type} {range_ann};"
+                else:
+                    seen[slot_name] = f"attribute {slot_name}, value {value_type};"
 
         # Enums used in slot ranges get @values(...) annotations to enforce permitted values.
         enum_attr_lines: list[str] = []

--- a/tests/linkml/test_generators/test_typedbgen.py
+++ b/tests/linkml/test_generators/test_typedbgen.py
@@ -1,5 +1,7 @@
 """Tests for the TypeDB TypeQL generator."""
 
+import re
+
 import pytest
 from click.testing import CliRunner
 
@@ -468,6 +470,97 @@ slots:
     # Parent is class-ranged (relation), child is scalar — no sub, just a normal attribute
     assert "attribute name-of-related, value string;" in output
     assert "sub related-to" not in output
+
+
+def test_mixin_slots_appear_on_consuming_class(tmp_path):
+    """Mixin-contributed slots are emitted as owns on the consuming class."""
+    schema_yaml = """
+id: http://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  HasAliases:
+    mixin: true
+    attributes:
+      aliases:
+        range: string
+        multivalued: true
+  Person:
+    mixins:
+      - HasAliases
+    slots:
+      - name
+slots:
+  name:
+    range: string
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    # Mixin class should NOT appear as a TypeDB entity
+    assert "entity hasaliases" not in output
+    # Mixin slot should appear as owns on the consuming class
+    person_block = re.search(r"^\s*entity person\b[^;]*;", output, re.MULTILINE | re.DOTALL)
+    assert person_block, f"person entity block not found:\n{output}"
+    assert "owns aliases" in person_block.group(0)
+    assert "owns name" in person_block.group(0)
+
+
+def test_mixin_with_object_ranged_slot(tmp_path):
+    """Mixin-contributed object-ranged slots produce plays on the consuming class."""
+    schema_yaml = """
+id: http://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Place:
+    slots:
+      - name
+  WithLocation:
+    mixin: true
+    slots:
+      - in_location
+  Event:
+    slots:
+      - description
+  MarriageEvent:
+    is_a: Event
+    mixins:
+      - WithLocation
+    slots:
+      - married_to
+  Person:
+    slots:
+      - name
+slots:
+  name:
+    range: string
+  in_location:
+    range: Place
+  description:
+    range: string
+  married_to:
+    range: Person
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    # Mixin class should NOT appear as a TypeDB entity
+    assert "entity withlocation" not in output
+    # MarriageEvent should have plays for in_location (from mixin)
+    marriage_block = re.search(r"^\s*entity marriageevent\b[^;]*;", output, re.MULTILINE | re.DOTALL)
+    assert marriage_block, f"marriageevent entity block not found:\n{output}"
+    assert "plays in-location:" in marriage_block.group(0) or "plays in-location-rel:" in marriage_block.group(0), (
+        f"mixin object-ranged slot missing from marriageevent:\n{marriage_block.group(0)}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/linkml/test_generators/test_typedbgen.py
+++ b/tests/linkml/test_generators/test_typedbgen.py
@@ -373,6 +373,103 @@ slots:
     assert "@range" not in output
 
 
+def test_attribute_subtyping_basic(tmp_path):
+    """A slot with is_a pointing to another scalar slot emits 'sub' instead of 'value'."""
+    schema_yaml = """
+id: http://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Thing:
+    slots:
+      - contact_info
+      - email
+slots:
+  contact_info:
+    range: string
+  email:
+    is_a: contact_info
+    range: string
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    assert "attribute contact-info, value string;" in output
+    assert "attribute email, sub contact-info;" in output
+    # Child should NOT have a value declaration
+    assert "attribute email, value string;" not in output
+
+
+def test_attribute_subtyping_chain(tmp_path):
+    """A chain of slot is_a relationships produces a chain of sub declarations."""
+    schema_yaml = """
+id: http://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Thing:
+    slots:
+      - base_field
+      - mid_field
+      - leaf_field
+slots:
+  base_field:
+    range: string
+  mid_field:
+    is_a: base_field
+    range: string
+  leaf_field:
+    is_a: mid_field
+    range: string
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    assert "attribute base-field, value string;" in output
+    assert "attribute mid-field, sub base-field;" in output
+    assert "attribute leaf-field, sub mid-field;" in output
+
+
+def test_attribute_subtyping_skipped_for_class_ranged_parent(tmp_path):
+    """A slot with is_a pointing to a class-ranged slot does NOT emit sub."""
+    schema_yaml = """
+id: http://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Person:
+    slots:
+      - related_to
+      - name_of_related
+  OtherPerson:
+    slots: []
+slots:
+  related_to:
+    range: OtherPerson
+  name_of_related:
+    is_a: related_to
+    range: string
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    # Parent is class-ranged (relation), child is scalar — no sub, just a normal attribute
+    assert "attribute name-of-related, value string;" in output
+    assert "sub related-to" not in output
+
+
 @pytest.mark.parametrize(
     "slot_extra,expected_card",
     [

--- a/tests/linkml/test_generators/test_typedbgen.py
+++ b/tests/linkml/test_generators/test_typedbgen.py
@@ -149,8 +149,8 @@ slots:
     assert f"attribute my-attr, value {expected_typedb_type}" in output
 
 
-def test_enum_produces_string_attribute_with_comment(tmp_path):
-    """Enums produce string attributes with a comment listing permitted values."""
+def test_enum_produces_values_annotation(tmp_path):
+    """Enums produce string attributes with a @values(...) annotation."""
     schema_yaml = """
 id: http://example.org/test
 name: test-schema
@@ -179,10 +179,47 @@ enums:
     gen = TypeDBGenerator(str(schema_file))
     output = gen.serialize()
     assert "attribute status, value string" in output
-    # enum values should be mentioned in a comment
-    assert "employed" in output
-    assert "unemployed" in output
-    assert "student" in output
+    assert '@values("employed", "unemployed", "student")' in output
+
+
+def test_multiple_enums_each_get_values_annotation(tmp_path):
+    """Each enum-ranged slot gets its own @values annotation on its attribute declaration."""
+    schema_yaml = """
+id: http://example.org/test
+name: test-schema
+types:
+  string:
+    base: str
+    uri: xsd:string
+prefixes:
+  xsd: http://www.w3.org/2001/XMLSchema#
+classes:
+  Person:
+    slots:
+      - status
+      - role
+slots:
+  status:
+    range: EmploymentStatus
+  role:
+    range: RoleType
+enums:
+  EmploymentStatus:
+    permissible_values:
+      employed: {}
+      unemployed: {}
+  RoleType:
+    permissible_values:
+      admin: {}
+      user: {}
+      guest: {}
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    assert 'attribute status, value string @values("employed", "unemployed");' in output
+    assert 'attribute role-attr, value string @values("admin", "user", "guest");' in output
 
 
 def test_abstract_class_produces_annotation(tmp_path):

--- a/tests/linkml/test_generators/test_typedbgen.py
+++ b/tests/linkml/test_generators/test_typedbgen.py
@@ -316,6 +316,64 @@ slots:
 
 
 @pytest.mark.parametrize(
+    "slot_extra,expected_range",
+    [
+        ("minimum_value: 0\n    maximum_value: 150", "@range(0..150)"),
+        ("minimum_value: 0", "@range(0..)"),
+        ("maximum_value: 100", "@range(..100)"),
+    ],
+)
+def test_range_annotation(slot_extra, expected_range, tmp_path):
+    """minimum_value / maximum_value produce @range annotations on attribute declarations."""
+    schema_yaml = f"""
+id: http://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Thing:
+    slots:
+      - score
+slots:
+  score:
+    range: integer
+    {slot_extra}
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    assert f"attribute score, value integer {expected_range};" in output
+
+
+def test_no_range_annotation_when_unset(tmp_path):
+    """No @range annotation when minimum_value and maximum_value are both unset."""
+    schema_yaml = """
+id: http://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Thing:
+    slots:
+      - score
+slots:
+  score:
+    range: integer
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    assert "attribute score, value integer;" in output
+    assert "@range" not in output
+
+
+@pytest.mark.parametrize(
     "slot_extra,expected_card",
     [
         ("minimum_cardinality: 1\n    maximum_cardinality: 5", "@card(1..5)"),

--- a/tests/linkml/test_generators/test_typedbgen.py
+++ b/tests/linkml/test_generators/test_typedbgen.py
@@ -315,6 +315,41 @@ slots:
     assert "owns person-attr" in output
 
 
+@pytest.mark.parametrize(
+    "slot_extra,expected_card",
+    [
+        ("minimum_cardinality: 1\n    maximum_cardinality: 5", "@card(1..5)"),
+        ("minimum_cardinality: 2", "@card(2..)"),
+        ("maximum_cardinality: 3", "@card(0..3)"),
+        ("exact_cardinality: 1", "@card(1..1)"),
+    ],
+)
+def test_precise_cardinality_annotation(slot_extra, expected_card, tmp_path):
+    """Precise cardinality fields produce exact @card(min..max) annotations."""
+    schema_yaml = f"""
+id: http://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Thing:
+    slots:
+      - tags
+slots:
+  tags:
+    range: string
+    multivalued: true
+    {slot_extra}
+"""
+    schema_file = tmp_path / "test.yaml"
+    schema_file.write_text(schema_yaml)
+    gen = TypeDBGenerator(str(schema_file))
+    output = gen.serialize()
+    assert f"owns tags {expected_card}" in output
+
+
 def test_represents_relationship_class_becomes_relation(tmp_path):
     """A class with represents_relationship: true becomes a TypeDB relation type."""
     schema_yaml = """


### PR DESCRIPTION
## Summary

Implements the TypeDB 3.x schema mapping improvements suggested by @flyingsilverfin in #3382 and tracked in #3534.

- Enums → `@values(...)` annotation (instead of comments)
- `minimum_value`/`maximum_value` → `@range(min..max)`
- Precise `@card(min..max)` from `minimum_cardinality`/`maximum_cardinality`
- Attribute subtyping via slot `is_a` → `sub`
- Mixin slot composition
- (Optional) Auto-detect entity vs. relation via `--infer-relations` flag

## Test plan

- [ ] Existing `typedbgen` tests pass (`uv run pytest tests/linkml/test_generators/test_typedbgen.py`)
- [ ] New tests for each feature: enums with `@values`, `@range`, precise `@card`, attribute `sub`, mixin slots
- [ ] Kitchen sink schema output reviewed for regressions
- [ ] Generated TypeQL validated against TypeDB 3.x syntax

Closes #3534

🤖 Generated with [Claude Code](https://claude.com/claude-code)