### PR TITLE
Align extra_slots support across pythongen/pydanticgen, per-class enabled

### DIFF
--- a/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
@@ -36,6 +36,7 @@ from linkml.generators.pydanticgen.template import (
 from linkml.utils.deprecation import deprecation_warning
 from linkml.utils.generator import shared_arguments
 from linkml_runtime.linkml_model.meta import (
+    AnonymousSlotExpression,
     ClassDefinition,
     ElementName,
     SchemaDefinition,
@@ -77,6 +78,7 @@ DEFAULT_IMPORTS = (
     + Import(
         module="typing",
         objects=[
+            ObjectImport(name="Annotated"),
             ObjectImport(name="Any"),
             ObjectImport(name="ClassVar"),
             ObjectImport(name="Literal"),
@@ -485,7 +487,9 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
                 raise ValueError(f"could not find suitable element in {clist} that does not ref {slist}")
         return slist
 
-    def _get_extra_for_class(self, cls: ClassDefinition) -> Literal["allow", "forbid", "ignore"] | None:
+    def _get_extra_for_class(
+        self, cls: ClassDefinition
+    ) -> Literal["allow", "forbid", "ignore"] | PydanticAttribute | None:
         """
         Determine the per-class ``extra`` value for the Pydantic ``ConfigDict``
         based on the class's ``extra_slots`` metadata.
@@ -493,9 +497,13 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
         Returns ``None`` if the class does not override the generator-wide default,
         so the inherited base-model configuration is used.
         """
-        if not cls.extra_slots or cls.extra_slots.allowed is None:
+        if not cls.extra_slots:
             return None
-        return "allow" if cls.extra_slots.allowed else "forbid"
+        elif cls.extra_slots.range_expression:
+            result = self.generate_slot(cls.extra_slots.range_expression, cls)
+            return result.attribute
+        else:
+            return "allow" if cls.extra_slots.allowed else "forbid"
 
     def generate_class(self, cls: ClassDefinition) -> ClassResult:
         # Handle union_of classes by creating a type alias instead of a class
@@ -588,31 +596,43 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
 
         return result
 
-    def generate_slot(self, slot: SlotDefinition, cls: ClassDefinition) -> SlotResult:
+    def generate_slot(self, slot: SlotDefinition | AnonymousSlotExpression, cls: ClassDefinition) -> SlotResult:
+        """
+        Generate the template representation of a slot.
+
+        If slot is a SlotDefinition, renders as a pydantic field,
+        if an AnonymousSlotExpression, renders as an annotated type.
+        """
         slot_args = {
             k: getattr(slot, k, None)
             for k in PydanticAttribute.model_fields.keys()
             if getattr(slot, k, None) is not None
         }
         slot_args["empty_list_for_multivalued_slots"] = self.empty_list_for_multivalued_slots
-        slot_alias = slot.alias if slot.alias else slot.name
 
-        # Create a valid Python identifier for the field name
-        python_field_name = make_valid_python_identifier(underscore(slot_alias))
-        slot_args["name"] = python_field_name
-
-        # If the original name is different from the Python identifier, set an alias
-        if slot_alias != python_field_name:
-            slot_args["alias"] = slot_alias
+        if isinstance(slot, AnonymousSlotExpression):
+            slot_args["name"] = "__anonymous__"
+            slot_args["as_annotated"] = True
         else:
-            # Remove any existing alias if the names are the same
-            if "alias" in slot_args:
-                del slot_args["alias"]
+            slot_alias = slot.alias if slot.alias else slot.name
+
+            # Create a valid Python identifier for the field name
+            python_field_name = make_valid_python_identifier(underscore(slot_alias))
+            slot_args["name"] = python_field_name
+
+            # If the original name is different from the Python identifier, set an alias
+            if slot_alias != python_field_name:
+                slot_args["alias"] = slot_alias
+            else:
+                # Remove any existing alias if the names are the same
+                if "alias" in slot_args:
+                    del slot_args["alias"]
+
+            predef = self.predefined_slot_values.get(self._get_class_python_name(cls.name), {}).get(slot.name, None)
+            if predef is not None:
+                slot_args["predefined"] = str(predef)
 
         slot_args["description"] = slot.description.replace('"', '\\"') if slot.description is not None else None
-        predef = self.predefined_slot_values.get(self._get_class_python_name(cls.name), {}).get(slot.name, None)
-        if predef is not None:
-            slot_args["predefined"] = str(predef)
 
         pyslot = PydanticAttribute(**slot_args)
         pyslot = self.include_metadata(pyslot, slot)
@@ -673,8 +693,13 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
                     result.attribute.range = f"dict[str, {simple_dict_value}]"
                 else:
                     result.attribute.range = f"dict[{collection_key}, {result.attribute.range}]"
-        if not (slot.required or slot.identifier or slot.key) and not slot.designates_type:
+
+        if isinstance(slot, AnonymousSlotExpression):
+            if not slot.required:
+                result.attribute.range = f"Optional[{result.attribute.range}]"
+        elif not (slot.required or slot.identifier or slot.key) and not slot.designates_type:
             result.attribute.range = f"Optional[{result.attribute.range}]"
+
         return result
 
     @property
@@ -821,7 +846,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
         """
         sv = self.schemaview
 
-        if slot_def.designates_type:
+        if getattr(slot_def, "designates_type", False):
             pyrange = (
                 "Literal["
                 + ",".join(['"' + x + '"' for x in get_accepted_type_designator_values(sv, slot_def, class_def)])
@@ -833,7 +858,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
             pyrange = "Literal[" + ", ".join([f'"{a_string}"' for a_string in slot_def.equals_string_in]) + "]"
         elif (
             self.expand_subproperty_of
-            and slot_def.subproperty_of
+            and getattr(slot_def, "subproperty_of", False)
             and slot_range not in sv.all_classes()
             and slot_range not in sv.all_enums()
         ):

--- a/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
@@ -33,6 +33,7 @@ from linkml.generators.pydanticgen.template import (
     PydanticModule,
     PydanticTemplateModel,
 )
+from linkml.utils.deprecation import deprecation_warning
 from linkml.utils.generator import shared_arguments
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
@@ -238,7 +239,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
     for each class. If a matching template is not found in the override directory,
     the default templates will be used.
     """
-    extra_fields: Literal["allow", "forbid", "ignore"] = "forbid"
+    extra_fields: Literal["allow", "forbid", "ignore"] | None = None
     """
     How to handle extra fields in Pydantic models. Sets the default for all classes;
     individual classes can override this via their ``extra_slots`` metadata.
@@ -409,6 +410,14 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
     # Private attributes
     _predefined_slot_values: dict[str, dict[str, str]] | None = None
     _class_bases: dict[str, list[str]] | None = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.extra_fields is not None:
+            deprecation_warning("pydanticgen-extra-fields")
+        else:
+            # preserve prior behavior until removal
+            self.extra_fields = "forbid"
 
     def compile_module(self, **kwargs) -> ModuleType:
         """

--- a/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/pydanticgen.py
@@ -239,6 +239,10 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
     the default templates will be used.
     """
     extra_fields: Literal["allow", "forbid", "ignore"] = "forbid"
+    """
+    How to handle extra fields in Pydantic models. Sets the default for all classes;
+    individual classes can override this via their ``extra_slots`` metadata.
+    """
     gen_mixin_inheritance: bool = True
     injected_classes: list[type | str] | None = None
     """
@@ -406,9 +410,6 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
     _predefined_slot_values: dict[str, dict[str, str]] | None = None
     _class_bases: dict[str, list[str]] | None = None
 
-    def __post_init__(self):
-        super().__post_init__()
-
     def compile_module(self, **kwargs) -> ModuleType:
         """
         Compiles generated python code to a module
@@ -475,6 +476,18 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
                 raise ValueError(f"could not find suitable element in {clist} that does not ref {slist}")
         return slist
 
+    def _get_extra_for_class(self, cls: ClassDefinition) -> Literal["allow", "forbid", "ignore"] | None:
+        """
+        Determine the per-class ``extra`` value for the Pydantic ``ConfigDict``
+        based on the class's ``extra_slots`` metadata.
+
+        Returns ``None`` if the class does not override the generator-wide default,
+        so the inherited base-model configuration is used.
+        """
+        if not cls.extra_slots or cls.extra_slots.allowed is None:
+            return None
+        return "allow" if cls.extra_slots.allowed else "forbid"
+
     def generate_class(self, cls: ClassDefinition) -> ClassResult:
         # Handle union_of classes by creating a type alias instead of a class
         if cls.union_of:
@@ -485,6 +498,7 @@ class PydanticGenerator(OOCodeGenerator, LifecycleMixin):
             name=class_python_name,
             bases=self.class_bases.get(class_python_name, PydanticBaseModel.default_name),
             description=cls.description.replace('"', '\\"') if cls.description is not None else None,
+            extra=self._get_extra_for_class(cls),
         )
 
         imports = self._get_imports(cls) if self.split else None
@@ -1360,7 +1374,7 @@ Available templates to override:
     "--extra-fields",
     type=click.Choice(["allow", "ignore", "forbid"], case_sensitive=False),
     default="forbid",
-    help="How to handle extra fields in BaseModel.",
+    help="How to handle extra fields in BaseModel (default for all classes; per-class overrides via extra_slots).",
 )
 @click.option(
     "--black",

--- a/packages/linkml/src/linkml/generators/pydanticgen/template.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/template.py
@@ -267,6 +267,14 @@ class PydanticClass(PydanticTemplateModel):
     """
     Metadata for the class to be included in a linkml_meta class attribute
     """
+    extra: Literal["allow", "forbid", "ignore"] | None = None
+    """
+    Per-class override for the ``extra`` argument of pydantic's ``ConfigDict``.
+
+    When set, emits ``model_config = ConfigDict(extra="...")`` in the generated
+    class body so the class overrides the base model's ``extra`` configuration.
+    Derived from the LinkML ``extra_slots`` metadata on the source class.
+    """
     is_type_alias: bool = False
     """
     If True, generate a type alias instead of a class

--- a/packages/linkml/src/linkml/generators/pydanticgen/template.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/template.py
@@ -214,6 +214,11 @@ class PydanticAttribute(PydanticTemplateModel):
     """
     Metadata for the slot to be included in a Field annotation
     """
+    as_annotated: bool = False
+    """
+    If ``True``, render as Annotated[range, Field()] form,
+    rather than model field form.
+    """
 
     @computed_field
     def field(self) -> str:
@@ -267,7 +272,7 @@ class PydanticClass(PydanticTemplateModel):
     """
     Metadata for the class to be included in a linkml_meta class attribute
     """
-    extra: Literal["allow", "forbid", "ignore"] | None = None
+    extra: Literal["allow", "forbid", "ignore"] | PydanticAttribute | None = None
     """
     Per-class override for the ``extra`` argument of pydantic's ``ConfigDict``.
 

--- a/packages/linkml/src/linkml/generators/pydanticgen/template.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/template.py
@@ -154,7 +154,7 @@ class PydanticBaseModel(PydanticTemplateModel):
 
     default_name: ClassVar[str] = "ConfiguredBaseModel"
     name: str = Field(default_factory=lambda: PydanticBaseModel.default_name)
-    extra_fields: Literal["allow", "forbid", "ignore"] = "forbid"
+    extra_fields: Literal["allow", "forbid", "ignore"] | None = "forbid"
     """
     Sets the ``extra`` model for pydantic models
     """

--- a/packages/linkml/src/linkml/generators/pydanticgen/templates/attribute.py.jinja
+++ b/packages/linkml/src/linkml/generators/pydanticgen/templates/attribute.py.jinja
@@ -1,4 +1,8 @@
+{%- if as_annotated -%}
+Annotated[{{ range }}, Field(...
+{%- else -%}
 {{name}}: {{ range }} = Field(default={{ field }}
+{%- endif -%}
 {%- if alias %}, alias="{{alias}}"{% endif -%}
 {%- if title != None %}, title="{{title}}"{% endif -%}
 {%- if description %}, description="""{{description}}"""{% endif -%}
@@ -17,3 +21,6 @@
 {%- if meta -%}
     , json_schema_extra = { "linkml_meta": {{ meta | pprint | indent(width=8) }} }
 {%- endif -%})
+{%- if as_annotated -%}
+]
+{%- endif -%}

--- a/packages/linkml/src/linkml/generators/pydanticgen/templates/base_model.py.jinja
+++ b/packages/linkml/src/linkml/generators/pydanticgen/templates/base_model.py.jinja
@@ -4,7 +4,7 @@ class {{ name }}(BaseModel):
         validate_by_name = True,
         validate_assignment = True,
         validate_default = True,
-        extra = "{{ extra_fields }}",
+        {% if extra_fields %}extra = "{{ extra_fields }}",{% endif %}
         arbitrary_types_allowed = True,
         use_enum_values = True,
         strict = {{ strict }},

--- a/packages/linkml/src/linkml/generators/pydanticgen/templates/base_model.py.jinja
+++ b/packages/linkml/src/linkml/generators/pydanticgen/templates/base_model.py.jinja
@@ -4,7 +4,9 @@ class {{ name }}(BaseModel):
         validate_by_name = True,
         validate_assignment = True,
         validate_default = True,
-        {% if extra_fields %}extra = "{{ extra_fields }}",{% endif %}
+        {% if extra_fields %}
+        extra = "{{ extra_fields }}",
+        {% endif %}
         arbitrary_types_allowed = True,
         use_enum_values = True,
         strict = {{ strict }},

--- a/packages/linkml/src/linkml/generators/pydanticgen/templates/class.py.jinja
+++ b/packages/linkml/src/linkml/generators/pydanticgen/templates/class.py.jinja
@@ -10,6 +10,10 @@ class {{ name }}({% if bases is string %}{{ bases }}{% else %}{{ bases | join(',
     {{ description | indent(width=4) }}
     """
     {% endif -%}
+    {% if extra %}
+    model_config = ConfigDict(extra = "{{ extra }}")
+
+    {% endif -%}
     {% if meta %}
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({{ meta | pprint | indent(width=8) }})
 

--- a/packages/linkml/src/linkml/generators/pydanticgen/templates/class.py.jinja
+++ b/packages/linkml/src/linkml/generators/pydanticgen/templates/class.py.jinja
@@ -11,7 +11,12 @@ class {{ name }}({% if bases is string %}{{ bases }}{% else %}{{ bases | join(',
     """
     {% endif -%}
     {% if extra %}
+      {% if extra in ("forbid", "allow", "ignore") %}
     model_config = ConfigDict(extra = "{{ extra }}")
+      {% else %}
+    __pydantic_extra__: dict[str, {{ extra }}]
+    model_config = ConfigDict(extra = "allow")
+      {% endif %}
 
     {% endif -%}
     {% if meta %}

--- a/packages/linkml/src/linkml/generators/pythongen.py
+++ b/packages/linkml/src/linkml/generators/pythongen.py
@@ -551,17 +551,62 @@ version = {'"' + self.schema.version + '"' if self.schema.version else None}
         if self.is_class_unconstrained(cls):
             return f"\n{self.class_or_type_name(cls.name)} = Any"
 
+        # If the class has extra_slots.allowed=true, disable dataclass init and generate
+        # a custom __init__ that accepts **kwargs so unknown attributes don't raise TypeError.
+        dataclass_decorator = ""
+        custom_init = ""
+        if slotdefs:
+            if self._extra_slots_allowed(cls) and not constructor:
+                dataclass_decorator = f"\n@dataclass(repr={self.dataclass_repr}, init=False)"
+                custom_init = self._gen_extra_slots_init(slotdefs)
+            else:
+                dataclass_decorator = f"\n@dataclass(repr={self.dataclass_repr})"
+
         cd_str = (
-            (f"\n@dataclass(repr={self.dataclass_repr})" if slotdefs else "")
+            dataclass_decorator
             + f"\nclass {self.class_or_type_name(cls.name)}{parentref}:{wrapped_description}"
             + f"{self.gen_inherited_slots(cls)}"
             + f"{self.gen_class_meta(cls)}"
             + (f"\n\t{slotdefs}" if slotdefs else "")
+            + (f"\n{custom_init}" if custom_init else "")
             + (f"\n{postinits}" if postinits else "")
             + (f"\n{constructor}" if constructor else "")
         )
 
         return cd_str
+
+    @staticmethod
+    def _extra_slots_allowed(cls: ClassDefinition) -> bool:
+        """Return True when the class's ``extra_slots`` metadata permits unknown attributes."""
+        return bool(cls.extra_slots and cls.extra_slots.allowed)
+
+    def _gen_extra_slots_init(self, slotdefs_str: str) -> str:
+        """
+        Generate a custom ``__init__`` for classes whose ``extra_slots`` permits
+        unknown attributes. The signature accepts the schema-declared slots
+        plus ``**kwargs``, and forwards extras to the parent ``__init__`` so they
+        land as attributes on the instance.
+        """
+        # Extract slot names from the generated slotdefs.
+        # Each slot line is like: "slotname: Type = default"
+        slot_names = []
+        for line in slotdefs_str.split("\n\t"):
+            if ":" in line:
+                slot_name = line.split(":")[0].strip()
+                if slot_name:
+                    slot_names.append(slot_name)
+
+        init_params = ", ".join([f"{sn}=None" for sn in slot_names])
+        init_sig = f"(self, {init_params}, **kwargs: Any)" if init_params else "(self, **kwargs: Any)"
+
+        assignments = []
+        for sn in slot_names:
+            assignments.append(f"        if {sn} is not None:")
+            assignments.append(f"            self.{sn} = {sn}")
+
+        assignments_str = "\n".join(assignments) if assignments else "        pass"
+
+        return f"\n    def __init__{init_sig}:\n{assignments_str}\n        super().__init__(**kwargs)"
 
     def gen_inherited_slots(self, cls: ClassDefinition) -> str:
         if not self.gen_classvars:

--- a/packages/linkml/src/linkml/utils/deprecation.py
+++ b/packages/linkml/src/linkml/utils/deprecation.py
@@ -300,6 +300,14 @@ DEPRECATIONS = (
         recommendation="Use 'linkml validate schema.yaml' for schema validation without lint rules.",
         issue=3387,
     ),
+    Deprecation(
+        name="pydanticgen-extra-fields",
+        deprecated_in=SemVer.from_str("1.11.1"),
+        removed_in=SemVer.from_str("1.13.0"),
+        message="Globally overriding `extra` on generated classes with `extra_fields` is deprecated.",
+        recommendation="Set `extra_slots` on individual classes within the schema",
+        issue=3630,
+    ),
 )  # type: tuple[Deprecation, ...]
 
 EMITTED = set()  # type: set[str]

--- a/tests/linkml/test_generators/test_extra_slots_per_class.py
+++ b/tests/linkml/test_generators/test_extra_slots_per_class.py
@@ -1,0 +1,145 @@
+"""
+Tests for honoring per-class ``extra_slots`` metadata in code generators.
+
+LinkML's metamodel lets a class declare ``extra_slots: {allowed: true}`` to opt
+in to open-world semantics (see https://github.com/linkml/linkml/issues/1341).
+These tests verify that 'gen-python' and 'gen-pydantic' honor per-class
+setting, matching behavior already seen in 'gen-json-schema'.
+"""
+
+import pytest
+
+from linkml.generators.pydanticgen import PydanticGenerator
+from linkml.generators.pythongen import PythonGenerator
+from linkml_runtime.utils.compile_python import compile_python
+
+SCHEMA_MIXED = """
+id: https://example.org/test
+name: test
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/
+default_prefix: ex
+default_range: string
+
+types:
+  string:
+    uri: xsd:string
+    base: str
+
+classes:
+  StrictPerson:
+    description: Person with closed-world semantics (default)
+    attributes:
+      name:
+        required: true
+
+  FlexiblePerson:
+    description: Person with open-world semantics via extra_slots
+    extra_slots:
+      allowed: true
+    attributes:
+      name:
+        required: true
+
+  ExplicitlyClosedPerson:
+    description: Person explicitly closed via extra_slots
+    extra_slots:
+      allowed: false
+    attributes:
+      name:
+        required: true
+"""
+
+
+@pytest.fixture
+def schema_file(tmp_path):
+    p = tmp_path / "schema.yaml"
+    p.write_text(SCHEMA_MIXED)
+    return str(p)
+
+
+class TestPythonGeneratorPerClassExtraSlots:
+    """PythonGenerator honors per-class ``extra_slots.allowed``."""
+
+    def test_default_class_rejects_extras(self, schema_file):
+        code = PythonGenerator(schema_file).serialize()
+        module = compile_python(code)
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            module.StrictPerson(name="Alice", extra_field="x")
+
+    def test_extra_slots_allowed_class_accepts_extras(self, schema_file):
+        code = PythonGenerator(schema_file).serialize()
+        module = compile_python(code)
+        instance = module.FlexiblePerson(name="Bob", extra_field="value", age=30)
+        assert instance.name == "Bob"
+        assert instance.extra_field == "value"
+        assert instance.age == 30
+
+    def test_extra_slots_disallowed_class_rejects_extras(self, schema_file):
+        code = PythonGenerator(schema_file).serialize()
+        module = compile_python(code)
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            module.ExplicitlyClosedPerson(name="Carol", extra_field="x")
+
+    def test_custom_init_only_emitted_for_open_classes(self, schema_file):
+        code = PythonGenerator(schema_file).serialize()
+
+        # The custom open-world __init__ is the only place ``def __init__`` is
+        # generated (the normal dataclass init is synthesized at runtime).
+        # It should appear exactly once – for FlexiblePerson only.
+        assert code.count("def __init__(") == 1
+        # And the strict classes should not have the init=False decorator.
+        assert code.count("init=False") == 1
+
+
+class TestPydanticGeneratorPerClassExtraSlots:
+    """PydanticGenerator honors per-class ``extra_slots.allowed``."""
+
+    def test_default_extra_fields_unchanged(self, schema_file):
+        """The generator-wide default is still ``forbid``."""
+        gen = PydanticGenerator(schema_file)
+        assert gen.extra_fields == "forbid"
+
+    def test_strict_class_has_no_per_class_override(self, schema_file):
+        code = PydanticGenerator(schema_file).serialize()
+        # StrictPerson should not have its own model_config override
+        strict_block = _extract_class_block(code, "StrictPerson")
+        assert "model_config" not in strict_block
+
+    def test_open_class_emits_extra_allow(self, schema_file):
+        code = PydanticGenerator(schema_file).serialize()
+        flex_block = _extract_class_block(code, "FlexiblePerson")
+        assert 'extra = "allow"' in flex_block
+
+    def test_explicitly_closed_class_emits_extra_forbid(self, schema_file):
+        code = PydanticGenerator(schema_file).serialize()
+        closed_block = _extract_class_block(code, "ExplicitlyClosedPerson")
+        assert 'extra = "forbid"' in closed_block
+
+    def test_runtime_open_class_accepts_extras(self, schema_file):
+        """Compile and verify that ``extra_slots.allowed=true`` enables extras at runtime."""
+        code = PydanticGenerator(schema_file).serialize()
+        module = compile_python(code)
+        instance = module.FlexiblePerson(name="Bob", extra_field="value")
+        assert instance.name == "Bob"
+        assert instance.extra_field == "value"
+
+    def test_runtime_strict_class_rejects_extras(self, schema_file):
+        """Default closed-world classes still reject extras at runtime."""
+        from pydantic import ValidationError
+
+        code = PydanticGenerator(schema_file).serialize()
+        module = compile_python(code)
+        with pytest.raises(ValidationError):
+            module.StrictPerson(name="Alice", extra_field="x")
+
+
+def _extract_class_block(code: str, class_name: str) -> str:
+    """Return the source block for ``class_name`` up to the next top-level class."""
+    marker = f"class {class_name}("
+    start = code.index(marker)
+    rest = code[start + len(marker) :]
+    next_class = rest.find("\nclass ")
+    end = start + len(marker) + (next_class if next_class != -1 else len(rest))
+    return code[start:end]

--- a/tests/linkml/test_generators/test_pydanticgen.py
+++ b/tests/linkml/test_generators/test_pydanticgen.py
@@ -3226,7 +3226,7 @@ def extra_slots(input_path) -> ModuleType:
             False,
             {
                 "x": 1,
-                "another": True,
+                "another": 1.5,
             },
         ),
         ("ExtraCardinality", True, {"x": 1, "another": [1, 2, 3, 4, 5]}),

--- a/tests/linkml/test_generators/test_pydanticgen.py
+++ b/tests/linkml/test_generators/test_pydanticgen.py
@@ -3174,3 +3174,69 @@ classes:
     # InteractionAssociation should have narrowed constraint
     # (interacts_with and its descendants only)
     assert 'Literal["interacts_with", "physically_interacts_with"]' in code
+
+
+# --------------------------------------------------
+# extra_slots
+# --------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def extra_slots(input_path) -> ModuleType:
+    schema = input_path("extra_slots.yaml")
+    generated = PydanticGenerator(schema).serialize()
+    mod = compile_python(generated)
+    return mod
+
+
+@pytest.mark.parametrize(
+    "clsname,valid,data",
+    [
+        ("ExtraNotAllowed", True, {"x": 1}),
+        ("ExtraNotAllowed", False, {"x": 1, "y": 2}),
+        ("ExtraAllowed", True, {"x": 1, "whatever": "else", "we": {"want": ["in", "here", True]}}),
+        (
+            "ExtraString",
+            True,
+            {
+                "x": 1,
+                "y": "string",
+            },
+        ),
+        (
+            "ExtraString",
+            False,
+            {
+                "x": 1,
+                "y": 2,
+            },
+        ),
+        ("ExtraClass", True, {"x": 1, "another": {"y": "string"}, "third": {"y": "some string"}}),
+        (
+            "ExtraClass",
+            False,
+            {
+                "x": 1,
+                "another": {"y": 1},
+            },
+        ),
+        ("ExtraAnyOf", True, {"x": 1, "another": "hey", "third": 2}),
+        (
+            "ExtraAnyOf",
+            False,
+            {
+                "x": 1,
+                "another": True,
+            },
+        ),
+        ("ExtraCardinality", True, {"x": 1, "another": [1, 2, 3, 4, 5]}),
+        ("ExtraCardinality", False, {"x": 1, "another": [1, 2, 3, 4, 5, 6]}),
+    ],
+)
+def test_extra_slots(data, clsname, valid, extra_slots):
+    cls = getattr(extra_slots, clsname)
+    if valid:
+        cls(**data)
+    else:
+        with pytest.raises(ValidationError):
+            cls(**data)


### PR DESCRIPTION
## Summary

Fixes #3629 

- Both generators read `cls.extra_slots.allowed` and emit per-class behavior that matches schema.


## How was this tested?

Added unit tests

## Areas of uncertainty

- Needs soaking by "open worlder's" as we enable feature that is not default.
- Expect future bugs on edge cases.
- Maybe #1341 should be closed also - tangential stale issue.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x]I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance
LLM assisted