### PR TITLE
fix(deps): bump idna to 3.17 in uv.lock (#3581)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1246,11 +1246,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

CI failed on every Linux job (Windows passed) with:

```
ImportError: cannot import name 'uts46data' from 'idna.uts46data'
  at .venv/.../idna/core.py:334
```

Meant to be an immediate unblock of #3581, but doesn't genuinely solve it.

## Root cause (confirmed via CI instrumentation)

The lock pinned idna **3.11**, but the notebook test `test_redo_notebook[ShExPrimerModel.ipynb]` executes a cell:

```
!uv pip install linkml --upgrade --disable-pip-version-check -q
```

`--upgrade` ignores the lock and pulls **idna 3.17** (latest as of 2026-05-28) into the **shared** CI venv. idna 3.17 restructured `uts46data.py` and dropped the legacy `uts46data` symbol. A later partial `uv` restore left 3.11's `core.py` (line 334: `from .uts46data import uts46data`) beside 3.17's `uts46data.py`, so the rewrite-rules test failed when `url_normalize` called `idna.encode(uts46=True)`. This is also why only Linux failed — notebook tests are skipped on Windows (`sys.platform == "win32"`).

A teardown probe caught the file changing mid-session: `243725 -> 234325 bytes` (= idna 3.17's `uts46data.py`), header `# This file is automatically generated by tools/idna-data`.

## Fix

Bump the lock to **idna 3.17** so the base install and the notebook's `--upgrade` converge on one consistent version — no more skew. idna 3.17 is compatible with our code; the 4 `test_rewrite_rules` tests pass on it locally.

## Follow-up

The underlying issue — notebook tests running `!uv pip install … --upgrade` against the shared test venv — is tracked separately and can recur on a future dep release.