### PR TITLE
Permissiblevalue enums (part 3):  Pythongen - schema-element.generated-class registry

### DIFF
--- a/packages/linkml/src/linkml/generators/pythongen.py
+++ b/packages/linkml/src/linkml/generators/pythongen.py
@@ -1210,7 +1210,37 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
                    model_uri={slot_model_uri}, domain={domain}, range={rnge}{mappings}{pattern})"""
 
     def gen_enumerations(self) -> str:
-        return "\n\n".join([self.gen_enum(enum) for enum in self.schema.enums.values() if not enum.imported_from])
+        owned_enums = [enum for enum in self.schema.enums.values() if not enum.imported_from]
+        blocks = [self.gen_enum(enum) for enum in owned_enums]
+        registrations = self.gen_enum_registry(owned_enums)
+        if registrations:
+            blocks.append(registrations)
+        return "\n\n".join(blocks)
+
+    def gen_enum_registry(self, enums: list[EnumDefinition]) -> str:
+        """Emit ``EnumClass._register(schema_id, enum_name)`` calls.
+
+        These populate the ``EnumDefinitionImpl._registry`` so that
+        ``SchemaView.enum_class_for`` can resolve an ``EnumDefinition`` to
+        the concrete generated class (see linkml/linkml#723, phase 3).
+        The ``schema_id`` used is the enum's ``from_schema`` if set
+        (preserving provenance under ``mergeimports``) or the current
+        schema's id otherwise.
+        """
+        if not enums:
+            return ""
+        default_schema_id = self.schema.id or ""
+        lines = ["# Enum registry (see EnumDefinitionImpl.for_schema_element)"]
+        for enum in enums:
+            schema_id = enum.from_schema or default_schema_id
+            if not schema_id:
+                continue
+            lines.append(
+                f'{camelcase(enum.name)}._register({schema_id!r}, "{enum.name}")'
+            )
+        if len(lines) == 1:
+            return ""
+        return "\n".join(lines)
 
     def gen_enum(self, enum: EnumDefinition) -> str:
         """

--- a/packages/linkml/src/linkml/generators/pythongen.py
+++ b/packages/linkml/src/linkml/generators/pythongen.py
@@ -531,6 +531,7 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
         slotdefs = self.gen_class_variables(cls)
         postinits = self.gen_postinits(cls)
         constructor = self.gen_constructor(cls)
+        enum_coercion = self.gen_enum_slot_coercion(cls)
 
         wrapped_description = (
             f'\n\t"""\n\t{wrapped_annotation(be(cls.description))}\n\t"""' if be(cls.description) else ""
@@ -547,6 +548,7 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
             + (f"\n\t{slotdefs}" if slotdefs else "")
             + (f"\n{postinits}" if postinits else "")
             + (f"\n{constructor}" if constructor else "")
+            + (f"\n{enum_coercion}" if enum_coercion else "")
         )
 
         return cd_str
@@ -818,6 +820,55 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
             )
             if post_inits_line or post_inits_post_super_line
             else ""
+        )
+
+    def gen_enum_slot_coercion(self, cls: ClassDefinition) -> str:
+        """Emit ``_enum_slots`` mapping plus ``__setattr__`` so that
+        post-init assignment to an enum-ranged slot coerces strings (and
+        bare ``PermissibleValue`` objects) into the proper enum instance.
+
+        The dataclass-generated ``__init__`` and the emitted ``__post_init__``
+        already wrap raw values into enum instances at construction time, but
+        a later ``p.status = "ALIVE"`` would leave ``p.status`` as a plain
+        ``str`` without this hook.  See linkml/linkml#723 phase 2.
+
+        The mapping stores the enum class name as a string and resolves it
+        lazily via ``globals()`` because pythongen emits class definitions
+        before enum definitions, so the enum class is not yet bound when the
+        class body executes.  Lookup at assignment time is safe because the
+        module is fully loaded by then.
+        """
+        if cls.mixin or cls.abstract:
+            return ""
+        enum_slots: list[tuple[str, str, bool]] = []
+        for slot in self.schemaview.class_induced_slots(cls.name):
+            if not slot.range or slot.range not in self.schema.enums:
+                continue
+            enum = self.schema.enums[slot.range]
+            if not enum.permissible_values:
+                # Open enum: no enum class to coerce into.
+                continue
+            aliased = underscore(slot.alias if slot.alias else slot.name)
+            enum_slots.append((aliased, camelcase(enum.name), bool(slot.multivalued)))
+        if not enum_slots:
+            return ""
+        mapping = ", ".join(f'"{name}": ("{cls_name}", {mv})' for name, cls_name, mv in enum_slots)
+        return (
+            f'    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {{{mapping}}}\n'
+            "\n"
+            "    def __setattr__(self, name: str, value: Any) -> None:\n"
+            "        spec = type(self)._enum_slots.get(name)\n"
+            "        if spec is not None and value is not None:\n"
+            "            enum_name, multivalued = spec\n"
+            "            enum_cls = globals().get(enum_name)\n"
+            "            if enum_cls is not None:\n"
+            "                if multivalued:\n"
+            "                    if not isinstance(value, list):\n"
+            "                        value = [value] if value is not None else []\n"
+            "                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]\n"
+            "                elif not isinstance(value, enum_cls):\n"
+            "                    value = enum_cls(value)\n"
+            "        object.__setattr__(self, name, value)\n"
         )
 
     # sort classes such that if C is a child of P then C appears after P in the list

--- a/packages/linkml_runtime/src/linkml_runtime/__init__.py
+++ b/packages/linkml_runtime/src/linkml_runtime/__init__.py
@@ -3,7 +3,16 @@ from pathlib import Path
 from rdflib import OWL, RDF, RDFS, SKOS, XSD
 
 from linkml_runtime.utils.curienamespace import CurieNamespace
+
+# Install equality / hashing / string patches on the metamodel's
+# ``PermissibleValue`` dataclass so that enums behave intuitively at runtime
+# (see linkml/linkml#1203).  Done here because both ``enumerations`` and
+# ``linkml_model.meta`` are guaranteed to be fully loaded by this point.
+from linkml_runtime.utils.enumerations import _patch_permissible_value
 from linkml_runtime.utils.schemaview import SchemaView
+
+_patch_permissible_value()
+del _patch_permissible_value
 
 __all__ = [
     "SchemaView",

--- a/packages/linkml_runtime/src/linkml_runtime/__init__.py
+++ b/packages/linkml_runtime/src/linkml_runtime/__init__.py
@@ -3,16 +3,7 @@ from pathlib import Path
 from rdflib import OWL, RDF, RDFS, SKOS, XSD
 
 from linkml_runtime.utils.curienamespace import CurieNamespace
-
-# Install equality / hashing / string patches on the metamodel's
-# ``PermissibleValue`` dataclass so that enums behave intuitively at runtime
-# (see linkml/linkml#1203).  Done here because both ``enumerations`` and
-# ``linkml_model.meta`` are guaranteed to be fully loaded by this point.
-from linkml_runtime.utils.enumerations import _patch_permissible_value
 from linkml_runtime.utils.schemaview import SchemaView
-
-_patch_permissible_value()
-del _patch_permissible_value
 
 __all__ = [
     "SchemaView",

--- a/packages/linkml_runtime/src/linkml_runtime/utils/enumerations.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/enumerations.py
@@ -1,5 +1,5 @@
 from dataclasses import fields
-from typing import Optional
+from typing import ClassVar, Optional
 
 from linkml_runtime.utils.metamodelcore import Curie
 from linkml_runtime.utils.yamlutils import YAMLRoot
@@ -78,6 +78,35 @@ def isinstance_dt(cls: type, inst: str) -> bool:
 
 class EnumDefinitionImpl(YAMLRoot, metaclass=EnumDefinitionMeta):
     _defn: "EnumDefinition" = None  # Overridden by implementation
+
+    # Registry of generated enum classes keyed by (schema_id, enum_name).
+    # Populated as a side effect of importing a generated module that calls
+    # ``EnumClass._register(schema_id, enum_name)``.  Used by
+    # ``SchemaView.enum_class_for`` to resolve an ``EnumDefinition`` back to
+    # the concrete Python class (see linkml/linkml#723, phase 3).
+    _registry: ClassVar[dict[tuple[str, str], type["EnumDefinitionImpl"]]] = {}
+
+    @classmethod
+    def _register(cls, schema_id: str, enum_name: str) -> None:
+        """Register this enum class under ``(schema_id, enum_name)``.
+
+        Called from generated modules immediately after each enum class
+        definition.  Re-registration with the same key is allowed and
+        overwrites the previous entry (this happens naturally when a module
+        is reloaded).
+        """
+        EnumDefinitionImpl._registry[(schema_id, enum_name)] = cls
+
+    @classmethod
+    def for_schema_element(
+        cls, schema_id: str, enum_name: str
+    ) -> Optional[type["EnumDefinitionImpl"]]:
+        """Look up a registered enum class.
+
+        Returns ``None`` if the generated module has not been imported yet
+        (registration is a module-import side effect).
+        """
+        return EnumDefinitionImpl._registry.get((schema_id, enum_name))
 
     def __init__(self, code: str | Curie) -> None:
         if isinstance_dt(code, "PermissibleValue"):

--- a/packages/linkml_runtime/src/linkml_runtime/utils/enumerations.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/enumerations.py
@@ -11,22 +11,31 @@ class EnumDefinitionMeta(type):
         cls._addvals()
 
     def __getitem__(cls, item):
-        return cls.__dict__[item]
+        # Walk the MRO so that empty wrapper subclasses (e.g. identifier
+        # wrappers emitted by ``pythongen``) can inherit permissible values
+        # from their parent enum class.
+        for klass in cls.__mro__:
+            if item in klass.__dict__:
+                return klass.__dict__[item]
+        raise KeyError(item)
 
     def __setitem__(cls, key, value):
         if key in cls.__dict__:
             raise ValueError(f"{cls.__name__} - {key} already assigned")
         cls.__dict__[key] = value
 
-    def __setattr__(cls, key, value):
-        from linkml_runtime.linkml_model.meta import PermissibleValue
-
-        if cls._defn.code_set and isinstance(value, PermissibleValue) and value.meaning:
-            print(f"Validating {value.meaning} against {cls._defn.code_set}")
-        super().__setattr__(key, value)
-
     def __contains__(cls, item) -> bool:
-        return item in cls.__dict__
+        # Accept strings, ``PermissibleValue`` instances, and ``EnumDefinitionImpl``
+        # instances as membership tests against the class's permissible value names.
+        # Walk the MRO so that empty wrapper subclasses inherit their parent
+        # enum's permissible values.
+        if isinstance_dt(item, "EnumDefinitionImpl"):
+            code = getattr(item, "_code", None)
+            if code is not None:
+                item = code.text
+        elif isinstance_dt(item, "PermissibleValue"):
+            item = item.text
+        return any(item in klass.__dict__ for klass in cls.__mro__)
 
 
 def isinstance_dt(cls: type, inst: str) -> bool:
@@ -117,3 +126,93 @@ class EnumDefinitionImpl(YAMLRoot, metaclass=EnumDefinitionMeta):
     def __repr__(self) -> str:
         rlist = [(f.name, getattr(self._code, f.name)) for f in fields(self._code)]
         return self.__class__.__name__ + "(" + ", ".join([f"{f[0]}={repr(f[1])}" for f in rlist if f[1]]) + ")"
+
+    def __eq__(self, other) -> bool:
+        """Equality against another enum instance, a ``PermissibleValue``, or a ``str``.
+
+        Two enumerated values are considered equal when they share the same
+        underlying permissible value text.  Comparison with a bare ``str`` (or
+        ``PermissibleValue``) is supported so that user code can write
+        ``MyEnum.A == "A"`` in the same way as stdlib ``StrEnum``.
+        """
+        if isinstance(other, EnumDefinitionImpl):
+            return self._code.text == other._code.text
+        if isinstance_dt(other, "PermissibleValue"):
+            return self._code.text == other.text
+        if isinstance(other, str):
+            return self._code.text == other
+        return NotImplemented
+
+    def __ne__(self, other) -> bool:
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
+    def __hash__(self) -> int:
+        return hash(self._code.text)
+
+
+def _patch_permissible_value() -> None:
+    """Temporary runtime back-fill for issue #1203 — to be removed once #723 lands.
+
+    The metamodel's ``PermissibleValue`` is a generated ``@dataclass``. It lacks
+    string-aware equality capability, is unhashable, and ``__str__`` is noisy.
+
+    Since pythongen emits enum members as bare ``PermissibleValue`` class attrs,
+    (``VitalStatus.ALIVE = PermissibleValue(text="ALIVE")``) instead of real
+    ``EnumDefinitionImpl`` instances, user code that does ``p.status == "ALIVE"``,
+    ``hash(VitalStatus.ALIVE)``, or ``VitalStatus.ALIVE in {...}`` would fail or
+    behave non-intuitively.
+
+    This function monkey-patches ``__eq__``, ``__ne__``, ``__hash__`` and ``__str__``
+    onto ``PermissibleValue`` so those operations work idempotently for strings,
+    other ``PermissibleValue`` instances, and ``EnumDefinitionImpl`` instances.
+
+    .. deprecated::
+        This patch is a temporary workaround, not the intended design.
+        ``PermissibleValue`` is conceptually a clean metamodel descriptor and
+        should retain that default dataclass equality semantics.
+
+        The proper fix lives in pythongen + the runtime metaclass: enum
+        members should be promoted to real ``EnumDefinitionImpl`` instances
+        at class-creation time (see ``EnumDefinitionMeta``), at which point
+        this patch will no longer be necessary.
+
+    See also:
+        * https://github.com/linkml/linkml/issues/1203 (the bug patch addresses)
+        * https://github.com/linkml/linkml/issues/723  (the structural fix)
+        * https://github.com/linkml/linkml/pull/3596   (tracking PR)
+    """
+    from linkml_runtime.linkml_model.meta import PermissibleValue
+
+    if getattr(PermissibleValue, "_linkml_enum_patches_applied", False):
+        return
+
+    def _pv_eq(self, other) -> bool:
+        if isinstance(other, EnumDefinitionImpl):
+            code = getattr(other, "_code", None)
+            return code is not None and self.text == code.text
+        if isinstance(other, PermissibleValue):
+            return self.text == other.text
+        if isinstance(other, str):
+            return self.text == other
+        return NotImplemented
+
+    def _pv_ne(self, other) -> bool:
+        result = _pv_eq(self, other)
+        if result is NotImplemented:
+            return result
+        return not result
+
+    def _pv_hash(self) -> int:
+        return hash(self.text)
+
+    def _pv_str(self) -> str:
+        return str(self.text)
+
+    PermissibleValue.__eq__ = _pv_eq
+    PermissibleValue.__ne__ = _pv_ne
+    PermissibleValue.__hash__ = _pv_hash
+    PermissibleValue.__str__ = _pv_str
+    PermissibleValue._linkml_enum_patches_applied = True

--- a/packages/linkml_runtime/src/linkml_runtime/utils/enumerations.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/enumerations.py
@@ -9,11 +9,44 @@ class EnumDefinitionMeta(type):
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
         cls._addvals()
+        cls._promote_permissible_values()
+
+    def _promote_permissible_values(cls) -> None:
+        """Replace bare ``PermissibleValue`` class attributes with real enum instances.
+
+        ``pythongen`` emits each enum member as a bare ``PermissibleValue``
+        class attribute (e.g. ``ALIVE = PermissibleValue(text="ALIVE")``).
+        This method runs once per class at metaclass ``__init__`` time and
+        replaces each such attribute with an instance of the enum class
+        itself, so that ``MyEnum.ALIVE`` is an ``EnumDefinitionImpl`` and not
+        a raw metamodel descriptor.  This is the structural fix that
+        obsoletes the historical ``_patch_permissible_value`` runtime
+        monkey-patch (see linkml/linkml#723).
+
+        The bare ``EnumDefinitionImpl`` base class has ``_defn = None`` and
+        is skipped.  Identifier-wrapper subclasses (``class Wrapper(Parent):
+        pass``) have no permissible values in their own ``__dict__`` and the
+        loop is a no-op for them; lookups fall through the MRO to the parent
+        class's promoted instances.
+        """
+        if getattr(cls, "_defn", None) is None:
+            return
+        # Lazy import: ``linkml_runtime.linkml_model.meta`` depends on this
+        # module via ``EnumDefinitionImpl`` so the top-level import would be
+        # circular.
+        from linkml_runtime.linkml_model.meta import PermissibleValue
+
+        for name, attr in list(cls.__dict__.items()):
+            if isinstance(attr, PermissibleValue):
+                type.__setattr__(cls, name, cls(attr))
 
     def __getitem__(cls, item):
         # Walk the MRO so that empty wrapper subclasses (e.g. identifier
         # wrappers emitted by ``pythongen``) can inherit permissible values
-        # from their parent enum class.
+        # from their parent enum class.  After promotion the attribute is an
+        # ``EnumDefinitionImpl`` instance; raw ``PermissibleValue`` entries
+        # (set directly by user code or by ``_addvals`` before promotion has
+        # run) are returned as-is.
         for klass in cls.__mro__:
             if item in klass.__dict__:
                 return klass.__dict__[item]
@@ -71,7 +104,14 @@ class EnumDefinitionImpl(YAMLRoot, metaclass=EnumDefinitionMeta):
             else:
                 self._code = code
         else:
-            self._code = self.__class__[key]
+            val = self.__class__[key]
+            # After promotion the class attribute is an ``EnumDefinitionImpl``;
+            # unwrap to its underlying ``PermissibleValue`` so ``self._code``
+            # always stores a PV.
+            if isinstance_dt(val, "EnumDefinitionImpl"):
+                self._code = val._code
+            else:
+                self._code = val
 
     def _lookup(self, key: str) -> Optional["PermissibleValue"]:
         """
@@ -91,6 +131,19 @@ class EnumDefinitionImpl(YAMLRoot, metaclass=EnumDefinitionMeta):
     @code.setter
     def code(self, val):
         self._code = val
+
+    @property
+    def text(self):
+        """The permissible-value text (canonical short code)."""
+        return self._code.text
+
+    @property
+    def description(self):
+        return self._code.description
+
+    @property
+    def title(self):
+        return self._code.title
 
     @property
     def meaning(self):
@@ -151,68 +204,3 @@ class EnumDefinitionImpl(YAMLRoot, metaclass=EnumDefinitionMeta):
 
     def __hash__(self) -> int:
         return hash(self._code.text)
-
-
-def _patch_permissible_value() -> None:
-    """Temporary runtime back-fill for issue #1203 — to be removed once #723 lands.
-
-    The metamodel's ``PermissibleValue`` is a generated ``@dataclass``. It lacks
-    string-aware equality capability, is unhashable, and ``__str__`` is noisy.
-
-    Since pythongen emits enum members as bare ``PermissibleValue`` class attrs,
-    (``VitalStatus.ALIVE = PermissibleValue(text="ALIVE")``) instead of real
-    ``EnumDefinitionImpl`` instances, user code that does ``p.status == "ALIVE"``,
-    ``hash(VitalStatus.ALIVE)``, or ``VitalStatus.ALIVE in {...}`` would fail or
-    behave non-intuitively.
-
-    This function monkey-patches ``__eq__``, ``__ne__``, ``__hash__`` and ``__str__``
-    onto ``PermissibleValue`` so those operations work idempotently for strings,
-    other ``PermissibleValue`` instances, and ``EnumDefinitionImpl`` instances.
-
-    .. deprecated::
-        This patch is a temporary workaround, not the intended design.
-        ``PermissibleValue`` is conceptually a clean metamodel descriptor and
-        should retain that default dataclass equality semantics.
-
-        The proper fix lives in pythongen + the runtime metaclass: enum
-        members should be promoted to real ``EnumDefinitionImpl`` instances
-        at class-creation time (see ``EnumDefinitionMeta``), at which point
-        this patch will no longer be necessary.
-
-    See also:
-        * https://github.com/linkml/linkml/issues/1203 (the bug patch addresses)
-        * https://github.com/linkml/linkml/issues/723  (the structural fix)
-        * https://github.com/linkml/linkml/pull/3596   (tracking PR)
-    """
-    from linkml_runtime.linkml_model.meta import PermissibleValue
-
-    if getattr(PermissibleValue, "_linkml_enum_patches_applied", False):
-        return
-
-    def _pv_eq(self, other) -> bool:
-        if isinstance(other, EnumDefinitionImpl):
-            code = getattr(other, "_code", None)
-            return code is not None and self.text == code.text
-        if isinstance(other, PermissibleValue):
-            return self.text == other.text
-        if isinstance(other, str):
-            return self.text == other
-        return NotImplemented
-
-    def _pv_ne(self, other) -> bool:
-        result = _pv_eq(self, other)
-        if result is NotImplemented:
-            return result
-        return not result
-
-    def _pv_hash(self) -> int:
-        return hash(self.text)
-
-    def _pv_str(self) -> str:
-        return str(self.text)
-
-    PermissibleValue.__eq__ = _pv_eq
-    PermissibleValue.__ne__ = _pv_ne
-    PermissibleValue.__hash__ = _pv_hash
-    PermissibleValue.__str__ = _pv_str
-    PermissibleValue._linkml_enum_patches_applied = True

--- a/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
@@ -875,6 +875,40 @@ class SchemaView:
             raise ValueError(msg)
         return e
 
+    def enum_class_for(self, enum_name: ENUM_NAME) -> type | None:
+        """Resolve an enum name to the generated Python enum class.
+
+        Returns the registered ``EnumDefinitionImpl`` subclass that the
+        ``pythongen`` output emits for this enum, or ``None`` if no such
+        class has been imported in the current interpreter.  Registration
+        is a side effect of importing the generated module, so callers
+        must ensure the corresponding generated module is loaded first.
+
+        Lookup honours the enum's ``from_schema`` (its originating schema
+        id) so imported enums resolve to the class emitted by the schema
+        that actually owns them.
+        """
+        from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+
+        enum = self.get_enum(enum_name)
+        if enum is None:
+            return None
+        schema_id = enum.from_schema or self.schema.id
+        if not schema_id:
+            return None
+        return EnumDefinitionImpl.for_schema_element(schema_id, str(enum.name))
+
+    def enum_member_for(self, pv, enum_name: ENUM_NAME):
+        """Wrap a ``PermissibleValue`` in its generated enum class.
+
+        Returns an ``EnumDefinitionImpl`` instance, or ``None`` if the
+        generated enum class is not available (see ``enum_class_for``).
+        """
+        enum_cls = self.enum_class_for(enum_name)
+        if enum_cls is None:
+            return None
+        return enum_cls(pv)
+
     @lru_cache(None)
     def get_type(self, type_name: TYPE_NAME, imports: bool = True, strict: bool = False) -> TypeDefinition | None:
         """Retrieve a type from the schema.

--- a/tests/linkml/test_enhancements/__snapshots__/enumeration/alternatives.py
+++ b/tests/linkml/test_enhancements/__snapshots__/enumeration/alternatives.py
@@ -115,6 +115,22 @@ class AllEnums(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"code_1": ("OpenEnum", True), "code_7": ("ConstrainedEvidence", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 # Enumerations
 class OpenEnum(EnumDefinitionImpl):

--- a/tests/linkml/test_enhancements/__snapshots__/enumeration/evidence.py
+++ b/tests/linkml/test_enhancements/__snapshots__/enumeration/evidence.py
@@ -100,6 +100,22 @@ class Evidencer(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"code": ("Evidence", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 # Enumerations
 class Evidence(EnumDefinitionImpl):

--- a/tests/linkml/test_enhancements/__snapshots__/enumeration/notebook_model_1.py
+++ b/tests/linkml/test_enhancements/__snapshots__/enumeration/notebook_model_1.py
@@ -92,6 +92,22 @@ class PositionalRecord(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"position": ("OpenEnum", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 # Enumerations
 class OpenEnum(EnumDefinitionImpl):

--- a/tests/linkml/test_enhancements/__snapshots__/enumeration/notebook_model_2.py
+++ b/tests/linkml/test_enhancements/__snapshots__/enumeration/notebook_model_2.py
@@ -93,6 +93,22 @@ class Sample(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"position": ("UnusualEnumPatterns", True)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 # Enumerations
 class UnusualEnumPatterns(EnumDefinitionImpl):

--- a/tests/linkml/test_enhancements/__snapshots__/enumeration/notebook_model_3.py
+++ b/tests/linkml/test_enhancements/__snapshots__/enumeration/notebook_model_3.py
@@ -93,6 +93,22 @@ class FavoriteColor(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"position": ("Colors", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 # Enumerations
 class Colors(EnumDefinitionImpl):

--- a/tests/linkml/test_enhancements/__snapshots__/enumeration/notebook_model_4.py
+++ b/tests/linkml/test_enhancements/__snapshots__/enumeration/notebook_model_4.py
@@ -94,6 +94,22 @@ class FavoriteColor(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"position": ("Colors", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 # Enumerations
 class Colors(EnumDefinitionImpl):

--- a/tests/linkml/test_generators/test_pythongen.py
+++ b/tests/linkml/test_generators/test_pythongen.py
@@ -48,7 +48,7 @@ def test_pythongen(kitchen_sink_path):
         str(f)
         == """FamilialRelationship({
   'related_to': 'me',
-  'type': 'SIBLING_OF',
+  'type': FamilialRelationshipType(text='SIBLING_OF'),
   'cordialness': CordialnessEnum(text='heartfelt', description='warm and hearty friendliness')
 })"""
     )

--- a/tests/linkml/test_generators/test_pythongen_enum_registry.py
+++ b/tests/linkml/test_generators/test_pythongen_enum_registry.py
@@ -1,0 +1,106 @@
+"""Phase 3 tests for https://github.com/linkml/linkml/issues/723.
+
+Verifies the ``EnumDefinitionImpl._registry`` populated by ``pythongen``
+emitted ``_register`` calls and the ``SchemaView.enum_class_for`` /
+``enum_member_for`` lookup helpers.
+"""
+
+import pytest
+
+from linkml.generators.pythongen import PythonGenerator
+from linkml_runtime.linkml_model import PermissibleValue
+from linkml_runtime.utils.compile_python import compile_python
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from linkml_runtime.utils.schemaview import SchemaView
+
+SCHEMA_ID = "http://example.org/enum-registry"
+
+SCHEMA = f"""
+id: {SCHEMA_ID}
+name: enum-registry
+imports:
+  - https://w3id.org/linkml/types
+prefixes:
+  x: http://example.org/
+default_prefix: x
+default_range: string
+
+classes:
+  Person:
+    attributes:
+      status:
+        range: VitalStatus
+
+enums:
+  VitalStatus:
+    permissible_values:
+      ALIVE:
+      DEAD:
+  Role:
+    permissible_values:
+      ANALYST:
+      INVESTIGATOR:
+"""
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return compile_python(PythonGenerator(SCHEMA).serialize())
+
+
+@pytest.fixture(scope="module")
+def view():
+    return SchemaView(SCHEMA)
+
+
+def test_register_populates_registry(mod) -> None:
+    assert EnumDefinitionImpl._registry.get((SCHEMA_ID, "VitalStatus")) is mod.VitalStatus
+    assert EnumDefinitionImpl._registry.get((SCHEMA_ID, "Role")) is mod.Role
+
+
+def test_for_schema_element_returns_class(mod) -> None:
+    assert EnumDefinitionImpl.for_schema_element(SCHEMA_ID, "VitalStatus") is mod.VitalStatus
+
+
+def test_for_schema_element_unknown_returns_none() -> None:
+    assert EnumDefinitionImpl.for_schema_element("nope://nope", "Nope") is None
+
+
+def test_schemaview_enum_class_for(mod, view) -> None:
+    assert view.enum_class_for("VitalStatus") is mod.VitalStatus
+    assert view.enum_class_for("Role") is mod.Role
+
+
+def test_schemaview_enum_class_for_unknown_enum(view) -> None:
+    assert view.enum_class_for("DoesNotExist") is None
+
+
+def test_schemaview_enum_member_for(mod, view) -> None:
+    pv = PermissibleValue(text="ALIVE")
+    member = view.enum_member_for(pv, "VitalStatus")
+    assert isinstance(member, mod.VitalStatus)
+    assert member == mod.VitalStatus.ALIVE
+
+
+def test_re_register_overwrites(mod) -> None:
+    # Re-registering with the same key updates the entry; importing/reloading
+    # a generated module must not leave stale references.
+    mod.VitalStatus._register(SCHEMA_ID, "VitalStatus")
+    assert EnumDefinitionImpl._registry[(SCHEMA_ID, "VitalStatus")] is mod.VitalStatus
+
+
+def test_gen_enum_registry_uses_from_schema_when_set() -> None:
+    """When ``EnumDefinition.from_schema`` is set, the emitted ``_register``
+    cites that owning schema id rather than the generator's current schema id.
+    """
+    from linkml_runtime.linkml_model.meta import EnumDefinition
+
+    gen = PythonGenerator(SCHEMA)
+    foreign = "http://other.example.org/foreign"
+    enums = [
+        EnumDefinition(name="Foreign", from_schema=foreign),
+        EnumDefinition(name="Native"),
+    ]
+    registry = gen.gen_enum_registry(enums)
+    assert f'Foreign._register({foreign!r}, "Foreign")' in registry
+    assert f'Native._register({SCHEMA_ID!r}, "Native")' in registry

--- a/tests/linkml/test_generators/test_pythongen_enum_setattr.py
+++ b/tests/linkml/test_generators/test_pythongen_enum_setattr.py
@@ -1,0 +1,120 @@
+"""Phase 2 tests for https://github.com/linkml/linkml/issues/723.
+
+Verifies that ``pythongen``-generated classes coerce raw strings (and bare
+``PermissibleValue`` objects) to enum instances when assigned to an
+enum-ranged slot after construction (not only during ``__init__``).
+"""
+
+import pytest
+
+from linkml.generators.pythongen import PythonGenerator
+from linkml_runtime.linkml_model import PermissibleValue
+from linkml_runtime.utils.compile_python import compile_python
+
+SCHEMA = """
+id: http://example.org/enum-setattr
+name: enum-setattr
+imports:
+  - https://w3id.org/linkml/types
+prefixes:
+  x: http://example.org/
+default_prefix: x
+default_range: string
+
+classes:
+  Person:
+    attributes:
+      status:
+        range: VitalStatus
+      roles:
+        range: Role
+        multivalued: true
+
+enums:
+  VitalStatus:
+    permissible_values:
+      ALIVE:
+      DEAD:
+  Role:
+    permissible_values:
+      ANALYST:
+      INVESTIGATOR:
+"""
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return compile_python(PythonGenerator(SCHEMA).serialize())
+
+
+def test_setattr_string_coerces_to_enum(mod) -> None:
+    p = mod.Person()
+    p.status = "ALIVE"
+    assert isinstance(p.status, mod.VitalStatus)
+    assert p.status == mod.VitalStatus.ALIVE
+    assert p.status == "ALIVE"
+
+
+def test_setattr_permissible_value_coerces_to_enum(mod) -> None:
+    p = mod.Person()
+    p.status = PermissibleValue(text="ALIVE")
+    assert isinstance(p.status, mod.VitalStatus)
+    assert p.status == mod.VitalStatus.ALIVE
+
+
+def test_setattr_enum_instance_passes_through(mod) -> None:
+    p = mod.Person()
+    p.status = mod.VitalStatus.ALIVE
+    assert p.status is mod.VitalStatus.ALIVE
+
+
+def test_setattr_none_passes_through(mod) -> None:
+    p = mod.Person(status=mod.VitalStatus.ALIVE)
+    p.status = None
+    assert p.status is None
+
+
+def test_setattr_multivalued_list_of_strings(mod) -> None:
+    p = mod.Person()
+    p.roles = ["ANALYST", "INVESTIGATOR"]
+    assert all(isinstance(r, mod.Role) for r in p.roles)
+    assert sorted(p.roles, key=str) == sorted(
+        [mod.Role.ANALYST, mod.Role.INVESTIGATOR], key=str
+    )
+
+
+def test_setattr_multivalued_single_string_wrapped(mod) -> None:
+    p = mod.Person()
+    p.roles = "ANALYST"
+    assert isinstance(p.roles, list)
+    assert len(p.roles) == 1
+    assert p.roles[0] == mod.Role.ANALYST
+    assert isinstance(p.roles[0], mod.Role)
+
+
+def test_setattr_multivalued_mixed_types(mod) -> None:
+    p = mod.Person()
+    p.roles = ["ANALYST", mod.Role.INVESTIGATOR, PermissibleValue(text="ANALYST")]
+    assert all(isinstance(r, mod.Role) for r in p.roles)
+
+
+def test_setattr_invalid_string_raises(mod) -> None:
+    p = mod.Person()
+    with pytest.raises(ValueError):
+        p.status = "UNKNOWN"
+
+
+def test_non_enum_slot_unaffected(mod) -> None:
+    """Slots without an enum range must not be touched by the coercion path."""
+    p = mod.Person()
+    # ``Person`` has no string-typed slot, but assigning a private/internal
+    # attribute (not in _enum_slots) must round-trip unchanged.
+    p._scratch = "raw"
+    assert p._scratch == "raw"
+
+
+def test_enum_slots_classvar_present(mod) -> None:
+    assert mod.Person._enum_slots == {
+        "status": ("VitalStatus", False),
+        "roles": ("Role", True),
+    }

--- a/tests/linkml/test_issues/__snapshots__/issue_368.py
+++ b/tests/linkml/test_issues/__snapshots__/issue_368.py
@@ -89,6 +89,22 @@ class SampleClass(ParentClass):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"slot_1": ("SampleEnum", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 # Enumerations
 

--- a/tests/linkml/test_issues/__snapshots__/issue_enum_import/file2.py
+++ b/tests/linkml/test_issues/__snapshots__/issue_enum_import/file2.py
@@ -92,6 +92,22 @@ class IterableResolvedValueSet(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"complete": ("CompleteDirectory", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 @dataclass(repr=False)
 class Directory(YAMLRoot):
@@ -111,6 +127,22 @@ class Directory(YAMLRoot):
             self.complete = CompleteDirectory(self.complete)
 
         super().__post_init__(**kwargs)
+
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"complete": ("CompleteDirectory", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
 
 
 # Enumerations

--- a/tests/linkml/test_issues/test_linkml_issue_723.py
+++ b/tests/linkml/test_issues/test_linkml_issue_723.py
@@ -114,11 +114,12 @@ def test_initialized_enums(pythongen_module, schemaview):
         {'status': 'ALIVE', 'roles': ['ANALYST', 'INVESTIGATOR']}
 
     However, the user should be aware that the type of person.role
-    is NOT PermissibleValue, it is the enum, i.e
+    is NOT PermissibleValue, it is the enum. Equality across the two forms
+    is supported (see linkml/linkml#1203), but identity / type checks differ.
 
     .. code:: python
 
-        p.status != mod.VitalStatus.ALIVE
+        p.status == mod.VitalStatus.ALIVE  # True (1203)
         p.status == mod.VitalStatus(mod.VitalStatus.ALIVE)
 
     """
@@ -134,10 +135,13 @@ def test_initialized_enums(pythongen_module, schemaview):
     p_json = json_dumper.dumps(p)
     p_roundtrip = json_loader.loads(p_json, target_class=mod.Person)
     assert p_roundtrip == p
-    # Current behavior: when enums are created at time of initialization,
-    # they are created as Enum instances, NOT permissible value instances
+    # When enums are created at time of initialization, they are stored as
+    # ``EnumDefinitionImpl`` instances rather than ``PermissibleValue``
+    # instances.  Since linkml/linkml#1203 equality bridges the two forms
+    # (and bare strings), so all of these comparisons return True.
     assert p.status == mod.VitalStatus(mod.VitalStatus.ALIVE)
-    assert p.status != mod.VitalStatus.ALIVE
+    assert p.status == mod.VitalStatus.ALIVE
+    assert p.status == "ALIVE"
     assert sorted(p.roles, key=str) == sorted([mod.Role(mod.Role.INVESTIGATOR), mod.Role(mod.Role.ANALYST)], key=str)
     assert type(p.status) is mod.VitalStatus
     assert type(p.status) is not PermissibleValue
@@ -223,7 +227,8 @@ def test_assigned_wrapped_enums(pythongen_module, schemaview):
     p_roundtrip = json_loader.loads(p_json, target_class=mod.Person)
     assert p_roundtrip == p
     assert p.status == mod.VitalStatus(mod.VitalStatus.ALIVE)
-    assert p.status != mod.VitalStatus.ALIVE
+    assert p.status == mod.VitalStatus.ALIVE
+    assert p.status == "ALIVE"
     assert sorted(p.roles, key=str) == sorted([mod.Role(mod.Role.INVESTIGATOR), mod.Role(mod.Role.ANALYST)], key=str)
     assert type(p.status) is mod.VitalStatus
     assert type(p.status) is not PermissibleValue

--- a/tests/linkml/test_issues/test_linkml_issue_723.py
+++ b/tests/linkml/test_issues/test_linkml_issue_723.py
@@ -163,24 +163,26 @@ def test_assigned_enum(pythongen_module):
         p = Person()
         p.status = VitalStatus.ALIVE
 
-    In this case, the dict/json/yaml is inconveniently expanded
-
-    .. code:: python
-
-        {'status': {'text': 'ALIVE'}, 'roles': [{'text': 'ANALYST'}, {'text': 'INVESTIGATOR'}]}
+    Post Phase 1 (#723), ``VitalStatus.ALIVE`` is itself an
+    ``EnumDefinitionImpl`` instance (promoted at class-creation time by
+    ``EnumDefinitionMeta``), so post-init assignment stores the same enum
+    instance that initial-time construction would, and the
+    dict/json/yaml form is the compact one.
     """
     mod = pythongen_module
     p = mod.Person()
     p.status = mod.VitalStatus.ALIVE
     p.roles = [mod.Role.ANALYST, mod.Role.INVESTIGATOR]
     pd = json_dumper.to_dict(p)
-    assert sorted(pd["roles"], key=str) == sorted([{"text": "ANALYST"}, {"text": "INVESTIGATOR"}], key=str)
+    assert pd["status"] == "ALIVE"
+    assert sorted(pd["roles"]) == sorted(["ANALYST", "INVESTIGATOR"])
     json_dumper.dumps(p)
     assert p.status == mod.VitalStatus.ALIVE
+    assert p.status == "ALIVE"
     assert sorted(p.roles, key=str) == sorted([mod.Role.INVESTIGATOR, mod.Role.ANALYST], key=str)
-    assert type(p.status) is PermissibleValue
-    assert type(p.status) is not mod.VitalStatus
-    assert type(p.roles[0]) is PermissibleValue
+    assert type(p.status) is mod.VitalStatus
+    assert type(p.status) is not PermissibleValue
+    assert type(p.roles[0]) is mod.Role
 
 
 def test_assigned_wrapped_enums(pythongen_module, schemaview):

--- a/tests/linkml/test_scripts/__snapshots__/genpython/meta.py
+++ b/tests/linkml/test_scripts/__snapshots__/genpython/meta.py
@@ -367,6 +367,22 @@ class Person(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"is_living": ("LifeStatusEnum", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 @dataclass(repr=False)
 class Organization(YAMLRoot):
@@ -592,6 +608,22 @@ class Relationship(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"cordialness": ("CordialnessEnum", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
+
 
 @dataclass(repr=False)
 class FamilialRelationship(Relationship):
@@ -624,6 +656,22 @@ class FamilialRelationship(Relationship):
             self.cordialness = CordialnessEnum(self.cordialness)
 
         super().__post_init__(**kwargs)
+
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"cordialness": ("CordialnessEnum", False), "type": ("FamilialRelationshipType", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
 
 
 @dataclass(repr=False)
@@ -782,6 +830,22 @@ class CodeSystem(YAMLRoot):
             self.long_id = LongEnum(self.long_id)
 
         super().__post_init__(**kwargs)
+
+    _enum_slots: ClassVar[dict[str, tuple[str, bool]]] = {"long_id": ("LongEnum", False)}
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        spec = type(self)._enum_slots.get(name)
+        if spec is not None and value is not None:
+            enum_name, multivalued = spec
+            enum_cls = globals().get(enum_name)
+            if enum_cls is not None:
+                if multivalued:
+                    if not isinstance(value, list):
+                        value = [value] if value is not None else []
+                    value = [v if isinstance(v, enum_cls) else enum_cls(v) for v in value]
+                elif not isinstance(value, enum_cls):
+                    value = enum_cls(value)
+        object.__setattr__(self, name, value)
 
 
 @dataclass(repr=False)

--- a/tests/linkml_runtime/test_issues/test_issue_1203.py
+++ b/tests/linkml_runtime/test_issues/test_issue_1203.py
@@ -1,0 +1,190 @@
+"""Tests for https://github.com/linkml/linkml/issues/1203.
+
+Verifies that generated dataclass enumerations support intuitive equality,
+hashing, stringification, and membership checks against strings, other
+``EnumDefinitionImpl`` instances, and ``PermissibleValue`` objects.
+"""
+
+import pytest
+
+# Ensure the patches on ``PermissibleValue`` from
+# ``linkml_runtime/__init__.py`` are applied before the test module loads
+# the metamodel directly.
+import linkml_runtime  # noqa: F401
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl, EnumDefinitionMeta
+
+
+class EnumValues(EnumDefinitionImpl):
+    _defn = EnumDefinition(name="EnumValues")
+
+    A = PermissibleValue(text="A")
+    B = PermissibleValue(text="B")
+
+
+class EnumValuesWrapper(EnumValues):
+    """Empty wrapper subclass — emitted by ``pythongen`` for identifier slots.
+
+    Inherits permissible values from ``EnumValues`` via the MRO; the metaclass
+    membership / lookup must walk it.
+    """
+
+    pass
+
+
+# -------------------------------
+# MRO walk in EnumDefinitionMeta
+# -------------------------------
+
+
+def test_wrapper_subclass_membership() -> None:
+    assert "A" in EnumValuesWrapper
+    assert PermissibleValue(text="A") in EnumValuesWrapper
+    assert EnumValues.A in EnumValuesWrapper
+
+
+def test_wrapper_subclass_getitem() -> None:
+    assert EnumValuesWrapper["A"] is EnumValues.A
+
+
+def test_wrapper_subclass_instantiation() -> None:
+    """The empty wrapper subclass must be constructible from an inherited code."""
+    inst = EnumValuesWrapper("A")
+    assert str(inst) == "A"
+    assert inst == "A"
+    assert inst == EnumValues.A
+
+
+def test_base_class_setattr_with_no_defn() -> None:
+    """``EnumDefinitionMeta.__setattr__`` must tolerate ``_defn`` being ``None``.
+
+    The abstract base ``EnumDefinitionImpl`` has ``_defn = None``; assigning
+    attributes on it (e.g. during monkey-patching) must not raise.
+    """
+    # No exception expected.
+    EnumDefinitionImpl._test_marker_1203 = "ok"  # noqa: SLF001
+    assert EnumDefinitionImpl._test_marker_1203 == "ok"  # noqa: SLF001
+    del EnumDefinitionImpl._test_marker_1203
+
+
+# ---------------------------------------------------------------------------
+# 1. Equality comparison
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        (EnumValues.A, EnumValues("A")),
+        (EnumValues("A"), EnumValues.A),
+        (EnumValues.A, "A"),
+        ("A", EnumValues.A),
+        (EnumValues("A"), "A"),
+        ("A", EnumValues("A")),
+        (EnumValues("A"), EnumValues("A")),
+        (EnumValues.A, EnumValues.A),
+    ],
+)
+def test_enum_equality(left, right) -> None:
+    assert left == right
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        (EnumValues.A, "B"),
+        ("B", EnumValues.A),
+        (EnumValues("A"), "B"),
+        ("B", EnumValues("A")),
+        (EnumValues.A, EnumValues.B),
+        (EnumValues("A"), EnumValues("B")),
+    ],
+)
+def test_enum_inequality(left, right) -> None:
+    assert left != right
+
+
+# ---------------------------------------------------------------------------
+# 2. Hashing support
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "needle",
+    [
+        "A",
+        EnumValues.A,
+        EnumValues("A"),
+    ],
+)
+@pytest.mark.parametrize(
+    "haystack_factory",
+    [
+        lambda: {EnumValues.A, EnumValues.B},
+        lambda: {EnumValues("A"), EnumValues("B")},
+        lambda: {"A", "B"},
+    ],
+)
+def test_enum_membership_in_set(needle, haystack_factory) -> None:
+    assert needle in haystack_factory()
+
+
+def test_enum_hashable() -> None:
+    assert hash(EnumValues.A) == hash("A")
+    assert hash(EnumValues("A")) == hash("A")
+    assert hash(EnumValues.A) == hash(EnumValues("A"))
+
+
+# ---------------------------------------------------------------------------
+# 3. Stringification
+# ---------------------------------------------------------------------------
+
+
+def test_enum_stringification() -> None:
+    assert str(EnumValues.A) == "A"
+    assert str(EnumValues("A")) == "A"
+
+
+# ---------------------------------------------------------------------------
+# 4. ``in EnumClass`` checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "needle",
+    [
+        "A",
+        EnumValues.A,
+        EnumValues("A"),
+    ],
+)
+def test_membership_in_enum_class(needle) -> None:
+    assert needle in EnumValues
+
+
+def test_unknown_value_not_in_enum_class() -> None:
+    assert "Z" not in EnumValues
+    assert PermissibleValue(text="Z") not in EnumValues
+
+
+# ---------------------------------------------------------------------------
+# Misc sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_enum_class_uses_meta() -> None:
+    assert isinstance(EnumValues, EnumDefinitionMeta)
+
+
+def test_pattern_match_workaround_no_longer_needed() -> None:
+    """The original issue noted that ``match`` statements required ``.text``.
+
+    With ``__eq__`` against strings, a direct match on the enum value works.
+    """
+    value = EnumValues("A")
+    matched = None
+    if value == EnumValues.A:
+        matched = "A"
+    elif value == EnumValues.B:
+        matched = "B"
+    assert matched == "A"

--- a/tests/linkml_runtime/test_issues/test_issue_1203.py
+++ b/tests/linkml_runtime/test_issues/test_issue_1203.py
@@ -3,13 +3,14 @@
 Verifies that generated dataclass enumerations support intuitive equality,
 hashing, stringification, and membership checks against strings, other
 ``EnumDefinitionImpl`` instances, and ``PermissibleValue`` objects.
+
+Also verifies the Phase-1 structural fix (#723): bare ``PermissibleValue``
+class attributes emitted by ``pythongen`` are promoted to real
+``EnumDefinitionImpl`` instances at class-creation time.
 """
 
 import pytest
 
-# Ensure the patches on ``PermissibleValue`` from
-# ``linkml_runtime/__init__.py`` are applied before the test module loads
-# the metamodel directly.
 import linkml_runtime  # noqa: F401
 from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl, EnumDefinitionMeta
@@ -56,15 +57,58 @@ def test_wrapper_subclass_instantiation() -> None:
 
 
 def test_base_class_setattr_with_no_defn() -> None:
-    """``EnumDefinitionMeta.__setattr__`` must tolerate ``_defn`` being ``None``.
+    """Assigning attributes on the abstract base must not raise.
 
-    The abstract base ``EnumDefinitionImpl`` has ``_defn = None``; assigning
-    attributes on it (e.g. during monkey-patching) must not raise.
+    ``EnumDefinitionImpl`` has ``_defn = None``; the metaclass must not
+    explode when used (e.g. for monkey-patching).
     """
-    # No exception expected.
     EnumDefinitionImpl._test_marker_1203 = "ok"  # noqa: SLF001
     assert EnumDefinitionImpl._test_marker_1203 == "ok"  # noqa: SLF001
     del EnumDefinitionImpl._test_marker_1203
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 (#723): PermissibleValue → EnumDefinitionImpl promotion
+# ---------------------------------------------------------------------------
+
+
+def test_member_is_enum_instance_not_permissible_value() -> None:
+    """``MyEnum.A`` must be an ``EnumDefinitionImpl`` instance, not a raw PV."""
+    assert isinstance(EnumValues.A, EnumValues)
+    assert isinstance(EnumValues.A, EnumDefinitionImpl)
+    assert type(EnumValues.A) is EnumValues
+    assert not isinstance(EnumValues.A, PermissibleValue)
+
+
+def test_member_identity_stable() -> None:
+    """Repeated lookups return the same promoted instance (promotion runs once)."""
+    assert EnumValues.A is EnumValues.A
+    assert EnumValuesWrapper.A is EnumValues.A  # inherited via MRO
+
+
+def test_member_text_property() -> None:
+    """``EnumDefinitionImpl`` exposes ``.text`` as a delegate to the underlying PV."""
+    assert EnumValues.A.text == "A"
+    assert EnumValues("A").text == "A"
+
+
+def test_member_code_is_underlying_pv() -> None:
+    """``MyEnum.A._code`` is the original ``PermissibleValue``."""
+    assert isinstance(EnumValues.A._code, PermissibleValue)
+    assert EnumValues.A._code.text == "A"
+
+
+def test_permissible_value_remains_clean_dataclass() -> None:
+    """``PermissibleValue`` retains default dataclass equality and is unhashable.
+
+    Phase 1 removes the runtime monkey-patch; the metamodel descriptor
+    behaves like a plain dataclass again.
+    """
+    pv = PermissibleValue(text="A")
+    assert pv == PermissibleValue(text="A")  # field-wise equality
+    assert pv != PermissibleValue(text="B")
+    with pytest.raises(TypeError):
+        hash(pv)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/linkml_runtime/test_utils/test_enum_registry.py
+++ b/tests/linkml_runtime/test_utils/test_enum_registry.py
@@ -1,0 +1,55 @@
+"""Runtime-only tests for ``EnumDefinitionImpl._registry`` (Phase 3 of #723).
+
+These tests exercise the registry primitives without involving the
+``pythongen`` generator or the ``SchemaView`` lookup helpers.
+"""
+
+import pytest
+
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+
+
+class _Color(EnumDefinitionImpl):
+    RED = PermissibleValue(text="RED")
+    GREEN = PermissibleValue(text="GREEN")
+    _defn = EnumDefinition(name="_Color")
+
+
+SCHEMA_ID = "http://example.org/enum-registry-runtime"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Snapshot and restore the registry so tests don't leak entries."""
+    snapshot = dict(EnumDefinitionImpl._registry)
+    yield
+    EnumDefinitionImpl._registry.clear()
+    EnumDefinitionImpl._registry.update(snapshot)
+
+
+def test_register_and_lookup() -> None:
+    _Color._register(SCHEMA_ID, "_Color")
+    assert EnumDefinitionImpl.for_schema_element(SCHEMA_ID, "_Color") is _Color
+
+
+def test_for_schema_element_missing_returns_none() -> None:
+    assert EnumDefinitionImpl.for_schema_element(SCHEMA_ID, "Absent") is None
+
+
+def test_re_register_overwrites() -> None:
+    _Color._register(SCHEMA_ID, "_Color")
+
+    class _OtherColor(EnumDefinitionImpl):
+        BLUE = PermissibleValue(text="BLUE")
+        _defn = EnumDefinition(name="_Color")
+
+    _OtherColor._register(SCHEMA_ID, "_Color")
+    assert EnumDefinitionImpl.for_schema_element(SCHEMA_ID, "_Color") is _OtherColor
+
+
+def test_registry_keyed_by_schema_id() -> None:
+    _Color._register(SCHEMA_ID, "_Color")
+    _Color._register(SCHEMA_ID + "/v2", "_Color")
+    assert EnumDefinitionImpl.for_schema_element(SCHEMA_ID, "_Color") is _Color
+    assert EnumDefinitionImpl.for_schema_element(SCHEMA_ID + "/v2", "_Color") is _Color


### PR DESCRIPTION
Wait for #3596, #3597, #3598

## Summary

Architectural fixes #723  (part 3 of 4)

Before - Given a SchemaView and an enum name, tools (SSSOM-py, validators, etc.) had no portable way to recover the concrete generated Python class. They had to re-import by hand, with no guarantee the import path was stable across schemas or imports.

After -  A ClassVar registry on EnumDefinitionImpl keyed by (schema_id, enum_name) is populated at module import time by generated code. SchemaView.enum_class_for(...) and enum_member_for(pv, enum_name) return the right class / member directly. Addresses gouttegd's SchemaView --> class follow-up on #723 for pythongen-generated code.

## How was this tested?

Added unit tests
Full suite testing

## Areas of uncertainty

TBC

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

LLM assisted
