### PR TITLE
fix(jsonschemagen): avoid duplicate subschemas

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -57,6 +57,25 @@ _base_implied_patterns: dict[str, str] = {
 }
 
 
+def _deduplicate_subschemas(subschemas: list["JsonSchema"]) -> list["JsonSchema"]:
+    """Return *subschemas* with duplicate entries removed, preserving order.
+
+    Two subschemas are considered duplicates when their JSON representations are
+    identical.  This can occur, for example, when multiple ``any_of`` branches
+    point to different classes whose identifier slot shares the same scalar type
+    (e.g. both ``Person.id`` and ``Organization.id`` have ``range: string``),
+    producing redundant ``{"type": "string"}`` entries.
+    """
+    seen: set[str] = set()
+    result: list[JsonSchema] = []
+    for schema in subschemas:
+        key = json.dumps(schema, sort_keys=True)
+        if key not in seen:
+            seen.add(key)
+            result.append(schema)
+    return result
+
+
 def _slot_examples_for_json_schema(
     examples: list[Example],
     *,
@@ -857,19 +876,27 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
 
         bool_subschema = JsonSchema()
         if slot.any_of is not None and len(slot.any_of) > 0:
-            bool_subschema["anyOf"] = [self.get_subschema_for_slot(s, include_null=False) for s in slot.any_of]
+            bool_subschema["anyOf"] = _deduplicate_subschemas(
+                [self.get_subschema_for_slot(s, include_null=False) for s in slot.any_of]
+            )
             if not slot.required and not prop.is_array and include_null:
                 bool_subschema["anyOf"].append({"type": "null"})
 
         if slot.all_of is not None and len(slot.all_of) > 0:
-            bool_subschema["allOf"] = [self.get_subschema_for_slot(s, include_null=False) for s in slot.all_of]
+            bool_subschema["allOf"] = _deduplicate_subschemas(
+                [self.get_subschema_for_slot(s, include_null=False) for s in slot.all_of]
+            )
 
         if slot.exactly_one_of is not None and len(slot.exactly_one_of) > 0:
-            bool_subschema["oneOf"] = [self.get_subschema_for_slot(s, include_null=False) for s in slot.exactly_one_of]
+            bool_subschema["oneOf"] = _deduplicate_subschemas(
+                [self.get_subschema_for_slot(s, include_null=False) for s in slot.exactly_one_of]
+            )
 
         if slot.none_of is not None and len(slot.none_of) > 0:
             bool_subschema["not"] = {
-                "anyOf": [self.get_subschema_for_slot(s, include_null=False) for s in slot.none_of]
+                "anyOf": _deduplicate_subschemas(
+                    [self.get_subschema_for_slot(s, include_null=False) for s in slot.none_of]
+                )
             }
 
         if bool_subschema:

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta.json
@@ -126,9 +126,6 @@
                             "type": "string"
                         },
                         {
-                            "type": "string"
-                        },
-                        {
                             "type": "null"
                         }
                     ],

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta_inline.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta_inline.json
@@ -126,9 +126,6 @@
                             "type": "string"
                         },
                         {
-                            "type": "string"
-                        },
-                        {
                             "type": "null"
                         }
                     ],


### PR DESCRIPTION
## Summary

Fixes #3616 

Multiple `any_of` boolean contraints pointing to different classes with same scalar type in JSON Schema resulted in multiple entries of the same scalar type (see fixed test snapshots for some examples). This patch removes those duplicates.

## How was this tested?

Adapting the tests, see changes.

## Areas of uncertainty

<!-- Are there parts of this change you'd like reviewers to look at more closely? -->

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
