### PR TITLE
Improve docs of sqlvalidation generator

### DIFF
--- a/docs/generators/sqlvalidation.rst
+++ b/docs/generators/sqlvalidation.rst
@@ -1,6 +1,13 @@
 SQL Validation
 ==============
 
+Example Output
+--------------
+
+A generated sql query for the `personinfo.yml` schema with `sqlite` syntax.
+
+`personinfo.sql <https://github.com/linkml/linkml/tree/main/examples/PersonSchema/personinfo/sqlvalidation/personinfo.sql>`_
+
 Overview
 --------
 
@@ -30,17 +37,48 @@ validation query would return:
      - P001
      - 200
 
-Example Output
---------------
 
-A generated sql query for the `personinfo.yml` schema with `sqlite` syntax.
+General Functionality
+^^^^^^^^^^^^^^^^^^^^^
 
-`personinfo.sql <https://github.com/linkml/linkml/tree/main/examples/PersonSchema/personinfo/sqlvalidation/personinfo.sql>`_
+For every constraint from the LinkML schema, one query is created. Each of those queries consists of a `SELECT` with one or multiple `WHERE` conditions.
+All queries are concated using the `UNION ALL`. Overall, the generated query looks like this
 
-Overview
---------
+.. code-block:: sql
 
+  SELECT <error information>
+  WHERE <constraint 1>
+  UNION ALL
+  SELECT <error information>
+  WHERE <constraint 2>
+  UNION ALL
+  ...
 
+To learn more about constraints in LinkML, check out :doc:`Adding constraints and rules <./../schemas/constraints>`.
+
+Constraint: Range
+^^^^^^^^^^^^^^^^^
+
+For the `range` keyword, checks for enumeration are implemented so far. A schema like this
+
+.. code-block:: yaml
+
+  enums:
+    OrganizationType:
+      permissible_values:
+        non profit:
+        for profit:
+  classes:
+    Organization:
+      attributes:
+        categories:
+          range: OrganizationType
+
+will generate the following constraint:
+
+.. code-block:: sql
+
+  WHERE "Organization".categories NOT IN ('non profit', 'for profit')
 
 
 

--- a/docs/generators/sqlvalidation.rst
+++ b/docs/generators/sqlvalidation.rst
@@ -94,7 +94,7 @@ For slots with ``minimum_value`` or ``maximum_value``, the generated query ident
       attributes:
         id:
           identifier: true
-        age_in_years:
+        age:
           range: integer
           minimum_value: 0
           maximum_value: 999
@@ -208,9 +208,9 @@ would generate the following constraint:
 
 .. code-block:: sql
 
-  SELECT 'Person' AS table_name, 'name_and_email' AS column_name, 'unique_key' AS constraint_type, id AS record_id, CAST(name AS TEXT) || '|' || CAST(primary_email AS TEXT) AS invalid_value
+  SELECT 'Person' AS table_name, 'name_and_email' AS column_name, 'unique_key' AS constraint_type, id AS record_id, (CAST(name AS TEXT) || '|') || CAST(primary_email AS TEXT) AS invalid_value
   FROM "Person"
-  WHERE (name, primary_email) IN (SELECT name, primary_email
+  WHERE ("Person".name, "Person".primary_email) IN (SELECT name, primary_email
   FROM "Person" GROUP BY name, primary_email
   HAVING count(*) > 1)
 

--- a/docs/generators/sqlvalidation.rst
+++ b/docs/generators/sqlvalidation.rst
@@ -56,6 +56,9 @@ All queries are concatenated using `UNION ALL`. Overall, the generated query loo
 
 To learn more about constraints in LinkML, check out :doc:`Adding constraints and rules <./../schemas/constraints>`.
 
+For simplicity, each example below shows only the query for the constraint being described. The full
+output for a schema also includes the ``required`` and uniqueness checks implied by every ``identifier`` slot.
+
 Constraint: Required
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/generators/sqlvalidation.rst
+++ b/docs/generators/sqlvalidation.rst
@@ -42,7 +42,7 @@ General Functionality
 ^^^^^^^^^^^^^^^^^^^^^
 
 For every constraint from the LinkML schema, one query is created. Each of those queries consists of a `SELECT` with one or multiple `WHERE` conditions.
-All queries are concated using the `UNION ALL`. Overall, the generated query looks like this
+All queries are concatenated using `UNION ALL`. Overall, the generated query looks like this:
 
 .. code-block:: sql
 
@@ -56,10 +56,54 @@ All queries are concated using the `UNION ALL`. Overall, the generated query loo
 
 To learn more about constraints in LinkML, check out :doc:`Adding constraints and rules <./../schemas/constraints>`.
 
-Constraint: Range
-^^^^^^^^^^^^^^^^^
+Constraint: Required
+^^^^^^^^^^^^^^^^^^^^
 
-For the `range` keyword, checks for enumeration are implemented so far. A schema like this
+For slots marked as ``required: true``, the generated query looks for ``NULL`` values. A schema like this
+
+.. code-block:: yaml
+
+  classes:
+    NamedThing:
+      attributes:
+        name:
+          required: true
+
+will generate the following constraint:
+
+.. code-block:: sql
+
+  SELECT 'NamedThing' AS table_name, 'name' AS column_name, 'required' AS constraint_type, id AS record_id, NULL AS invalid_value
+  FROM "NamedThing"
+  WHERE "NamedThing".name IS NULL
+
+Constraint: Minimum/Maximum Value
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For slots with ``minimum_value`` or ``maximum_value``, the generated query identifies out-of-range numeric values. A schema like this
+
+.. code-block:: yaml
+
+  classes:
+    Person:
+      attributes:
+        age_in_years:
+          range: integer
+          minimum_value: 0
+          maximum_value: 999
+
+will generate the following constraint:
+
+.. code-block:: sql
+
+  SELECT 'Person' AS table_name, 'age' AS column_name, 'range' AS constraint_type, id AS record_id, age AS invalid_value
+  FROM "Person"
+  WHERE "Person".age < 0 OR "Person".age > 999
+
+Constraint: Range (Enum)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For the ``range`` keyword pointing to an enum, the generated query flags values outside the set of permissible values. A schema like this
 
 .. code-block:: yaml
 
@@ -78,8 +122,84 @@ will generate the following constraint:
 
 .. code-block:: sql
 
+  SELECT 'Organization' AS table_name, 'categories' AS column_name, 'enum' AS constraint_type, id AS record_id, categories AS invalid_value
+  FROM "Organization"
   WHERE "Organization".categories NOT IN ('non profit', 'for profit')
 
+Constraint: Pattern
+^^^^^^^^^^^^^^^^^^^
+
+For slots with a ``pattern`` (regular expression), the generated query returns values that do not match the pattern. The SQL syntax is dialect-specific: PostgreSQL uses the ``~`` operator, while SQLite uses a ``REGEXP`` function (requires an extension). A schema like this
+
+.. code-block:: yaml
+
+  classes:
+    Person:
+      attributes:
+        primary_email:
+          pattern: "^\\S+@[\\S+\\.]+\\S+"
+
+will generate the following constraint (SQLite dialect):
+
+.. code-block:: sql
+
+  SELECT 'Person' AS table_name, 'primary_email' AS column_name, 'pattern' AS constraint_type, id AS record_id, primary_email AS invalid_value
+  FROM "Person"
+  WHERE "Person".primary_email NOT REGEXP '^\S+@[\S+\.]+\S+'
+
+
+Constraint: Identifier / Key
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For slots marked as ``identifier: true`` or ``key: true``, the generated query detects duplicate values using a subquery. A schema like this
+
+.. code-block:: yaml
+
+  classes:
+    Person:
+      attributes:
+        id:
+          identifier: true
+
+will generate the following constraint:
+
+.. code-block:: sql
+
+  SELECT 'Person' AS table_name, 'id' AS column_name, 'identifier' AS constraint_type, id AS record_id, id AS invalid_value
+  FROM "Person"
+  WHERE "Person".id IN (SELECT id
+  FROM "Person" GROUP BY id
+  HAVING count(*) > 1)
+
+All records sharing a duplicate value are returned, not just one of them.
+
+Constraint: Unique Keys
+^^^^^^^^^^^^^^^^^^^^^^^
+
+For classes with ``unique_keys`` (multi-column uniqueness constraints), the generated query detects duplicate combinations of values across the specified columns. The combined value is returned as a pipe-separated string. A schema like this
+
+.. code-block:: yaml
+
+  classes:
+    Person:
+      attributes:
+        name:
+        primary_email:
+      unique_keys:
+        name_and_email:
+          unique_key_slots:
+            - name
+            - primary_email
+
+would generate the following constraint:
+
+.. code-block:: sql
+
+  SELECT 'Person' AS table_name, 'name_and_email' AS column_name, 'unique_key' AS constraint_type, id AS record_id, CAST(name AS TEXT) || '|' || CAST(primary_email AS TEXT) AS invalid_value
+  FROM "Person"
+  WHERE (name, primary_email) IN (SELECT name, primary_email
+  FROM "Person" GROUP BY name, primary_email
+  HAVING count(*) > 1)
 
 
 Docs

--- a/docs/generators/sqlvalidation.rst
+++ b/docs/generators/sqlvalidation.rst
@@ -41,8 +41,8 @@ validation query would return:
 General Functionality
 ^^^^^^^^^^^^^^^^^^^^^
 
-For every constraint from the LinkML schema, one query is created. Each of those queries consists of a `SELECT` with one or multiple `WHERE` conditions.
-All queries are concatenated using `UNION ALL`. Overall, the generated query looks like this:
+For every constraint from the LinkML schema, one query is created. Each of those queries consists of a ``SELECT`` with one or multiple ``WHERE`` conditions.
+All queries are concatenated using ``UNION ALL``. Overall, the generated query looks like this:
 
 .. code-block:: sql
 
@@ -78,7 +78,12 @@ will generate the following constraint:
 
 .. code-block:: sql
 
-  SELECT 'NamedThing' AS table_name, 'name' AS column_name, 'required' AS constraint_type, id AS record_id, NULL AS invalid_value
+  SELECT
+      'NamedThing' AS table_name,
+      'name' AS column_name,
+      'required' AS constraint_type,
+      id AS record_id,
+      NULL AS invalid_value
   FROM "NamedThing"
   WHERE "NamedThing".name IS NULL
 
@@ -103,7 +108,12 @@ will generate the following constraint:
 
 .. code-block:: sql
 
-  SELECT 'Person' AS table_name, 'age' AS column_name, 'range' AS constraint_type, id AS record_id, age AS invalid_value
+  SELECT
+      'Person' AS table_name,
+      'age' AS column_name,
+      'range' AS constraint_type,
+      id AS record_id,
+      age AS invalid_value
   FROM "Person"
   WHERE "Person".age < 0 OR "Person".age > 999
 
@@ -131,7 +141,12 @@ will generate the following constraint:
 
 .. code-block:: sql
 
-  SELECT 'Organization' AS table_name, 'categories' AS column_name, 'enum' AS constraint_type, id AS record_id, categories AS invalid_value
+  SELECT
+      'Organization' AS table_name,
+      'categories' AS column_name,
+      'enum' AS constraint_type,
+      id AS record_id,
+      categories AS invalid_value
   FROM "Organization"
   WHERE "Organization".categories NOT IN ('non profit', 'for profit')
 
@@ -154,7 +169,12 @@ will generate the following constraint (SQLite dialect):
 
 .. code-block:: sql
 
-  SELECT 'Person' AS table_name, 'primary_email' AS column_name, 'pattern' AS constraint_type, id AS record_id, primary_email AS invalid_value
+  SELECT
+      'Person' AS table_name,
+      'primary_email' AS column_name,
+      'pattern' AS constraint_type,
+      id AS record_id,
+      primary_email AS invalid_value
   FROM "Person"
   WHERE "Person".primary_email NOT REGEXP '^\S+@[\S+\.]+\S+'
 
@@ -176,11 +196,19 @@ will generate the following constraint:
 
 .. code-block:: sql
 
-  SELECT 'Person' AS table_name, 'id' AS column_name, 'identifier' AS constraint_type, id AS record_id, id AS invalid_value
+  SELECT
+      'Person' AS table_name,
+      'id' AS column_name,
+      'identifier' AS constraint_type,
+      id AS record_id,
+      id AS invalid_value
   FROM "Person"
-  WHERE "Person".id IN (SELECT id
-  FROM "Person" GROUP BY id
-  HAVING count(*) > 1)
+  WHERE "Person".id IN (
+      SELECT id
+      FROM "Person"
+      GROUP BY id
+      HAVING count(*) > 1
+  )
 
 All records sharing a duplicate value are returned, not just one of them.
 
@@ -208,11 +236,19 @@ would generate the following constraint:
 
 .. code-block:: sql
 
-  SELECT 'Person' AS table_name, 'name_and_email' AS column_name, 'unique_key' AS constraint_type, id AS record_id, (CAST(name AS TEXT) || '|') || CAST(primary_email AS TEXT) AS invalid_value
+  SELECT
+      'Person' AS table_name,
+      'name_and_email' AS column_name,
+      'unique_key' AS constraint_type,
+      id AS record_id,
+      (CAST(name AS TEXT) || '|') || CAST(primary_email AS TEXT) AS invalid_value
   FROM "Person"
-  WHERE ("Person".name, "Person".primary_email) IN (SELECT name, primary_email
-  FROM "Person" GROUP BY name, primary_email
-  HAVING count(*) > 1)
+  WHERE ("Person".name, "Person".primary_email) IN (
+      SELECT name, primary_email
+      FROM "Person"
+      GROUP BY name, primary_email
+      HAVING count(*) > 1
+  )
 
 
 Docs

--- a/docs/generators/sqlvalidation.rst
+++ b/docs/generators/sqlvalidation.rst
@@ -66,6 +66,8 @@ For slots marked as ``required: true``, the generated query looks for ``NULL`` v
   classes:
     NamedThing:
       attributes:
+        id:
+          identifier: true
         name:
           required: true
 
@@ -87,6 +89,8 @@ For slots with ``minimum_value`` or ``maximum_value``, the generated query ident
   classes:
     Person:
       attributes:
+        id:
+          identifier: true
         age_in_years:
           range: integer
           minimum_value: 0
@@ -115,6 +119,8 @@ For the ``range`` keyword pointing to an enum, the generated query flags values 
   classes:
     Organization:
       attributes:
+        id:
+          identifier: true
         categories:
           range: OrganizationType
 
@@ -136,6 +142,8 @@ For slots with a ``pattern`` (regular expression), the generated query returns v
   classes:
     Person:
       attributes:
+        id:
+          identifier: true
         primary_email:
           pattern: "^\\S+@[\\S+\\.]+\\S+"
 
@@ -183,6 +191,8 @@ For classes with ``unique_keys`` (multi-column uniqueness constraints), the gene
   classes:
     Person:
       attributes:
+        id:
+          identifier: true
         name:
         primary_email:
       unique_keys:


### PR DESCRIPTION
## Summary

Fixes #3280 

<!-- Briefly describe what this PR does and why. -->

## How was this tested?
* Format was tested using `uv run tox -e format`
* Successfully building docs was tested using `uv run make html`

## Areas of uncertainty

In the issue I write about refering the sqlvalidation generator at several places in the docs. However I am fine with not doing this for now and first wait until the generator is used (and tested) by more people.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
