### PR TITLE
fix(docgen): render example descriptions in the Examples table (#2714)

### DIFF
--- a/packages/linkml/src/linkml/generators/docgen/common_metadata.md.jinja2
+++ b/packages/linkml/src/linkml/generators/docgen/common_metadata.md.jinja2
@@ -33,10 +33,10 @@
 {% if element.examples %}
 ## Examples
 
-| Value |
-| --- |
+| Value | Description |
+| --- | --- |
 {% for x in element.examples -%}
-| {{ x.value }} |
+| {{ x.value }} | {{ x.description if x.description is not none else '' }} |
 {% endfor %}
 {% endif -%}
 

--- a/tests/linkml/test_generators/test_docgen.py
+++ b/tests/linkml/test_generators/test_docgen.py
@@ -1730,3 +1730,46 @@ classes:
     # Each file must describe only its own element type
     assert_mdfile_does_not_contain(class_file, "# Subset:")
     assert_mdfile_does_not_contain(subset_file, "# Class:")
+
+
+def test_docgen_example_description(tmp_path):
+    """Regression for linkml/linkml#2714 -- gen-doc must render the ``description`` of
+    metamodel ``examples`` entries, not just their ``value``.
+
+    The Examples table previously had a single ``Value`` column and silently dropped
+    each example's ``description``.
+    """
+    schema_yaml = """\
+id: https://example.org/test
+name: test
+default_prefix: test
+prefixes:
+  test: https://example.org/test/
+  linkml: https://w3id.org/linkml/
+imports: [linkml:types]
+default_range: string
+
+classes:
+  Instrument:
+    description: a manufactured device
+    examples:
+      - value: centrifuge
+        description: a device that spins samples
+      - value: microtome
+"""
+    gen = DocGenerator(schema_yaml, mergeimports=False, no_types_dir=True)
+    gen.serialize(directory=str(tmp_path))
+
+    instrument_file = tmp_path / "Instrument.md"
+    # The example value and its description are both rendered, in the same table row.
+    assert_mdfile_contains(
+        instrument_file,
+        "| centrifuge | a device that spins samples |",
+        after="## Examples",
+    )
+    # An example without a description still renders without leaking ``None``.
+    assert_mdfile_contains(
+        instrument_file,
+        "| microtome |  |",
+        after="## Examples",
+    )


### PR DESCRIPTION
Fixes part of #2714.

### Problem

The docgen Examples table only rendered each example's `value`. The metamodel `Example` class has a `value_description` slot (exposed as `.description`), which the issue uses to qualify a value, but the template dropped it entirely, so the rendered docs lost that information.

### Fix

`packages/linkml/src/linkml/generators/docgen/common_metadata.md.jinja2`: add a `Description` column to the Examples table and render `x.description`, falling back to an empty cell when an example has no description (so missing descriptions don't render as `None`). This affects every element that renders examples (classes, slots, etc.), which is the intended behaviour.

### Test

`test_docgen_example_description` builds an inline schema with two examples (one with a description, one without) and asserts both rows render correctly. Without the template change the test fails; with it the full `test_docgen.py` module passes (44 passed, 1 skipped).

Scope: this addresses the gen-doc rendering half of #2714. The validation/alias question raised in the first half of the issue is independent and left untouched.

Disclosure: I used AI assistance (Claude) to help locate and draft this fix, under my direction and review.
