### PR TITLE
Implement linkml arrays for JSON Schema generator

### DIFF
--- a/docs/generators/json-schema.rst
+++ b/docs/generators/json-schema.rst
@@ -1,3 +1,5 @@
+.. _jsonschemagen:
+
 JSON Schema
 ===========
 

--- a/docs/schemas/arrays.md
+++ b/docs/schemas/arrays.md
@@ -544,6 +544,7 @@ At release, only pydanticgen supports arrays, but arrays will be implemented gra
 |---------------------------|----------------|----------|---------|---------------|---------|
 | [pydantic](pydanticgen)   | List of Lists  | Y        | Y       | Y             | Y       |
 | [pydantic](pydanticgen)   | Numpydantic    | Y        | Y       | Y             | Y       |
+| [jsonschema](jsonschemagen) | Arrays of Arrays | Y    | Y       | Y             | Y       |
 | ... (the rest of em)      |                |          |         |               |         |
 
 (array-representations)=

--- a/packages/linkml/src/linkml/generators/common/array.py
+++ b/packages/linkml/src/linkml/generators/common/array.py
@@ -1,0 +1,227 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, ClassVar
+
+from linkml.generators.common.build import RangeResult
+from linkml.utils.exceptions import SchemaValidationError
+from linkml_runtime.linkml_model import Element
+from linkml_runtime.linkml_model.meta import ArrayExpression, DimensionExpression
+
+_BOUNDED_ARRAY_FIELDS = ("exact_number_dimensions", "minimum_number_dimensions", "maximum_number_dimensions")
+
+
+class ArrayRepresentation(Enum):
+    LIST = "list"
+    NUMPYDANTIC = "numpydantic"  # numpydantic must be installed to use this
+    JSON_SCHEMA = "json_schema"
+
+
+class ArrayValidator:
+    """
+    Validate the specification of a LinkML Array
+
+    .. todo::
+
+        It looks like :mod:`linkml.validator` is for validating instances against schema, rather
+        than validating the schema itself, so am not subclassing/writing as a plugin.
+        Unsure if there is a more general means of validating schema, but for now this is
+        an independent class
+    """
+
+    @classmethod
+    def validate(cls, array: ArrayExpression):
+        """
+        Validate an array expression.
+
+        Raises:
+            :class:`.SchemaValidationError` if invalid
+        """
+        cls.array_exact_dimensions(array)
+        cls.array_consistent_n_dimensions(array)
+        cls.array_explicitly_unbounded(array)
+        cls.array_dimensions_ordinal(array)
+
+        if array.dimensions:
+            for dimension in array.dimensions:
+                cls.validate_dimension(dimension)
+
+    @classmethod
+    def validate_dimension(cls, dimension: DimensionExpression):
+        """
+        Validate a single array dimension
+
+        Raises:
+            :class:`.SchemaValidationError` if invalid
+        """
+        cls.dimension_exact_cardinality(dimension)
+        cls.dimension_ordinal(dimension)
+
+    @staticmethod
+    def array_exact_dimensions(array: ArrayExpression):
+        """Arrays can have exact_number_dimensions OR min/max_number_dimensions, but not both"""
+        if array.exact_number_dimensions is not None and (
+            array.minimum_number_dimensions is not None or array.maximum_number_dimensions is not None
+        ):
+            raise SchemaValidationError(
+                f"Can only specify EITHER exact_number_dimensions OR minimum/maximum dimensions, got: {array}"
+            )
+
+    @staticmethod
+    def array_consistent_n_dimensions(array: ArrayExpression):
+        """
+        Complex arrays with both exact/min/max_number_dimensions and parameterized dimensions
+        need to have the exact/min/max_number_dimensions greater than the number of parameterized dimensions!
+        """
+        if not array.dimensions:
+            return
+
+        for field_name in _BOUNDED_ARRAY_FIELDS:
+            field = getattr(array, field_name, None)
+            if field and field < len(array.dimensions):
+                raise SchemaValidationError(
+                    "if exact/minimum/maximum_number_dimensions is provided, "
+                    "it must be greater than the parameterized dimensions. "
+                    f"got\n- {field_name}: {field}\n- dimensions: {array.dimensions}"
+                )
+
+    @staticmethod
+    def array_dimensions_ordinal(array: ArrayExpression):
+        """
+        minimum_number_dimensions needs to be less than maximum_number_dimensions when both are set
+        """
+        if array.minimum_number_dimensions is not None and array.maximum_number_dimensions:
+            if array.minimum_number_dimensions > array.maximum_number_dimensions:
+                raise SchemaValidationError(
+                    "minimum_number_dimensions must be lesser than maximum_number_dimensions when both are set. "
+                    f"got minimum: {array.minimum_number_dimensions}, maximum: {array.maximum_number_dimensions}"
+                )
+
+    @staticmethod
+    def array_explicitly_unbounded(array: ArrayExpression):
+        """
+        Complex arrays with a minimum_number_dimensions and parameterized dimensions
+        need to either use exact_number_dimensions to specify extra anonymous dimensions
+        or set maximum_number_dimensions to ``False`` to specify unbounded extra anonymous
+        dimensions to avoid ambiguity.
+        """
+        if array.minimum_number_dimensions is not None and array.maximum_number_dimensions is None and array.dimensions:
+            raise SchemaValidationError(
+                "Cannot specify a minimum_number_dimensions while maximum is None while using labeled dimensions - "
+                "either use exact_number_dimensions > len(dimensions) for extra parameterized dimensions or set "
+                "maximum_number_dimensions explicitly to False for unbounded dimensions"
+            )
+
+    @staticmethod
+    def dimension_exact_cardinality(dimension: DimensionExpression):
+        """Dimensions can only have exact_cardinality OR min/max_cardinality, but not both"""
+        if dimension.exact_cardinality is not None and (
+            dimension.minimum_cardinality is not None or dimension.maximum_cardinality is not None
+        ):
+            raise SchemaValidationError(
+                f"Can only specify EITHER exact_cardinality OR minimum/maximum cardinality, got: {dimension}"
+            )
+
+    @staticmethod
+    def dimension_ordinal(dimension: DimensionExpression):
+        """minimum_cardinality must be less than maximum_cardinality when both are set"""
+        if dimension.minimum_cardinality is not None and dimension.maximum_cardinality is not None:
+            if dimension.minimum_cardinality > dimension.maximum_cardinality:
+                raise SchemaValidationError(
+                    "minimum_cardinality must be lesser than maximum_cardinality when both are set. "
+                    f"got minimum: {dimension.minimum_cardinality}, maximum: {dimension.maximum_cardinality}"
+                )
+
+
+class ArrayRangeGenerator(ABC):
+    """
+    Metaclass for generating a given format of array range.
+
+    See :ref:`array-forms` for more details on array range forms.
+
+    These classes do only enough validation of the array specification to decide
+    which kind of representation to generate. Proper value validation should
+    happen elsewhere (ie. in the metamodel and generated :class:`.ArrayExpression` class.)
+
+    Each of the array representation generation methods should be able to handle
+    the supported pydantic versions (currently still 1 and 2).
+
+    Notes:
+
+        When checking for array specification, recall that there is a semantic difference between
+        ``None`` and ``False`` , particularly for :attr:`.ArrayExpression.max_number_dimensions` -
+        check for absence of specification with ``is None`` rather than checking for truthiness/falsiness
+        (unless that's what you intend to do ofc ;)
+
+    Attributes:
+        array (:class:`.ArrayExpression` ): Array to create a range for
+        dtype (Union[str, :class:`.Element` ): dtype of the entire array as a string
+
+    """
+
+    REPR: ClassVar[ArrayRepresentation]
+
+    def __init__(self, array: ArrayExpression | None, dtype: str | Element | dict):
+        self.array = array
+        self.dtype = dtype
+
+    def make(self) -> RangeResult:
+        """
+        Create the string form of the array representation, validating first
+        """
+        self.validate()
+
+        if not self.array.dimensions and not self.has_bounded_dimensions:
+            return self._any_shape(self.array)
+        elif not self.array.dimensions and self.has_bounded_dimensions:
+            return self._bounded_dimensions(self.array)
+        elif self.array.dimensions and not self.has_bounded_dimensions:
+            return self._parameterized_dimensions(self.array)
+        else:
+            return self._complex_dimensions(self.array)
+
+    def validate(self):
+        """
+        Ensure that the given ArrayExpression is valid using :class:`.ArrayValidator`
+
+        .. todo::
+
+            Integrate with more general schema validation that happens when a schema is loaded,
+            rather than when an array is generated
+
+        Raises:
+            :class:`.SchemaValidationError` if the schema is invalid
+        """
+        ArrayValidator.validate(self.array)
+
+    @property
+    def has_bounded_dimensions(self) -> bool:
+        """Whether the :class:`.ArrayExpression` has some shape specification aside from ``dimensions``"""
+        return any([getattr(self.array, arr_field, None) is not None for arr_field in _BOUNDED_ARRAY_FIELDS])
+
+    @classmethod
+    def get_generator(cls, repr: ArrayRepresentation) -> type["ArrayRangeGenerator"]:
+        """Get the generator class for a given array representation"""
+        for subclass in cls.__subclasses__():
+            if repr in (subclass.REPR, subclass.REPR.value):
+                return subclass
+        raise ValueError(f"Generator for array representation {repr} not found!")
+
+    @abstractmethod
+    def _any_shape(self, array: ArrayRepresentation | None = None) -> Any:
+        """Any shaped array!"""
+        pass
+
+    @abstractmethod
+    def _bounded_dimensions(self, array: ArrayExpression) -> Any:
+        """Array shape specified numerically, without axis parameterization"""
+        pass
+
+    @abstractmethod
+    def _parameterized_dimensions(self, array: ArrayExpression) -> Any:
+        """Array shape specified with ``dimensions`` without additional parameterized dimensions"""
+        pass
+
+    @abstractmethod
+    def _complex_dimensions(self, array: ArrayExpression) -> Any:
+        """Array shape with both ``parameterized`` and ``bounded`` dimensions"""
+        pass

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -961,7 +961,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         ).schema_
         return self.top_level_schema
 
-    def serialize(self, as_json: bool = True, **kwargs) -> str | JsonSchema:
+    def serialize(self, **kwargs) -> str:
         if self.materialize_patterns:
             logger.info("Materializing patterns in the schema before serialization")
             self.schemaview.materialize_patterns()

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -8,9 +8,12 @@ from typing import Any
 
 import click
 from jsonasobj2 import as_dict
+from pydantic import Field
 
 from linkml._version import __version__
 from linkml.generators.common import build
+from linkml.generators.common.array import ArrayRangeGenerator, ArrayRepresentation
+from linkml.generators.common.build import RangeResult
 from linkml.generators.common.lifecycle import LifecycleMixin
 from linkml.generators.common.subproperty import get_subproperty_values
 from linkml.generators.common.type_designators import get_type_designator_value
@@ -19,8 +22,10 @@ from linkml.utils.helpers import get_range_associated_slots
 from linkml_runtime.linkml_model.meta import (
     AnonymousClassExpression,
     AnonymousSlotExpression,
+    ArrayExpression,
     ClassDefinition,
     ClassDefinitionName,
+    DimensionExpression,
     EnumDefinition,
     Example,
     PermissibleValue,
@@ -194,8 +199,8 @@ class JsonSchema(dict):
         super().__init__(*args, **kwargs)
         self._lax_forward_refs = {}
 
-    def add_def(self, name: str, subschema: "JsonSchema") -> None:
-        canonical_name = name if self.PRESERVE_NAMES else camelcase(name)
+    def add_def(self, name: str, subschema: "JsonSchema", preserve_name: bool = False) -> None:
+        canonical_name = name if self.PRESERVE_NAMES or preserve_name else camelcase(name)
 
         if "$defs" not in self:
             self["$defs"] = {}
@@ -673,7 +678,8 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         slot_is_inlined = self.schemaview.is_inlined(slot)
         if slot.range in self.schemaview.all_types().keys():
             schema_type = self.schemaview.induced_type(slot.range)
-            (typ, fmt) = json_schema_types.get(schema_type.base.lower(), ("string", None))
+            if schema_type.base:
+                (typ, fmt) = json_schema_types.get(schema_type.base.lower(), ("string", None))
         elif slot.range in self.schemaview.all_enums().keys():
             reference = slot.range
         elif slot.range in self.schemaview.all_classes().keys():
@@ -739,26 +745,17 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         return constraints
 
     def get_subschema_for_slot(
-        self, slot: SlotDefinition | AnonymousSlotExpression, omit_type: bool = False, include_null: bool = True
+        self,
+        slot: SlotDefinition | AnonymousSlotExpression,
+        omit_type: bool = False,
+        include_null: bool = True,
+        cls: ClassDefinition | None = None,
     ) -> JsonSchema:
         """
         Args:
             include_null: Include ``type: null`` when generating ranges that are not required
         """
         prop = JsonSchema()
-        if isinstance(slot, SlotDefinition) and slot.array:
-            # TODO: this is currently too lax, in that it will validate ANY array.
-            # see https://github.com/linkml/linkml/issues/2188
-            prop = JsonSchema(
-                {
-                    "type": ["null", "boolean", "object", "number", "string", "array"],
-                    "additionalProperties": True,
-                }
-            )
-            prop = JsonSchema.array_of(prop, include_null, required=slot.required)
-            if slot.examples:
-                prop.add_keyword("examples", _slot_examples_for_json_schema(slot.examples, is_array_valued=True))
-            return prop
         slot_is_multivalued = "multivalued" in slot and slot.multivalued
         slot_is_inlined = self.schemaview.is_inlined(slot)
         slot_is_boolean = any([slot.any_of, slot.all_of, slot.exactly_one_of, slot.none_of])
@@ -888,6 +885,11 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                 ),
             )
 
+        if isinstance(slot, SlotDefinition) and slot.array:
+            # TODO: this is currently too lax, in that it will validate ANY array.
+            # see https://github.com/linkml/linkml/issues/2188
+            prop = self.get_array_subschema(slot, prop, cls=cls)
+
         return prop
 
     def handle_class_slot(self, subschema: JsonSchema, cls: ClassDefinition, slot: SlotDefinition) -> None:
@@ -899,7 +901,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         value_disallowed = slot.value_presence == PresenceEnum(PresenceEnum.ABSENT)
 
         aliased_slot_name = self.aliased_slot_name(slot)
-        prop = self.get_subschema_for_slot(slot, include_null=self.include_null)
+        prop = self.get_subschema_for_slot(slot, include_null=self.include_null, cls=cls)
         prop = self.after_generate_class_slot(
             SlotResult.model_construct(schema_=prop, source=slot), cls, self.schemaview
         ).schema_
@@ -929,6 +931,20 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         else:
             return False
 
+    def get_array_subschema(
+        self, slot: SlotDefinition, prop: JsonSchema, cls: ClassDefinition | None = None
+    ) -> JsonSchema:
+        """
+        Generate a constrained array schema.
+        Treat the `prop` as the inner type of the array
+        """
+        # TODO: clear conflicting outer declarations
+        arraygen = JsonSchemaArrayGenerator(slot.array, prop, slot, cls_name=cls.name if cls else None)
+        result = arraygen.make()
+        for name, top_def in result.defs.items():
+            self.top_level_schema.add_def(name, top_def, preserve_name=True)
+        return result.schema_
+
     def generate(self) -> JsonSchema:
         self.schema = self.before_generate_schema(self.schema, self.schemaview)
         self.start_schema()
@@ -946,12 +962,159 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         ).schema_
         return self.top_level_schema
 
-    def serialize(self, **kwargs) -> str:
+    def serialize(self, as_json: bool = True, **kwargs) -> str | JsonSchema:
         if self.materialize_patterns:
             logger.info("Materializing patterns in the schema before serialization")
             self.schemaview.materialize_patterns()
         result = self.generate().to_json(sort_keys=True, indent=self.indent if self.indent > 0 else None)
         return result.rstrip() + "\n"
+
+
+class ArrayRangeResult(RangeResult):
+    schema_: JsonSchema
+    defs: dict[str, JsonSchema] = Field(default_factory=dict)
+    """top-level defs to inject, used when a recursive schema is needed"""
+
+
+class JsonSchemaArrayGenerator(ArrayRangeGenerator):
+    """Generate the JSON Schema for a LinkML Array!"""
+
+    REPR = ArrayRepresentation.JSON_SCHEMA
+
+    def __init__(
+        self, array: ArrayExpression | None, dtype: JsonSchema, slot: SlotDefinition, cls_name: str | None = None
+    ):
+        super().__init__(array, dtype)
+        self.slot = slot
+        self.dtype: JsonSchema = dtype
+        self.cls_name = cls_name
+
+    def make(self) -> ArrayRangeResult:
+        return super().make()
+
+    def _any_shape(self, array: ArrayExpression | None = None, with_inner_union: bool = False) -> ArrayRangeResult:
+        if self.cls_name:
+            fullname = f"{self.cls_name}-{self.slot.name}-anyshape"
+        else:
+            fullname = f"{self.slot.name}-anyshape"
+
+        schema = JsonSchema(items={"$ref": f"#/$defs/{fullname}"}, type="array")
+        if with_inner_union:
+            schema = JsonSchema(anyOf=[schema, self.dtype])
+        # dtype = self.dtype['anyOf'] if 'anyOf' in self.dtype else [self.dtype]
+
+        defs = {fullname: JsonSchema(anyOf=[{"items": {"$ref": f"#/$defs/{fullname}"}, "type": "array"}, self.dtype])}
+        return ArrayRangeResult(schema_=schema, defs=defs)
+
+    def _bounded_dimensions(self, array: ArrayExpression) -> ArrayRangeResult:
+        if array.exact_number_dimensions or (
+            array.minimum_number_dimensions
+            and array.maximum_number_dimensions
+            and array.minimum_number_dimensions == array.maximum_number_dimensions
+        ):
+            exact_dims = array.exact_number_dimensions or array.minimum_number_dimensions
+            return ArrayRangeResult(schema_=self._n_depth_array(exact_dims, self.dtype))
+        elif not array.maximum_number_dimensions and (
+            array.minimum_number_dimensions is None or array.minimum_number_dimensions == 1
+        ):
+            return self._any_shape()
+        elif array.maximum_number_dimensions:
+            # e.g., if min = 2, max = 3, range = Union[list[list[dtype]], list[list[list[dtype]]]]
+            min_dims = array.minimum_number_dimensions if array.minimum_number_dimensions is not None else 1
+            ranges = [self._n_depth_array(i, self.dtype) for i in range(min_dims, array.maximum_number_dimensions + 1)]
+            return ArrayRangeResult(schema_=JsonSchema(anyOf=ranges))
+        else:
+            # min specified with no max
+            # e.g., if min = 3, range = list[list[AnyShapeArray[dtype]]]
+            anyshape = self._any_shape(array)
+            return ArrayRangeResult(
+                schema_=self._n_depth_array(array.minimum_number_dimensions - 1, anyshape.schema_), defs=anyshape.defs
+            )
+
+    def _parameterized_dimensions(self, array: ArrayExpression) -> ArrayRangeResult:
+        range = self.dtype
+        for dimension in reversed(array.dimensions):
+            range = self._parameterized_dimension(dimension, range)
+        return ArrayRangeResult(schema_=range)
+
+    def _complex_dimensions(self, array: ArrayExpression) -> ArrayRangeResult:
+        res = None
+        # first process any unlabeled dimensions which must be the innermost level of the range,
+        # then wrap that with labeled dimensions
+        if array.exact_number_dimensions or (
+            array.minimum_number_dimensions
+            and array.maximum_number_dimensions
+            and array.minimum_number_dimensions == array.maximum_number_dimensions
+        ):
+            exact_dims = array.exact_number_dimensions or array.minimum_number_dimensions
+            if exact_dims > len(array.dimensions):
+                res = ArrayRangeResult(schema_=self._n_depth_array(exact_dims - len(array.dimensions), self.dtype))
+            elif exact_dims == len(array.dimensions):
+                # equivalent to labeled shape
+                return self._parameterized_dimensions(array)
+            # else is invalid, see: ArrayValidator.array_consistent_n_dimensions
+
+        elif array.maximum_number_dimensions is not None and not array.maximum_number_dimensions:
+            # unlimited n dimensions, so innermost is AnyShape with dtype
+            res = self._any_shape(with_inner_union=True)
+
+            if array.minimum_number_dimensions:
+                # some minimum anonymous dimensions but unlimited max dimensions
+                # e.g., if min = 3, len(dim) = 2, then res.range = list[Union[AnyShapeArray[dtype], dtype]]
+                # res.range will be wrapped with the 2 labeled dimensions later
+                res.schema_ = self._n_depth_array(array.minimum_number_dimensions - len(array.dimensions), res.schema_)
+
+        elif array.maximum_number_dimensions:
+            initial_min = array.minimum_number_dimensions if array.minimum_number_dimensions is not None else 0
+            dmin = max(len(array.dimensions), initial_min) - len(array.dimensions)
+            dmax = array.maximum_number_dimensions - len(array.dimensions)
+
+            res = self._bounded_dimensions(
+                ArrayExpression(minimum_number_dimensions=dmin, maximum_number_dimensions=dmax)
+            )
+
+        if res is None:
+            raise ValueError("Unsupported array specification! this is almost certainly a bug!")  # pragma: no cover
+
+        # Wrap inner dimension with labeled dimension
+        # e.g., if dimensions = [{min_card: 3}, {min_card: 2}]
+        # and res.range = list[Union[AnyShapeArray[dtype], dtype]]
+        # (min 3 dims, no max dims)
+        # then the final range = conlist(
+        #     min_length=3,
+        #     item_type=conlist(
+        #         min_length=2,
+        #         item_type=list[Union[AnyShapeArray[dtype], dtype]]
+        #     )
+        # )
+
+        for dim in reversed(array.dimensions):
+            res.schema_ = self._parameterized_dimension(dim, dtype=res.schema_)
+
+        return res
+
+    def _n_depth_array(self, dimensions: int, dtype: JsonSchema) -> JsonSchema:
+        if dimensions <= 0:
+            return dtype
+        arr = dtype
+        for _ in range(dimensions):
+            arr = JsonSchema(type="array", items=arr)
+        return arr
+
+    def _parameterized_dimension(self, dimension: DimensionExpression, dtype: JsonSchema) -> JsonSchema:
+        if dimension.exact_cardinality:
+            dmin = dimension.exact_cardinality
+            dmax = dimension.exact_cardinality
+        else:
+            dmin = dimension.minimum_cardinality
+            dmax = dimension.maximum_cardinality
+
+        arr = JsonSchema(type="array", items=dtype)
+        if dmin is not None:
+            arr["minItems"] = dmin
+        if dmax is not None:
+            arr["maxItems"] = dmax
+        return arr
 
 
 @shared_arguments(JsonSchemaGenerator)

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -938,7 +938,6 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         Generate a constrained array schema.
         Treat the `prop` as the inner type of the array
         """
-        # TODO: clear conflicting outer declarations
         arraygen = JsonSchemaArrayGenerator(slot.array, prop, slot, cls_name=cls.name if cls else None)
         result = arraygen.make()
         for name, top_def in result.defs.items():
@@ -1001,7 +1000,6 @@ class JsonSchemaArrayGenerator(ArrayRangeGenerator):
         schema = JsonSchema(items={"$ref": f"#/$defs/{fullname}"}, type="array")
         if with_inner_union:
             schema = JsonSchema(anyOf=[schema, self.dtype])
-        # dtype = self.dtype['anyOf'] if 'anyOf' in self.dtype else [self.dtype]
 
         defs = {fullname: JsonSchema(anyOf=[{"items": {"$ref": f"#/$defs/{fullname}"}, "type": "array"}, self.dtype])}
         return ArrayRangeResult(schema_=schema, defs=defs)
@@ -1077,17 +1075,6 @@ class JsonSchemaArrayGenerator(ArrayRangeGenerator):
             raise ValueError("Unsupported array specification! this is almost certainly a bug!")  # pragma: no cover
 
         # Wrap inner dimension with labeled dimension
-        # e.g., if dimensions = [{min_card: 3}, {min_card: 2}]
-        # and res.range = list[Union[AnyShapeArray[dtype], dtype]]
-        # (min 3 dims, no max dims)
-        # then the final range = conlist(
-        #     min_length=3,
-        #     item_type=conlist(
-        #         min_length=2,
-        #         item_type=list[Union[AnyShapeArray[dtype], dtype]]
-        #     )
-        # )
-
         for dim in reversed(array.dimensions):
             res.schema_ = self._parameterized_dimension(dim, dtype=res.schema_)
 

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -1017,7 +1017,6 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         Generate a constrained array schema.
         Treat the `prop` as the inner type of the array
         """
-        # TODO: clear conflicting outer declarations
         arraygen = JsonSchemaArrayGenerator(slot.array, prop, slot, cls_name=cls.name if cls else None)
         result = arraygen.make()
         for name, top_def in result.defs.items():
@@ -1077,7 +1076,6 @@ class JsonSchemaArrayGenerator(ArrayRangeGenerator):
         schema = JsonSchema(items={"$ref": f"#/$defs/{fullname}"}, type="array")
         if with_inner_union:
             schema = JsonSchema(anyOf=[schema, self.dtype])
-        # dtype = self.dtype['anyOf'] if 'anyOf' in self.dtype else [self.dtype]
 
         defs = {fullname: JsonSchema(anyOf=[{"items": {"$ref": f"#/$defs/{fullname}"}, "type": "array"}, self.dtype])}
         return ArrayRangeResult(schema_=schema, defs=defs)
@@ -1153,17 +1151,6 @@ class JsonSchemaArrayGenerator(ArrayRangeGenerator):
             raise ValueError("Unsupported array specification! this is almost certainly a bug!")  # pragma: no cover
 
         # Wrap inner dimension with labeled dimension
-        # e.g., if dimensions = [{min_card: 3}, {min_card: 2}]
-        # and res.range = list[Union[AnyShapeArray[dtype], dtype]]
-        # (min 3 dims, no max dims)
-        # then the final range = conlist(
-        #     min_length=3,
-        #     item_type=conlist(
-        #         min_length=2,
-        #         item_type=list[Union[AnyShapeArray[dtype], dtype]]
-        #     )
-        # )
-
         for dim in reversed(array.dimensions):
             res.schema_ = self._parameterized_dimension(dim, dtype=res.schema_)
 

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -962,8 +962,6 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
             )
 
         if isinstance(slot, SlotDefinition) and slot.array:
-            # TODO: this is currently too lax, in that it will validate ANY array.
-            # see https://github.com/linkml/linkml/issues/2188
             prop = self.get_array_subschema(slot, prop, cls=cls)
 
         return prop

--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -8,9 +8,12 @@ from typing import Any, cast
 
 import click
 from jsonasobj2 import as_dict
+from pydantic import Field
 
 from linkml._version import __version__
 from linkml.generators.common import build
+from linkml.generators.common.array import ArrayRangeGenerator, ArrayRepresentation
+from linkml.generators.common.build import RangeResult
 from linkml.generators.common.lifecycle import LifecycleMixin
 from linkml.generators.common.subproperty import get_subproperty_values
 from linkml.generators.common.type_designators import (
@@ -23,8 +26,10 @@ from linkml.utils.helpers import get_range_associated_slots
 from linkml_runtime.linkml_model.meta import (
     AnonymousClassExpression,
     AnonymousSlotExpression,
+    ArrayExpression,
     ClassDefinition,
     ClassDefinitionName,
+    DimensionExpression,
     Element,
     EnumDefinition,
     Example,
@@ -218,8 +223,8 @@ class JsonSchema(dict):
         super().__init__(*args, **kwargs)
         self._lax_forward_refs = {}
 
-    def add_def(self, name: str, subschema: "JsonSchema", is_curie: bool = False) -> None:
-        canonical_name = name if self.PRESERVE_NAMES or is_curie else camelcase(name)
+    def add_def(self, name: str, subschema: "JsonSchema", is_curie: bool = False, preserve_name: bool = False) -> None:
+        canonical_name = name if self.PRESERVE_NAMES or preserve_name or is_curie else camelcase(name)
 
         if "$defs" not in self:
             self["$defs"] = {}
@@ -731,7 +736,8 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         slot_is_inlined = self.schemaview.is_inlined(slot)
         if slot.range in self.schemaview.all_types().keys():
             schema_type = self.schemaview.induced_type(slot.range)
-            (typ, fmt) = json_schema_types.get(schema_type.base.lower(), ("string", None))
+            if schema_type.base:
+                (typ, fmt) = json_schema_types.get(schema_type.base.lower(), ("string", None))
         elif slot.range in self.schemaview.all_enums().keys():
             reference = slot.range
         elif slot.range in self.schemaview.all_classes().keys():
@@ -797,26 +803,17 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         return constraints
 
     def get_subschema_for_slot(
-        self, slot: SlotDefinition | AnonymousSlotExpression, omit_type: bool = False, include_null: bool = True
+        self,
+        slot: SlotDefinition | AnonymousSlotExpression,
+        omit_type: bool = False,
+        include_null: bool = True,
+        cls: ClassDefinition | None = None,
     ) -> JsonSchema:
         """
         Args:
             include_null: Include ``type: null`` when generating ranges that are not required
         """
         prop = JsonSchema()
-        if isinstance(slot, SlotDefinition) and slot.array:
-            # TODO: this is currently too lax, in that it will validate ANY array.
-            # see https://github.com/linkml/linkml/issues/2188
-            prop = JsonSchema(
-                {
-                    "type": ["null", "boolean", "object", "number", "string", "array"],
-                    "additionalProperties": True,
-                }
-            )
-            prop = JsonSchema.array_of(prop, include_null, required=slot.required)
-            if slot.examples:
-                prop.add_keyword("examples", _slot_examples_for_json_schema(slot.examples, is_array_valued=True))
-            return prop
         slot_is_multivalued = cast(bool, "multivalued" in slot and slot.multivalued)
         slot_is_inlined = self.schemaview.is_inlined(slot)
         slot_is_boolean = any([slot.any_of, slot.all_of, slot.exactly_one_of, slot.none_of])
@@ -964,6 +961,11 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                 ),
             )
 
+        if isinstance(slot, SlotDefinition) and slot.array:
+            # TODO: this is currently too lax, in that it will validate ANY array.
+            # see https://github.com/linkml/linkml/issues/2188
+            prop = self.get_array_subschema(slot, prop, cls=cls)
+
         return prop
 
     def handle_class_slot(self, subschema: JsonSchema, cls: ClassDefinition, slot: SlotDefinition) -> None:
@@ -978,7 +980,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
             prop_name = self._curie(slot)
         else:
             prop_name = self.aliased_slot_name(slot)
-        prop = self.get_subschema_for_slot(slot, include_null=self.include_null)
+        prop = self.get_subschema_for_slot(slot, include_null=self.include_null, cls=cls)
         prop = self.after_generate_class_slot(
             SlotResult.model_construct(schema_=prop, source=slot), cls, self.schemaview
         ).schema_
@@ -1008,6 +1010,20 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         else:
             return False
 
+    def get_array_subschema(
+        self, slot: SlotDefinition, prop: JsonSchema, cls: ClassDefinition | None = None
+    ) -> JsonSchema:
+        """
+        Generate a constrained array schema.
+        Treat the `prop` as the inner type of the array
+        """
+        # TODO: clear conflicting outer declarations
+        arraygen = JsonSchemaArrayGenerator(slot.array, prop, slot, cls_name=cls.name if cls else None)
+        result = arraygen.make()
+        for name, top_def in result.defs.items():
+            self.top_level_schema.add_def(name, top_def, preserve_name=True)
+        return result.schema_
+
     def generate(self) -> JsonSchema:
         self.schema = self.before_generate_schema(self.schema, self.schemaview)
         self.start_schema()
@@ -1028,6 +1044,153 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
     def serialize(self, **kwargs) -> str:
         result = self.generate().to_json(sort_keys=True, indent=self.indent if self.indent > 0 else None)
         return result.rstrip() + "\n"
+
+
+class ArrayRangeResult(RangeResult):
+    schema_: JsonSchema
+    defs: dict[str, JsonSchema] = Field(default_factory=dict)
+    """top-level defs to inject, used when a recursive schema is needed"""
+
+
+class JsonSchemaArrayGenerator(ArrayRangeGenerator):
+    """Generate the JSON Schema for a LinkML Array!"""
+
+    REPR = ArrayRepresentation.JSON_SCHEMA
+
+    def __init__(
+        self, array: ArrayExpression | None, dtype: JsonSchema, slot: SlotDefinition, cls_name: str | None = None
+    ):
+        super().__init__(array, dtype)
+        self.slot = slot
+        self.dtype: JsonSchema = dtype
+        self.cls_name = cls_name
+
+    def make(self) -> ArrayRangeResult:
+        return super().make()
+
+    def _any_shape(self, array: ArrayExpression | None = None, with_inner_union: bool = False) -> ArrayRangeResult:
+        if self.cls_name:
+            fullname = f"{self.cls_name}-{self.slot.name}-anyshape"
+        else:
+            fullname = f"{self.slot.name}-anyshape"
+
+        schema = JsonSchema(items={"$ref": f"#/$defs/{fullname}"}, type="array")
+        if with_inner_union:
+            schema = JsonSchema(anyOf=[schema, self.dtype])
+        # dtype = self.dtype['anyOf'] if 'anyOf' in self.dtype else [self.dtype]
+
+        defs = {fullname: JsonSchema(anyOf=[{"items": {"$ref": f"#/$defs/{fullname}"}, "type": "array"}, self.dtype])}
+        return ArrayRangeResult(schema_=schema, defs=defs)
+
+    def _bounded_dimensions(self, array: ArrayExpression) -> ArrayRangeResult:
+        if array.exact_number_dimensions or (
+            array.minimum_number_dimensions
+            and array.maximum_number_dimensions
+            and array.minimum_number_dimensions == array.maximum_number_dimensions
+        ):
+            exact_dims = array.exact_number_dimensions or array.minimum_number_dimensions
+            return ArrayRangeResult(schema_=self._n_depth_array(exact_dims, self.dtype))
+        elif not array.maximum_number_dimensions and (
+            array.minimum_number_dimensions is None or array.minimum_number_dimensions == 1
+        ):
+            return self._any_shape()
+        elif array.maximum_number_dimensions:
+            # e.g., if min = 2, max = 3, range = Union[list[list[dtype]], list[list[list[dtype]]]]
+            min_dims = array.minimum_number_dimensions if array.minimum_number_dimensions is not None else 1
+            ranges = [self._n_depth_array(i, self.dtype) for i in range(min_dims, array.maximum_number_dimensions + 1)]
+            return ArrayRangeResult(schema_=JsonSchema(anyOf=ranges))
+        else:
+            # min specified with no max
+            # e.g., if min = 3, range = list[list[AnyShapeArray[dtype]]]
+            anyshape = self._any_shape(array)
+            return ArrayRangeResult(
+                schema_=self._n_depth_array(array.minimum_number_dimensions - 1, anyshape.schema_), defs=anyshape.defs
+            )
+
+    def _parameterized_dimensions(self, array: ArrayExpression) -> ArrayRangeResult:
+        range = self.dtype
+        for dimension in reversed(array.dimensions):
+            range = self._parameterized_dimension(dimension, range)
+        return ArrayRangeResult(schema_=range)
+
+    def _complex_dimensions(self, array: ArrayExpression) -> ArrayRangeResult:
+        res = None
+        # first process any unlabeled dimensions which must be the innermost level of the range,
+        # then wrap that with labeled dimensions
+        if array.exact_number_dimensions or (
+            array.minimum_number_dimensions
+            and array.maximum_number_dimensions
+            and array.minimum_number_dimensions == array.maximum_number_dimensions
+        ):
+            exact_dims = array.exact_number_dimensions or array.minimum_number_dimensions
+            if exact_dims > len(array.dimensions):
+                res = ArrayRangeResult(schema_=self._n_depth_array(exact_dims - len(array.dimensions), self.dtype))
+            elif exact_dims == len(array.dimensions):
+                # equivalent to labeled shape
+                return self._parameterized_dimensions(array)
+            # else is invalid, see: ArrayValidator.array_consistent_n_dimensions
+
+        elif array.maximum_number_dimensions is not None and not array.maximum_number_dimensions:
+            # unlimited n dimensions, so innermost is AnyShape with dtype
+            res = self._any_shape(with_inner_union=True)
+
+            if array.minimum_number_dimensions:
+                # some minimum anonymous dimensions but unlimited max dimensions
+                # e.g., if min = 3, len(dim) = 2, then res.range = list[Union[AnyShapeArray[dtype], dtype]]
+                # res.range will be wrapped with the 2 labeled dimensions later
+                res.schema_ = self._n_depth_array(array.minimum_number_dimensions - len(array.dimensions), res.schema_)
+
+        elif array.maximum_number_dimensions:
+            initial_min = array.minimum_number_dimensions if array.minimum_number_dimensions is not None else 0
+            dmin = max(len(array.dimensions), initial_min) - len(array.dimensions)
+            dmax = array.maximum_number_dimensions - len(array.dimensions)
+
+            res = self._bounded_dimensions(
+                ArrayExpression(minimum_number_dimensions=dmin, maximum_number_dimensions=dmax)
+            )
+
+        if res is None:
+            raise ValueError("Unsupported array specification! this is almost certainly a bug!")  # pragma: no cover
+
+        # Wrap inner dimension with labeled dimension
+        # e.g., if dimensions = [{min_card: 3}, {min_card: 2}]
+        # and res.range = list[Union[AnyShapeArray[dtype], dtype]]
+        # (min 3 dims, no max dims)
+        # then the final range = conlist(
+        #     min_length=3,
+        #     item_type=conlist(
+        #         min_length=2,
+        #         item_type=list[Union[AnyShapeArray[dtype], dtype]]
+        #     )
+        # )
+
+        for dim in reversed(array.dimensions):
+            res.schema_ = self._parameterized_dimension(dim, dtype=res.schema_)
+
+        return res
+
+    def _n_depth_array(self, dimensions: int, dtype: JsonSchema) -> JsonSchema:
+        if dimensions <= 0:
+            return dtype
+        arr = dtype
+        for _ in range(dimensions):
+            arr = JsonSchema(type="array", items=arr)
+        return arr
+
+    def _parameterized_dimension(self, dimension: DimensionExpression, dtype: JsonSchema) -> JsonSchema:
+        if dimension.exact_cardinality:
+            dmin = dimension.exact_cardinality
+            dmax = dimension.exact_cardinality
+        else:
+            dmin = dimension.minimum_cardinality
+            dmax = dimension.maximum_cardinality
+
+        arr = JsonSchema(type="array", items=dtype)
+        if dmin is not None:
+            arr["minItems"] = dmin
+        if dmax is not None:
+            arr["maxItems"] = dmax
+        return arr
 
 
 @shared_arguments(JsonSchemaGenerator)

--- a/packages/linkml/src/linkml/generators/pydanticgen/array.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/array.py
@@ -1,13 +1,10 @@
 import sys
-from abc import ABC, abstractmethod
-from enum import Enum
 from typing import (
-    ClassVar,
     TypeVar,
     Union,
 )
 
-from linkml_runtime.linkml_model import Element
+from linkml.generators.common.array import ArrayRangeGenerator, ArrayRepresentation
 from linkml_runtime.linkml_model.meta import ArrayExpression, DimensionExpression
 
 if sys.version_info.minor < 12:
@@ -18,15 +15,6 @@ else:
 
 from linkml.generators.pydanticgen.build import RangeResult
 from linkml.generators.pydanticgen.template import ConditionalImport, Import, Imports, ObjectImport
-from linkml.utils.exceptions import SchemaValidationError
-
-
-class ArrayRepresentation(Enum):
-    LIST = "list"
-    NUMPYDANTIC = "numpydantic"  # numpydantic must be installed to use this
-
-
-_BOUNDED_ARRAY_FIELDS = ("exact_number_dimensions", "minimum_number_dimensions", "maximum_number_dimensions")
 
 _T = TypeVar("_T")
 AnyShapeArray = TypeAliasType("AnyShapeArray", list[Union[_T, "AnyShapeArray[_T]"]], type_params=(_T,))
@@ -57,217 +45,6 @@ _AnyShapeArrayInjects = [
 ]
 
 _ConListImports = Imports() + Import(module="pydantic", objects=[ObjectImport(name="conlist")])
-
-
-class ArrayValidator:
-    """
-    Validate the specification of a LinkML Array
-
-    .. todo::
-
-        It looks like :mod:`linkml.validator` is for validating instances against schema, rather
-        than validating the schema itself, so am not subclassing/writing as a plugin.
-        Unsure if there is a more general means of validating schema, but for now this is
-        an independent class
-    """
-
-    @classmethod
-    def validate(cls, array: ArrayExpression):
-        """
-        Validate an array expression.
-
-        Raises:
-            :class:`.SchemaValidationError` if invalid
-        """
-        cls.array_exact_dimensions(array)
-        cls.array_consistent_n_dimensions(array)
-        cls.array_explicitly_unbounded(array)
-        cls.array_dimensions_ordinal(array)
-
-        if array.dimensions:
-            for dimension in array.dimensions:
-                cls.validate_dimension(dimension)
-
-    @classmethod
-    def validate_dimension(cls, dimension: DimensionExpression):
-        """
-        Validate a single array dimension
-
-        Raises:
-            :class:`.SchemaValidationError` if invalid
-        """
-        cls.dimension_exact_cardinality(dimension)
-        cls.dimension_ordinal(dimension)
-
-    @staticmethod
-    def array_exact_dimensions(array: ArrayExpression):
-        """Arrays can have exact_number_dimensions OR min/max_number_dimensions, but not both"""
-        if array.exact_number_dimensions is not None and (
-            array.minimum_number_dimensions is not None or array.maximum_number_dimensions is not None
-        ):
-            raise SchemaValidationError(
-                f"Can only specify EITHER exact_number_dimensions OR minimum/maximum dimensions, got: {array}"
-            )
-
-    @staticmethod
-    def array_consistent_n_dimensions(array: ArrayExpression):
-        """
-        Complex arrays with both exact/min/max_number_dimensions and parameterized dimensions
-        need to have the exact/min/max_number_dimensions greater than the number of parameterized dimensions!
-        """
-        if not array.dimensions:
-            return
-
-        for field_name in _BOUNDED_ARRAY_FIELDS:
-            field = getattr(array, field_name, None)
-            if field and field < len(array.dimensions):
-                raise SchemaValidationError(
-                    "if exact/minimum/maximum_number_dimensions is provided, "
-                    "it must be greater than the parameterized dimensions. "
-                    f"got\n- {field_name}: {field}\n- dimensions: {array.dimensions}"
-                )
-
-    @staticmethod
-    def array_dimensions_ordinal(array: ArrayExpression):
-        """
-        minimum_number_dimensions needs to be less than maximum_number_dimensions when both are set
-        """
-        if array.minimum_number_dimensions is not None and array.maximum_number_dimensions:
-            if array.minimum_number_dimensions > array.maximum_number_dimensions:
-                raise SchemaValidationError(
-                    "minimum_number_dimensions must be lesser than maximum_number_dimensions when both are set. "
-                    f"got minimum: {array.minimum_number_dimensions}, maximum: {array.maximum_number_dimensions}"
-                )
-
-    @staticmethod
-    def array_explicitly_unbounded(array: ArrayExpression):
-        """
-        Complex arrays with a minimum_number_dimensions and parameterized dimensions
-        need to either use exact_number_dimensions to specify extra anonymous dimensions
-        or set maximum_number_dimensions to ``False`` to specify unbounded extra anonymous
-        dimensions to avoid ambiguity.
-        """
-        if array.minimum_number_dimensions is not None and array.maximum_number_dimensions is None and array.dimensions:
-            raise SchemaValidationError(
-                "Cannot specify a minimum_number_dimensions while maximum is None while using labeled dimensions - "
-                "either use exact_number_dimensions > len(dimensions) for extra parameterized dimensions or set "
-                "maximum_number_dimensions explicitly to False for unbounded dimensions"
-            )
-
-    @staticmethod
-    def dimension_exact_cardinality(dimension: DimensionExpression):
-        """Dimensions can only have exact_cardinality OR min/max_cardinality, but not both"""
-        if dimension.exact_cardinality is not None and (
-            dimension.minimum_cardinality is not None or dimension.maximum_cardinality is not None
-        ):
-            raise SchemaValidationError(
-                f"Can only specify EITHER exact_cardinality OR minimum/maximum cardinality, got: {dimension}"
-            )
-
-    @staticmethod
-    def dimension_ordinal(dimension: DimensionExpression):
-        """minimum_cardinality must be less than maximum_cardinality when both are set"""
-        if dimension.minimum_cardinality is not None and dimension.maximum_cardinality is not None:
-            if dimension.minimum_cardinality > dimension.maximum_cardinality:
-                raise SchemaValidationError(
-                    "minimum_cardinality must be lesser than maximum_cardinality when both are set. "
-                    f"got minimum: {dimension.minimum_cardinality}, maximum: {dimension.maximum_cardinality}"
-                )
-
-
-class ArrayRangeGenerator(ABC):
-    """
-    Metaclass for generating a given format of array range.
-
-    See :ref:`array-forms` for more details on array range forms.
-
-    These classes do only enough validation of the array specification to decide
-    which kind of representation to generate. Proper value validation should
-    happen elsewhere (ie. in the metamodel and generated :class:`.ArrayExpression` class.)
-
-    Each of the array representation generation methods should be able to handle
-    the supported pydantic versions (currently still 1 and 2).
-
-    Notes:
-
-        When checking for array specification, recall that there is a semantic difference between
-        ``None`` and ``False`` , particularly for :attr:`.ArrayExpression.max_number_dimensions` -
-        check for absence of specification with ``is None`` rather than checking for truthiness/falsiness
-        (unless that's what you intend to do ofc ;)
-
-    Attributes:
-        array (:class:`.ArrayExpression` ): Array to create a range for
-        dtype (Union[str, :class:`.Element` ): dtype of the entire array as a string
-
-    """
-
-    REPR: ClassVar[ArrayRepresentation]
-
-    def __init__(self, array: ArrayExpression | None, dtype: str | Element):
-        self.array = array
-        self.dtype = dtype
-
-    def make(self) -> RangeResult:
-        """
-        Create the string form of the array representation, validating first
-        """
-        self.validate()
-
-        if not self.array.dimensions and not self.has_bounded_dimensions:
-            return self._any_shape(self.array)
-        elif not self.array.dimensions and self.has_bounded_dimensions:
-            return self._bounded_dimensions(self.array)
-        elif self.array.dimensions and not self.has_bounded_dimensions:
-            return self._parameterized_dimensions(self.array)
-        else:
-            return self._complex_dimensions(self.array)
-
-    def validate(self):
-        """
-        Ensure that the given ArrayExpression is valid using :class:`.ArrayValidator`
-
-        .. todo::
-
-            Integrate with more general schema validation that happens when a schema is loaded,
-            rather than when an array is generated
-
-        Raises:
-            :class:`.SchemaValidationError` if the schema is invalid
-        """
-        ArrayValidator.validate(self.array)
-
-    @property
-    def has_bounded_dimensions(self) -> bool:
-        """Whether the :class:`.ArrayExpression` has some shape specification aside from ``dimensions``"""
-        return any([getattr(self.array, arr_field, None) is not None for arr_field in _BOUNDED_ARRAY_FIELDS])
-
-    @classmethod
-    def get_generator(cls, repr: ArrayRepresentation) -> type["ArrayRangeGenerator"]:
-        """Get the generator class for a given array representation"""
-        for subclass in cls.__subclasses__():
-            if repr in (subclass.REPR, subclass.REPR.value):
-                return subclass
-        raise ValueError(f"Generator for array representation {repr} not found!")
-
-    @abstractmethod
-    def _any_shape(self, array: ArrayRepresentation | None = None) -> RangeResult:
-        """Any shaped array!"""
-        pass
-
-    @abstractmethod
-    def _bounded_dimensions(self, array: ArrayExpression) -> RangeResult:
-        """Array shape specified numerically, without axis parameterization"""
-        pass
-
-    @abstractmethod
-    def _parameterized_dimensions(self, array: ArrayExpression) -> RangeResult:
-        """Array shape specified with ``dimensions`` without additional parameterized dimensions"""
-        pass
-
-    @abstractmethod
-    def _complex_dimensions(self, array: ArrayExpression) -> RangeResult:
-        """Array shape with both ``parameterized`` and ``bounded`` dimensions"""
-        pass
 
 
 class ListOfListsArray(ArrayRangeGenerator):

--- a/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
@@ -828,6 +828,8 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
             pyrange = _get_pyrange(t, sv)
         elif slot_range is None:
             pyrange = "str"
+        elif slot_range == "Any":
+            return slot_range
         else:
             # TODO: default ranges in schemagen
             # pyrange = 'str'

--- a/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
@@ -837,6 +837,8 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
             pyrange = _get_pyrange(t, sv)
         elif slot_range is None:
             pyrange = "str"
+        elif slot_range == "Any":
+            return slot_range
         else:
             # TODO: default ranges in schemagen
             # pyrange = 'str'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,8 @@ markers = [
   "owlgen: Tests for OWL generator",
   "yamlgen: Tests for the YAML generator",
   "yarrrml: End-to-end tests for the YARRRML generator",
-  "typedbgen: Tests for the TypeDB generator"
+  "typedbgen: Tests for the TypeDB generator",
+  "arrays: Array specifications!",
 ]
 
 # https://docs.astral.sh/ruff/settings/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,8 @@ markers = [
   "owlgen: Tests for OWL generator",
   "yamlgen: Tests for the YAML generator",
   "yarrrml: End-to-end tests for the YARRRML generator",
-  "typedbgen: Tests for the TypeDB generator"
+  "typedbgen: Tests for the TypeDB generator",
+  "arrays: Array specifications!",
 ]
 
 # https://docs.astral.sh/ruff/settings/

--- a/tests/linkml/test_generators/conftest.py
+++ b/tests/linkml/test_generators/conftest.py
@@ -1,4 +1,9 @@
+from pathlib import Path
+
 import pytest
+
+from linkml_runtime.linkml_model import ClassDefinition, SchemaDefinition
+from linkml_runtime.utils.schemaview import load_schema_wrap
 
 
 @pytest.fixture
@@ -11,3 +16,52 @@ class MyInjectedClass:
 
     def __init__(self, up: str = "doc"):
         self.what = up
+
+
+@pytest.fixture(scope="module")
+def array_anyshape(input_path) -> SchemaDefinition:
+    schema = str(Path(input_path("arrays")) / "any_shape.yaml")
+    return load_schema_wrap(schema)
+
+
+@pytest.fixture(scope="module")
+def array_bounded(input_path) -> SchemaDefinition:
+    schema = str(Path(input_path("arrays")) / "bounded_dimensions.yaml")
+    return load_schema_wrap(schema)
+
+
+@pytest.fixture(scope="module")
+def array_parameterized(input_path) -> SchemaDefinition:
+    schema = str(Path(input_path("arrays")) / "parameterized_dimensions.yaml")
+    return load_schema_wrap(schema)
+
+
+@pytest.fixture(scope="module")
+def array_complex(input_path) -> SchemaDefinition:
+    schema = str(Path(input_path("arrays")) / "complex_dimensions.yaml")
+    return load_schema_wrap(schema)
+
+
+@pytest.fixture(scope="module")
+def array_dtype(input_path) -> SchemaDefinition:
+    schema = str(Path(input_path("arrays")) / "dtype.yaml")
+    return load_schema_wrap(schema)
+
+
+@pytest.fixture(scope="module")
+def array_error_complex_dimensions(input_path) -> SchemaDefinition:
+    schema = str(Path(input_path("arrays")) / "error_complex_dimensions.yaml")
+    return load_schema_wrap(schema)
+
+
+@pytest.fixture(scope="module")
+def array_error_complex_unbounded(input_path) -> SchemaDefinition:
+    schema = str(Path(input_path("arrays")) / "error_complex_unbounded.yaml")
+    return load_schema_wrap(schema)
+
+
+@pytest.fixture(scope="module")
+def array_validator_errors(input_path) -> ClassDefinition:
+    schema_file = str(Path(input_path("arrays")) / "validator_errors.yaml")
+    schema = load_schema_wrap(schema_file)
+    return schema.classes["ErrorRiddenClass"]

--- a/tests/linkml/test_generators/input/arrays/any_shape.yaml
+++ b/tests/linkml/test_generators/input/arrays/any_shape.yaml
@@ -5,10 +5,10 @@ imports:
   - linkml:types
 
 classes:
-  AnyType:
+  AnyType_:
     attributes:
       array:
-        range: AnyType
+        range: Any
         array: {}
 
   Typed:
@@ -20,7 +20,7 @@ classes:
   AnyTypeUnset:
     attributes:
       array:
-        range: AnyType
+        range: Any
         array:
 
   TypedUnset:

--- a/tests/linkml/test_generators/test_jsonschemagen.py
+++ b/tests/linkml/test_generators/test_jsonschemagen.py
@@ -1,9 +1,13 @@
 import json
 import logging
 from collections.abc import Iterable
+from contextlib import nullcontext as does_not_raise
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 import jsonschema
+import numpy as np
 import pytest
 import yaml
 
@@ -1090,3 +1094,501 @@ def test_add_lax_def_missing_required():
     schema["$defs"]["NormalClass"] = {"type": "object", "properties": {"id": {}}, "required": ["id", "name"]}
     schema.add_lax_def("NormalClass", "id")
     assert schema["$defs"]["NormalClass__identifier_optional"]["required"] == ["name"]
+
+
+# --------------------------------------------------
+# Arrays!!!
+# --------------------------------------------------
+
+
+@dataclass
+class TestCase:
+    __test__ = False
+    type: Literal["pass", "fail-shape", "fail-dtype", "fail-scalar"]
+    array: np.ndarray
+
+    # def __post_init__(self):
+    #     self.array = self.array.tolist()
+
+    def expectation(self):
+        if self.type == "pass":
+            return does_not_raise()
+        else:
+            return pytest.raises(jsonschema.exceptions.ValidationError)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [TestCase(type="pass", array=np.zeros((3, 4, 5, 6), dtype=dt)) for dt in (int, float, str)]
+    + [TestCase(type="fail-scalar", array=a) for a in (4, 3.0, "three")],
+)
+def test_generate_array_anyshape(case, array_anyshape):
+    """
+    Any array shape, any dtype!
+    """
+
+    generated = JsonSchemaGenerator(array_anyshape, top_class="AnyType").generate()
+
+    if isinstance(case.array, np.ndarray):
+        array = case.array.tolist()
+    else:
+        array = case.array
+
+    with case.expectation():
+        jsonschema.validate({"array": array}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="fail-dtype", array=np.random.default_rng().random((2, 3, 4), dtype=float)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+    ],
+)
+def test_generate_array_anyshape_typed(case, array_anyshape):
+    """
+    Same as above, except dtype mismatches should cause a failure
+    """
+
+    generated = JsonSchemaGenerator(array_anyshape, top_class="Typed").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=float)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+    ],
+)
+def test_generate_array_dtype_union(case, array_dtype):
+    """
+    Array representations can validate union dtypes
+    """
+
+    generated = JsonSchemaGenerator(array_dtype, top_class="UnionDtype").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+def test_generate_array_dtype_class(array_dtype):
+    """
+    Array representations can use classes as ranges
+    """
+
+    generated = JsonSchemaGenerator(array_dtype, top_class="ClassDtype").generate()
+
+    array = np.full(shape=(2, 3, 4), fill_value={"x": 1, "y": 2})
+
+    # validates
+    jsonschema.validate({"array": array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((6, 3, 1, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2,), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+        TestCase(type="fail-dtype", array=np.zeros((2,), dtype=str)),
+    ],
+)
+def test_generate_array_bounded_min(case, array_bounded):
+    """
+    Any integer array with greater than 2 dimensions.
+    """
+    generated = JsonSchemaGenerator(array_bounded, top_class="MinDimensions").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 6, 7, 2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 6, 7, 2, 3, 6), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 6, 7, 2, 3, 6), dtype=str)),
+    ],
+)
+def test_generate_array_bounded_max(case, array_bounded):
+    """
+    Any integer array with less or equal dimensions than 5
+    """
+
+    generated = JsonSchemaGenerator(array_bounded, top_class="MaxDimensions").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((6, 3, 1, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2,), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+        TestCase(type="fail-dtype", array=np.zeros((2,), dtype=str)),
+        TestCase(type="pass", array=np.zeros((2, 6, 7, 2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 6, 7, 2, 3, 6), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 6, 7, 2, 3, 6), dtype=str)),
+    ],
+)
+def test_generate_array_bounded_range(case, array_bounded):
+    """
+    Any integer array equal to or between 2 and 5 dimensions
+    """
+    generated = JsonSchemaGenerator(array_bounded, top_class="RangeDimensions").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((6, 3, 1), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+        TestCase(type="fail-shape", array=np.zeros((2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 3, 4, 5), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 2), dtype=str)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4, 5), dtype=str)),
+    ],
+)
+def test_generate_array_bounded_exact(case, array_bounded):
+    """
+    Any integer array with exactly 3 dimensions
+    """
+
+    generated = JsonSchemaGenerator(array_bounded, top_class="ExactDimensions").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 5, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((3, 5, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((1, 5, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 5, 4), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 5, 4, 6, 6), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((3, 5, 4, 6), dtype=str)),
+        # FIXME: Add a float testcase back in here when https://github.com/linkml/linkml/issues/1955 is resolved
+    ],
+)
+def test_generate_array_parameterized_min(case, array_parameterized):
+    """
+    Any 4 dimensional integer array, the first dimension is equal to or greater than cardinality 2
+    """
+
+    generated = JsonSchemaGenerator(array_parameterized, top_class="ParameterizedArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 5, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 4, 4, 6), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 6, 4, 6), dtype=int)),
+        # this is the same field, so dtype failures only need to be tested in one case
+    ],
+)
+def test_generate_array_parameterized_max(case, array_parameterized):
+    """
+    Any 4 dimensional integer array, the second dimension is equal to or less than cardinality 5
+    """
+
+    generated = JsonSchemaGenerator(array_parameterized, top_class="ParameterizedArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 5, 2, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 5, 5, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 5, 1, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 5, 6, 6), dtype=int)),
+        # this is the same field, so dtype failures only need to be tested in one case
+    ],
+)
+def test_generate_array_parameterized_range(case, array_parameterized):
+    """
+    Any 4 dimensional integer array, the third dimension has a cardinality between 2 and 5, inclusive
+    """
+
+    generated = JsonSchemaGenerator(array_parameterized, top_class="ParameterizedArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 5, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 5, 4, 4), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 5, 4, 7), dtype=int)),
+        # this is the same field, so dtype failures only need to be tested in one case
+    ],
+)
+def test_generate_array_parameterized_exact(case, array_parameterized):
+    """
+    Any 4 dimensional integer array, the fourch dimension has a cardinality of exactly 6
+    """
+
+    generated = JsonSchemaGenerator(array_parameterized, top_class="ParameterizedArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 7, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 2, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 1, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 1, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 6, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 5), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 7), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((5, 2, 4, 6), dtype=str)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4), dtype=int)),
+    ],
+)
+def test_generate_array_complex_any(case, array_complex):
+    """
+    An array with at least four dimensions,
+    - the first of which has a maximum cardinality of 5, and
+    - the second of which has a minimum cardinality of 2
+    - the third of which has a cardinality between 2 and 5, inclusive, and
+    - the fourth of which has an exact cardinality of 6
+    """
+
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexAnyShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 7, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 7, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 2, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 1, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 1, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 6, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 5), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 7), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((5, 2, 4, 6), dtype=str)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4), dtype=int)),
+    ],
+)
+def test_generate_array_complex_max(case, array_complex):
+    """
+    An array with at most, or equal to 6 dimensions,
+    - the first of which has a maximum cardinality of 5, and
+    - the second of which has a minimum cardinality of 2
+    - the third of which has a cardinality between 2 and 5, inclusive, and
+    - the fourth of which has an exact cardinality of 6
+    """
+
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexMaxShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 7), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 7, 1, 1), dtype=int)),
+    ],
+)
+def test_generate_array_complex_min(case, array_complex):
+    """
+    An array with at least 5 dimensions (with the rest of the usual requirements for complex shape test)
+    """
+
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexMinShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 1), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 1, 1), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 1, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1, 1, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 2, 4, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 1, 4, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 1, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 6, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 5, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 7, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1), dtype=str)),
+    ],
+)
+def test_generate_array_complex_range(case, array_complex):
+    """
+    An array with between 5 and 7 dimensions, inclusive,
+    - the first of which has a maximum cardinality of 5, and
+    - the second of which has a minimum cardinality of 2
+    - the third of which has a cardinality between 2 and 5, inclusive, and
+    - the fourth of which has an exact cardinality of 6
+    """
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexRangeShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 2, 4, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 1, 4, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 1, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 6, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 5, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 7, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1), dtype=str)),
+    ],
+)
+def test_generate_array_complex_exact(case, array_complex):
+    """
+    An array with exactly 6 dimensions,
+    - the first of which has a maximum cardinality of 5, and
+    - the second of which has a minimum cardinality of 2
+    - the third of which has a cardinality between 2 and 5, inclusive, and
+    - the fourth of which has an exact cardinality of 6
+    """
+
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexExactShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+def test_generate_array_bounded_implicit_exact(array_bounded):
+    """
+    The representation of an bounded array with min and max dimensions that are equal should be the same as
+    setting an exact dimensionality.
+    """
+
+    generated = JsonSchemaGenerator(
+        array_bounded,
+    ).generate()
+
+    explicit = generated["$defs"]["ExactDimensions"]["properties"]["array"]
+    implicit = generated["$defs"]["ImplicitExact"]["properties"]["array"]
+    assert explicit == implicit
+
+
+@pytest.mark.arrays
+def test_generate_array_complex_implicit_exact(array_complex):
+    """
+    The representation of an complex array with min and max dimensions that are equal should be the same as
+    setting an exact dimensionality.
+    """
+
+    generated = JsonSchemaGenerator(
+        array_complex,
+    ).generate()
+    explicit = generated["$defs"]["ComplexExactShapeArray"]["properties"]["array"]
+    implicit = generated["$defs"]["ComplexImplicitExactShapeArray"]["properties"]["array"]
+    assert explicit == implicit
+
+
+@pytest.mark.arrays
+def test_generate_array_complex_noop_exact(array_complex, array_parameterized):
+    """
+    When the exact number of dimensions is equal to the number of parameterized dimensions,
+    the representation should be equivalent to if it hadn't been specified
+    """
+
+    generated_complex = JsonSchemaGenerator(
+        array_complex,
+    ).generate()
+    generated_parameterized = JsonSchemaGenerator(
+        array_parameterized,
+    ).generate()
+    complex = generated_complex["$defs"]["ComplexNoOpExactShapeArray"]["properties"]["array"]
+    parameterized = generated_parameterized["$defs"]["ParameterizedArray"]["properties"]["array"]
+    assert complex == parameterized
+
+
+@pytest.mark.arrays
+def test_generate_array_error_complex_exact_shape(array_error_complex_dimensions):
+    """
+    When we try and make a complex array where the exact number of dimensions are lower than the parameterized
+    dimensions, we should throw an error
+    """
+
+    with pytest.raises(ValueError, match=".*must be greater than the parameterized dimensions.*"):
+        _ = JsonSchemaGenerator(array_error_complex_dimensions).generate()
+
+
+@pytest.mark.arrays
+def test_generate_array_error_complex_unbounded_shape(array_error_complex_unbounded):
+    """
+    When we specify a minimum number of dimensions without a max (or setting max to False) in a complex array,
+    we should throw an error - min without a max is undefined behavior, to set unbounded we need the max to be
+    explicitly false.
+    """
+
+    with pytest.raises(ValueError, match=".*Cannot specify a minimum_number_dimensions while maximum is None.*"):
+        _ = JsonSchemaGenerator(
+            array_error_complex_unbounded,
+        ).generate()

--- a/tests/linkml/test_generators/test_jsonschemagen.py
+++ b/tests/linkml/test_generators/test_jsonschemagen.py
@@ -2,9 +2,13 @@ import json
 import logging
 import re
 from collections.abc import Iterable
+from contextlib import nullcontext as does_not_raise
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 import jsonschema
+import numpy as np
 import pytest
 import yaml
 
@@ -1127,3 +1131,498 @@ def test_use_uris(caplog, input_path, use_curies):
         assert "schema_location" in generated["$defs"]["SchemaEvent"]["properties"]
         assert "SarefEvent" in generated["$defs"]
         assert "saref_location" in generated["$defs"]["SarefEvent"]["properties"]
+
+
+# --------------------------------------------------
+# Arrays!!!
+# --------------------------------------------------
+
+
+@dataclass
+class TestCase:
+    __test__ = False
+    type: Literal["pass", "fail-shape", "fail-dtype", "fail-scalar"]
+    array: np.ndarray
+
+    def expectation(self):
+        if self.type == "pass":
+            return does_not_raise()
+        else:
+            return pytest.raises(jsonschema.exceptions.ValidationError)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [TestCase(type="pass", array=np.zeros((3, 4, 5, 6), dtype=dt)) for dt in (int, float, str)]
+    + [TestCase(type="fail-scalar", array=a) for a in (4, 3.0, "three")],
+)
+def test_generate_array_anyshape(case, array_anyshape):
+    """
+    Any array shape, any dtype!
+    """
+
+    generated = JsonSchemaGenerator(array_anyshape, top_class="AnyType").generate()
+
+    if isinstance(case.array, np.ndarray):
+        array = case.array.tolist()
+    else:
+        array = case.array
+
+    with case.expectation():
+        jsonschema.validate({"array": array}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="fail-dtype", array=np.random.default_rng().random((2, 3, 4), dtype=float)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+    ],
+)
+def test_generate_array_anyshape_typed(case, array_anyshape):
+    """
+    Same as above, except dtype mismatches should cause a failure
+    """
+
+    generated = JsonSchemaGenerator(array_anyshape, top_class="Typed").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=float)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+    ],
+)
+def test_generate_array_dtype_union(case, array_dtype):
+    """
+    Array representations can validate union dtypes
+    """
+
+    generated = JsonSchemaGenerator(array_dtype, top_class="UnionDtype").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+def test_generate_array_dtype_class(array_dtype):
+    """
+    Array representations can use classes as ranges
+    """
+
+    generated = JsonSchemaGenerator(array_dtype, top_class="ClassDtype").generate()
+
+    array = np.full(shape=(2, 3, 4), fill_value={"x": 1, "y": 2})
+
+    # validates
+    jsonschema.validate({"array": array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((6, 3, 1, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2,), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+        TestCase(type="fail-dtype", array=np.zeros((2,), dtype=str)),
+    ],
+)
+def test_generate_array_bounded_min(case, array_bounded):
+    """
+    Any integer array with greater than 2 dimensions.
+    """
+    generated = JsonSchemaGenerator(array_bounded, top_class="MinDimensions").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 6, 7, 2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 6, 7, 2, 3, 6), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 6, 7, 2, 3, 6), dtype=str)),
+    ],
+)
+def test_generate_array_bounded_max(case, array_bounded):
+    """
+    Any integer array with less or equal dimensions than 5
+    """
+
+    generated = JsonSchemaGenerator(array_bounded, top_class="MaxDimensions").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((6, 3, 1, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2,), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+        TestCase(type="fail-dtype", array=np.zeros((2,), dtype=str)),
+        TestCase(type="pass", array=np.zeros((2, 6, 7, 2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 6, 7, 2, 3, 6), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 6, 7, 2, 3, 6), dtype=str)),
+    ],
+)
+def test_generate_array_bounded_range(case, array_bounded):
+    """
+    Any integer array equal to or between 2 and 5 dimensions
+    """
+    generated = JsonSchemaGenerator(array_bounded, top_class="RangeDimensions").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 3, 4), dtype=int)),
+        TestCase(type="pass", array=np.zeros((6, 3, 1), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4), dtype=str)),
+        TestCase(type="fail-shape", array=np.zeros((2, 3), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 3, 4, 5), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 2), dtype=str)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 3, 4, 5), dtype=str)),
+    ],
+)
+def test_generate_array_bounded_exact(case, array_bounded):
+    """
+    Any integer array with exactly 3 dimensions
+    """
+
+    generated = JsonSchemaGenerator(array_bounded, top_class="ExactDimensions").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 5, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((3, 5, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((1, 5, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 5, 4), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 5, 4, 6, 6), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((3, 5, 4, 6), dtype=str)),
+        # FIXME: Add a float testcase back in here when https://github.com/linkml/linkml/issues/1955 is resolved
+    ],
+)
+def test_generate_array_parameterized_min(case, array_parameterized):
+    """
+    Any 4 dimensional integer array, the first dimension is equal to or greater than cardinality 2
+    """
+
+    generated = JsonSchemaGenerator(array_parameterized, top_class="ParameterizedArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 5, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 4, 4, 6), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((2, 6, 4, 6), dtype=int)),
+        # this is the same field, so dtype failures only need to be tested in one case
+    ],
+)
+def test_generate_array_parameterized_max(case, array_parameterized):
+    """
+    Any 4 dimensional integer array, the second dimension is equal to or less than cardinality 5
+    """
+
+    generated = JsonSchemaGenerator(array_parameterized, top_class="ParameterizedArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 5, 2, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((2, 5, 5, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 5, 1, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 5, 6, 6), dtype=int)),
+        # this is the same field, so dtype failures only need to be tested in one case
+    ],
+)
+def test_generate_array_parameterized_range(case, array_parameterized):
+    """
+    Any 4 dimensional integer array, the third dimension has a cardinality between 2 and 5, inclusive
+    """
+
+    generated = JsonSchemaGenerator(array_parameterized, top_class="ParameterizedArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((2, 5, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 5, 4, 4), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((2, 5, 4, 7), dtype=int)),
+        # this is the same field, so dtype failures only need to be tested in one case
+    ],
+)
+def test_generate_array_parameterized_exact(case, array_parameterized):
+    """
+    Any 4 dimensional integer array, the fourch dimension has a cardinality of exactly 6
+    """
+
+    generated = JsonSchemaGenerator(array_parameterized, top_class="ParameterizedArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 7, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 2, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 1, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 1, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 6, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 5), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 7), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((5, 2, 4, 6), dtype=str)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4), dtype=int)),
+    ],
+)
+def test_generate_array_complex_any(case, array_complex):
+    """
+    An array with at least four dimensions,
+    - the first of which has a maximum cardinality of 5, and
+    - the second of which has a minimum cardinality of 2
+    - the third of which has a cardinality between 2 and 5, inclusive, and
+    - the fourth of which has an exact cardinality of 6
+    """
+
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexAnyShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 7, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 7, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 2, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 1, 4, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 1, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 6, 6), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 5), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 7), dtype=int)),
+        TestCase(type="fail-dtype", array=np.zeros((5, 2, 4, 6), dtype=str)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4), dtype=int)),
+    ],
+)
+def test_generate_array_complex_max(case, array_complex):
+    """
+    An array with at most, or equal to 6 dimensions,
+    - the first of which has a maximum cardinality of 5, and
+    - the second of which has a minimum cardinality of 2
+    - the third of which has a cardinality between 2 and 5, inclusive, and
+    - the fourth of which has an exact cardinality of 6
+    """
+
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexMaxShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 7), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 7, 1, 1), dtype=int)),
+    ],
+)
+def test_generate_array_complex_min(case, array_complex):
+    """
+    An array with at least 5 dimensions (with the rest of the usual requirements for complex shape test)
+    """
+
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexMinShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 1), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 1, 1), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 1, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1, 1, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 2, 4, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 1, 4, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 1, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 6, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 5, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 7, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1), dtype=str)),
+    ],
+)
+def test_generate_array_complex_range(case, array_complex):
+    """
+    An array with between 5 and 7 dimensions, inclusive,
+    - the first of which has a maximum cardinality of 5, and
+    - the second of which has a minimum cardinality of 2
+    - the third of which has a cardinality between 2 and 5, inclusive, and
+    - the fourth of which has an exact cardinality of 6
+    """
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexRangeShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+@pytest.mark.parametrize(
+    "case",
+    [
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1), dtype=int)),
+        TestCase(type="pass", array=np.zeros((5, 2, 4, 6, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1, 1, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((6, 2, 4, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 1, 4, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 1, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 6, 6, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 5, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 7, 1), dtype=int)),
+        TestCase(type="fail-shape", array=np.zeros((5, 2, 4, 6, 1), dtype=str)),
+    ],
+)
+def test_generate_array_complex_exact(case, array_complex):
+    """
+    An array with exactly 6 dimensions,
+    - the first of which has a maximum cardinality of 5, and
+    - the second of which has a minimum cardinality of 2
+    - the third of which has a cardinality between 2 and 5, inclusive, and
+    - the fourth of which has an exact cardinality of 6
+    """
+
+    generated = JsonSchemaGenerator(array_complex, top_class="ComplexExactShapeArray").generate()
+
+    with case.expectation():
+        jsonschema.validate({"array": case.array.tolist()}, generated)
+
+
+@pytest.mark.arrays
+def test_generate_array_bounded_implicit_exact(array_bounded):
+    """
+    The representation of an bounded array with min and max dimensions that are equal should be the same as
+    setting an exact dimensionality.
+    """
+
+    generated = JsonSchemaGenerator(
+        array_bounded,
+    ).generate()
+
+    explicit = generated["$defs"]["ExactDimensions"]["properties"]["array"]
+    implicit = generated["$defs"]["ImplicitExact"]["properties"]["array"]
+    assert explicit == implicit
+
+
+@pytest.mark.arrays
+def test_generate_array_complex_implicit_exact(array_complex):
+    """
+    The representation of an complex array with min and max dimensions that are equal should be the same as
+    setting an exact dimensionality.
+    """
+
+    generated = JsonSchemaGenerator(
+        array_complex,
+    ).generate()
+    explicit = generated["$defs"]["ComplexExactShapeArray"]["properties"]["array"]
+    implicit = generated["$defs"]["ComplexImplicitExactShapeArray"]["properties"]["array"]
+    assert explicit == implicit
+
+
+@pytest.mark.arrays
+def test_generate_array_complex_noop_exact(array_complex, array_parameterized):
+    """
+    When the exact number of dimensions is equal to the number of parameterized dimensions,
+    the representation should be equivalent to if it hadn't been specified
+    """
+
+    generated_complex = JsonSchemaGenerator(
+        array_complex,
+    ).generate()
+    generated_parameterized = JsonSchemaGenerator(
+        array_parameterized,
+    ).generate()
+    complex = generated_complex["$defs"]["ComplexNoOpExactShapeArray"]["properties"]["array"]
+    parameterized = generated_parameterized["$defs"]["ParameterizedArray"]["properties"]["array"]
+    assert complex == parameterized
+
+
+@pytest.mark.arrays
+def test_generate_array_error_complex_exact_shape(array_error_complex_dimensions):
+    """
+    When we try and make a complex array where the exact number of dimensions are lower than the parameterized
+    dimensions, we should throw an error
+    """
+
+    with pytest.raises(ValueError, match=".*must be greater than the parameterized dimensions.*"):
+        _ = JsonSchemaGenerator(array_error_complex_dimensions).generate()
+
+
+@pytest.mark.arrays
+def test_generate_array_error_complex_unbounded_shape(array_error_complex_unbounded):
+    """
+    When we specify a minimum number of dimensions without a max (or setting max to False) in a complex array,
+    we should throw an error - min without a max is undefined behavior, to set unbounded we need the max to be
+    explicitly false.
+    """
+
+    with pytest.raises(ValueError, match=".*Cannot specify a minimum_number_dimensions while maximum is None.*"):
+        _ = JsonSchemaGenerator(
+            array_error_complex_unbounded,
+        ).generate()

--- a/tests/linkml/test_generators/test_pydanticgen.py
+++ b/tests/linkml/test_generators/test_pydanticgen.py
@@ -18,6 +18,7 @@ from jinja2 import DictLoader, Environment, Template
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from linkml.generators import pydanticgen as pydanticgen_root
+from linkml.generators.common.array import ArrayValidator
 from linkml.generators.common.lifecycle import TClass, TSlot
 from linkml.generators.pydanticgen import (
     MetadataMode,
@@ -27,7 +28,7 @@ from linkml.generators.pydanticgen import (
     pydanticgen,
     template,
 )
-from linkml.generators.pydanticgen.array import AnyShapeArray, ArrayRepresentation, ArrayValidator
+from linkml.generators.pydanticgen.array import AnyShapeArray, ArrayRepresentation
 from linkml.generators.pydanticgen.template import (
     ConditionalImport,
     Import,
@@ -46,7 +47,6 @@ from linkml_runtime.linkml_model import ClassDefinition, Definition, SchemaDefin
 from linkml_runtime.utils.compile_python import compile_python
 from linkml_runtime.utils.formatutils import camelcase, remove_empty_items, underscore
 from linkml_runtime.utils.schema_builder import SchemaBuilder
-from linkml_runtime.utils.schemaview import load_schema_wrap
 
 from .conftest import MyInjectedClass
 
@@ -1738,55 +1738,6 @@ def test_arrays_anyshape_strict():
 # --------------------------------------------------
 
 
-@pytest.fixture(scope="module")
-def array_anyshape(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "any_shape.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_bounded(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "bounded_dimensions.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_parameterized(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "parameterized_dimensions.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_complex(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "complex_dimensions.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_dtype(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "dtype.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_error_complex_dimensions(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "error_complex_dimensions.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_error_complex_unbounded(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "error_complex_unbounded.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_validator_errors(input_path) -> ClassDefinition:
-    schema_file = str(Path(input_path("arrays")) / "validator_errors.yaml")
-    schema = load_schema_wrap(schema_file)
-    return schema.classes["ErrorRiddenClass"]
-
-
 @pytest.fixture(
     scope="function",
     params=[
@@ -1814,6 +1765,7 @@ class TestCase:
             return pytest.raises(ValidationError)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [TestCase(type="pass", array=np.zeros((3, 4, 5, 6), dtype=dt)) for dt in (int, float, str)]
@@ -1835,6 +1787,7 @@ def test_generate_array_anyshape(case, array_representation, array_anyshape):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1857,6 +1810,7 @@ def test_generate_array_anyshape_typed(case, array_representation, array_anyshap
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1881,6 +1835,7 @@ def test_generate_array_dtype_union(case, array_representation, array_dtype):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1904,6 +1859,7 @@ def test_generate_array_dtype_numpy(case, array_representation, array_dtype):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 def test_generate_array_dtype_class(array_representation, array_dtype):
     """
     Array representations can use classes as ranges
@@ -1927,6 +1883,7 @@ def test_generate_array_dtype_class(array_representation, array_dtype):
     assert isinstance(instance.array[0][0][0], target_cls)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1952,6 +1909,7 @@ def test_generate_array_bounded_min(case, array_representation, array_bounded):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1976,6 +1934,7 @@ def test_generate_array_bounded_max(case, array_representation, array_bounded):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2004,6 +1963,7 @@ def test_generate_array_bounded_range(case, array_representation, array_bounded)
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2030,6 +1990,7 @@ def test_generate_array_bounded_exact(case, array_representation, array_bounded)
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2056,6 +2017,7 @@ def test_generate_array_parameterized_min(case, array_representation, array_para
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2079,6 +2041,7 @@ def test_generate_array_parameterized_max(case, array_representation, array_para
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2103,6 +2066,7 @@ def test_generate_array_parameterized_range(case, array_representation, array_pa
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2126,6 +2090,7 @@ def test_generate_array_parameterized_exact(case, array_representation, array_pa
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2159,6 +2124,7 @@ def test_generate_array_complex_any(case, array_representation, array_complex):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2193,6 +2159,7 @@ def test_generate_array_complex_max(case, array_representation, array_complex):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2215,6 +2182,7 @@ def test_generate_array_complex_min(case, array_representation, array_complex):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2250,6 +2218,7 @@ def test_generate_array_complex_range(case, array_representation, array_complex)
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2283,6 +2252,7 @@ def test_generate_array_complex_exact(case, array_representation, array_complex)
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 def test_generate_array_bounded_implicit_exact(array_representation, array_bounded):
     """
     The representation of an bounded array with min and max dimensions that are equal should be the same as
@@ -2297,6 +2267,7 @@ def test_generate_array_bounded_implicit_exact(array_representation, array_bound
     assert explicit.render() == implicit.render()
 
 
+@pytest.mark.arrays
 def test_generate_array_complex_implicit_exact(array_representation, array_complex):
     """
     The representation of an complex array with min and max dimensions that are equal should be the same as
@@ -2311,6 +2282,7 @@ def test_generate_array_complex_implicit_exact(array_representation, array_compl
     assert explicit.render() == implicit.render()
 
 
+@pytest.mark.arrays
 def test_generate_array_complex_noop_exact(array_representation, array_complex, array_parameterized):
     """
     When the exact number of dimensions is equal to the number of parameterized dimensions,
@@ -2328,6 +2300,7 @@ def test_generate_array_complex_noop_exact(array_representation, array_complex, 
     assert complex.render() == parameterized.render()
 
 
+@pytest.mark.arrays
 def test_generate_array_error_complex_exact_shape(array_representation, array_error_complex_dimensions):
     """
     When we try and make a complex array where the exact number of dimensions are lower than the parameterized
@@ -2338,6 +2311,7 @@ def test_generate_array_error_complex_exact_shape(array_representation, array_er
         _ = PydanticGenerator(array_error_complex_dimensions, array_representations=array_representation).serialize()
 
 
+@pytest.mark.arrays
 def test_generate_array_error_complex_unbounded_shape(array_representation, array_error_complex_unbounded):
     """
     When we specify a minimum number of dimensions without a max (or setting max to False) in a complex array,
@@ -2349,6 +2323,7 @@ def test_generate_array_error_complex_unbounded_shape(array_representation, arra
         _ = PydanticGenerator(array_error_complex_unbounded, array_representations=array_representation).serialize()
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "method",
     [
@@ -2374,6 +2349,7 @@ def test_array_validator(method, array_validator_errors):
         getattr(ArrayValidator, method)(array_expr)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize("method", ["dimension_exact_cardinality", "dimension_ordinal"])
 def test_dimension_validator(method, array_validator_errors):
     """Dimension-level validator method testing for ArrayValidator"""

--- a/tests/linkml/test_generators/test_pydanticgen.py
+++ b/tests/linkml/test_generators/test_pydanticgen.py
@@ -18,6 +18,7 @@ from jinja2 import DictLoader, Environment, Template
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from linkml.generators import pydanticgen as pydanticgen_root
+from linkml.generators.common.array import ArrayValidator
 from linkml.generators.common.lifecycle import TClass, TSlot
 from linkml.generators.pydanticgen import (
     MetadataMode,
@@ -27,7 +28,7 @@ from linkml.generators.pydanticgen import (
     pydanticgen,
     template,
 )
-from linkml.generators.pydanticgen.array import AnyShapeArray, ArrayRepresentation, ArrayValidator
+from linkml.generators.pydanticgen.array import AnyShapeArray, ArrayRepresentation
 from linkml.generators.pydanticgen.template import (
     ConditionalImport,
     Import,
@@ -46,7 +47,6 @@ from linkml_runtime.linkml_model import ClassDefinition, Definition, SchemaDefin
 from linkml_runtime.utils.compile_python import compile_python
 from linkml_runtime.utils.formatutils import camelcase, remove_empty_items, underscore
 from linkml_runtime.utils.schema_builder import SchemaBuilder
-from linkml_runtime.utils.schemaview import load_schema_wrap
 
 from .conftest import MyInjectedClass
 
@@ -1744,55 +1744,6 @@ def test_arrays_anyshape_strict():
 # --------------------------------------------------
 
 
-@pytest.fixture(scope="module")
-def array_anyshape(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "any_shape.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_bounded(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "bounded_dimensions.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_parameterized(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "parameterized_dimensions.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_complex(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "complex_dimensions.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_dtype(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "dtype.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_error_complex_dimensions(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "error_complex_dimensions.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_error_complex_unbounded(input_path) -> SchemaDefinition:
-    schema = str(Path(input_path("arrays")) / "error_complex_unbounded.yaml")
-    return load_schema_wrap(schema)
-
-
-@pytest.fixture(scope="module")
-def array_validator_errors(input_path) -> ClassDefinition:
-    schema_file = str(Path(input_path("arrays")) / "validator_errors.yaml")
-    schema = load_schema_wrap(schema_file)
-    return schema.classes["ErrorRiddenClass"]
-
-
 @pytest.fixture(
     scope="function",
     params=[
@@ -1820,6 +1771,7 @@ class TestCase:
             return pytest.raises(ValidationError)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [TestCase(type="pass", array=np.zeros((3, 4, 5, 6), dtype=dt)) for dt in (int, float, str)]
@@ -1841,6 +1793,7 @@ def test_generate_array_anyshape(case, array_representation, array_anyshape):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1863,6 +1816,7 @@ def test_generate_array_anyshape_typed(case, array_representation, array_anyshap
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1887,6 +1841,7 @@ def test_generate_array_dtype_union(case, array_representation, array_dtype):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1910,6 +1865,7 @@ def test_generate_array_dtype_numpy(case, array_representation, array_dtype):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 def test_generate_array_dtype_class(array_representation, array_dtype):
     """
     Array representations can use classes as ranges
@@ -1933,6 +1889,7 @@ def test_generate_array_dtype_class(array_representation, array_dtype):
     assert isinstance(instance.array[0][0][0], target_cls)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1958,6 +1915,7 @@ def test_generate_array_bounded_min(case, array_representation, array_bounded):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -1982,6 +1940,7 @@ def test_generate_array_bounded_max(case, array_representation, array_bounded):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2010,6 +1969,7 @@ def test_generate_array_bounded_range(case, array_representation, array_bounded)
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2036,6 +1996,7 @@ def test_generate_array_bounded_exact(case, array_representation, array_bounded)
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2062,6 +2023,7 @@ def test_generate_array_parameterized_min(case, array_representation, array_para
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2085,6 +2047,7 @@ def test_generate_array_parameterized_max(case, array_representation, array_para
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2109,6 +2072,7 @@ def test_generate_array_parameterized_range(case, array_representation, array_pa
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2132,6 +2096,7 @@ def test_generate_array_parameterized_exact(case, array_representation, array_pa
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2165,6 +2130,7 @@ def test_generate_array_complex_any(case, array_representation, array_complex):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2199,6 +2165,7 @@ def test_generate_array_complex_max(case, array_representation, array_complex):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2221,6 +2188,7 @@ def test_generate_array_complex_min(case, array_representation, array_complex):
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2256,6 +2224,7 @@ def test_generate_array_complex_range(case, array_representation, array_complex)
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "case",
     [
@@ -2289,6 +2258,7 @@ def test_generate_array_complex_exact(case, array_representation, array_complex)
         cls(array=case.array)
 
 
+@pytest.mark.arrays
 def test_generate_array_bounded_implicit_exact(array_representation, array_bounded):
     """
     The representation of an bounded array with min and max dimensions that are equal should be the same as
@@ -2303,6 +2273,7 @@ def test_generate_array_bounded_implicit_exact(array_representation, array_bound
     assert explicit.render() == implicit.render()
 
 
+@pytest.mark.arrays
 def test_generate_array_complex_implicit_exact(array_representation, array_complex):
     """
     The representation of an complex array with min and max dimensions that are equal should be the same as
@@ -2317,6 +2288,7 @@ def test_generate_array_complex_implicit_exact(array_representation, array_compl
     assert explicit.render() == implicit.render()
 
 
+@pytest.mark.arrays
 def test_generate_array_complex_noop_exact(array_representation, array_complex, array_parameterized):
     """
     When the exact number of dimensions is equal to the number of parameterized dimensions,
@@ -2334,6 +2306,7 @@ def test_generate_array_complex_noop_exact(array_representation, array_complex, 
     assert complex.render() == parameterized.render()
 
 
+@pytest.mark.arrays
 def test_generate_array_error_complex_exact_shape(array_representation, array_error_complex_dimensions):
     """
     When we try and make a complex array where the exact number of dimensions are lower than the parameterized
@@ -2344,6 +2317,7 @@ def test_generate_array_error_complex_exact_shape(array_representation, array_er
         _ = PydanticGenerator(array_error_complex_dimensions, array_representations=array_representation).serialize()
 
 
+@pytest.mark.arrays
 def test_generate_array_error_complex_unbounded_shape(array_representation, array_error_complex_unbounded):
     """
     When we specify a minimum number of dimensions without a max (or setting max to False) in a complex array,
@@ -2355,6 +2329,7 @@ def test_generate_array_error_complex_unbounded_shape(array_representation, arra
         _ = PydanticGenerator(array_error_complex_unbounded, array_representations=array_representation).serialize()
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize(
     "method",
     [
@@ -2380,6 +2355,7 @@ def test_array_validator(method, array_validator_errors):
         getattr(ArrayValidator, method)(array_expr)
 
 
+@pytest.mark.arrays
 @pytest.mark.parametrize("method", ["dimension_exact_cardinality", "dimension_ordinal"])
 def test_dimension_validator(method, array_validator_errors):
     """Dimension-level validator method testing for ArrayValidator"""


### PR DESCRIPTION
## Summary

Fix: #1889 

What up its yer blob, me, back again with another "implementing linkml arrays"

- move some of the pydantic-specific array generation stuff to a common module
- move the array testcase fixtures to the conftest file
- copy paste baby
- now it works

## How was this tested?

exactly how pydanticgen arrays are tested!

## Areas of uncertainty

there are probably some weird cases about how the inner dtype is handled - what i did is just like "assumed that the current method for getting a slot's range as a schema did that" and then "put that inside of arrays." idk just @ me about stuff idk this generator at all.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

i have to eat bowls full of dogshit all day long already why would i bring a bowl full of dogshit to my zen garden project