### PR TITLE
fix(docgen): omit empty Cardinality table in slot pages

### DIFF
--- a/packages/linkml/src/linkml/generators/docgen/slot.md.jinja2
+++ b/packages/linkml/src/linkml/generators/docgen/slot.md.jinja2
@@ -105,7 +105,11 @@ Alias: {{ element.alias }}
 {%- if element.is_grouping_slot %}
 | Is Grouping Slot | Yes |
 {%- endif %}
+{%- set has_cardinality = element.required or element.recommended
+    or element.multivalued or element.minimum_cardinality is not none
+    or element.maximum_cardinality is not none or element.exact_cardinality is not none %}
 
+{%- if has_cardinality %}
 ### Cardinality and Requirements
 
 | Property | Value |
@@ -128,6 +132,7 @@ Alias: {{ element.alias }}
 | Exact Cardinality | {{ element.exact_cardinality }} |
 {%- endif %}
 
+{% endif %}
 {%- if element.multivalued and (element.list_elements_unique is not none or element.list_elements_ordered is not none) %}
 ### List/Collection Properties
 

--- a/tests/linkml/test_generators/test_docgen.py
+++ b/tests/linkml/test_generators/test_docgen.py
@@ -1640,6 +1640,10 @@ def test_core_element_properties(input_path, tmp_path):
     # Test inherited slot
     base_property_file = tmp_path / "base_property.md"
     assert_mdfile_contains(base_property_file, "| Inherited | Yes |", after="Slot Characteristics")
+    # Issue #3569: empty Cardinality table swallowed the next heading. The "Cardinality and
+    # Requirements" section must be omitted entirely when the slot has no cardinality data,
+    # otherwise an empty Markdown table consumes the following ### heading as a table row.
+    assert_mdfile_does_not_contain(base_property_file, "### Cardinality and Requirements")
 
     # Test designates_type slot
     type_designator_file = tmp_path / "type_designator.md"


### PR DESCRIPTION
When a slot has no cardinality data, the slot template was still emitting the `### Cardinality and Requirements` heading plus an empty `| Property | Value | / | --- | --- |` table. Python-Markdown's `tables` extension then consumed the next `### Slot Characteristics` heading as a one-cell row of that empty table, breaking the rest of the page (visible in every slot/class page in the [linkml-model dev docs](https://linkml.io/linkml-model/dev/docs/readonly/)).

Guard the section behind a `has_cardinality` check, matching the existing `has_slot_chars` / `has_basic_constraints` pattern in the same template. Added an assertion in `test_core_element_properties` against the existing `base_property` fixture (an `inherited: true` slot with no cardinality data) to lock the fix in.

Closes #3569.