### PR TITLE
Fix jsonschema extraslots allowed

### DIFF
--- a/examples/tutorial/tutorial01/personinfo.json
+++ b/examples/tutorial/tutorial01/personinfo.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "Person": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "age": {

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -920,7 +920,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         if self.is_class_unconstrained(cls):
             return True
         elif not cls.extra_slots:
-            return False
+            return self.not_closed
         elif cls.extra_slots.allowed is not None:
             return cls.extra_slots.allowed
         elif cls.extra_slots.range_expression:

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -434,6 +434,12 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
     def start_schema(self, inline: bool = False):
         self.inline = inline
 
+        top_additional_properties = self.not_closed
+        if self.top_class:
+            top_class_def = self.schemaview.get_class(self.top_class)
+            if top_class_def is not None:
+                top_additional_properties = self.get_additional_properties(top_class_def)
+
         self.top_level_schema = JsonSchema(
             {
                 "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -442,7 +448,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                 "version": self.schema.version if self.schema.version else None,
                 "title": self.schema.title if self.title_from == "title" and self.schema.title else self.schema.name,
                 "type": "object",
-                "additionalProperties": self.not_closed,
+                "additionalProperties": top_additional_properties,
             }
         )
 

--- a/tests/linkml/test_biolink_model/__snapshots__/biolink.schema.json
+++ b/tests/linkml/test_biolink_model/__snapshots__/biolink.schema.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "AccessibleDnaRegion": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A region (or regions) of a chromatinized genome that has been measured to be more accessible to an enzyme such as DNase-I or Tn5 Transpose",
             "properties": {
                 "category": {
@@ -135,7 +135,7 @@
             "type": "object"
         },
         "Activity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.",
             "properties": {
                 "category": {
@@ -245,13 +245,13 @@
             "type": "object"
         },
         "ActivityAndBehavior": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Activity or behavior of any independent integral living, organization or mechanical actor in the world",
             "title": "ActivityAndBehavior",
             "type": "object"
         },
         "AdministrativeEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -361,7 +361,7 @@
             "type": "object"
         },
         "Agent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "person, group, organization or project that provides a piece of information (i.e. a knowledge association)",
             "properties": {
                 "address": {
@@ -503,7 +503,7 @@
             "type": "string"
         },
         "AnatomicalEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A subcellular location, cell type or gross anatomical part",
             "properties": {
                 "category": {
@@ -630,7 +630,7 @@
             "type": "object"
         },
         "AnatomicalEntityToAnatomicalEntityAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -1000,7 +1000,7 @@
             "type": "object"
         },
         "AnatomicalEntityToAnatomicalEntityOntogenicAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A relationship between two anatomical entities where the relationship is ontogenic, i.e. the two entities are related by development. A number of different relationship types can be used to specify the precise nature of the relationship.",
             "properties": {
                 "adjusted_p_value": {
@@ -1373,7 +1373,7 @@
             "type": "object"
         },
         "AnatomicalEntityToAnatomicalEntityPartOfAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A relationship between two anatomical entities where the relationship is mereological, i.e the two entities are related by parthood. This includes relationships between cellular components and cells, between cells and tissues, tissues and whole organisms",
             "properties": {
                 "adjusted_p_value": {
@@ -1752,7 +1752,7 @@
             "type": "object"
         },
         "Annotation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Biolink Model root class for entity annotations.",
             "title": "Annotation",
             "type": "object"
@@ -1780,7 +1780,7 @@
             "type": "string"
         },
         "Article": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a piece of writing on a particular topic presented as a stand-alone section of a larger publication",
             "properties": {
                 "authors": {
@@ -1997,7 +1997,7 @@
             "type": "object"
         },
         "Association": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A typed association between two entities, supported by evidence",
             "properties": {
                 "adjusted_p_value": {
@@ -2367,7 +2367,7 @@
             "type": "object"
         },
         "Attribute": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A property or characteristic of an entity. For example, an apple may have properties such as color, shape, age, crispiness. An environmental sample may have attributes such as depth, lat, long, material.",
             "properties": {
                 "category": {
@@ -2499,7 +2499,7 @@
             "type": "object"
         },
         "Bacterium": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A member of a group of unicellular microorganisms lacking a nuclear membrane, that reproduce by binary fission and are often motile.",
             "properties": {
                 "category": {
@@ -2626,7 +2626,7 @@
             "type": "object"
         },
         "Behavior": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -2783,7 +2783,7 @@
             "type": "object"
         },
         "BehaviorToBehavioralFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between an mixture behavior and a behavioral feature manifested by the individual exhibited or has exhibited the behavior.",
             "properties": {
                 "adjusted_p_value": {
@@ -3276,7 +3276,7 @@
             "type": "object"
         },
         "BehavioralExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A behavioral exposure is a factor relating to behavior impacting an individual.",
             "properties": {
                 "category": {
@@ -3416,7 +3416,7 @@
             "type": "object"
         },
         "BehavioralFeature": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A phenotypic feature which is behavioral in nature.",
             "properties": {
                 "category": {
@@ -3543,13 +3543,13 @@
             "type": "object"
         },
         "BehavioralOutcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An outcome resulting from an exposure event which is the manifestation of human behavior.",
             "title": "BehavioralOutcome",
             "type": "object"
         },
         "BiologicalEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -3676,7 +3676,7 @@
             "type": "object"
         },
         "BiologicalProcess": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "One or more causally connected executions of molecular functions",
             "properties": {
                 "category": {
@@ -3833,7 +3833,7 @@
             "type": "object"
         },
         "BiologicalProcessOrActivity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Either an individual molecular activity, or a collection of causally connected molecular activities in a biological system.",
             "properties": {
                 "category": {
@@ -3990,7 +3990,7 @@
             "type": "object"
         },
         "BiologicalSex": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -4122,7 +4122,7 @@
             "type": "object"
         },
         "BioticExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An external biotic exposure is an intake of (sometimes pathological) biological organisms (including viruses).",
             "properties": {
                 "category": {
@@ -4262,7 +4262,7 @@
             "type": "object"
         },
         "Book": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "This class may rarely be instantiated except if use cases of a given knowledge graph support its utility.",
             "properties": {
                 "authors": {
@@ -4454,7 +4454,7 @@
             "type": "object"
         },
         "BookChapter": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "authors": {
@@ -4664,7 +4664,7 @@
             "type": "object"
         },
         "Case": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An individual (human) organism that has a patient role in some clinical context.",
             "properties": {
                 "category": {
@@ -4791,7 +4791,7 @@
             "type": "object"
         },
         "CaseToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An abstract association for use where the case is the subject",
             "properties": {
                 "object": {
@@ -4816,7 +4816,7 @@
             "type": "object"
         },
         "CaseToPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a case (e.g. individual patient) and a phenotypic feature in which the individual has or has had the phenotype.",
             "properties": {
                 "adjusted_p_value": {
@@ -5309,7 +5309,7 @@
             "type": "object"
         },
         "CausalGeneToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -5837,7 +5837,7 @@
             "type": "string"
         },
         "Cell": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -5964,7 +5964,7 @@
             "type": "object"
         },
         "CellLine": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -6091,7 +6091,7 @@
             "type": "object"
         },
         "CellLineAsAModelOfDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -6526,7 +6526,7 @@
             "type": "object"
         },
         "CellLineToDiseaseOrPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An relationship between a cell line and a disease or a phenotype, where the cell line is derived from an individual with that disease or phenotype.",
             "properties": {
                 "adjusted_p_value": {
@@ -6900,7 +6900,7 @@
             "type": "object"
         },
         "CellLineToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An relationship between a cell line and another entity",
             "properties": {
                 "object": {
@@ -6925,7 +6925,7 @@
             "type": "object"
         },
         "CellularComponent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A location in or around a cell",
             "properties": {
                 "category": {
@@ -7052,7 +7052,7 @@
             "type": "object"
         },
         "CellularOrganism": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -7179,7 +7179,7 @@
             "type": "object"
         },
         "ChemicalAffectsGeneAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Describes an effect that a chemical has on a gene or gene product (e.g. an impact of on its abundance, activity,localization, processing, expression, etc.)",
             "properties": {
                 "adjusted_p_value": {
@@ -7674,7 +7674,7 @@
             "type": "object"
         },
         "ChemicalEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A chemical entity is a physical entity that pertains to chemistry or biochemistry.",
             "properties": {
                 "available_from": {
@@ -7825,7 +7825,7 @@
             "type": "object"
         },
         "ChemicalEntityAssessesNamedThingAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -8206,13 +8206,13 @@
             "type": "string"
         },
         "ChemicalEntityOrGeneOrGeneProduct": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A union of chemical entities and children, and gene or gene product. This mixin is helpful to use when searching across chemical entities that must include genes and their children as chemical entities.",
             "title": "ChemicalEntityOrGeneOrGeneProduct",
             "type": "object"
         },
         "ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A regulatory relationship between two genes",
             "properties": {
                 "adjusted_p_value": {
@@ -8589,13 +8589,13 @@
             "type": "object"
         },
         "ChemicalEntityOrProteinOrPolypeptide": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A union of chemical entities and children, and protein and polypeptide. This mixin is helpful to use when searching across chemical entities that must include genes and their children as chemical entities.",
             "title": "ChemicalEntityOrProteinOrPolypeptide",
             "type": "object"
         },
         "ChemicalEntityToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction between a chemical entity and another entity",
             "properties": {
                 "object": {
@@ -8620,7 +8620,7 @@
             "type": "object"
         },
         "ChemicalExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A chemical exposure is an intake of a particular chemical entity.",
             "properties": {
                 "category": {
@@ -8760,7 +8760,7 @@
             "type": "object"
         },
         "ChemicalGeneInteractionAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "describes a physical interaction between a chemical entity and a gene or gene product. Any biological or chemical effect resulting from such an interaction are out of scope, and covered by the ChemicalAffectsGeneAssociation type (e.g. impact of a chemical on the abundance, activity, structure, etc, of either participant in the interaction)",
             "properties": {
                 "adjusted_p_value": {
@@ -9196,7 +9196,7 @@
             "type": "object"
         },
         "ChemicalMixture": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A chemical mixture is a chemical entity composed of two or more molecular entities.",
             "properties": {
                 "available_from": {
@@ -9372,13 +9372,13 @@
             "type": "object"
         },
         "ChemicalOrDrugOrTreatment": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "ChemicalOrDrugOrTreatment",
             "type": "object"
         },
         "ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "This association defines a relationship between a chemical or treatment (or procedure) and a disease or phenotypic feature where the disesae or phenotypic feature is a secondary, typically (but not always) undesirable effect.",
             "properties": {
                 "FDA_adverse_event_level": {
@@ -9818,7 +9818,7 @@
             "type": "object"
         },
         "ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "This association defines a relationship between a chemical or treatment (or procedure) and a disease or phenotypic feature where the disease or phenotypic feature is a secondary undesirable effect.",
             "properties": {
                 "FDA_adverse_event_level": {
@@ -10272,7 +10272,7 @@
             "type": "string"
         },
         "ChemicalRole": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A role played by the molecular entity or part thereof within a chemical context.",
             "examples": [
                 "CHEBI:35469"
@@ -10407,7 +10407,7 @@
             "type": "object"
         },
         "ChemicalToChemicalAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A relationship between two chemical entities. This can encompass actual interactions as well as temporal causal edges, e.g. one chemical converted to another.",
             "properties": {
                 "adjusted_p_value": {
@@ -10777,7 +10777,7 @@
             "type": "object"
         },
         "ChemicalToChemicalDerivationAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A causal relationship between two chemical entities, where the subject represents the upstream entity and the object represents the downstream. For any such association there is an implicit reaction: IF R has-input C1 AND R has-output C2 AND R enabled-by P AND R type Reaction THEN C1 derives-into C2 catalyst qualifier P",
             "properties": {
                 "adjusted_p_value": {
@@ -11161,7 +11161,7 @@
             "type": "object"
         },
         "ChemicalToDiseaseOrPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction between a chemical entity and a phenotype or disease, where the presence of the chemical gives rise to or exacerbates the phenotype.",
             "properties": {
                 "adjusted_p_value": {
@@ -11535,7 +11535,7 @@
             "type": "object"
         },
         "ChemicalToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction between a chemical entity and another entity",
             "properties": {
                 "object": {
@@ -11560,7 +11560,7 @@
             "type": "object"
         },
         "ChemicalToPathwayAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction between a chemical entity and a biological process or pathway.",
             "properties": {
                 "adjusted_p_value": {
@@ -11930,7 +11930,7 @@
             "type": "object"
         },
         "ChiSquaredAnalysisResult": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A result of a chi squared analysis.",
             "properties": {
                 "category": {
@@ -12079,7 +12079,7 @@
             "type": "string"
         },
         "ClinicalAttribute": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Attributes relating to a clinical manifestation",
             "properties": {
                 "category": {
@@ -12211,7 +12211,7 @@
             "type": "object"
         },
         "ClinicalCourse": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "The course a disease typically takes from its onset, progression in time, and eventual resolution or death of the affected individual",
             "properties": {
                 "category": {
@@ -12343,7 +12343,7 @@
             "type": "object"
         },
         "ClinicalEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any entity or process that exists in the clinical domain and outside the biological realm. Diseases are placed under biological entities",
             "properties": {
                 "category": {
@@ -12453,7 +12453,7 @@
             "type": "object"
         },
         "ClinicalFinding": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "this category is currently considered broad enough to tag clinical lab measurements and other biological attributes taken as 'clinical traits' with some statistical score, for example, a p value in genetic associations.",
             "properties": {
                 "category": {
@@ -12580,7 +12580,7 @@
             "type": "object"
         },
         "ClinicalIntervention": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -12690,7 +12690,7 @@
             "type": "object"
         },
         "ClinicalMeasurement": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A clinical measurement is a special kind of attribute which results from a laboratory observation from a subject individual or sample. Measurements can be connected to their subject by the 'has attribute' slot.",
             "properties": {
                 "category": {
@@ -12822,7 +12822,7 @@
             "type": "object"
         },
         "ClinicalModifier": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Used to characterize and specify the phenotypic abnormalities defined in the phenotypic abnormality sub-ontology, with respect to severity, laterality, and other aspects",
             "properties": {
                 "category": {
@@ -12954,7 +12954,7 @@
             "type": "object"
         },
         "ClinicalTrial": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -13064,7 +13064,7 @@
             "type": "object"
         },
         "CodingSequence": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -13198,7 +13198,7 @@
             "type": "object"
         },
         "Cohort": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A group of people banded together or treated as a group who share common characteristics. A cohort 'study' is a particular form of longitudinal study that samples a cohort, performing a cross-section at intervals through time.",
             "properties": {
                 "category": {
@@ -13325,7 +13325,7 @@
             "type": "object"
         },
         "CommonDataElement": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A Common Data Element (CDE) is a standardized, precisely defined question, paired with a set of allowable responses, used systematically across different sites, studies, or clinical trials to ensure consistent data collection. Multiple CDEs (from one or more Collections) can be curated into Forms. (https://cde.nlm.nih.gov/home)",
             "properties": {
                 "category": {
@@ -13461,7 +13461,7 @@
             "type": "object"
         },
         "ComplexChemicalExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A complex chemical exposure is an intake of a chemical mixture (e.g. gasoline), other than a drug.",
             "properties": {
                 "category": {
@@ -13593,7 +13593,7 @@
             "type": "object"
         },
         "ComplexMolecularMixture": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A complex molecular mixture is a chemical mixture composed of two or more molecular entities with unknown concentration and stoichiometry.",
             "properties": {
                 "available_from": {
@@ -13769,7 +13769,7 @@
             "type": "object"
         },
         "ConceptCountAnalysisResult": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A result of a concept count analysis.",
             "properties": {
                 "category": {
@@ -13905,7 +13905,7 @@
             "type": "object"
         },
         "ConfidenceLevel": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Level of confidence in a statement",
             "properties": {
                 "category": {
@@ -14041,7 +14041,7 @@
             "type": "object"
         },
         "ContributorAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any association between an entity (such as a publication) and various agents that contribute to its realisation",
             "properties": {
                 "adjusted_p_value": {
@@ -14418,7 +14418,7 @@
             "type": "object"
         },
         "CorrelatedGeneToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -14921,7 +14921,7 @@
             "type": "object"
         },
         "Dataset": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "an item that refers to a collection of data from a data source.",
             "properties": {
                 "category": {
@@ -15057,7 +15057,7 @@
             "type": "object"
         },
         "DatasetDistribution": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "an item that holds distribution level information about a dataset.",
             "properties": {
                 "category": {
@@ -15199,7 +15199,7 @@
             "type": "object"
         },
         "DatasetSummary": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "an item that holds summary level information about a dataset.",
             "properties": {
                 "category": {
@@ -15347,7 +15347,7 @@
             "type": "object"
         },
         "DatasetVersion": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "an item that holds version level information about a dataset.",
             "properties": {
                 "category": {
@@ -15501,7 +15501,7 @@
             "type": "object"
         },
         "Device": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A thing made or adapted for a particular purpose, especially a piece of mechanical or electronic equipment",
             "properties": {
                 "category": {
@@ -15611,7 +15611,7 @@
             "type": "object"
         },
         "DiagnosticAid": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A device or substance used to help diagnose disease or injury",
             "properties": {
                 "category": {
@@ -15732,7 +15732,7 @@
             "type": "string"
         },
         "Disease": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A disorder of structure or function, especially one that produces specific signs, phenotypes or symptoms or that affects a specific location and is not simply a direct result of physical injury.  A disposition to undergo pathological processes that exists in an organism because of one or more disorders in that organism.",
             "properties": {
                 "category": {
@@ -15859,7 +15859,7 @@
             "type": "object"
         },
         "DiseaseOrPhenotypicFeature": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Either one of a disease or an individual phenotypic feature. Some knowledge resources such as Monarch treat these as distinct, others such as MESH conflate.  Please see definitions of phenotypic feature and disease in this model for their independent descriptions.  This class is helpful to enforce domains and ranges that may involve either a disease or a phenotypic feature.",
             "properties": {
                 "category": {
@@ -15986,7 +15986,7 @@
             "type": "object"
         },
         "DiseaseOrPhenotypicFeatureExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A disease or phenotypic feature state, when viewed as an exposure, represents an precondition, leading to or influencing an outcome, e.g. HIV predisposing an individual to infections; a relative deficiency of skin pigmentation predisposing an individual to skin cancer.",
             "properties": {
                 "category": {
@@ -16126,13 +16126,13 @@
             "type": "object"
         },
         "DiseaseOrPhenotypicFeatureOutcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Physiological outcomes resulting from an exposure event which is the manifestation of a disease or other characteristic phenotype.",
             "title": "DiseaseOrPhenotypicFeatureOutcome",
             "type": "object"
         },
         "DiseaseOrPhenotypicFeatureToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "object": {
@@ -16161,7 +16161,7 @@
             "type": "object"
         },
         "DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between either a disease or a phenotypic feature and its mode of (genetic) inheritance.",
             "properties": {
                 "adjusted_p_value": {
@@ -16541,7 +16541,7 @@
             "type": "object"
         },
         "DiseaseOrPhenotypicFeatureToLocationAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between either a disease or a phenotypic feature and an anatomical entity, where the disease/feature manifests in that site.",
             "properties": {
                 "adjusted_p_value": {
@@ -16918,7 +16918,7 @@
             "type": "object"
         },
         "DiseaseToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "object": {
@@ -16946,7 +16946,7 @@
             "type": "object"
         },
         "DiseaseToExposureEventAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between an exposure event and a disease.",
             "properties": {
                 "adjusted_p_value": {
@@ -17319,7 +17319,7 @@
             "type": "object"
         },
         "DiseaseToPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a disease and a phenotypic feature in which the phenotypic feature is associated with the disease in some way.",
             "properties": {
                 "adjusted_p_value": {
@@ -17822,7 +17822,7 @@
             "type": "object"
         },
         "Drug": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A substance intended for use in the diagnosis, cure, mitigation, treatment, or prevention of disease",
             "properties": {
                 "available_from": {
@@ -18018,7 +18018,7 @@
             "type": "string"
         },
         "DrugExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A drug exposure is an intake of a particular drug.",
             "properties": {
                 "category": {
@@ -18158,7 +18158,7 @@
             "type": "object"
         },
         "DrugLabel": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a document accompanying a drug or its container that provides written, printed or graphic information about the drug, including drug contents, specific instructions or warnings for administration, storage and disposal instructions, etc.",
             "properties": {
                 "authors": {
@@ -18349,7 +18349,7 @@
             "type": "object"
         },
         "DrugToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction between a drug and another entity",
             "properties": {
                 "object": {
@@ -18374,7 +18374,7 @@
             "type": "object"
         },
         "DrugToGeneAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction between a drug and a gene or gene product.",
             "properties": {
                 "adjusted_p_value": {
@@ -18744,7 +18744,7 @@
             "type": "object"
         },
         "DrugToGeneInteractionExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "drug to gene interaction exposure is a drug exposure is where the interactions of the drug with specific genes are known to constitute an 'exposure' to the organism, leading to or influencing an outcome.",
             "properties": {
                 "category": {
@@ -18905,7 +18905,7 @@
             "type": "string"
         },
         "DruggableGeneToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -19399,7 +19399,7 @@
             "type": "object"
         },
         "Entity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Root Biolink Model class for all things and informational relationships, real or imagined.",
             "properties": {
                 "category": {
@@ -19474,7 +19474,7 @@
             "type": "object"
         },
         "EntityToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -19851,7 +19851,7 @@
             "type": "object"
         },
         "EntityToDiseaseAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "mixin class for any association whose object (target node) is a disease",
             "properties": {
                 "disease_context_qualifier": {
@@ -19938,7 +19938,7 @@
             "type": "object"
         },
         "EntityToDiseaseOrPhenotypicFeatureAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "object": {
@@ -19967,7 +19967,7 @@
             "type": "object"
         },
         "EntityToExposureEventAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between some entity and an exposure event.",
             "properties": {
                 "object": {
@@ -19992,7 +19992,7 @@
             "type": "object"
         },
         "EntityToFeatureOrDiseaseQualifiersMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Qualifiers for entity to disease or phenotype associations.",
             "properties": {
                 "disease_context_qualifier": {
@@ -20076,7 +20076,7 @@
             "type": "object"
         },
         "EntityToOutcomeAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between some entity and an outcome",
             "properties": {
                 "object": {
@@ -20101,7 +20101,7 @@
             "type": "object"
         },
         "EntityToPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -20478,7 +20478,7 @@
             "type": "object"
         },
         "EntityToPhenotypicFeatureAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "anatomical_context_qualifier": {
@@ -20626,7 +20626,7 @@
             "type": "object"
         },
         "EnvironmentalExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A environmental exposure is a factor relating to abiotic processes in the environment including sunlight (UV-B), atmospheric (heat, cold, general pollution) and water-born contaminants.",
             "properties": {
                 "category": {
@@ -20766,7 +20766,7 @@
             "type": "object"
         },
         "EnvironmentalFeature": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -20876,7 +20876,7 @@
             "type": "object"
         },
         "EnvironmentalFoodContaminant": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "available_from": {
@@ -21027,7 +21027,7 @@
             "type": "object"
         },
         "EnvironmentalProcess": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -21137,13 +21137,13 @@
             "type": "object"
         },
         "EpidemiologicalOutcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An epidemiological outcome, such as societal disease burden, resulting from an exposure event.",
             "title": "EpidemiologicalOutcome",
             "type": "object"
         },
         "EpigenomicEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "has_biological_sequence": {
@@ -21158,7 +21158,7 @@
             "type": "object"
         },
         "Event": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Something that happens at a given place and time.",
             "properties": {
                 "category": {
@@ -21268,7 +21268,7 @@
             "type": "object"
         },
         "EvidenceType": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Class of evidence that supports an association",
             "properties": {
                 "category": {
@@ -21404,7 +21404,7 @@
             "type": "object"
         },
         "Exon": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A region of the transcript sequence within a gene which is not removed from the primary RNA transcript by RNA splicing.",
             "properties": {
                 "category": {
@@ -21531,7 +21531,7 @@
             "type": "object"
         },
         "ExonToTranscriptRelationship": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A transcript is formed from multiple exons",
             "properties": {
                 "adjusted_p_value": {
@@ -21901,7 +21901,7 @@
             "type": "object"
         },
         "ExposureEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A (possibly time bounded) incidence of a feature of the environment of an organism that influences one or more phenotypic features of that organism, potentially mediated by genes",
             "properties": {
                 "id": {
@@ -21924,7 +21924,7 @@
             "type": "object"
         },
         "ExposureEventToOutcomeAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between an exposure event and an outcome.",
             "properties": {
                 "adjusted_p_value": {
@@ -22309,7 +22309,7 @@
             "type": "object"
         },
         "ExposureEventToPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any association between an environment and a phenotypic feature, where being in the environment influences the phenotype.",
             "properties": {
                 "adjusted_p_value": {
@@ -22813,7 +22813,7 @@
             "type": "string"
         },
         "FeatureOrDiseaseQualifiersToEntityMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Qualifiers for disease or phenotype to entity associations.",
             "properties": {
                 "frequency_qualifier": {
@@ -22886,7 +22886,7 @@
             "type": "object"
         },
         "Food": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A substance consumed by a living organism as a source of nutrition",
             "properties": {
                 "available_from": {
@@ -23062,7 +23062,7 @@
             "type": "object"
         },
         "FoodAdditive": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "available_from": {
@@ -23213,7 +23213,7 @@
             "type": "object"
         },
         "FrequencyQualifierMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Qualifier for frequency type associations",
             "properties": {
                 "frequency_qualifier": {
@@ -23245,7 +23245,7 @@
             "type": "object"
         },
         "FrequencyQuantifier": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "has_count": {
@@ -23280,7 +23280,7 @@
             "type": "object"
         },
         "FunctionalAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a macromolecular machine mixin (gene, gene product or complex of gene products) and either a molecular activity, a biological process or a cellular location in which a function is executed.",
             "properties": {
                 "adjusted_p_value": {
@@ -23657,7 +23657,7 @@
             "type": "object"
         },
         "Fungus": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A kingdom of eukaryotic, heterotrophic organisms that live as saprobes or parasites, including mushrooms, yeasts, smuts, molds, etc. They reproduce either sexually or asexually, and have life cycles that range from simple to complex. Filamentous fungi refer to those that grow as multicellular colonies (mushrooms and molds).",
             "properties": {
                 "category": {
@@ -23784,7 +23784,7 @@
             "type": "object"
         },
         "Gene": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene locus may include regulatory regions, transcribed regions and/or other functional sequence regions.",
             "properties": {
                 "category": {
@@ -23925,7 +23925,7 @@
             "type": "object"
         },
         "GeneAffectsChemicalAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Describes an effect that a gene or gene product has on a chemical entity (e.g. an impact of on its abundance, activity, localization, processing, transport, etc.)",
             "examples": [
                 "JsonObj(subject='TRPC4', predicate='affects', qualified_predicte='causes', object='Barium', object_aspect_qualifier='transport', object_direction_qualifier='increased')"
@@ -24433,7 +24433,7 @@
             "type": "object"
         },
         "GeneAsAModelOfDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -24927,7 +24927,7 @@
             "type": "object"
         },
         "GeneExpressionMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Observed gene expression intensity, context (site, stage) and associated phenotypic status within which the expression occurs.",
             "properties": {
                 "expression_site": {
@@ -24969,7 +24969,7 @@
             "type": "object"
         },
         "GeneFamily": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "any grouping of multiple genes or gene products related by common descent",
             "properties": {
                 "category": {
@@ -25106,7 +25106,7 @@
             "type": "object"
         },
         "GeneGroupingMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "any grouping of multiple genes or gene products",
             "properties": {
                 "has_gene_or_gene_product": {
@@ -25124,7 +25124,7 @@
             "type": "object"
         },
         "GeneHasVariantThatContributesToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -25633,7 +25633,7 @@
             "type": "object"
         },
         "GeneOrGeneProduct": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A union of gene loci or gene products. Frequently an identifier for one will be used as proxy for another",
             "properties": {
                 "name": {
@@ -25723,7 +25723,7 @@
             "type": "string"
         },
         "GeneProductIsoformMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "This is an abstract class that can be mixed in with different kinds of gene products to indicate that the gene product is intended to represent a specific isoform rather than a canonical or reference or generic product. The designation of canonical or reference may be arbitrary, or it may represent the superclass of all isoforms.",
             "properties": {
                 "name": {
@@ -25758,7 +25758,7 @@
             "type": "object"
         },
         "GeneProductMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "The functional molecular product of a single gene locus. Gene products are either proteins or functional RNA molecules.",
             "properties": {
                 "name": {
@@ -25793,7 +25793,7 @@
             "type": "object"
         },
         "GeneRegulatesGeneAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Describes a regulatory relationship between two genes or gene products.",
             "examples": [
                 "JsonObj(subject='NCBIGene:551', predicate='regulates', qualified_predicte='causes', object='NCBIGene:1636', object_aspect_qualifier='activity_or_abundance', object_direction_qualifier='downregulated')"
@@ -26201,7 +26201,7 @@
             "type": "object"
         },
         "GeneToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -26704,7 +26704,7 @@
             "type": "object"
         },
         "GeneToDiseaseOrPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -27209,7 +27209,7 @@
             "type": "object"
         },
         "GeneToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "object": {
@@ -27234,7 +27234,7 @@
             "type": "object"
         },
         "GeneToExpressionSiteAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a gene and a gene expression site, possibly qualified by stage/timing info.",
             "properties": {
                 "adjusted_p_value": {
@@ -27627,7 +27627,7 @@
             "type": "object"
         },
         "GeneToGeneAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "abstract parent class for different kinds of gene-gene or gene product to gene product relationships. Includes homology and interaction.",
             "properties": {
                 "adjusted_p_value": {
@@ -27997,7 +27997,7 @@
             "type": "object"
         },
         "GeneToGeneCoexpressionAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Indicates that two genes are co-expressed, generally under the same conditions.",
             "properties": {
                 "adjusted_p_value": {
@@ -28404,7 +28404,7 @@
             "type": "object"
         },
         "GeneToGeneFamilyAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Set membership of a gene in a family of genes related by common evolutionary ancestry usually inferred by sequence comparisons. The genes in a given family generally share common sequence motifs which generally map onto shared gene product structure-function relationships.",
             "properties": {
                 "adjusted_p_value": {
@@ -28777,7 +28777,7 @@
             "type": "object"
         },
         "GeneToGeneHomologyAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A homology association between two genes. May be orthology (in which case the species of subject and object should differ) or paralogy (in which case the species may be the same)",
             "properties": {
                 "adjusted_p_value": {
@@ -29153,7 +29153,7 @@
             "type": "object"
         },
         "GeneToGeneProductRelationship": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A gene is transcribed and potentially translated to a gene product",
             "properties": {
                 "adjusted_p_value": {
@@ -29526,7 +29526,7 @@
             "type": "object"
         },
         "GeneToGoTermAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -29902,7 +29902,7 @@
             "type": "object"
         },
         "GeneToPathwayAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction between a gene or gene product and a biological process or pathway.",
             "properties": {
                 "adjusted_p_value": {
@@ -30272,7 +30272,7 @@
             "type": "object"
         },
         "GeneToPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -30777,7 +30777,7 @@
             "type": "object"
         },
         "GeneticInheritance": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "The pattern or 'mode' in which a particular genetic trait or disorder is passed from one generation to the next, e.g. autosomal dominant, autosomal recessive, etc.",
             "properties": {
                 "category": {
@@ -30904,7 +30904,7 @@
             "type": "object"
         },
         "Genome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A genome is the sum of genetic material within a cell or virion.",
             "properties": {
                 "category": {
@@ -31038,7 +31038,7 @@
             "type": "object"
         },
         "GenomicBackgroundExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A genomic background exposure is where an individual's specific genomic background of genes, sequence variants or other pre-existing genomic conditions constitute a kind of 'exposure' to the organism, leading to or influencing an outcome.",
             "properties": {
                 "category": {
@@ -31212,7 +31212,7 @@
             "type": "object"
         },
         "GenomicEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "has_biological_sequence": {
@@ -31227,7 +31227,7 @@
             "type": "object"
         },
         "GenomicSequenceLocalization": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A relationship between a sequence feature and a nucleic acid entity it is localized to. The reference entity may be a chromosome, chromosome region or information entity such as a contig.",
             "properties": {
                 "adjusted_p_value": {
@@ -31626,7 +31626,7 @@
             "type": "object"
         },
         "Genotype": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An information content entity that describes a genome by specifying the total variation in genomic sequence and/or gene expression, relative to some established background",
             "properties": {
                 "category": {
@@ -31766,7 +31766,7 @@
             "type": "object"
         },
         "GenotypeAsAModelOfDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -32201,7 +32201,7 @@
             "type": "object"
         },
         "GenotypeToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -32636,7 +32636,7 @@
             "type": "object"
         },
         "GenotypeToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "object": {
@@ -32661,7 +32661,7 @@
             "type": "object"
         },
         "GenotypeToGeneAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any association between a genotype and a gene. The genotype have have multiple variants in that gene or a single one. There is no assumption of cardinality",
             "properties": {
                 "adjusted_p_value": {
@@ -33031,7 +33031,7 @@
             "type": "object"
         },
         "GenotypeToGenotypePartAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any association between one genotype and a genotypic entity that is a sub-component of it",
             "properties": {
                 "adjusted_p_value": {
@@ -33404,7 +33404,7 @@
             "type": "object"
         },
         "GenotypeToPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any association between one genotype and a phenotypic feature, where having the genotype confers the phenotype, either in isolation or through environment",
             "properties": {
                 "adjusted_p_value": {
@@ -33900,7 +33900,7 @@
             "type": "object"
         },
         "GenotypeToVariantAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any association between a genotype and a sequence variant.",
             "properties": {
                 "adjusted_p_value": {
@@ -34270,7 +34270,7 @@
             "type": "object"
         },
         "GenotypicSex": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An attribute corresponding to the genotypic sex of the individual, based upon genotypic composition of sex chromosomes.",
             "properties": {
                 "category": {
@@ -34402,7 +34402,7 @@
             "type": "object"
         },
         "GeographicExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A geographic exposure is a factor relating to geographic proximity to some impactful entity.",
             "properties": {
                 "category": {
@@ -34542,7 +34542,7 @@
             "type": "object"
         },
         "GeographicLocation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a location that can be described in lat/long coordinates",
             "properties": {
                 "category": {
@@ -34666,7 +34666,7 @@
             "type": "object"
         },
         "GeographicLocationAtTime": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a location that can be described in lat/long coordinates, for a particular time",
             "properties": {
                 "category": {
@@ -34798,7 +34798,7 @@
             "type": "object"
         },
         "GrossAnatomicalStructure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -34925,7 +34925,7 @@
             "type": "object"
         },
         "Haplotype": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A set of zero or more Alleles on a single instance of a Sequence[VMC]",
             "properties": {
                 "category": {
@@ -35059,7 +35059,7 @@
             "type": "object"
         },
         "Hospitalization": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -35169,13 +35169,13 @@
             "type": "object"
         },
         "HospitalizationOutcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An outcome resulting from an exposure event which is the increased manifestation of acute (e.g. emergency room visit) or chronic (inpatient) hospitalization.",
             "title": "HospitalizationOutcome",
             "type": "object"
         },
         "Human": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A member of the the species Homo sapiens.",
             "properties": {
                 "category": {
@@ -35302,7 +35302,7 @@
             "type": "object"
         },
         "IndividualOrganism": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An instance of an organism. For example, Richard Nixon, Charles Darwin, my pet cat. Example ID: ORCID:0000-0002-5355-2576",
             "properties": {
                 "category": {
@@ -35429,7 +35429,7 @@
             "type": "object"
         },
         "InformationContentEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a piece of information that typically describes some topic of discourse or is used as support.",
             "properties": {
                 "category": {
@@ -35565,7 +35565,7 @@
             "type": "object"
         },
         "InformationContentEntityToNamedThingAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "association between a named thing and a information content entity where the specific context of the relationship between that named thing and the publication is unknown. For example, model organisms databases often capture the knowledge that a gene is found in a journal article, but not specifically the context in which that gene was documented in the article. In these cases, this association with the accompanying predicate 'mentions' could be used. Conversely, for more specific associations (like 'gene to disease association', the publication should be captured as an edge property).",
             "properties": {
                 "adjusted_p_value": {
@@ -35938,7 +35938,7 @@
             "type": "object"
         },
         "Invertebrate": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An animal lacking a vertebral column. This group consists of 98% of all animal species.",
             "properties": {
                 "category": {
@@ -36065,7 +36065,7 @@
             "type": "object"
         },
         "JournalArticle": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "an article, typically presenting results of research, that is published in an issue of a scientific journal.",
             "properties": {
                 "authors": {
@@ -36295,7 +36295,7 @@
             "type": "string"
         },
         "LifeStage": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A stage of development or growth of an organism, including post-natal adult stages",
             "properties": {
                 "category": {
@@ -36422,7 +36422,7 @@
             "type": "object"
         },
         "LogOddsAnalysisResult": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A result of a log odds ratio analysis.",
             "properties": {
                 "category": {
@@ -36568,7 +36568,7 @@
             "type": "string"
         },
         "MacromolecularComplex": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A stable assembly of two or more macromolecules, i.e. proteins, nucleic acids, carbohydrates or lipids, in which at least one component is a protein and the constituent parts function together.",
             "properties": {
                 "category": {
@@ -36695,7 +36695,7 @@
             "type": "object"
         },
         "MacromolecularMachineMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A union of gene locus, gene product, and macromolecular complex. These are the basic units of function in a cell. They either carry out individual biological activities, or they encode molecules which do this.",
             "properties": {
                 "name": {
@@ -36710,7 +36710,7 @@
             "type": "object"
         },
         "MacromolecularMachineToBiologicalProcessAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A functional association between a macromolecular machine (gene, gene product or complex) and a biological process or pathway (as represented in the GO biological process branch), where the entity carries out some part of the process, regulates it, or acts upstream of it.",
             "properties": {
                 "adjusted_p_value": {
@@ -37098,7 +37098,7 @@
             "type": "object"
         },
         "MacromolecularMachineToCellularComponentAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A functional association between a macromolecular machine (gene, gene product or complex) and a cellular component (as represented in the GO cellular component branch), where the entity carries out its function in the cellular component.",
             "properties": {
                 "adjusted_p_value": {
@@ -37486,7 +37486,7 @@
             "type": "object"
         },
         "MacromolecularMachineToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "an association which has a macromolecular machine mixin as a subject",
             "properties": {
                 "object": {
@@ -37522,7 +37522,7 @@
             "type": "object"
         },
         "MacromolecularMachineToMolecularActivityAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A functional association between a macromolecular machine (gene, gene product or complex) and a molecular activity (as represented in the GO molecular function branch), where the entity carries out the activity, or contributes to its execution.",
             "properties": {
                 "adjusted_p_value": {
@@ -37910,7 +37910,7 @@
             "type": "object"
         },
         "Mammal": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A member of the class Mammalia, a clade of endothermic amniotes distinguished from reptiles and birds by the possession of hair, three middle ear bones, mammary glands, and a neocortex",
             "properties": {
                 "category": {
@@ -38037,7 +38037,7 @@
             "type": "object"
         },
         "MappingCollection": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A collection of deprecated mappings.",
             "properties": {
                 "predicate_mappings": {
@@ -38055,7 +38055,7 @@
             "type": "object"
         },
         "MaterialSample": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A sample is a limited quantity of something (e.g. an individual or set of individuals from a population, or a portion of a substance) to be used for testing, analysis, inspection, investigation, demonstration, or trial use. [SIO]",
             "properties": {
                 "category": {
@@ -38165,7 +38165,7 @@
             "type": "object"
         },
         "MaterialSampleDerivationAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a material sample and the material entity from which it is derived.",
             "properties": {
                 "adjusted_p_value": {
@@ -38539,7 +38539,7 @@
             "type": "object"
         },
         "MaterialSampleToDiseaseOrPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a material sample and a disease or phenotype.",
             "properties": {
                 "adjusted_p_value": {
@@ -38913,7 +38913,7 @@
             "type": "object"
         },
         "MaterialSampleToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a material sample and something.",
             "properties": {
                 "object": {
@@ -38938,7 +38938,7 @@
             "type": "object"
         },
         "MicroRNA": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -39065,7 +39065,7 @@
             "type": "object"
         },
         "ModelToDiseaseAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "This mixin is used for any association class for which the subject (source node) plays the role of a 'model', in that it recapitulates some features of the disease in a way that is useful for studying the disease outside a patient carrying the disease",
             "properties": {
                 "object": {
@@ -39093,7 +39093,7 @@
             "type": "object"
         },
         "MolecularActivity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An execution of a molecular function carried out by a gene product or macromolecular complex.",
             "properties": {
                 "category": {
@@ -39250,7 +39250,7 @@
             "type": "object"
         },
         "MolecularActivityToChemicalEntityAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples",
             "properties": {
                 "adjusted_p_value": {
@@ -39620,7 +39620,7 @@
             "type": "object"
         },
         "MolecularActivityToMolecularActivityAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples",
             "properties": {
                 "adjusted_p_value": {
@@ -39990,7 +39990,7 @@
             "type": "object"
         },
         "MolecularActivityToPathwayAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Association that holds the relationship between a reaction and the pathway it participates in.",
             "properties": {
                 "adjusted_p_value": {
@@ -40369,7 +40369,7 @@
             "type": "object"
         },
         "MolecularEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A molecular entity is a chemical entity composed of individual or covalently bonded atoms.",
             "properties": {
                 "available_from": {
@@ -40527,7 +40527,7 @@
             "type": "object"
         },
         "MolecularMixture": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A molecular mixture is a chemical mixture composed of two or more molecular entities with known concentration and stoichiometry.",
             "properties": {
                 "available_from": {
@@ -40703,13 +40703,13 @@
             "type": "object"
         },
         "MortalityOutcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An outcome of death from resulting from an exposure event.",
             "title": "MortalityOutcome",
             "type": "object"
         },
         "NamedThing": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a databased entity or concept/class",
             "properties": {
                 "category": {
@@ -40819,7 +40819,7 @@
             "type": "object"
         },
         "NamedThingAssociatedWithLikelihoodOfNamedThingAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -41258,7 +41258,7 @@
             "type": "object"
         },
         "NoncodingRNAProduct": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -41385,7 +41385,7 @@
             "type": "object"
         },
         "NucleicAcidEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A nucleic acid entity is a molecular entity characterized by availability in gene databases of nucleotide-based sequence representations of its precise sequence; for convenience of representation, partial sequences of various kinds are included.",
             "properties": {
                 "available_from": {
@@ -41567,7 +41567,7 @@
             "type": "object"
         },
         "NucleicAcidSequenceMotif": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A linear nucleotide sequence pattern that is widespread and has, or is conjectured to have, a biological significance. e.g. the TATA box promoter motif, transcription factor binding consensus sequences.",
             "properties": {
                 "category": {
@@ -41694,7 +41694,7 @@
             "type": "object"
         },
         "NucleosomeModification": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A chemical modification of a histone protein within a nucleosome octomer or a substitution of a histone with a variant histone isoform. e.g. Histone 4 Lysine 20 methylation (H4K20me), histone variant H2AZ substituting H2A.",
             "properties": {
                 "category": {
@@ -41828,7 +41828,7 @@
             "type": "object"
         },
         "ObservedExpectedFrequencyAnalysisResult": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A result of a observed expected frequency analysis.",
             "properties": {
                 "category": {
@@ -41964,13 +41964,13 @@
             "type": "object"
         },
         "Occurrent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A processual entity.",
             "title": "Occurrent",
             "type": "object"
         },
         "Onset": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "The age group in which (disease) symptom manifestations appear.",
             "properties": {
                 "category": {
@@ -42102,7 +42102,7 @@
             "type": "object"
         },
         "OntologyClass": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a concept or class in an ontology, vocabulary or thesaurus. Note that nodes in a biolink compatible KG can be considered both instances of biolink classes, and OWL classes in their own right. In general you should not need to use this class directly. Instead, use the appropriate biolink class. For example, for the GO concept of endocytosis (GO:0006897), use bl:BiologicalProcess as the type.",
             "examples": [
                 "UBERON:0000955"
@@ -42120,7 +42120,7 @@
             "type": "object"
         },
         "OrganismAttribute": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "describes a characteristic of an organismal entity.",
             "properties": {
                 "category": {
@@ -42252,7 +42252,7 @@
             "type": "object"
         },
         "OrganismTaxon": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A classification of a set of organisms. Example instances: NCBITaxon:9606 (Homo sapiens), NCBITaxon:2 (Bacteria). Can also be used to represent strains or subspecies.",
             "properties": {
                 "category": {
@@ -42368,7 +42368,7 @@
             "type": "object"
         },
         "OrganismTaxonToEntityAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between an organism taxon and another entity",
             "properties": {
                 "object": {
@@ -42393,7 +42393,7 @@
             "type": "object"
         },
         "OrganismTaxonToEnvironmentAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -42763,7 +42763,7 @@
             "type": "object"
         },
         "OrganismTaxonToOrganismTaxonAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A relationship between two organism taxon nodes",
             "properties": {
                 "adjusted_p_value": {
@@ -43133,7 +43133,7 @@
             "type": "object"
         },
         "OrganismTaxonToOrganismTaxonInteraction": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction relationship between two taxa. This may be a symbiotic relationship (encompassing mutualism and parasitism), or it may be non-symbiotic. Example: plague transmitted_by flea; cattle domesticated_by Homo sapiens; plague infects Homo sapiens",
             "properties": {
                 "adjusted_p_value": {
@@ -43521,7 +43521,7 @@
             "type": "object"
         },
         "OrganismTaxonToOrganismTaxonSpecialization": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A child-parent relationship between two taxa. For example: Homo sapiens subclass_of Homo",
             "properties": {
                 "adjusted_p_value": {
@@ -43894,7 +43894,7 @@
             "type": "object"
         },
         "OrganismToOrganismAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -44264,7 +44264,7 @@
             "type": "object"
         },
         "OrganismalEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A named entity that is either a part of an organism, a whole organism, population or clade of organisms, excluding chemical entities",
             "properties": {
                 "category": {
@@ -44391,7 +44391,7 @@
             "type": "object"
         },
         "OrganismalEntityAsAModelOfDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -44826,13 +44826,13 @@
             "type": "object"
         },
         "Outcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An entity that has the role of being the consequence of an exposure event. This is an abstract mixin grouping of various categories of possible biological or non-biological (e.g. clinical) outcomes.",
             "title": "Outcome",
             "type": "object"
         },
         "PairwiseGeneToGeneInteraction": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction between two genes or two gene products. May be physical (e.g. protein binding) or genetic (between genes). May be symmetric (e.g. protein interaction) or directed (e.g. phosphorylation)",
             "properties": {
                 "adjusted_p_value": {
@@ -45213,7 +45213,7 @@
             "type": "object"
         },
         "PairwiseMolecularInteraction": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An interaction at the molecular level between two physical entities",
             "properties": {
                 "adjusted_p_value": {
@@ -45609,7 +45609,7 @@
             "type": "object"
         },
         "Patent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a legal document granted by a patent issuing authority which confers upon the patenter the sole right to make, use and sell an invention for a set period of time.",
             "properties": {
                 "authors": {
@@ -45800,13 +45800,13 @@
             "type": "object"
         },
         "PathognomonicityQuantifier": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A relationship quantifier between a variant or symptom and a disease, which is high when the presence of the feature implies the existence of the disease",
             "title": "PathognomonicityQuantifier",
             "type": "object"
         },
         "PathologicalAnatomicalExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An abnormal anatomical structure, when viewed as an exposure, representing an precondition, leading to or influencing an outcome, e.g. thrombosis leading to an ischemic disease outcome.",
             "properties": {
                 "category": {
@@ -45946,13 +45946,13 @@
             "type": "object"
         },
         "PathologicalAnatomicalOutcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An outcome resulting from an exposure event which is the manifestation of an abnormal anatomical structure.",
             "title": "PathologicalAnatomicalOutcome",
             "type": "object"
         },
         "PathologicalAnatomicalStructure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An anatomical structure with the potential of have an abnormal or deleterious effect at the subcellular, cellular, multicellular, or organismal level.",
             "properties": {
                 "category": {
@@ -46079,13 +46079,13 @@
             "type": "object"
         },
         "PathologicalEntityMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A pathological (abnormal) structure or process.",
             "title": "PathologicalEntityMixin",
             "type": "object"
         },
         "PathologicalProcess": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A biologic function or a process having an abnormal or deleterious effect at the subcellular, cellular, multicellular, or organismal level.",
             "properties": {
                 "category": {
@@ -46242,7 +46242,7 @@
             "type": "object"
         },
         "PathologicalProcessExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A pathological process, when viewed as an exposure, representing a precondition, leading to or influencing an outcome, e.g. autoimmunity leading to disease.",
             "properties": {
                 "category": {
@@ -46382,13 +46382,13 @@
             "type": "object"
         },
         "PathologicalProcessOutcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An outcome resulting from an exposure event which is the manifestation of a pathological process.",
             "title": "PathologicalProcessOutcome",
             "type": "object"
         },
         "Pathway": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -46555,7 +46555,7 @@
             "type": "string"
         },
         "Phenomenon": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a fact or situation that is observed to exist or happen, especially one whose cause or explanation is in question",
             "properties": {
                 "category": {
@@ -46665,7 +46665,7 @@
             "type": "object"
         },
         "PhenotypicFeature": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A combination of entity and quality that makes up a phenotyping statement. An observable characteristic of an individual resulting from the interaction of its genotype with its molecular and physical environment.",
             "examples": [
                 "MP:0001262"
@@ -46795,7 +46795,7 @@
             "type": "object"
         },
         "PhenotypicFeatureToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -47290,7 +47290,7 @@
             "type": "object"
         },
         "PhenotypicFeatureToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "frequency_qualifier": {
@@ -47402,7 +47402,7 @@
             "type": "object"
         },
         "PhenotypicFeatureToPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Association between two concept nodes of phenotypic character, qualified by the predicate used. This association may typically be used to specify 'similar_to' or 'member_of' relationships.",
             "properties": {
                 "adjusted_p_value": {
@@ -47900,7 +47900,7 @@
             "type": "object"
         },
         "PhenotypicQuality": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A property of a phenotype",
             "examples": [
                 "weight"
@@ -48035,7 +48035,7 @@
             "type": "object"
         },
         "PhenotypicSex": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An attribute corresponding to the phenotypic sex of the individual, based upon the reproductive organs present.",
             "properties": {
                 "category": {
@@ -48167,7 +48167,7 @@
             "type": "object"
         },
         "PhysicalEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An entity that has material reality (a.k.a. physical essence).",
             "properties": {
                 "category": {
@@ -48277,19 +48277,19 @@
             "type": "object"
         },
         "PhysicalEssence": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Semantic mixin concept.  Pertains to entities that have physical properties such as mass, volume, or charge.",
             "title": "PhysicalEssence",
             "type": "object"
         },
         "PhysicalEssenceOrOccurrent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Either a physical or processual entity.",
             "title": "PhysicalEssenceOrOccurrent",
             "type": "object"
         },
         "PhysiologicalProcess": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -48446,7 +48446,7 @@
             "type": "object"
         },
         "PlanetaryEntity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any entity or process that exists at the level of the whole planet",
             "properties": {
                 "category": {
@@ -48556,7 +48556,7 @@
             "type": "object"
         },
         "Plant": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -48683,7 +48683,7 @@
             "type": "object"
         },
         "Polypeptide": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A polypeptide is a molecular entity characterized by availability in protein databases of amino-acid-based sequence representations of its precise primary structure; for convenience of representation, partial sequences of various kinds are included, even if they do not represent a physical molecule.",
             "properties": {
                 "category": {
@@ -48810,7 +48810,7 @@
             "type": "object"
         },
         "PopulationOfIndividualOrganisms": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A collection of individuals from the same taxonomic class distinguished by one or more characteristics.  Characteristics can include, but are not limited to, shared geographic location, genetics, phenotypes.",
             "properties": {
                 "category": {
@@ -48937,7 +48937,7 @@
             "type": "object"
         },
         "PopulationToPopulationAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a two populations",
             "properties": {
                 "adjusted_p_value": {
@@ -49307,7 +49307,7 @@
             "type": "object"
         },
         "PosttranslationalModification": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A chemical modification of a polypeptide or protein that occurs after translation. e.g. polypeptide cleavage to form separate proteins, methylation or acetylation of histone tail amino acids, protein ubiquitination.",
             "properties": {
                 "category": {
@@ -49434,7 +49434,7 @@
             "type": "object"
         },
         "PredicateMapping": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A deprecated predicate mapping object contains the deprecated predicate and an example of the rewiring that should be done to use a qualified statement in its place.",
             "properties": {
                 "anatomical_context_qualifier": {
@@ -49627,7 +49627,7 @@
             "type": "object"
         },
         "PreprintPublication": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a document reresenting an early version of an author's original scholarly work, such as a research paper or a review, prior to formal peer review and publication in a peer-reviewed scholarly or scientific journal.",
             "properties": {
                 "authors": {
@@ -49818,7 +49818,7 @@
             "type": "object"
         },
         "Procedure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A series of actions conducted in a certain order or manner",
             "properties": {
                 "category": {
@@ -49928,7 +49928,7 @@
             "type": "object"
         },
         "ProcessRegulatesProcessAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Describes a regulatory relationship between two genes or gene products.",
             "properties": {
                 "adjusted_p_value": {
@@ -50301,7 +50301,7 @@
             "type": "object"
         },
         "ProcessedMaterial": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A chemical entity (often a mixture) processed for consumption for nutritional, medical or technical use. Is a material entity that is created or changed during material processing.",
             "properties": {
                 "available_from": {
@@ -50477,7 +50477,7 @@
             "type": "object"
         },
         "Protein": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A gene product that is composed of a chain of amino acid sequences and is produced by ribosome-mediated translation of mRNA",
             "properties": {
                 "category": {
@@ -50604,7 +50604,7 @@
             "type": "object"
         },
         "ProteinDomain": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A conserved part of protein sequence and (tertiary) structure that can evolve, function, and exist independently of the rest of the protein chain. Protein domains maintain their structure and function independently of the proteins in which they are found. e.g. an SH3 domain.",
             "properties": {
                 "category": {
@@ -50741,7 +50741,7 @@
             "type": "object"
         },
         "ProteinFamily": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -50878,7 +50878,7 @@
             "type": "object"
         },
         "ProteinIsoform": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Represents a protein that is a specific isoform of the canonical or reference protein. See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4114032/",
             "properties": {
                 "category": {
@@ -51005,7 +51005,7 @@
             "type": "object"
         },
         "Publication": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Any \u2018published\u2019 piece of information. Publications are considered broadly to include any document or document part made available in print or on the web - which may include scientific journal issues, individual articles, and books - as well as things like pre-prints, white papers, patents, drug labels, web pages, protocol documents,  and even a part of a publication if of significant knowledge scope (e.g. a figure, figure legend, or section highlighted by NLP).",
             "properties": {
                 "authors": {
@@ -51196,7 +51196,7 @@
             "type": "object"
         },
         "QuantityValue": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A value of an attribute that is quantitative and measurable, expressed as a combination of a unit and a numeric value",
             "properties": {
                 "has_numeric_value": {
@@ -51218,7 +51218,7 @@
             "type": "object"
         },
         "RNAProduct": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {
@@ -51345,7 +51345,7 @@
             "type": "object"
         },
         "RNAProductIsoform": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Represents a protein that is a specific isoform of the canonical or reference RNA",
             "properties": {
                 "category": {
@@ -51492,7 +51492,7 @@
             "type": "string"
         },
         "ReactionToCatalystAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -51877,7 +51877,7 @@
             "type": "object"
         },
         "ReactionToParticipantAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -52262,7 +52262,7 @@
             "type": "object"
         },
         "ReagentTargetedGene": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A gene altered in its expression level in the context of some experiment as a result of being targeted by gene-knockdown reagent(s) such as a morpholino or RNAi.",
             "properties": {
                 "category": {
@@ -52396,7 +52396,7 @@
             "type": "object"
         },
         "RegulatoryRegion": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A region (or regions) of the genome that contains known or putative regulatory elements that act in cis- or trans- to affect the transcription of gene",
             "properties": {
                 "category": {
@@ -52530,13 +52530,13 @@
             "type": "object"
         },
         "RelationshipQuantifier": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "RelationshipQuantifier",
             "type": "object"
         },
         "RelationshipType": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An OWL property used as an edge label",
             "properties": {
                 "id": {
@@ -52551,7 +52551,7 @@
             "type": "object"
         },
         "RelativeFrequencyAnalysisResult": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A result of a relative frequency analysis.",
             "properties": {
                 "category": {
@@ -52711,7 +52711,7 @@
             "type": "string"
         },
         "RetrievalSource": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Provides information about how a particular InformationResource served as a source from which knowledge expressed in an Edge, or data used to generate this knowledge, was retrieved.",
             "properties": {
                 "category": {
@@ -52864,13 +52864,13 @@
             "type": "object"
         },
         "SensitivityQuantifier": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "SensitivityQuantifier",
             "type": "object"
         },
         "SequenceAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a sequence feature and a nucleic acid entity it is localized to.",
             "properties": {
                 "adjusted_p_value": {
@@ -53249,7 +53249,7 @@
             "type": "string"
         },
         "SequenceFeatureRelationship": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "For example, a particular exon is part of a particular transcript or gene",
             "properties": {
                 "adjusted_p_value": {
@@ -53619,7 +53619,7 @@
             "type": "object"
         },
         "SequenceVariant": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A sequence_variant is a non exact copy of a sequence_feature or genome exhibiting one or more sequence_alteration.",
             "properties": {
                 "category": {
@@ -53767,7 +53767,7 @@
             "type": "object"
         },
         "SequenceVariantModulatesTreatmentAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a sequence variant and a treatment or health intervention. The treatment object itself encompasses both the disease and the drug used.",
             "properties": {
                 "adjusted_p_value": {
@@ -54137,7 +54137,7 @@
             "type": "object"
         },
         "Serial": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "This class may rarely be instantiated except if use cases of a given knowledge graph support its utility.",
             "properties": {
                 "authors": {
@@ -54350,7 +54350,7 @@
             "type": "object"
         },
         "SeverityValue": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "describes the severity of a phenotypic feature or disease",
             "properties": {
                 "category": {
@@ -54482,7 +54482,7 @@
             "type": "object"
         },
         "SiRNA": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A small RNA molecule that is the product of a longer exogenous or endogenous dsRNA, which is either a bimolecular duplex or very long hairpin, processed (via the Dicer pathway) such that numerous siRNAs accumulate from both strands of the dsRNA. SRNAs trigger the cleavage of their target molecules.",
             "properties": {
                 "category": {
@@ -54609,7 +54609,7 @@
             "type": "object"
         },
         "SmallMolecule": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A small molecule entity is a molecular entity characterized by availability in small-molecule databases of SMILES, InChI, IUPAC, or other unambiguous representation of its precise chemical structure; for convenience of representation, any valid chemical representation is included, even if it is not strictly molecular (e.g., sodium ion).",
             "properties": {
                 "available_from": {
@@ -54767,7 +54767,7 @@
             "type": "object"
         },
         "Snv": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "SNVs are single nucleotide positions in genomic DNA at which different sequence alternatives exist",
             "properties": {
                 "category": {
@@ -54915,7 +54915,7 @@
             "type": "object"
         },
         "SocioeconomicAttribute": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Attributes relating to a socioeconomic manifestation",
             "properties": {
                 "category": {
@@ -55047,7 +55047,7 @@
             "type": "object"
         },
         "SocioeconomicExposure": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A socioeconomic exposure is a factor relating to social and financial status of an affected individual (e.g. poverty).",
             "properties": {
                 "category": {
@@ -55185,13 +55185,13 @@
             "type": "object"
         },
         "SocioeconomicOutcome": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An general social or economic outcome, such as healthcare costs, utilization, etc., resulting from an exposure event",
             "title": "SocioeconomicOutcome",
             "type": "object"
         },
         "SpecificityQuantifier": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "SpecificityQuantifier",
             "type": "object"
@@ -55208,7 +55208,7 @@
             "type": "string"
         },
         "Study": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a detailed investigation and/or analysis",
             "properties": {
                 "category": {
@@ -55318,7 +55318,7 @@
             "type": "object"
         },
         "StudyPopulation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A group of people banded together or treated as a group as participants in a research study.",
             "properties": {
                 "category": {
@@ -55445,7 +55445,7 @@
             "type": "object"
         },
         "StudyResult": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A collection of data items from a study that are about a particular study subject or experimental unit (the 'focus' of the Result) - optionally with context/provenance metadata that may be relevant to the interpretation of this data as evidence.",
             "properties": {
                 "category": {
@@ -55581,7 +55581,7 @@
             "type": "object"
         },
         "StudyVariable": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a variable that is used as a measure in the investigation of a study",
             "properties": {
                 "category": {
@@ -55717,13 +55717,13 @@
             "type": "object"
         },
         "SubjectOfInvestigation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An entity that has the role of being studied in an investigation, study, or experiment",
             "title": "SubjectOfInvestigation",
             "type": "object"
         },
         "TaxonToTaxonAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -56093,7 +56093,7 @@
             "type": "object"
         },
         "TaxonomicRank": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A descriptor for the rank within a taxonomic classification. Example instance: TAXRANK:0000017 (kingdom)",
             "properties": {
                 "id": {
@@ -56108,7 +56108,7 @@
             "type": "object"
         },
         "TextMiningResult": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A result of text mining.",
             "properties": {
                 "category": {
@@ -56244,7 +56244,7 @@
             "type": "object"
         },
         "ThingWithTaxon": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A mixin that can be used on any entity that can be taxonomically classified. This includes individual organisms; genes, their products and other molecular entities; body parts; biological processes",
             "properties": {
                 "in_taxon": {
@@ -56269,7 +56269,7 @@
             "type": "object"
         },
         "Transcript": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An RNA synthesized on a DNA or RNA template by an RNA polymerase.",
             "properties": {
                 "category": {
@@ -56396,7 +56396,7 @@
             "type": "object"
         },
         "TranscriptToGeneRelationship": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A gene is a collection of transcripts",
             "properties": {
                 "adjusted_p_value": {
@@ -56766,7 +56766,7 @@
             "type": "object"
         },
         "TranscriptionFactorBindingSite": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A region (or regions) of the genome that contains a region of DNA known or predicted to bind a protein that modulates gene transcription",
             "properties": {
                 "category": {
@@ -56900,7 +56900,7 @@
             "type": "object"
         },
         "Treatment": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A treatment is targeted at a disease or phenotype and may involve multiple drug 'exposures', medical devices and/or procedures",
             "properties": {
                 "category": {
@@ -57048,7 +57048,7 @@
             "type": "object"
         },
         "VariantAsAModelOfDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -57486,7 +57486,7 @@
             "type": "object"
         },
         "VariantToDiseaseAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -57924,7 +57924,7 @@
             "type": "object"
         },
         "VariantToEntityAssociationMixin": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "object": {
@@ -57953,7 +57953,7 @@
             "type": "object"
         },
         "VariantToGeneAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a variant and a gene, where the variant has a genetic association with the gene (i.e. is in linkage disequilibrium)",
             "properties": {
                 "adjusted_p_value": {
@@ -58332,7 +58332,7 @@
             "type": "object"
         },
         "VariantToGeneExpressionAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a variant and expression of a gene (i.e. e-QTL)",
             "properties": {
                 "adjusted_p_value": {
@@ -58752,7 +58752,7 @@
             "type": "object"
         },
         "VariantToPhenotypicFeatureAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "adjusted_p_value": {
@@ -59249,7 +59249,7 @@
             "type": "object"
         },
         "VariantToPopulationAssociation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An association between a variant and a population, where the variant has particular frequency in the population",
             "properties": {
                 "adjusted_p_value": {
@@ -59669,7 +59669,7 @@
             "type": "object"
         },
         "Vertebrate": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A sub-phylum of animals consisting of those having a bony or cartilaginous vertebral column.",
             "properties": {
                 "category": {
@@ -59796,7 +59796,7 @@
             "type": "object"
         },
         "Virus": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A virus is a microorganism that replicates itself as a microRNA and infects the host cell.",
             "properties": {
                 "category": {
@@ -59923,7 +59923,7 @@
             "type": "object"
         },
         "WebPage": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a document that is published according to World Wide Web standards, which may incorporate text, graphics, sound, and/or other features.",
             "properties": {
                 "authors": {
@@ -60114,7 +60114,7 @@
             "type": "object"
         },
         "Zygosity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "category": {

--- a/tests/linkml/test_compliance/helper.py
+++ b/tests/linkml/test_compliance/helper.py
@@ -90,7 +90,10 @@ GENERATORS: dict[FRAMEWORK, type[Generator] | tuple[type[Generator], dict[str, A
     PYDANTIC: generators.PydanticGenerator,
     PYTHON_DATACLASSES: generators.PythonGenerator,
     JAVA: generators.JavaGenerator,
-    JSON_SCHEMA: generators.JsonSchemaGenerator,
+    JSON_SCHEMA: (
+        generators.JsonSchemaGenerator,
+        {"not_closed": False}
+    ),
     SHACL: generators.ShaclGenerator,
     SHEX: generators.ShExGenerator,
     JSONLD: generators.JSONLDGenerator,

--- a/tests/linkml/test_compliance/helper.py
+++ b/tests/linkml/test_compliance/helper.py
@@ -90,10 +90,7 @@ GENERATORS: dict[FRAMEWORK, type[Generator] | tuple[type[Generator], dict[str, A
     PYDANTIC: generators.PydanticGenerator,
     PYTHON_DATACLASSES: generators.PythonGenerator,
     JAVA: generators.JavaGenerator,
-    JSON_SCHEMA: (
-        generators.JsonSchemaGenerator,
-        {"not_closed": False}
-    ),
+    JSON_SCHEMA: (generators.JsonSchemaGenerator, {"not_closed": False}),
     SHACL: generators.ShaclGenerator,
     SHEX: generators.ShExGenerator,
     JSONLD: generators.JSONLDGenerator,

--- a/tests/linkml/test_issues/__snapshots__/issue_120.json
+++ b/tests/linkml/test_issues/__snapshots__/issue_120.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "Course": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "name": {
@@ -12,7 +12,7 @@
             "type": "object"
         },
         "Student": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "courses": {

--- a/tests/linkml/test_issues/__snapshots__/issue_177.json
+++ b/tests/linkml/test_issues/__snapshots__/issue_177.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "C1": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "sa": {
@@ -21,7 +21,7 @@
             "type": "object"
         },
         "C2": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "sb": {

--- a/tests/linkml/test_issues/__snapshots__/issue_202.json.schema
+++ b/tests/linkml/test_issues/__snapshots__/issue_202.json.schema
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "GeospatialDDCoordLocation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "latitude": {

--- a/tests/linkml/test_issues/__snapshots__/issue_239.json
+++ b/tests/linkml/test_issues/__snapshots__/issue_239.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "C": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {},

--- a/tests/linkml/test_issues/__snapshots__/issue_2499.json
+++ b/tests/linkml/test_issues/__snapshots__/issue_2499.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "Thing": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "identifier": {

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "Activity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a provence-generating activity",
             "properties": {
                 "description": {
@@ -53,7 +53,7 @@
             "type": "object"
         },
         "Address": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "altitude": {
@@ -79,7 +79,7 @@
             "type": "object"
         },
         "Agent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a provence-generating agent",
             "properties": {
                 "acted_on_behalf_of": {
@@ -117,7 +117,7 @@
             ]
         },
         "AnyOfClasses": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute2": {
@@ -139,7 +139,7 @@
             "type": "object"
         },
         "AnyOfEnums": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute3": {
@@ -161,7 +161,7 @@
             "type": "object"
         },
         "AnyOfMix": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute4": {
@@ -186,7 +186,7 @@
             "type": "object"
         },
         "AnyOfSimpleType": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute1": {
@@ -208,7 +208,7 @@
             "type": "object"
         },
         "BirthEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "ended_at_time": {
@@ -253,7 +253,7 @@
             "type": "object"
         },
         "ClassWithSpaces": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "slot_with_space_1": {
@@ -267,7 +267,7 @@
             "type": "object"
         },
         "CodeSystem": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {
@@ -290,7 +290,7 @@
             "type": "object"
         },
         "Company": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "aliases": {
@@ -325,7 +325,7 @@
             "type": "object"
         },
         "Concept": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {
@@ -361,7 +361,7 @@
             "type": "string"
         },
         "Dataset": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "activities": {
@@ -416,7 +416,7 @@
             "type": "object"
         },
         "DiagnosisConcept": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {
@@ -450,7 +450,7 @@
             "type": "string"
         },
         "EmploymentEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "employed_at": {
@@ -520,7 +520,7 @@
             "type": "string"
         },
         "EqualsString": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute5": {
@@ -535,7 +535,7 @@
             "type": "object"
         },
         "EqualsStringIn": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute6": {
@@ -553,7 +553,7 @@
             "type": "object"
         },
         "Event": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "ended_at_time": {
@@ -592,7 +592,7 @@
             "type": "object"
         },
         "FakeClass": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "test_attribute": {
@@ -606,7 +606,7 @@
             "type": "object"
         },
         "FamilialRelationship": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "cordialness": {
@@ -651,7 +651,7 @@
             "type": "string"
         },
         "Friend": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "name": {
@@ -665,7 +665,7 @@
             "type": "object"
         },
         "HasAliases": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "aliases": {
@@ -725,7 +725,7 @@
             "type": "string"
         },
         "MarriageEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "ended_at_time": {
@@ -776,7 +776,7 @@
             "type": "object"
         },
         "MedicalEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "diagnosis": {
@@ -841,7 +841,7 @@
             "type": "object"
         },
         "Organization": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list",
             "properties": {
                 "aliases": {
@@ -878,7 +878,7 @@
             "type": "string"
         },
         "Person": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A person, living or dead",
             "properties": {
                 "addresses": {
@@ -981,7 +981,7 @@
             "type": "object"
         },
         "Place": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "aliases": {
@@ -1010,7 +1010,7 @@
             "type": "object"
         },
         "ProcedureConcept": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {
@@ -1036,7 +1036,7 @@
             "type": "object"
         },
         "Relationship": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "cordialness": {
@@ -1073,7 +1073,7 @@
             "type": "object"
         },
         "SubSubClass2": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "slot_with_space_1": {
@@ -1097,7 +1097,7 @@
             "type": "object"
         },
         "SubclassTest": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "slot_with_space_1": {
@@ -1121,7 +1121,7 @@
             "type": "object"
         },
         "TubSubClass1": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Same depth as Sub sub class 1",
             "properties": {
                 "slot_with_space_1": {
@@ -1145,7 +1145,7 @@
             "type": "object"
         },
         "WithLocation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "in_location": {

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta_inline.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta_inline.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "Activity": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a provence-generating activity",
             "properties": {
                 "description": {
@@ -53,7 +53,7 @@
             "type": "object"
         },
         "Address": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "altitude": {
@@ -79,7 +79,7 @@
             "type": "object"
         },
         "Agent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "a provence-generating agent",
             "properties": {
                 "acted_on_behalf_of": {
@@ -117,7 +117,7 @@
             ]
         },
         "AnyOfClasses": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute2": {
@@ -139,7 +139,7 @@
             "type": "object"
         },
         "AnyOfEnums": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute3": {
@@ -161,7 +161,7 @@
             "type": "object"
         },
         "AnyOfMix": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute4": {
@@ -186,7 +186,7 @@
             "type": "object"
         },
         "AnyOfSimpleType": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute1": {
@@ -208,7 +208,7 @@
             "type": "object"
         },
         "BirthEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "ended_at_time": {
@@ -253,7 +253,7 @@
             "type": "object"
         },
         "ClassWithSpaces": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "slot_with_space_1": {
@@ -267,7 +267,7 @@
             "type": "object"
         },
         "CodeSystem": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {
@@ -290,7 +290,7 @@
             "type": "object"
         },
         "Company": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "aliases": {
@@ -325,7 +325,7 @@
             "type": "object"
         },
         "Concept": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {
@@ -361,7 +361,7 @@
             "type": "string"
         },
         "Dataset": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "activities": {
@@ -416,7 +416,7 @@
             "type": "object"
         },
         "DiagnosisConcept": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {
@@ -450,7 +450,7 @@
             "type": "string"
         },
         "EmploymentEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "employed_at": {
@@ -520,7 +520,7 @@
             "type": "string"
         },
         "EqualsString": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute5": {
@@ -535,7 +535,7 @@
             "type": "object"
         },
         "EqualsStringIn": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "attribute6": {
@@ -553,7 +553,7 @@
             "type": "object"
         },
         "Event": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "ended_at_time": {
@@ -592,7 +592,7 @@
             "type": "object"
         },
         "FakeClass": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "test_attribute": {
@@ -606,7 +606,7 @@
             "type": "object"
         },
         "FamilialRelationship": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "cordialness": {
@@ -651,7 +651,7 @@
             "type": "string"
         },
         "Friend": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "name": {
@@ -665,7 +665,7 @@
             "type": "object"
         },
         "HasAliases": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "aliases": {
@@ -725,7 +725,7 @@
             "type": "string"
         },
         "MarriageEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "ended_at_time": {
@@ -776,7 +776,7 @@
             "type": "object"
         },
         "MedicalEvent": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "diagnosis": {
@@ -841,7 +841,7 @@
             "type": "object"
         },
         "Organization": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "An organization.\n\nThis description\nincludes newlines\n\n## Markdown headers\n\n * and\n * a\n * list",
             "properties": {
                 "aliases": {
@@ -878,7 +878,7 @@
             "type": "string"
         },
         "Person": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "A person, living or dead",
             "properties": {
                 "addresses": {
@@ -981,7 +981,7 @@
             "type": "object"
         },
         "Place": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "aliases": {
@@ -1010,7 +1010,7 @@
             "type": "object"
         },
         "ProcedureConcept": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "id": {
@@ -1036,7 +1036,7 @@
             "type": "object"
         },
         "Relationship": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "cordialness": {
@@ -1073,7 +1073,7 @@
             "type": "object"
         },
         "SubSubClass2": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "slot_with_space_1": {
@@ -1097,7 +1097,7 @@
             "type": "object"
         },
         "SubclassTest": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "slot_with_space_1": {
@@ -1121,7 +1121,7 @@
             "type": "object"
         },
         "TubSubClass1": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Same depth as Sub sub class 1",
             "properties": {
                 "slot_with_space_1": {
@@ -1145,7 +1145,7 @@
             "type": "object"
         },
         "WithLocation": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "properties": {
                 "in_location": {

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/roottest.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/roottest.json
@@ -1,13 +1,13 @@
 {
     "$defs": {
         "C1": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "C1",
             "type": "object"
         },
         "C2": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "C2",
             "type": "object"

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/roottest2.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/roottest2.json
@@ -1,13 +1,13 @@
 {
     "$defs": {
         "C1": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "C1",
             "type": "object"
         },
         "C2": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "C2",
             "type": "object"

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/roottest4.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/roottest4.json
@@ -1,13 +1,13 @@
 {
     "$defs": {
         "C1": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "C1",
             "type": "object"
         },
         "C2": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "",
             "title": "C2",
             "type": "object"

--- a/tests/linkml/test_validator/test_jsonschema_validation_plugin.py
+++ b/tests/linkml/test_validator/test_jsonschema_validation_plugin.py
@@ -85,14 +85,14 @@ def test_include_range_class_descendants():
     )
     validation_context = ValidationContext(schema)
 
-    plugin = JsonschemaValidationPlugin(include_range_class_descendants=True)
+    plugin = JsonschemaValidationPlugin(include_range_class_descendants=True, closed=True)
     results = list(plugin.process({"thing": {"a": "1"}}, validation_context))
     assert results == []
 
     results = list(plugin.process({"thing": {"a": "1", "b": "2"}}, validation_context))
     assert results == []
 
-    plugin = JsonschemaValidationPlugin(include_range_class_descendants=False)
+    plugin = JsonschemaValidationPlugin(include_range_class_descendants=False, closed=True)
     results = list(plugin.process({"thing": {"a": "1"}}, validation_context))
     assert results == []
 


### PR DESCRIPTION
## Summary

Fixes #3608 and #3611

This PR implements the fix discussed and agreed upon in the comments of PR #2940 (from [this comment](https://github.com/linkml/linkml/pull/2940#issuecomment-4266306472) onward.

Basically, the gist of it is that the value of the top-level `additionalProperties` in the generated JSON-Schema should depend on the `extra_slots.allowed` property of the root class: if the root class is set to allow “extra slots“, then setting `additionalProperties: true` in the definition of the object (which is what the JSON-Schema generator currently does) **is not enough**, because what matters for the root class is _only_ the top-level `additionalProperties`, whose value must therefore be set according to the wishes of the schema author.

Additionally (and again as agreed upon on #2940), the _default_ value of `additionalProperties` is set according to the global `closed` setting of the JSON-Schema generator. (Arguably this global setting is no longer really relevant now that `extra_slots` gives schema authors a much finer control about allowing “extra slots” / “additional properties”, but since it exists, it should be honoured when possible.)

## How was this tested?

Tested locally against the schema provided in #3608. I plan to add that schema to the test suite later on.

## Areas of uncertainty

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [ ] I have added tests that prove my fix/feature works – Not yet
- [x] Existing tests pass locally with my changes

## AI Assistance

None.
