### PR TITLE
feat(jsonschemagen): emit `readOnly: true` for slots with `readonly` set

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -829,6 +829,8 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         prop.add_keyword("description", slot.description)
         if self.title_from == "title" and slot.title:
             prop.add_keyword("title", slot.title)
+        if getattr(slot, "readonly", None):
+            prop.add_keyword("readOnly", True)
 
         own_constraints = self.get_value_constraints_for_slot(slot)
 

--- a/tests/linkml/test_generators/input/jsonschema_slot_readonly.yaml
+++ b/tests/linkml/test_generators/input/jsonschema_slot_readonly.yaml
@@ -1,0 +1,24 @@
+id: https://example.org/readonly-test
+name: readonly_test
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+
+slots:
+  managed:
+    readonly: assigned by the server
+  empty_reason:
+    readonly: ""
+  plain:
+    description: not read only
+
+classes:
+  Base:
+    slots:
+      - managed
+      - empty_reason
+      - plain
+  Sub:
+    is_a: Base

--- a/tests/linkml/test_generators/test_jsonschemagen.py
+++ b/tests/linkml/test_generators/test_jsonschemagen.py
@@ -332,6 +332,27 @@ def test_slot_title_from_title_slot(subtests, input_path):
     external_file_test(subtests, input_path("jsonschema_slot_title_from_title.yaml"), {"title_from": "title"})
 
 
+def test_slot_readonly_emits_read_only(input_path):
+    """A slot with a non-empty ``readonly`` value should emit ``readOnly: true`` on
+    the JSON Schema property; absent or empty ``readonly`` should omit the keyword.
+    Inherited slots must also carry ``readOnly: true`` on every subclass, because
+    JSON Schema has no class inheritance.
+
+    See: https://github.com/linkml/linkml/issues/3528
+    """
+    generated = json.loads(JsonSchemaGenerator(input_path("jsonschema_slot_readonly.yaml")).serialize())
+
+    # ``Sub`` inherits all three slots from ``Base`` via ``is_a``; JSON Schema has no
+    # class inheritance, so both classes must independently carry ``readOnly: true``
+    # on ``managed`` and omit it on the others.
+    for cls_name in ("Base", "Sub"):
+        props = generated["$defs"][cls_name]["properties"]
+        assert "readOnly" in props["managed"]
+        assert props["managed"]["readOnly"] is True
+        assert "readOnly" not in props["empty_reason"]
+        assert "readOnly" not in props["plain"]
+
+
 @pytest.mark.parametrize("not_closed", [True, False])
 def test_slot_identifier_non_nullability(input_path, not_closed):
     """


### PR DESCRIPTION
## Summary

Map LinkML's `readonly` meta slot to JSON Schema's `readOnly` annotation in `JsonSchemaGenerator`. When a slot has a non-empty `readonly` value, the generated JSON Schema property now carries `"readOnly": true`. Absent or empty values produce no change. The free-text reason is dropped — JSON Schema has no equivalent.

Closes #3528.

## Test plan

- [x] New test `test_slot_readonly_emits_read_only` with fixture `tests/linkml/test_generators/input/jsonschema_slot_readonly.yaml` covering: non-empty `readonly` → `readOnly: true`; empty-string `readonly` → keyword omitted; absent `readonly` → keyword omitted; inherited slot via `is_a` → subclass property also carries `readOnly: true`.
- [x] Existing `tests/linkml/test_generators/test_jsonschemagen.py` and `test_jsonschemagen_examples.py` suites pass.
- [x] `tests/linkml/test_scripts/test_gen_json_schema.py` snapshot tests pass (no metamodel-derived snapshot drift).
- [x] Broader sweep `uv run pytest tests/linkml/ -k "jsonschema or json_schema"`: 868 passed, 90 skipped.
