### PR TITLE
fix(processing): hoist SimpleDict compact-key list items, error on missing-pk items (#3578)

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/processing/referencevalidator.py
+++ b/packages/linkml_runtime/src/linkml_runtime/processing/referencevalidator.py
@@ -590,6 +590,57 @@ class ReferenceValidator:
             return [_obj_from_item(k, v) for k, v in list(input_object.items())]
         return input_object
 
+    def _try_hoist_compact_key_item(
+        self,
+        v: Any,
+        parent_slot: SlotDefinition,
+        pk_slot_name: SlotDefinitionName,
+    ) -> dict | None:
+        """Hoist a compact-key list item ``{key: {...}}`` to expanded form.
+
+        The shape ``[{key: {...}}]`` is semantically equivalent to
+        ``[{<pk>: key, ...}]`` (and to ``{key: {...}}``) when the conversion is
+        unambiguous. To avoid silently rescuing typos that would otherwise be
+        valid expanded items (per the project's no-footgun policy), only hoist
+        when the key is not a slot of the range class and the value is a dict.
+        Returns ``None`` if the item is not eligible for hoisting.
+        """
+        if pk_slot_name is None:
+            return None
+        if not isinstance(v, dict) or len(v) != 1:
+            return None
+        ((key, value),) = v.items()
+        if not isinstance(value, dict):
+            return None
+        range_element = self._slot_range_element(parent_slot)
+        if isinstance(range_element, ClassDefinition) and key in range_element.attributes:
+            return None
+        return {pk_slot_name: key, **value}
+
+    def _list_to_dict_items(
+        self,
+        input_object: list,
+        parent_slot: SlotDefinition,
+        pk_slot_name: SlotDefinitionName,
+        report: Report,
+    ) -> Iterator[tuple[Any, dict]]:
+        """Yield (pk_value, expanded_item) pairs from a list, hoisting compact-key
+        items where unambiguous and reporting items that still lack a pk."""
+        for v in input_object:
+            hoisted = self._try_hoist_compact_key_item(v, parent_slot, pk_slot_name)
+            if hoisted is not None:
+                v = hoisted
+            pk = v.get(pk_slot_name) if isinstance(v, dict) and pk_slot_name else None
+            if pk is None:
+                report.add_problem(
+                    ConstraintType.DictCollectionFormConstraint,
+                    parent_slot.name,
+                    v,
+                    pk_slot_name,
+                )
+                continue
+            yield pk, v
+
     def ensure_expanded_dict(
         self,
         input_object: Any,
@@ -604,7 +655,7 @@ class ReferenceValidator:
                 CollectionForm.List,
                 CollectionForm.ExpandedDict,
             )
-            return {v.get(pk_slot_name): v for v in input_object}
+            return {pk: v for pk, v in self._list_to_dict_items(input_object, parent_slot, pk_slot_name, report)}
         if isinstance(input_object, dict):
             simple_dict_value_slot = self._slot_as_simple_dict_value_slot(parent_slot)
             if simple_dict_value_slot and any(
@@ -638,7 +689,10 @@ class ReferenceValidator:
                 CollectionForm.List,
                 CollectionForm.CompactDict,
             )
-            return {v.get(pk_slot_name): _remove_pk(v, pk_slot_name) for v in input_object}
+            return {
+                pk: _remove_pk(v, pk_slot_name)
+                for pk, v in self._list_to_dict_items(input_object, parent_slot, pk_slot_name, report)
+            }
         elif isinstance(input_object, dict):
             if pk_slot_name and any(
                 v for k, v in input_object.items() if isinstance(v, dict) and v.get(pk_slot_name, None) is not None

--- a/packages/linkml_runtime/src/linkml_runtime/processing/referencevalidator.py
+++ b/packages/linkml_runtime/src/linkml_runtime/processing/referencevalidator.py
@@ -595,14 +595,25 @@ class ReferenceValidator:
         v: Any,
         parent_slot: SlotDefinition,
         pk_slot_name: SlotDefinitionName,
+        simple_value_slot_name: str | None = None,
     ) -> dict | None:
-        """Hoist a compact-key list item ``{key: {...}}`` to expanded form.
+        """Hoist a compact-key list item ``{key: value}`` to expanded form.
 
-        The shape ``[{key: {...}}]`` is semantically equivalent to
-        ``[{<pk>: key, ...}]`` (and to ``{key: {...}}``) when the conversion is
+        The shape ``[{key: ...}]`` is semantically equivalent to
+        ``[{<pk>: key, ...}]`` (and to ``{key: ...}``) when the conversion is
         unambiguous. To avoid silently rescuing typos that would otherwise be
         valid expanded items (per the project's no-footgun policy), only hoist
-        when the key is not a slot of the range class and the value is a dict.
+        when the key is not a slot of the range class.
+
+        Value handling:
+
+        * If ``value`` is a dict, it's the compact-expanded inner form; merge
+          it into the hoisted item.
+        * If ``value`` is not a dict and ``simple_value_slot_name`` is set
+          (caller is normalizing to SimpleDict), wrap the value under that slot
+          so the simplification step can reduce it.
+        * Otherwise the item isn't a compact-key shape this caller accepts.
+
         Returns ``None`` if the item is not eligible for hoisting.
         """
         if pk_slot_name is None:
@@ -610,12 +621,14 @@ class ReferenceValidator:
         if not isinstance(v, dict) or len(v) != 1:
             return None
         ((key, value),) = v.items()
-        if not isinstance(value, dict):
-            return None
         range_element = self._slot_range_element(parent_slot)
         if isinstance(range_element, ClassDefinition) and key in range_element.attributes:
             return None
-        return {pk_slot_name: key, **value}
+        if isinstance(value, dict):
+            return {pk_slot_name: key, **value}
+        if simple_value_slot_name is not None:
+            return {pk_slot_name: key, simple_value_slot_name: value}
+        return None
 
     def _list_to_dict_items(
         self,
@@ -623,17 +636,24 @@ class ReferenceValidator:
         parent_slot: SlotDefinition,
         pk_slot_name: SlotDefinitionName,
         report: Report,
+        simple_value_slot_name: str | None = None,
+        constraint_type: ConstraintType = ConstraintType.DictCollectionFormConstraint,
     ) -> Iterator[tuple[Any, dict]]:
         """Yield (pk_value, expanded_item) pairs from a list, hoisting compact-key
-        items where unambiguous and reporting items that still lack a pk."""
+        items where unambiguous and reporting items that still lack a pk.
+
+        Pass ``simple_value_slot_name`` and
+        ``ConstraintType.SimpleDictCollectionFormConstraint`` when the caller
+        is normalizing to SimpleDict form.
+        """
         for v in input_object:
-            hoisted = self._try_hoist_compact_key_item(v, parent_slot, pk_slot_name)
+            hoisted = self._try_hoist_compact_key_item(v, parent_slot, pk_slot_name, simple_value_slot_name)
             if hoisted is not None:
                 v = hoisted
             pk = v.get(pk_slot_name) if isinstance(v, dict) and pk_slot_name else None
             if pk is None:
                 report.add_problem(
-                    ConstraintType.DictCollectionFormConstraint,
+                    constraint_type,
                     parent_slot.name,
                     v,
                     pk_slot_name,
@@ -725,7 +745,16 @@ class ReferenceValidator:
             raise AssertionError(f"Should have simple dict slot value: {parent_slot.name}")
         normalized_object = input_object
         if isinstance(input_object, list):
-            normalized_object = {v[pk_slot_name]: v for v in input_object}
+            normalized_object = dict(
+                self._list_to_dict_items(
+                    input_object,
+                    parent_slot,
+                    pk_slot_name,
+                    report,
+                    simple_value_slot_name=simple_dict_value_slot.name,
+                    constraint_type=ConstraintType.SimpleDictCollectionFormConstraint,
+                )
+            )
             original_form = CollectionForm.List
         else:
             original_form = CollectionForm.ExpandedDict

--- a/tests/linkml_runtime/test_processing/test_referencevalidator.py
+++ b/tests/linkml_runtime/test_processing/test_referencevalidator.py
@@ -1158,3 +1158,139 @@ class ReferenceValidatorTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# --- Compact-key list hoist (issue #3529) -----------------------------------
+
+_COMPACT_KEY_SCHEMA_YAML = """
+id: https://example.org/test
+name: test_compact_key_list
+prefixes: {linkml: 'https://w3id.org/linkml/'}
+default_prefix: test
+imports: [linkml:types]
+
+classes:
+  Container:
+    tree_root: true
+    attributes:
+      items: {range: Item, multivalued: true, inlined: true}
+  Item:
+    attributes:
+      name: {identifier: true}
+      sources: {multivalued: true}
+      label: {}
+"""
+
+
+_COLLIDING_SLOT_SCHEMA_YAML = """
+id: https://example.org/test
+name: test_colliding_slot
+prefixes: {linkml: 'https://w3id.org/linkml/'}
+default_prefix: test
+imports: [linkml:types]
+
+classes:
+  Container:
+    tree_root: true
+    attributes:
+      items: {range: Item, multivalued: true, inlined: true}
+  Item:
+    attributes:
+      name: {identifier: true}
+      red: {range: integer}
+      sources: {multivalued: true}
+"""
+
+
+def _normalizer(schema_yaml: str, *, expand_all: bool = True) -> ReferenceValidator:
+    rv = ReferenceValidator(SchemaView(schema_yaml))
+    rv.expand_all = expand_all
+    return rv
+
+
+@pytest.mark.parametrize(
+    "input_items,expected_items",
+    [
+        # Issue #3529 reproducer: compact-key list hoists to expanded dict.
+        (
+            [{"red": {"sources": ["a"]}}],
+            {"red": {"name": "red", "sources": ["a"]}},
+        ),
+        # Multiple compact-key items.
+        (
+            [{"red": {"sources": ["a"]}}, {"blue": {"sources": ["b"]}}],
+            {
+                "red": {"name": "red", "sources": ["a"]},
+                "blue": {"name": "blue", "sources": ["b"]},
+            },
+        ),
+        # Mixed: expanded item alongside compact-key item.
+        (
+            [{"name": "green", "sources": ["g"]}, {"red": {"sources": ["a"]}}],
+            {
+                "green": {"name": "green", "sources": ["g"]},
+                "red": {"name": "red", "sources": ["a"]},
+            },
+        ),
+    ],
+)
+def test_compact_key_list_hoists_to_expanded_dict(input_items, expected_items):
+    """`[{key: {...}}]` is semantically `{key: {...}}` when unambiguous; hoist it."""
+    rv = _normalizer(_COMPACT_KEY_SCHEMA_YAML)
+    report = Report()
+    out = rv.normalize({"items": input_items}, report=report)
+    assert out["items"] == expected_items
+    assert report.errors() == []
+
+
+def test_compact_key_list_hoists_to_compact_dict_when_not_expanding():
+    """The same input also normalizes correctly when the canonical form is CompactDict."""
+    rv = _normalizer(_COMPACT_KEY_SCHEMA_YAML, expand_all=False)
+    report = Report()
+    out = rv.normalize({"items": [{"red": {"sources": ["a"]}}]}, report=report)
+    # CompactDict form: pk is the key, not duplicated inside the value.
+    assert out["items"] == {"red": {"sources": ["a"]}}
+    assert report.errors() == []
+
+
+@pytest.mark.parametrize(
+    "input_items,reason",
+    [
+        # Missing-pk expanded item (was producing `{None: ...}` before fix).
+        ([{"sources": ["a"]}], "expanded item without identifier"),
+        # Multi-key list item is not a compact-key shape; treated as expanded, missing pk.
+        ([{"red": {"x": 1}, "blue": {"y": 2}}], "multi-key list item with no pk"),
+        # Value is a scalar — not a compact-key shape; expanded read also missing pk.
+        ([{"some_label": "scalar"}], "scalar value, no pk"),
+        # Value is null — same.
+        ([{"some_label": None}], "null value, no pk"),
+    ],
+)
+def test_list_items_without_pk_emit_error_not_none_key(input_items, reason):
+    """Items the heuristic can't safely hoist must error, never produce `{None: ...}`."""
+    rv = _normalizer(_COMPACT_KEY_SCHEMA_YAML)
+    report = Report()
+    out = rv.normalize({"items": input_items}, report=report)
+    assert out["items"] == {}, f"unexpected output for case: {reason}"
+    assert None not in out["items"], f"None key leaked for case: {reason}"
+    assert len(report.errors()) == 1, f"expected one error for case: {reason}"
+
+
+def test_compact_key_refused_when_key_collides_with_slot_name():
+    """No-footgun: if the key matches a slot of the range class, refuse to hoist —
+    the user may have indented incorrectly and meant the key as an attribute."""
+    rv = _normalizer(_COLLIDING_SLOT_SCHEMA_YAML)
+    report = Report()
+    out = rv.normalize({"items": [{"red": {"sources": ["a"]}}]}, report=report)
+    # Heuristic refuses hoist; expanded read of {red: {...}} has no pk → error.
+    assert out["items"] == {}
+    assert len(report.errors()) == 1
+
+
+def test_non_colliding_key_still_hoists_under_colliding_schema():
+    """The collision check is per-key, not per-schema: keys that aren't slots still hoist."""
+    rv = _normalizer(_COLLIDING_SLOT_SCHEMA_YAML)
+    report = Report()
+    out = rv.normalize({"items": [{"purple": {"sources": ["a"]}}]}, report=report)
+    assert out["items"] == {"purple": {"name": "purple", "sources": ["a"]}}
+    assert report.errors() == []

--- a/tests/linkml_runtime/test_processing/test_referencevalidator.py
+++ b/tests/linkml_runtime/test_processing/test_referencevalidator.py
@@ -1294,3 +1294,89 @@ def test_non_colliding_key_still_hoists_under_colliding_schema():
     out = rv.normalize({"items": [{"purple": {"sources": ["a"]}}]}, report=report)
     assert out["items"] == {"purple": {"name": "purple", "sources": ["a"]}}
     assert report.errors() == []
+
+
+# --- SimpleDict list-input hoist (issue #3578) ------------------------------
+
+# Range class has exactly one non-pk slot → canonical form is SimpleDict.
+_SIMPLE_DICT_SCHEMA_YAML = """
+id: https://example.org/test
+name: test_simple_dict_list
+prefixes: {linkml: 'https://w3id.org/linkml/'}
+default_prefix: test
+imports: [linkml:types]
+
+classes:
+  Container:
+    tree_root: true
+    attributes:
+      items: {range: Item, multivalued: true, inlined: true}
+  Item:
+    attributes:
+      name: {identifier: true}
+      sources: {multivalued: true}
+"""
+
+
+@pytest.mark.parametrize(
+    "input_items,expected_items",
+    [
+        # Compact-simple: [{key: <simple_value>}] where value is the
+        # simple-dict value type directly.
+        ([{"red": ["a"]}], {"red": ["a"]}),
+        # Compact-expanded: [{key: {<inner_slot>: <value>}}] where the value
+        # is the expanded inner-class form.
+        ([{"red": {"sources": ["a"]}}], {"red": ["a"]}),
+        # Multiple compact items.
+        (
+            [{"red": ["a"]}, {"blue": ["b"]}],
+            {"red": ["a"], "blue": ["b"]},
+        ),
+        # Mixed list: expanded + compact-simple + compact-expanded.
+        (
+            [
+                {"name": "green", "sources": ["g"]},
+                {"red": ["r"]},
+                {"blue": {"sources": ["b"]}},
+            ],
+            {"green": ["g"], "red": ["r"], "blue": ["b"]},
+        ),
+    ],
+)
+def test_simple_dict_list_input_normalizes(input_items, expected_items):
+    """List input to a SimpleDict-form slot normalizes correctly via hoist + simplification."""
+    rv = ReferenceValidator(SchemaView(_SIMPLE_DICT_SCHEMA_YAML))
+    report = Report()
+    out = rv.normalize({"items": input_items}, report=report)
+    assert out["items"] == expected_items
+    assert report.errors() == []
+
+
+@pytest.mark.parametrize(
+    "input_items,reason",
+    [
+        # Was crashing with KeyError before the fix.
+        ([{"sources": ["a"]}], "expanded item without identifier"),
+        # Multi-key list item, neither key is a pk.
+        ([{"red": ["a"], "blue": ["b"]}], "multi-key list item with no pk"),
+    ],
+)
+def test_simple_dict_list_items_without_pk_emit_error_not_crash(input_items, reason):
+    """Items the heuristic can't safely hoist must error, never crash with KeyError."""
+    rv = ReferenceValidator(SchemaView(_SIMPLE_DICT_SCHEMA_YAML))
+    report = Report()
+    out = rv.normalize({"items": input_items}, report=report)
+    assert out["items"] == {}, f"unexpected output for case: {reason}"
+    assert None not in out["items"], f"None key leaked for case: {reason}"
+    assert len(report.errors()) == 1, f"expected one error for case: {reason}"
+
+
+def test_simple_dict_compact_key_refused_when_key_collides_with_slot_name():
+    """No-footgun: if the key matches a slot of the range class (e.g. the simple
+    value slot itself), refuse to hoist."""
+    rv = ReferenceValidator(SchemaView(_SIMPLE_DICT_SCHEMA_YAML))
+    report = Report()
+    # `sources` IS a slot — heuristic refuses to hoist; expanded read has no pk → error.
+    out = rv.normalize({"items": [{"sources": ["a"]}]}, report=report)
+    assert out["items"] == {}
+    assert len(report.errors()) == 1


### PR DESCRIPTION
Closes #3578.

**Stacks on top of #3533** — this branch contains the #3533 commit plus one new commit for the SimpleDict path. Review the second commit (\`c8f69bb28\`) for the changes specific to this PR, or wait until #3533 merges and GitHub will auto-rebase.

## Problem

\`ensure_simple_dict\` crashes with \`KeyError\` on list input when any item is missing the pk. Line 728 used \`v[pk_slot_name]\` with no guard. This is the SimpleDict counterpart to #3529 — same family of bug, different failure mode (hard crash vs silent \`{None: ...}\`), different code path.

## Fix

Same shape as #3529, extended for SimpleDict's broader value type:

1. **Extended hoist heuristic.** \`_try_hoist_compact_key_item\` gains an optional \`simple_value_slot_name\` parameter. When set (caller normalizing to SimpleDict), non-dict values are accepted and wrapped under the simple-value slot so the existing simplification step can reduce them. The slot-name collision check still applies — no footgun.
2. **Reused \`_list_to_dict_items\` iterator.** Now parameterized with \`simple_value_slot_name\` and \`constraint_type\`, so SimpleDict callers emit \`SimpleDictCollectionFormConstraint\` errors. Default behavior for the Expanded/Compact callers is unchanged.
3. **\`ensure_simple_dict\` list branch** now feeds items through the iterator, then the existing dict-value simplification loop handles the rest.

Result — all three previously-crashing shapes now normalize correctly:

| Input | Before | After |
|---|---|---|
| \`[{red: ['a']}]\` (compact-simple) | KeyError | \`{red: ['a']}\` |
| \`[{red: {sources: ['a']}}]\` (compact-expanded) | KeyError | \`{red: ['a']}\` |
| \`[{sources: ['a']}]\` (missing pk) | KeyError | empty + validation error |

## Test plan

- [x] 7 new pytest cases: hoist happy path (parametrized: compact-simple, compact-expanded, multiple, mixed), missing-pk error (parametrized: missing pk, multi-key), slot-name collision refusal.
- [x] All existing \`tests/linkml_runtime/test_processing/\` pass.
- [x] Full \`tests/linkml_runtime/\` suite passes (1748 passed, no regressions).
- [x] \`ruff format\` + \`ruff check\` clean.