### PR TITLE
fix(jsonschema): ignore default_schema if boolean constraint

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -835,16 +835,22 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                     prop = JsonSchema.ref_for(reference, required=slot.required or not include_null)
 
             else:
-                if reference is not None:
-                    # for multivalued slots, nullability applies to the array (via array_of
-                    # below), not to the individual elements
-                    prop = JsonSchema.ref_for(
-                        reference, required=slot.required or slot_is_multivalued or not include_null
-                    )
-                elif typ and fmt is None:
-                    prop = JsonSchema({"type": typ})
-                elif typ:
-                    prop = JsonSchema({"type": typ, "format": fmt})
+                if not slot_is_boolean or slot.range != self.schemaview.schema.default_range:
+                    # When a slot uses boolean constraints (any_of, all_of, etc.) AND its range
+                    # was not set explicitly but inherited from the schema's default_range, the
+                    # boolean constraints already fully describe the type.  Emitting prop["type"]
+                    # from the default_range would duplicate that constraint.  Skip it.
+                    # An explicit range on a boolean slot is intentional and is kept.
+                    if reference is not None:
+                        # for multivalued slots, nullability applies to the array (via array_of
+                        # below), not to the individual elements
+                        prop = JsonSchema.ref_for(
+                            reference, required=slot.required or slot_is_multivalued or not include_null
+                        )
+                    elif typ and fmt is None:
+                        prop = JsonSchema({"type": typ})
+                    elif typ:
+                        prop = JsonSchema({"type": typ, "format": fmt})
 
                 if slot_is_multivalued:
                     prop = JsonSchema.array_of(prop, include_null, required=slot.required)

--- a/tests/linkml/test_compliance/test_boolean_slot_compliance.py
+++ b/tests/linkml/test_compliance/test_boolean_slot_compliance.py
@@ -93,11 +93,6 @@ def test_slot_any_of(framework, data_name, value, is_valid, use_any_type, use_de
     :return:
     """
     expected_json_schema = {"s1": {"anyOf": [{"$ref": "#/$defs/D"}, {"type": "integer"}, {"type": "null"}]}}
-    if use_default_range and not use_any_type:
-        # default_range is set to string, any no explicit range set.
-        # in this case the schema is violating monotonicity.
-        # TODO: undesired behavior, see https://github.com/linkml/linkml/issues/1483
-        expected_json_schema["s1"]["type"] = "string"
 
     classes = {
         CLASS_D: {

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta.json
@@ -128,8 +128,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "AnyOfClasses",
@@ -150,8 +149,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "AnyOfEnums",
@@ -175,8 +173,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "AnyOfMix",
@@ -197,8 +194,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "AnyOfSimpleType",
@@ -505,8 +501,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "EmploymentEvent",

--- a/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta_inline.json
+++ b/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta_inline.json
@@ -128,8 +128,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "AnyOfClasses",
@@ -150,8 +149,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "AnyOfEnums",
@@ -175,8 +173,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "AnyOfMix",
@@ -197,8 +194,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "AnyOfSimpleType",
@@ -505,8 +501,7 @@
                         {
                             "type": "null"
                         }
-                    ],
-                    "type": "string"
+                    ]
                 }
             },
             "title": "EmploymentEvent",


### PR DESCRIPTION
## Summary

Fixes #3618
Fixes #2929

A slot with [boolean constraints][1] in a schema with `default_range` is getting `type` information in two different ways (a `type` array and an `anyOf` list of `type`s). The duplication is not needed, additionally they are not even compatible, since the `type` array does not include nullable slots.

Not only that, even when the `default_range` is not part of the `anyOf`, it's being added. Notice how in the [kitchen_sink.yaml schema AnyOfEnum.attribute3](https://github.com/linkml/linkml/blob/7585adae0c58dd9a981624c9a9c8d167134a56c4/tests/linkml/test_generators/input/kitchen_sink.yaml#L80) is not specifying `string` as one of the options, but the [generated JSON-Schema](https://github.com/linkml/linkml/blob/7585adae0c58dd9a981624c9a9c8d167134a56c4/tests/linkml/test_scripts/__snapshots__/genjsonschema/meta.json#L138) is nevertheless adding the `default_range` (`string` in this case) as one of the options.

This patch fixes it. If a [boolean constraint][1] has been provided in the schema, then `default_range` is ignored for the generation of JSON-Schema `type` constraint in the slot.

[1]: https://linkml.io/linkml/schemas/advanced.html#boolean-constraints

## How was this tested?

Tests adapted to reflect the changes.

## Areas of uncertainty

Reviewing the changes in the tests help better understanding the result of this patch.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
