### PR TITLE
fix: handle inlined slot with primitive range in pythongen (issue #3564)

### DIFF
--- a/packages/linkml/src/linkml/generators/pythongen.py
+++ b/packages/linkml/src/linkml/generators/pythongen.py
@@ -990,7 +990,7 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
                     rlines.append(f"\tself.{aliased_slot_name} = {base_type_name}(self.{aliased_slot_name})")
                 else:
                     rlines.append(f"\tself.{aliased_slot_name} = {base_type_name}(**as_dict(self.{aliased_slot_name}))")
-        elif slot.inlined:
+        elif slot.inlined and slot.range in self.schema.classes:
             slot_range_cls = self.schema.classes[slot.range]
             identifier = self.class_identifier(slot_range_cls)
             if not identifier:


### PR DESCRIPTION
## Summary

Fixes `KeyError: 'string'` when `linkml-convert` is used with `inlined: true` on a slot with a primitive range (e.g., `string`).

## Problem

When a slot has `inlined: true` and a primitive range like `string`, the Python code generator (`pythongen.py`) unconditionally tries to look up `slot.range` in `self.schema.classes`:

```python
elif slot.inlined:
    slot_range_cls = self.schema.classes[slot.range]  # KeyError: 'string'
```

Since `string` is a type (not a class), this lookup fails with `KeyError: 'string'`.

## Fix

Added a guard to only process the `inlined` code path when the range is actually a class definition:

```python
elif slot.inlined and slot.range in self.schema.classes:
```

When the range is a primitive type, the code now falls through to the existing `else` block which correctly handles non-inlined multivalued slots (converting values to a list and casting each to the base type).

## Reproduction

```yaml
# schema.yaml
classes:
  MyData:
    tree_root: true
    attributes:
      id:
        identifier: true
        range: uriorcurie
      items:
        multivalued: true
        inlined: true
        range: string
```

```json
{"id": "ex:foo", "items": ["item #1", "item #2", "item #3"]}
```

```bash
linkml-convert -t ttl -s schema.yaml data.json
# Before fix: KeyError: 'string'
# After fix: successfully produces RDF/TTL output
```

## Testing

- All 152 existing issue tests pass
- All 12 pythongen tests pass
- Manual verification with the reproduction case produces correct TTL output

Fixes #3564