### PR TITLE
fix(rustgen): emit serde tag for type designators on subtype enums

### DIFF
--- a/packages/linkml/src/linkml/generators/rustgen/rustgen.py
+++ b/packages/linkml/src/linkml/generators/rustgen/rustgen.py
@@ -574,7 +574,7 @@ class RustGenerator(Generator, LifecycleMixin):
             return RustStructOrSubtypeEnum(
                 enum_name=get_name(cls) + "OrSubtype",
                 struct_names=[get_name(self.schemaview.get_class(d)) for d in descendants],
-                type_designator_name=get_name(td) if td else None,
+                type_designator_field=get_name(td) if td else None,
                 as_key_value=get_key_or_identifier_slot(cls, self.schemaview) is not None,
                 type_designators=td_mapping,
                 key_property_type=key_type,

--- a/packages/linkml/src/linkml/generators/rustgen/template.py
+++ b/packages/linkml/src/linkml/generators/rustgen/template.py
@@ -397,7 +397,7 @@ class RustStructOrSubtypeEnum(RustTemplateModel):
     struct_names: list[str]
     as_key_value: bool = False
     type_designator_field: str | None = None
-    type_designators: dict[str, str]
+    type_designators: dict[str, list[str]]
     key_property_type: str = "String"
 
 

--- a/packages/linkml/src/linkml/generators/rustgen/template.py
+++ b/packages/linkml/src/linkml/generators/rustgen/template.py
@@ -402,7 +402,7 @@ class RustStructOrSubtypeEnum(RustTemplateModel):
     struct_names: list[str]
     as_key_value: bool = False
     type_designator_field: str | None = None
-    type_designators: dict[str, str]
+    type_designators: dict[str, list[str]]
     key_property_type: str = "String"
 
 

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -1326,3 +1326,131 @@ def test_subproperty_of_cargo_check(temp_dir):
         pytest.fail(
             f"cargo check failed for subproperty_of schema.\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
         )
+
+
+_TYPE_DESIGNATOR_SCHEMA = textwrap.dedent(
+    """
+    id: https://example.org/rustgen/type_designator
+    name: rustgen_type_designator
+    prefixes:
+      ex: https://example.org/rustgen/
+      linkml: https://w3id.org/linkml/
+    default_prefix: ex
+    default_range: string
+    imports:
+      - linkml:types
+
+    classes:
+      Event:
+        tree_root: true
+        slots:
+          - category
+          - name
+        slot_usage:
+          category:
+            designates_type: true
+      EmploymentEvent:
+        is_a: Event
+        slots:
+          - employer
+      MedicalEvent:
+        is_a: Event
+        slots:
+          - diagnosis
+
+    slots:
+      category:
+        range: string
+      name:
+        range: string
+      employer:
+        range: string
+      diagnosis:
+        range: string
+    """
+)
+
+
+def test_rustgen_type_designator_emits_serde_tag(temp_dir):
+    """A ``designates_type`` slot on a class with subtypes produces an internally
+    tagged ``*OrSubtype`` enum (``#[serde(tag = ...)]``), not an untagged one.
+
+    Regression for two compounding bugs: ``type_designators`` was typed
+    ``dict[str, str]`` while the generator supplies ``list[str]`` (which crashed
+    generation with a ``ValidationError``), and the enum was built with a
+    ``type_designator_name`` kwarg that did not match the model field
+    ``type_designator_field`` (silently dropped, so the tag was never emitted).
+    """
+    schema_path = Path(temp_dir) / "rustgen_type_designator.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_file = Path(temp_dir) / "type_designator.rs"
+    gen = RustGenerator(
+        str(schema_path),
+        mode="file",
+        pyo3=False,
+        serde=True,
+        output=str(out_file),
+    )
+    # Generation itself must not raise (covers the dict[str, list[str]] crash).
+    gen.serialize(force=True)
+
+    contents = out_file.read_text(encoding="utf-8")
+
+    # The designator slot drives an internally tagged enum.
+    assert 'serde(tag = "category")' in contents
+    # And the fall-back untagged form is no longer used for the OrSubtype enum.
+    assert "serde(untagged)" not in contents
+    # Each subtype variant is renamed to the value carried by the designator.
+    assert 'serde(rename = "EmploymentEvent"' in contents
+    assert 'serde(rename = "MedicalEvent"' in contents
+
+
+def test_rustgen_type_designator_tagged_roundtrip(temp_dir):
+    """The tagged ``*OrSubtype`` enum discriminates variants by the designator
+    value and round-trips it through serde."""
+    schema_path = Path(temp_dir) / "rustgen_type_designator_rt.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_dir = _generate_rust_crate(str(schema_path), Path(temp_dir) / "type_designator_crate")
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "type_designator.rs").write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn tagged_discriminates_by_designator() {\n"
+            f"    use {crate_ident}::EventOrSubtype;\n"
+            '    let yaml = "category: MedicalEvent\\nname: x\\ndiagnosis: flu\\n";\n'
+            '    let value: EventOrSubtype = serde_yml::from_str(yaml).expect("decode tagged");\n'
+            "    match value {\n"
+            "        EventOrSubtype::MedicalEvent(_) => {}\n"
+            '        _ => panic!("expected MedicalEvent variant"),\n'
+            "    }\n"
+            '    let out = serde_yml::to_string(&value).expect("encode");\n'
+            '    assert!(out.contains("category: MedicalEvent"), "designator tag not round-tripped: {out}");\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "type_designator"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "cargo test failed, likely due to a missing Rust toolchain:\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -1208,3 +1208,131 @@ def test_subproperty_of_cargo_check(temp_dir):
         pytest.fail(
             f"cargo check failed for subproperty_of schema.\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
         )
+
+
+_TYPE_DESIGNATOR_SCHEMA = textwrap.dedent(
+    """
+    id: https://example.org/rustgen/type_designator
+    name: rustgen_type_designator
+    prefixes:
+      ex: https://example.org/rustgen/
+      linkml: https://w3id.org/linkml/
+    default_prefix: ex
+    default_range: string
+    imports:
+      - linkml:types
+
+    classes:
+      Event:
+        tree_root: true
+        slots:
+          - category
+          - name
+        slot_usage:
+          category:
+            designates_type: true
+      EmploymentEvent:
+        is_a: Event
+        slots:
+          - employer
+      MedicalEvent:
+        is_a: Event
+        slots:
+          - diagnosis
+
+    slots:
+      category:
+        range: string
+      name:
+        range: string
+      employer:
+        range: string
+      diagnosis:
+        range: string
+    """
+)
+
+
+def test_rustgen_type_designator_emits_serde_tag(temp_dir):
+    """A ``designates_type`` slot on a class with subtypes produces an internally
+    tagged ``*OrSubtype`` enum (``#[serde(tag = ...)]``), not an untagged one.
+
+    Regression for two compounding bugs: ``type_designators`` was typed
+    ``dict[str, str]`` while the generator supplies ``list[str]`` (which crashed
+    generation with a ``ValidationError``), and the enum was built with a
+    ``type_designator_name`` kwarg that did not match the model field
+    ``type_designator_field`` (silently dropped, so the tag was never emitted).
+    """
+    schema_path = Path(temp_dir) / "rustgen_type_designator.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_file = Path(temp_dir) / "type_designator.rs"
+    gen = RustGenerator(
+        str(schema_path),
+        mode="file",
+        pyo3=False,
+        serde=True,
+        output=str(out_file),
+    )
+    # Generation itself must not raise (covers the dict[str, list[str]] crash).
+    gen.serialize(force=True)
+
+    contents = out_file.read_text(encoding="utf-8")
+
+    # The designator slot drives an internally tagged enum.
+    assert 'serde(tag = "category")' in contents
+    # And the fall-back untagged form is no longer used for the OrSubtype enum.
+    assert "serde(untagged)" not in contents
+    # Each subtype variant is renamed to the value carried by the designator.
+    assert 'serde(rename = "EmploymentEvent"' in contents
+    assert 'serde(rename = "MedicalEvent"' in contents
+
+
+def test_rustgen_type_designator_tagged_roundtrip(temp_dir):
+    """The tagged ``*OrSubtype`` enum discriminates variants by the designator
+    value and round-trips it through serde."""
+    schema_path = Path(temp_dir) / "rustgen_type_designator_rt.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_dir = _generate_rust_crate(str(schema_path), Path(temp_dir) / "type_designator_crate")
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "type_designator.rs").write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn tagged_discriminates_by_designator() {\n"
+            f"    use {crate_ident}::EventOrSubtype;\n"
+            '    let yaml = "category: MedicalEvent\\nname: x\\ndiagnosis: flu\\n";\n'
+            '    let value: EventOrSubtype = serde_yml::from_str(yaml).expect("decode tagged");\n'
+            "    match value {\n"
+            "        EventOrSubtype::MedicalEvent(_) => {}\n"
+            '        _ => panic!("expected MedicalEvent variant"),\n'
+            "    }\n"
+            '    let out = serde_yml::to_string(&value).expect("encode");\n'
+            '    assert!(out.contains("category: MedicalEvent"), "designator tag not round-tripped: {out}");\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "type_designator"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "cargo test failed, likely due to a missing Rust toolchain:\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )


### PR DESCRIPTION
First of a class of defects in the rust generator code found by a llm scan, i'm actually quite surprised that this bug went unnoticed for such a long time. This one should be obvious/simple to review.


## Summary

A `designates_type` slot on a class with subtypes was meant to produce an internally tagged `*OrSubtype` enum (`#[serde(tag = "...")]`), but two compounding bugs broke the path:

- `RustStructOrSubtypeEnum.type_designators` was typed `dict[str, str]`, while the generator supplies `list[str]` per descendant (and the template consumes the list). This raised a pydantic `ValidationError`, crashing generation for any schema with a type designator on a parent class.
- The enum was constructed with a `type_designator_name` kwarg that does not match the model field `type_designator_field`. Pydantic silently dropped it (`extra="ignore"`), so the field stayed `None` and the enum always fell back to `#[serde(untagged)]`.

Fix the field annotation to `dict[str, list[str]]` and pass the correct `type_designator_field` kwarg. Add tests covering both the emitted `#[serde(tag = ...)]`/variant renames and an end-to-end serde round-trip that discriminates variants by the designator value.

## How was this tested?

This PR contains a test that fails without the fix applies.

## Areas of uncertainty

No

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
