### PR TITLE
ci: isolate notebook tests in their own job (#3583)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,8 +86,10 @@ jobs:
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2
       - name: Test linkml package
+        # Notebook tests run their own `!uv pip install` cells that mutate the
+        # shared venv; they run in the isolated `test_notebooks` job instead (#3583).
         run: |
-          uv run pytest tests/linkml/ --with-network -m "not kroki" -n auto --dist loadgroup --cov --cov-report xml:coverage-linkml.xml --cov-report term-missing
+          uv run pytest tests/linkml/ --ignore=tests/linkml/test_notebooks --with-network -m "not kroki" -n auto --dist loadgroup --cov --cov-report xml:coverage-linkml.xml --cov-report term-missing
         shell: bash
       - name: Test linkml-runtime package
         run: |
@@ -157,6 +159,53 @@ jobs:
           name: codecov-linkml-slow-${{ matrix.os }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage-linkml-slow.xml
+          flags: linkml
+          fail_ci_if_error: true
+
+  test_notebooks:
+    name: Notebook Tests
+    # Notebooks execute `!uv pip install ... --upgrade` cells that mutate the
+    # venv off the lock. Run them in a dedicated job with its own fresh runner
+    # so they cannot pollute the primary test environment (#3581, #3583).
+    # Linux only: notebook tests are skipped on Windows.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ "3.10", "3.13" ]
+    needs:
+      - quality-checks
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        id: setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --all-groups
+      - name: Run notebook tests
+        # Run serially (no xdist): concurrent `!uv pip install` would race on the venv.
+        run: |
+          uv run pytest tests/linkml/test_notebooks/ --with-network -m "not kroki" --cov --cov-report xml:coverage-notebooks.xml --cov-report term-missing
+      - name: Upload notebook coverage
+        if: github.repository == 'linkml/linkml' && github.actor != 'dependabot[bot]'
+        uses: codecov/codecov-action@v6.0.0
+        with:
+          name: codecov-notebooks-${{ matrix.os }}-${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage-notebooks.xml
           flags: linkml
           fail_ci_if_error: true
 


### PR DESCRIPTION
## Problem

`test_redo_notebook` executes the `notebooks/*.ipynb` in-process, in the **shared** test venv. Several notebooks contain `!uv pip install …` cells — notably `ShExPrimerModel.ipynb`'s `!uv pip install linkml --upgrade` — which mutate that venv off `uv.lock`. This was the root cause of #3581 (pulled idna 3.17 over the locked version mid-session, breaking `test_rewrite_rules`).

Closes #3583.

## Approach (Option B: isolation via a separate job)

- Deselect notebook tests from the main `test` job (`--ignore=tests/linkml/test_notebooks`).
- Add a dedicated `test_notebooks` job on its own fresh runner/venv, so notebook installs can only affect that disposable environment. Run **serially** (no `-n auto`) so concurrent `!uv pip install` can't race on the venv. Linux only (notebook tests already skip Windows).

This isolates the footgun in CI without editing notebook contents (no "magical" cell filtering).

## Coverage

The notebook job runs under coverage and uploads to the existing `linkml` flag, so codecov still combines notebook coverage with the rest.

## Known limitation

This isolates CI. A local `pytest tests/linkml/` (full suite) still runs notebooks in your active venv and could upgrade it. If we want local protection too, the follow-up is the dedicated-venv-kernel approach (discussed on #3583).