### PR TITLE
fix(rustgen): correctly parse annotations and extensions

### DIFF
--- a/packages/linkml/src/linkml/generators/rustgen/rustgen.py
+++ b/packages/linkml/src/linkml/generators/rustgen/rustgen.py
@@ -50,6 +50,7 @@ from linkml.generators.rustgen.template import (
     StubUtilsFile,
 )
 from linkml.utils.generator import Generator
+from linkml.utils.helpers import get_range_associated_slots
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
     EnumDefinition,
@@ -609,14 +610,28 @@ class RustGenerator(Generator, LifecycleMixin):
             # attribute to serve as the value, do not treat this as a key/value class.
             if len(value_attrs) == 0:
                 return None
-            value_attr = value_attrs[0]
+            # Defer to linkml's documented `SimpleDict` rules (see
+            # `linkml.utils.helpers.get_range_associated_slots` and linkml/linkml#1250):
+            #   1. The class has exactly one non-key slot, or
+            #   2. Exactly one non-key slot is annotated with `simple_dict_value: true`, or
+            #   3. Exactly one non-key slot is required.
+            # When one of those conditions selects a value slot, the inlined-dict
+            # entry `key: <primitive>` may collapse into that slot.
+            # `get_range_associated_slots` is `lru_cache`d and unhashable on
+            # ClassDefinition; pass the class name (it normalizes internally).
+            _, simple_dict_value_slot, _ = get_range_associated_slots(self.schemaview, cls.name)
+            value_attr = simple_dict_value_slot or value_attrs[0]
+            # Additional Rust-specific guard: a primitive scalar can only deserialize
+            # into a value slot whose Rust type is a primitive or a linkml:Any
+            # wildcard (`Anything`/`AnyValue`, which wraps `serde_value::Value`).
+            # Other class ranges either store an inlined struct (which can't accept a
+            # primitive) or a reference string (which would mismatch `Self::Value`).
+            value_range_is_primitive_friendly = (
+                value_attr.range not in self.schemaview.all_classes()
+                or self.schemaview.get_class(value_attr.range).class_uri == "linkml:Any"
+            )
             simple_dict_possible = (
-                len(non_key_attrs) == 1
-                and not value_attr.multivalued
-                and (
-                    value_attr.range not in self.schemaview.all_classes()
-                    or not bool(getattr(value_attr, "inlined", False))
-                )
+                simple_dict_value_slot is not None and not value_attr.multivalued and value_range_is_primitive_friendly
             )
             key_property_name = get_name(key_attr)
             # The generated struct field for the key slot accepts its canonical name

--- a/packages/linkml/src/linkml/generators/rustgen/rustgen.py
+++ b/packages/linkml/src/linkml/generators/rustgen/rustgen.py
@@ -618,10 +618,20 @@ class RustGenerator(Generator, LifecycleMixin):
                     or not bool(getattr(value_attr, "inlined", False))
                 )
             )
+            key_property_name = get_name(key_attr)
+            # The generated struct field for the key slot accepts its canonical name
+            # plus the slot's `alias` (via serde(alias = "...")). When building the
+            # deserialization map from an inlined-as-dict entry we must not inject
+            # the canonical key if the inner map already carries the alias for it,
+            # or serde will reject the duplicate field.
+            key_property_aliases: list[str] = []
+            if key_attr.alias and key_attr.alias != key_property_name:
+                key_property_aliases.append(key_attr.alias)
             return AsKeyValue(
                 name=get_name(cls),
-                key_property_name=get_name(key_attr),
+                key_property_name=key_property_name,
                 key_property_type=get_rust_type(key_attr.range, self.schemaview, self.pyo3),
+                key_property_aliases=key_property_aliases,
                 value_property_name=get_name(value_attr),
                 value_property_type=get_rust_type(value_attr.range, self.schemaview, self.pyo3),
                 can_convert_from_primitive=simple_dict_possible,

--- a/packages/linkml/src/linkml/generators/rustgen/template.py
+++ b/packages/linkml/src/linkml/generators/rustgen/template.py
@@ -366,6 +366,7 @@ class AsKeyValue(RustTemplateModel):
     name: str
     key_property_name: str
     key_property_type: str
+    key_property_aliases: list[str] = []
     value_property_name: str
     value_property_type: str
     can_convert_from_primitive: bool = False

--- a/packages/linkml/src/linkml/generators/rustgen/templates/as_key_value.rs.jinja
+++ b/packages/linkml/src/linkml/generators/rustgen/templates/as_key_value.rs.jinja
@@ -19,7 +19,14 @@ impl serde_utils::InlinedPair for {{ name }} {
         };
         let key_value = serde_value::to_value(k.clone())
             .map_err(|e| format!("unable to serialize key: {}", e))?;
-        map.insert(Value::String("{{key_property_name}}".into()), key_value);
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("{{ key_property_name }}".into()))
+            {%- for a in key_property_aliases %} || map.contains_key(&Value::String("{{ a }}".into())){%- endfor %};
+        if !already_keyed {
+            map.insert(Value::String("{{ key_property_name }}".into()), key_value);
+        }
         let de          = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok)  => Ok(ok),

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -682,6 +682,138 @@ def test_rustgen_aliased_key_preserves_explicit_value_in_inlined_dict(temp_dir):
         )
 
 
+def test_rustgen_simple_dict_with_recursive_multivalued_sibling(temp_dir):
+    """
+    When a class has a key slot, a primitive-typed required value slot, and a
+    recursive multivalued sibling slot (the linkml metamodel
+    ``Annotation``/``Extension`` shape), the inlined-as-dict form must still
+    accept the ``key: <primitive>`` simple-dict shorthand. The required value
+    slot is selected via the ``simple_dict_value: true`` annotation per the
+    rules in ``linkml.utils.helpers.get_range_associated_slots`` (the same
+    ladder linkml/linkml#1250 documents).
+
+    Earlier versions of rustgen disqualified this shape because they counted
+    *all* non-key slots (including the multivalued recursive ones) when
+    deciding whether ``can_convert_from_primitive`` should hold, which caused
+    every consumer schema using annotations in their simple form to fail
+    deserialization with "Cannot create a … from a primitive value!".
+    """
+    schema_yaml = textwrap.dedent(
+        """
+        id: https://example.org/rustgen/simple_dict_recursive
+        name: rustgen_simple_dict_recursive
+        prefixes:
+          ex: https://example.org/rustgen/
+          linkml: https://w3id.org/linkml/
+        default_prefix: ex
+        default_range: string
+        imports:
+          - linkml:types
+
+        classes:
+          # ``Anything`` is the canonical wildcard class linkml gen-rust
+          # special-cases (`class_uri: linkml:Any`). It's emitted as
+          # `struct Anything(serde_value::Value)`, accepting any primitive.
+          Anything:
+            class_uri: linkml:Any
+
+          AnnotationLike:
+            attributes:
+              tag:
+                identifier: true
+                range: string
+              value:
+                required: true
+                range: Anything
+                annotations:
+                  simple_dict_value: true
+              annotations:
+                range: AnnotationLike
+                multivalued: true
+                inlined: true
+
+          Root:
+            tree_root: true
+            attributes:
+              annotations:
+                range: AnnotationLike
+                inlined: true
+                multivalued: true
+        """
+    )
+
+    schema_path = Path(temp_dir) / "rustgen_simple_dict_recursive.yaml"
+    schema_path.write_text(schema_yaml, encoding="utf-8")
+
+    sv = SchemaView(str(schema_path))
+    out_dir = Path(temp_dir) / "simple_dict_recursive_crate"
+    RustGenerator(
+        sv.schema,
+        mode="crate",
+        pyo3=False,
+        serde=True,
+        output=str(out_dir),
+        handwritten_lib=False,
+    ).serialize(force=True)
+
+    lib_rs = (out_dir / "src" / "lib.rs").read_text(encoding="utf-8")
+
+    # The shape qualifies for primitive-form deserialization: from_pair_simple
+    # should be a real synthesizer, not the "Cannot create …" stub.
+    assert "Cannot create a AnnotationLike from a primitive value!" not in lib_rs
+    # And `simple_value` should be emitted, exposing the chosen value slot.
+    assert "fn simple_value(&self)" in lib_rs
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    test_rs = tests_dir / "simple_dict_recursive.rs"
+    test_rs.write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn simple_dict_with_recursive_sibling_round_trips() {\n"
+            f"    use {crate_ident}::Root;\n"
+            '    // The classic linkml "annotations: {tag: value}" shorthand.\n'
+            '    let yaml = "annotations:\\n  color: blue\\n  weight: 42\\n";\n'
+            '    let value: Root = serde_yml::from_str(yaml).expect("decode simple-dict");\n'
+            '    let anns = value.annotations.as_ref().expect("annotations present");\n'
+            "    assert_eq!(anns.len(), 2);\n"
+            "}\n"
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn nested_simple_dict_round_trips() {\n"
+            f"    use {crate_ident}::Root;\n"
+            "    // Recursive use of the multivalued sibling slot.\n"
+            '    let yaml = "annotations:\\n  outer:\\n    value: top\\n    annotations:\\n      inner: bottom\\n";\n'
+            '    let value: Root = serde_yml::from_str(yaml).expect("decode nested");\n'
+            '    let outer = value.annotations.as_ref().unwrap().get("outer").unwrap();\n'
+            '    assert!(outer.annotations.is_some(), "inner annotations populated");\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "simple_dict_recursive"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "cargo test failed, likely due to a missing Rust toolchain:\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )
+
+
 def test_subproperty_of_generates_rust_enum(temp_dir):
     """Test that subproperty_of generates a Rust enum with slot descendants."""
     schema_yaml = textwrap.dedent(

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -551,6 +551,137 @@ def test_rustgen_special_cases_roundtrip(temp_dir):
         assert key in output_data
 
 
+def test_rustgen_aliased_key_preserves_explicit_value_in_inlined_dict(temp_dir):
+    """
+    When a class is used as an inlined-as-dict and its key slot has a serde alias,
+    the generated InlinedPair::from_pair_mapping must not unconditionally inject
+    the inferred key. If the inner map already carries the key under either its
+    canonical name or its alias, the inferred insert produces a duplicate field
+    that serde rejects via alias resolution.
+
+    This mirrors the linkml metamodel's Extension/Annotation pattern where the
+    key slot ``extension_tag`` has ``alias: tag`` and real-world schemas write
+    the tag explicitly inside the inner mapping.
+    """
+    schema_yaml = textwrap.dedent(
+        """
+        id: https://example.org/rustgen/aliased_key
+        name: rustgen_aliased_key
+        prefixes:
+          ex: https://example.org/rustgen/
+          linkml: https://w3id.org/linkml/
+        default_prefix: ex
+        default_range: string
+        imports:
+          - linkml:types
+
+        classes:
+          AnnotationLike:
+            attributes:
+              ann_tag:
+                identifier: true
+                alias: tag
+                range: string
+              ann_value:
+                range: string
+                required: true
+
+          Root:
+            tree_root: true
+            attributes:
+              annotations:
+                range: AnnotationLike
+                inlined: true
+                multivalued: true
+        """
+    )
+
+    schema_path = Path(temp_dir) / "rustgen_aliased_key.yaml"
+    schema_path.write_text(schema_yaml, encoding="utf-8")
+
+    sv = SchemaView(str(schema_path))
+    out_dir = Path(temp_dir) / "aliased_key_crate"
+    rg = RustGenerator(
+        sv.schema,
+        mode="crate",
+        pyo3=False,
+        serde=True,
+        output=str(out_dir),
+        handwritten_lib=False,
+    )
+    rg.serialize(force=True)
+
+    generated_rs = (out_dir / "src" / "lib.rs").read_text(encoding="utf-8")
+
+    # Template-level assertions: the guard exists and references both names.
+    assert 'contains_key(&Value::String("ann_tag".into()))' in generated_rs
+    assert 'contains_key(&Value::String("tag".into()))' in generated_rs
+
+    # And the struct really does declare the serde alias we are guarding against.
+    assert 'serde(alias = "tag")' in generated_rs
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    roundtrip_rs = tests_dir / "aliased_key.rs"
+    roundtrip_rs.write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn explicit_alias_inside_inlined_dict_round_trips() {\n"
+            f"    use {crate_ident}::Root;\n"
+            "    // Inner map carries `tag:` (the alias) explicitly. The outer key\n"
+            "    // agrees with it. The old generator injected `ann_tag` on top of\n"
+            "    // the existing `tag`, which serde then rejected as a duplicate.\n"
+            '    let yaml = "annotations:\\n  foo:\\n    tag: foo\\n    ann_value: bar\\n";\n'
+            '    let value: Root = serde_yml::from_str(yaml).expect("decode with alias key");\n'
+            '    let anns = value.annotations.as_ref().expect("annotations present");\n'
+            '    let entry = anns.get("foo").expect("foo entry");\n'
+            '    assert_eq!(entry.ann_tag, "foo");\n'
+            '    assert_eq!(entry.ann_value, "bar");\n'
+            "}\n"
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn explicit_canonical_key_inside_inlined_dict_round_trips() {\n"
+            f"    use {crate_ident}::Root;\n"
+            '    let yaml = "annotations:\\n  foo:\\n    ann_tag: foo\\n    ann_value: bar\\n";\n'
+            '    let value: Root = serde_yml::from_str(yaml).expect("decode with canonical key");\n'
+            '    let entry = value.annotations.as_ref().unwrap().get("foo").unwrap();\n'
+            '    assert_eq!(entry.ann_tag, "foo");\n'
+            "}\n"
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn missing_inner_key_is_synthesized_from_outer_key() {\n"
+            f"    use {crate_ident}::Root;\n"
+            '    let yaml = "annotations:\\n  foo:\\n    ann_value: bar\\n";\n'
+            '    let value: Root = serde_yml::from_str(yaml).expect("decode without inner key");\n'
+            '    let entry = value.annotations.as_ref().unwrap().get("foo").unwrap();\n'
+            '    assert_eq!(entry.ann_tag, "foo");\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "aliased_key"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "cargo test failed, likely due to a missing Rust toolchain:\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )
+
+
 def test_subproperty_of_generates_rust_enum(temp_dir):
     """Test that subproperty_of generates a Rust enum with slot descendants."""
     schema_yaml = textwrap.dedent(


### PR DESCRIPTION
## Summary

See also https://github.com/Kapernikov/rust-linkml-core/pull/94

Regenerating a Rust crate from the linkml metamodel currently produces code
that fails to deserialize any schema using `annotations` or `extensions` in
their canonical simple-dict form. Two distinct bugs, both related to simpledict handling, combine to cause this;
this PR fixes both.

1. **`as_key_value.rs.jinja`** unconditionally injected the inferred key into the inlined-dict entry. correct is to honour `alias` if present.

2.  **`simple_dict_possible`** was changed in #2930 to `len(non_key_attrs) == 1`, which disqualifies `Annotation`/`Extension` (one primitive value slot + a recursive multivalued sibling). The gate now defers to `linkml.utils.helpers.get_range_associated_slots`, which encodes the documented SimpleDict rules (linkml/linkml#1250)

<!-- Briefly describe what this PR does and why. -->

## How was this tested?

* regenerated the metamodel in rust-linkml-core. after regeneration, rust-linkml-core again parses linkml documents correctly.

## Areas of uncertainty

N/A

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
