### PR TITLE
fix: merge imported schema prefixes into schema.prefixes (closes #3574)

### DIFF
--- a/packages/linkml/src/linkml/generators/pythongen.py
+++ b/packages/linkml/src/linkml/generators/pythongen.py
@@ -82,6 +82,13 @@ class PythonGenerator(Generator):
             logger.error("Generating metamodel without --genmeta is highly inadvisable!")
         if not self.schema.source_file and isinstance(self.sourcefile, str) and "\n" not in self.sourcefile:
             self.schema.source_file = os.path.basename(self.sourcefile)
+        # Merge prefixes from imported schemas into schema.prefixes
+        for imp in self.schema.imports:
+            if imp in self.schemaview.schema_map:
+                imported_schema = self.schemaview.schema_map[imp]
+                for prefix in imported_schema.prefixes.values():
+                    if prefix.prefix_prefix not in self.schema.prefixes:
+                        self.schema.prefixes[prefix.prefix_prefix] = prefix
 
     def compile_module(self, **kwargs) -> ModuleType:
         """


### PR DESCRIPTION
## What
When a parent schema imports a child schema that declares additional prefixes, the Python generator (and other generators with `uses_schemaloader = True`) only iterates over `self.schema.prefixes`, which contains only the root schema's prefixes. Prefixes declared exclusively on imported sub-schemas are silently dropped, leading to `NameError` at import time because permissible-value `meaning:` URIs reference an undefined prefix variable (e.g., `ISO3166`).

## Fix
In `__post_init__`, after the `SchemaView` is created, we iterate over the schema's imports and copy any prefix from the imported schema into `self.schema.prefixes` if it is not already defined. This ensures that all prefixes reachable via the import closure are available when generators later iterate over `schema.prefixes`.

Closes #3574