### PR TITLE
ci: bump codecov-action to v6.0.2 (fixes GPG signature verification failures)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
       - name: Upload linkml coverage report
         if: github.repository == 'linkml/linkml' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.2
         with:
           name: codecov-linkml-${{ matrix.os }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -108,7 +108,7 @@ jobs:
           fail_ci_if_error: true
       - name: Upload runtime coverage report
         if: github.repository == 'linkml/linkml' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.2
         with:
           name: codecov-runtime-${{ matrix.os }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -154,7 +154,7 @@ jobs:
           uv run coverage report -m
       - name: Upload linkml slow test coverage
         if: github.repository == 'linkml/linkml' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.2
         with:
           name: codecov-linkml-slow-${{ matrix.os }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -201,7 +201,7 @@ jobs:
           uv run pytest tests/linkml/test_notebooks/ --with-network -m "not kroki" --cov --cov-report xml:coverage-notebooks.xml --cov-report term-missing
       - name: Upload notebook coverage
         if: github.repository == 'linkml/linkml' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.2
         with:
           name: codecov-notebooks-${{ matrix.os }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rustgen.yaml
+++ b/.github/workflows/rustgen.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload coverage report
         if: github.repository == 'linkml/linkml' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.2
         with:
           name: codecov-results-rustgen
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Bumps `codecov/codecov-action` v6.0.0 -> v6.0.2 (5 refs).

Codecov deleted the `codecovsecurity` keybase account holding the GPG key our pinned v6.0.0 uses to verify the downloaded CLI, so every `Build and test` job has failed on coverage upload since Jun 7 (`Could not verify signature`). v6.0.2 is Codecov's drop-in fix for v6.x. See https://github.com/codecov/codecov-action/releases/tag/v7.0.0.

Note: dependabot #3607's v6.0.1 predates the fix and won't resolve this.