### PR TITLE
don't leave files open 2: this time, they're errors

### DIFF
--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -97,7 +97,8 @@ class OpenApiGenerator(Generator, LifecycleMixin):
         return class_schemas
 
     def serialize(self, template_file: str = "", **kwargs) -> str:
-        self._template = yaml.safe_load(open(template_file))
+        with open(template_file) as f:
+            self._template = yaml.safe_load(f)
         referenced_classes = self._find_referenced_classes()
         self._template["components"]["schemas"] = {}
         class_schemas = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,10 @@ force-exclude = '''
 [tool.pytest.ini_options]
 filterwarnings = [
   # https://github.com/RDFLib/rdflib/issues/1830
-  "ignore:.*_pytestfixturefunction is not defined in namespace:UserWarning"
+  "ignore:.*_pytestfixturefunction is not defined in namespace:UserWarning",
+  # testing discipline - force warnings to errors to prevent accumulation
+  "error::ResourceWarning",
+  "error::pytest.PytestUnraisableExceptionWarning", # Needed to treat ResourceWarnings as errors
 ]
 markers = [
   "network: mark tests that make external network requests",
@@ -106,7 +109,8 @@ markers = [
   "owlgen: Tests for OWL generator",
   "yamlgen: Tests for the YAML generator",
   "yarrrml: End-to-end tests for the YARRRML generator",
-  "typedbgen: Tests for the TypeDB generator"
+  "typedbgen: Tests for the TypeDB generator",
+  "notebooks: Notebook generation and execution",
 ]
 
 # https://docs.astral.sh/ruff/settings/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,12 @@ import os
 import re
 import shutil
 import sys
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from importlib.abc import MetaPathFinder
 from importlib.metadata import version
 from pathlib import Path
 
-import docker
 import pytest
 import requests_cache
 from _pytest.assertion.util import _diff_text
@@ -253,6 +251,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--with-rustgen", action="store_true", help="Include tests marked as rustgen (Rust codegen/maturin)"
     )
+    parser.addoption("--with-docker", action="store_true", help="include docker tests")
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -282,6 +281,12 @@ def pytest_collection_modifyitems(config, items: list[pytest.Item]):
             if item.get_closest_marker("network"):
                 item.add_marker(skip_network)
 
+    if not config.getoption("--with-docker"):
+        skip_docker = pytest.mark.skip(reason="need --with-docker option to run")
+        for item in items:
+            if item.get_closest_marker("docker"):
+                item.add_marker(skip_docker)
+
     # Group compliance tests on a single xdist worker - they share
     # mutable module-level caches in helper.py that are not safe to split.
     for item in items:
@@ -300,13 +305,6 @@ def pytest_collection_modifyitems(config, items: list[pytest.Item]):
             if item.get_closest_marker("pydanticgen_npd"):
                 item.add_marker(skip_npd)
 
-    # skip docker tests when docker server not present on the system
-    if not _docker_server_running():
-        skip_docker = pytest.mark.skip(reason="Docker server not running on host machine")
-        for item in items:
-            if item.get_closest_marker("docker"):
-                item.add_marker(skip_docker)
-
     # the fixture that mocks black import failures should always come all the way last
     # see: https://github.com/linkml/linkml/pull/2209#issuecomment-2231548078
     # this causes really hard to diagnose errors, but we can't fail a test run if
@@ -322,23 +320,6 @@ def pytest_sessionstart(session: pytest.Session):
     tests.WITH_OUTPUT = session.config.getoption("--with-output")
     if session.config.getoption("--generate-snapshots"):
         tests.DEFAULT_MISMATCH_ACTION = "MismatchAction.Ignore"
-
-    # Clear all warning registries at session start
-    for module in list(sys.modules.values()):
-        if hasattr(module, "__warningregistry__"):
-            del module.__warningregistry__
-
-    warnings.resetwarnings()
-    warnings.simplefilter("always")
-
-
-def pytest_runtest_setup(item):
-    # Clear warning registries before each test
-    for module in list(sys.modules.values()):
-        if hasattr(module, "__warningregistry__"):
-            del module.__warningregistry__
-
-    warnings.simplefilter("always")
 
 
 def pytest_assertrepr_compare(config, op, left, right):
@@ -424,32 +405,8 @@ def mock_black_import():
 @pytest.fixture(autouse=True)
 def reset_warnings():
     """Reset warnings for each test."""
-    # Pre-test cleanup
-    for module in list(sys.modules.values()):
-        if hasattr(module, "__warningregistry__"):
-            del module.__warningregistry__
-
-    warnings.resetwarnings()
-    warnings.simplefilter("always")
     EMITTED.clear()
 
     yield
 
-    # Post-test cleanup
-    for module in list(sys.modules.values()):
-        if hasattr(module, "__warningregistry__"):
-            del module.__warningregistry__
     EMITTED.clear()
-
-
-# --------------------------------------------------
-# Helper functions ~only~
-# --------------------------------------------------
-
-
-def _docker_server_running() -> bool:
-    try:
-        _ = docker.from_env()
-        return True
-    except docker.errors.DockerException:
-        return False

--- a/tests/linkml/test_compliance/helper.py
+++ b/tests/linkml/test_compliance/helper.py
@@ -326,15 +326,15 @@ def _generate_framework_output(
         gen_args["base_dir"] = str(_schema_out_path(schema))
         gen = gen_class(schema=SchemaDefinition(**schema), **gen_args)
         if framework == JAVA:
-            temp_dir = tempfile.TemporaryDirectory()
-            gen.serialize(temp_dir.name)
-            # walk all files in temp_dir and concatenate them
-            output = ""
-            for root, _dirs, files in os.walk(temp_dir.name):
-                for file in files:
-                    path = os.path.join(root, file)
-                    with open(path) as stream:
-                        output += stream.read()
+            with tempfile.TemporaryDirectory() as temp_dir:
+                gen.serialize(temp_dir)
+                # walk all files in temp_dir and concatenate them
+                output = ""
+                for root, _dirs, files in os.walk(temp_dir):
+                    for file in files:
+                        path = os.path.join(root, file)
+                        with open(path) as stream:
+                            output += stream.read()
         else:
             output = gen.serialize()
 
@@ -903,15 +903,19 @@ def check_data(
             except Exception as e:
                 if not valid:
                     raise e
-            endpoint.db_exists(force=True)
-            py_cls = endpoint.native_module.__dict__[target_class]
-            if valid:
-                py_obj = py_cls(**object_to_validate)
-                endpoint.dump(py_obj)
-            else:
-                with pytest.raises(Exception):
+
+            try:
+                endpoint.db_exists(force=True)
+                py_cls = endpoint.native_module.__dict__[target_class]
+                if valid:
                     py_obj = py_cls(**object_to_validate)
                     endpoint.dump(py_obj)
+                else:
+                    with pytest.raises(Exception):
+                        py_obj = py_cls(**object_to_validate)
+                        endpoint.dump(py_obj)
+            finally:
+                endpoint.engine.dispose()
         else:
             logger.warning(f"Unsupported generator {gen}")
             expected_behavior = ValidationBehavior.UNTESTED

--- a/tests/linkml/test_data/test_sqlite.py
+++ b/tests/linkml/test_data/test_sqlite.py
@@ -85,36 +85,38 @@ def test_csv_limit(tmp_outputs, diff, size):
     csv.field_size_limit(size)
     name = "N" * (size + diff)
     endpoint = SQLStore(schema, database_path=tmp_outputs["db"])
-    endpoint.db_exists(force=True)
-    mod = endpoint.compile_native()
+    try:
+        endpoint.db_exists(force=True)
+        mod = endpoint.compile_native()
 
-    with open(tmp_outputs["tsv"], "w", encoding="UTF-8") as file:
-        file.write("name\n")
-        file.write(name)
-        file.write("\n")
+        with open(tmp_outputs["tsv"], "w", encoding="UTF-8") as file:
+            file.write("name\n")
+            file.write(name)
+            file.write("\n")
 
-    if diff == -1:
-        obj = csv_loader.load(
-            str(tmp_outputs["tsv"]),
-            target_class=mod.Container,
-            index_slot="Person_index",
-            schema=schema,
-        )
-        endpoint.dump(obj)
-        obj2 = endpoint.load(target_class=mod.Container)
-        person = getattr(obj2, "Person_index")[0]
-        name2 = getattr(person, "name")
-        assert name == name2
-    else:
-        with pytest.raises(Exception):
-            csv_loader.load(
-                tmp_outputs["tsv"],
+        if diff == -1:
+            obj = csv_loader.load(
+                str(tmp_outputs["tsv"]),
                 target_class=mod.Container,
                 index_slot="Person_index",
                 schema=schema,
             )
+            endpoint.dump(obj)
+            obj2 = endpoint.load(target_class=mod.Container)
+            person = getattr(obj2, "Person_index")[0]
+            name2 = getattr(person, "name")
+            assert name == name2
+        else:
+            with pytest.raises(Exception):
+                csv_loader.load(
+                    tmp_outputs["tsv"],
+                    target_class=mod.Container,
+                    index_slot="Person_index",
+                    schema=schema,
+                )
 
-    # mod holds a reference to sqlite that prevents file closing
-    del mod
-    # dispose engine to allow creating of a new engine of same name
-    endpoint.engine.dispose()
+        # mod holds a reference to sqlite that prevents file closing
+        del mod
+    finally:
+        # dispose engine to allow creating of a new engine of same name
+        endpoint.engine.dispose()

--- a/tests/linkml/test_notebooks/test_examples.py
+++ b/tests/linkml/test_notebooks/test_examples.py
@@ -12,6 +12,8 @@ from tests.linkml.test_notebooks import output_directory
 
 logger = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.notebooks
+
 
 def eval_test(target: str, import_module: str) -> None:
     output = StringIO()

--- a/tests/linkml/test_notebooks/test_notebooks.py
+++ b/tests/linkml/test_notebooks/test_notebooks.py
@@ -14,6 +14,8 @@ FORCE_REWRITE = True
 # Tests moved to root: tests/linkml/test_notebooks, notebooks at root
 NBBASEDIR = os.path.join(env.cwd, "..", "notebooks")
 
+pytestmark = pytest.mark.notebooks
+
 
 @pytest.fixture
 def ep():

--- a/tests/linkml_runtime/test_processing/test_arrays.py
+++ b/tests/linkml_runtime/test_processing/test_arrays.py
@@ -20,7 +20,8 @@ def normalizer():
 @pytest.fixture
 def matrix_data():
     """Load matrix data from array example data file."""
-    return yaml.safe_load(open(str(Path(INPUT_DIR) / "array_example_data.yaml")))
+    with open(str(Path(INPUT_DIR) / "array_example_data.yaml")) as f:
+        return yaml.safe_load(f)
 
 
 def test_array_normalization(normalizer, matrix_data):


### PR DESCRIPTION
from the producers of: [dont leave files open](https://github.com/linkml/linkml/pull/3207), now playing:

## don't leave files open 2

### *this time, they're errors*

---

Continues: #3207, #2288, #1939, #1954
Part of: #2985 

I'm a little bit like [this guy](https://www.youtube.com/watch?v=ymHyOmlUlP0) when it comes to warnings in the tests and now specifically leaving files open.

I think it's fair to say:
- we should not ship code that leaves files open
- we should not have to suffer an avalanche of warnings about leaving files open that prevent us from seeing any important information from warnings

so I am making a proposal that we start making some classes of warnings emitted during testing errors. 

ideally, the only kind of error that would be unhandled and emitted without error are deprecation warnings from other packages, because those are the kind of warnings-as-output that are actually useful during testing. but all the other warnings are indications that something is wrong and should be fixed - 
particularly when they are emitted from our own code. 
particularly *particularly* when they are emitted from code that we ship in the package.

let us begin by `/voteban`ning `ResourceWarning`s, which are strictly programming mistakes, and they are mistakes that can have consequences.

i am opening this as a draft because my zen garden-based attention span for cleaning up the linkml tests needs to be given a cap, but i draft as an offering and will return.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [ ] Existing tests pass locally with my changes

## AI Assistance

I would never let a robot take away the joy of cleaning, crafting, or coding from me.