### PR TITLE
Fix/rustgen orsubtype base variant

### DIFF
--- a/packages/linkml/src/linkml/generators/rustgen/rustgen.py
+++ b/packages/linkml/src/linkml/generators/rustgen/rustgen.py
@@ -212,6 +212,26 @@ def has_real_subtypes(sv: SchemaView, class_name: str) -> bool:
     return len(class_real_descendants(sv, class_name)) > 0
 
 
+def class_subtype_enum_members(sv: SchemaView, class_name: str) -> list[str]:
+    """Members of a class's ``*OrSubtype`` enum.
+
+    Returns the class's real descendants and, when the class itself is concrete
+    (i.e. instantiable — not ``abstract`` and not a ``mixin``), the class itself.
+    The base class is placed *last* so that ``untagged`` deserialization prefers
+    the more specific subtype variants; for type-designator (tagged) enums the
+    order is irrelevant.
+
+    Both the enum definition (:meth:`gen_struct_or_subtype_enum`) and the trait
+    dispatch match arms (:meth:`gen_poly_trait`) must enumerate the same set, or
+    the generated ``match`` becomes non-exhaustive and fails to compile.
+    """
+    members = list(class_real_descendants(sv, class_name))
+    cls = sv.get_class(class_name)
+    if cls is not None and not getattr(cls, "abstract", False) and not getattr(cls, "mixin", False):
+        members.append(class_name)
+    return members
+
+
 def determine_slot_mode(s: SlotDefinition, sv: SchemaView) -> tuple[SlotContainerMode, SlotInlineMode]:
     """Return container and inline modes for a slot."""
 
@@ -559,10 +579,11 @@ class RustGenerator(Generator, LifecycleMixin):
 
     def gen_struct_or_subtype_enum(self, cls: ClassDefinition) -> RustStructOrSubtypeEnum | None:
         descendants = class_real_descendants(self.schemaview, cls.name)
+        members = class_subtype_enum_members(self.schemaview, cls.name)
         td = self.schemaview.get_type_designator_slot(cls.name)
         td_mapping = {}
         if td is not None:
-            for d in descendants:
+            for d in members:
                 d_class = self.schemaview.get_class(d)
                 values = get_accepted_type_designator_values(self.schemaview, td, d_class)
                 td_mapping[d] = values
@@ -573,7 +594,7 @@ class RustGenerator(Generator, LifecycleMixin):
                 key_type = get_rust_type(key_slot.range, self.schemaview, self.pyo3)
             return RustStructOrSubtypeEnum(
                 enum_name=get_name(cls) + "OrSubtype",
-                struct_names=[get_name(self.schemaview.get_class(d)) for d in descendants],
+                struct_names=[get_name(self.schemaview.get_class(d)) for d in members],
                 type_designator_field=get_name(td) if td else None,
                 as_key_value=get_key_or_identifier_slot(cls, self.schemaview) is not None,
                 type_designators=td_mapping,
@@ -1014,7 +1035,7 @@ class RustGenerator(Generator, LifecycleMixin):
             impls.append(PolyTraitImpl(name=class_name, struct_name=get_name(sco), attrs=ptis))
             has_subtypes = has_real_subtypes(self.schemaview, sc)
             if has_subtypes:
-                cases = [get_name(self.schemaview.get_class(x)) for x in class_real_descendants(self.schemaview, sc)]
+                cases = [get_name(self.schemaview.get_class(x)) for x in class_subtype_enum_members(self.schemaview, sc)]
                 matches = [
                     PolyTraitPropertyMatch(
                         name=get_name(a),

--- a/packages/linkml/src/linkml/generators/rustgen/rustgen.py
+++ b/packages/linkml/src/linkml/generators/rustgen/rustgen.py
@@ -574,7 +574,7 @@ class RustGenerator(Generator, LifecycleMixin):
             return RustStructOrSubtypeEnum(
                 enum_name=get_name(cls) + "OrSubtype",
                 struct_names=[get_name(self.schemaview.get_class(d)) for d in descendants],
-                type_designator_name=get_name(td) if td else None,
+                type_designator_field=get_name(td) if td else None,
                 as_key_value=get_key_or_identifier_slot(cls, self.schemaview) is not None,
                 type_designators=td_mapping,
                 key_property_type=key_type,

--- a/packages/linkml/src/linkml/generators/rustgen/rustgen.py
+++ b/packages/linkml/src/linkml/generators/rustgen/rustgen.py
@@ -212,6 +212,26 @@ def has_real_subtypes(sv: SchemaView, class_name: str) -> bool:
     return len(class_real_descendants(sv, class_name)) > 0
 
 
+def class_subtype_enum_members(sv: SchemaView, class_name: str) -> list[str]:
+    """Members of a class's ``*OrSubtype`` enum.
+
+    Returns the class's real descendants and, when the class itself is concrete
+    (i.e. instantiable — not ``abstract`` and not a ``mixin``), the class itself.
+    The base class is placed *last* so that ``untagged`` deserialization prefers
+    the more specific subtype variants; for type-designator (tagged) enums the
+    order is irrelevant.
+
+    Both the enum definition (:meth:`gen_struct_or_subtype_enum`) and the trait
+    dispatch match arms (:meth:`gen_poly_trait`) must enumerate the same set, or
+    the generated ``match`` becomes non-exhaustive and fails to compile.
+    """
+    members = list(class_real_descendants(sv, class_name))
+    cls = sv.get_class(class_name)
+    if cls is not None and not getattr(cls, "abstract", False) and not getattr(cls, "mixin", False):
+        members.append(class_name)
+    return members
+
+
 def determine_slot_mode(s: SlotDefinition, sv: SchemaView) -> tuple[SlotContainerMode, SlotInlineMode]:
     """Return container and inline modes for a slot."""
 
@@ -559,10 +579,11 @@ class RustGenerator(Generator, LifecycleMixin):
 
     def gen_struct_or_subtype_enum(self, cls: ClassDefinition) -> RustStructOrSubtypeEnum | None:
         descendants = class_real_descendants(self.schemaview, cls.name)
+        members = class_subtype_enum_members(self.schemaview, cls.name)
         td = self.schemaview.get_type_designator_slot(cls.name)
         td_mapping = {}
         if td is not None:
-            for d in descendants:
+            for d in members:
                 d_class = self.schemaview.get_class(d)
                 values = get_accepted_type_designator_values(self.schemaview, td, d_class)
                 td_mapping[d] = values
@@ -573,7 +594,7 @@ class RustGenerator(Generator, LifecycleMixin):
                 key_type = get_rust_type(key_slot.range, self.schemaview, self.pyo3)
             return RustStructOrSubtypeEnum(
                 enum_name=get_name(cls) + "OrSubtype",
-                struct_names=[get_name(self.schemaview.get_class(d)) for d in descendants],
+                struct_names=[get_name(self.schemaview.get_class(d)) for d in members],
                 type_designator_field=get_name(td) if td else None,
                 as_key_value=get_key_or_identifier_slot(cls, self.schemaview) is not None,
                 type_designators=td_mapping,
@@ -1014,7 +1035,9 @@ class RustGenerator(Generator, LifecycleMixin):
             impls.append(PolyTraitImpl(name=class_name, struct_name=get_name(sco), attrs=ptis))
             has_subtypes = has_real_subtypes(self.schemaview, sc)
             if has_subtypes:
-                cases = [get_name(self.schemaview.get_class(x)) for x in class_real_descendants(self.schemaview, sc)]
+                cases = [
+                    get_name(self.schemaview.get_class(x)) for x in class_subtype_enum_members(self.schemaview, sc)
+                ]
                 matches = [
                     PolyTraitPropertyMatch(
                         name=get_name(a),

--- a/packages/linkml/src/linkml/generators/rustgen/template.py
+++ b/packages/linkml/src/linkml/generators/rustgen/template.py
@@ -397,7 +397,7 @@ class RustStructOrSubtypeEnum(RustTemplateModel):
     struct_names: list[str]
     as_key_value: bool = False
     type_designator_field: str | None = None
-    type_designators: dict[str, str]
+    type_designators: dict[str, list[str]]
     key_property_type: str = "String"
 
 

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -905,6 +905,132 @@ def test_rustgen_simple_dict_with_recursive_multivalued_sibling(temp_dir):
         )
 
 
+_ORSUBTYPE_BASE_SCHEMA = textwrap.dedent(
+    """
+    id: https://example.org/rustgen/orsubtype_base
+    name: rustgen_orsubtype_base
+    prefixes:
+      ex: https://example.org/rustgen/
+      linkml: https://w3id.org/linkml/
+    default_prefix: ex
+    default_range: string
+    imports:
+      - linkml:types
+
+    classes:
+      Animal:
+        slots:
+          - category
+          - name
+        slot_usage:
+          category:
+            designates_type: true
+      Dog:
+        is_a: Animal
+        slots:
+          - breed
+      Shelter:
+        tree_root: true
+        slots:
+          - occupant
+        slot_usage:
+          occupant:
+            inlined: true
+
+    slots:
+      category:
+        range: string
+      name:
+        range: string
+      breed:
+        range: string
+      occupant:
+        range: Animal
+    """
+)
+
+
+def test_rustgen_orsubtype_includes_concrete_base(temp_dir):
+    """A concrete base class is itself a variant of its ``*OrSubtype`` enum.
+
+    Regression: the enum was built from ``class_real_descendants`` (which excludes
+    the class itself), so a field ranged on a concrete base could not represent a
+    plain base instance — under untagged enums it was silently mis-decoded as an
+    arbitrary subtype, and under tagged enums it became an ``unknown variant`` error.
+    """
+    schema_path = Path(temp_dir) / "rustgen_orsubtype_base.yaml"
+    schema_path.write_text(_ORSUBTYPE_BASE_SCHEMA, encoding="utf-8")
+
+    out_file = Path(temp_dir) / "orsubtype_base.rs"
+    RustGenerator(str(schema_path), mode="file", pyo3=False, serde=True, output=str(out_file)).serialize(force=True)
+
+    contents = out_file.read_text(encoding="utf-8")
+    enum_block = contents[contents.index("enum AnimalOrSubtype") :].split("}", 1)[0]
+    # Both the subtype and the concrete base are variants; base is last.
+    assert "Dog(Dog)" in enum_block
+    assert "Animal(Animal)" in enum_block
+    assert enum_block.index("Dog(Dog)") < enum_block.index("Animal(Animal)")
+
+
+def test_rustgen_orsubtype_base_roundtrip(temp_dir):
+    """A plain concrete-base instance round-trips as the base variant, and a
+    subtype instance as the subtype variant (tagged by the designator)."""
+    schema_path = Path(temp_dir) / "rustgen_orsubtype_base_rt.yaml"
+    schema_path.write_text(_ORSUBTYPE_BASE_SCHEMA, encoding="utf-8")
+
+    out_dir = _generate_rust_crate(str(schema_path), Path(temp_dir) / "orsubtype_base_crate")
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "orsubtype_base.rs").write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn base_decodes_as_base() {\n"
+            f"    use {crate_ident}::{{Shelter, AnimalOrSubtype}};\n"
+            '    let yaml = "occupant:\\n  category: Animal\\n  name: Rex\\n";\n'
+            '    let v: Shelter = serde_yml::from_str(yaml).expect("plain base decode");\n'
+            "    match v.occupant.expect(\"occupant\") {\n"
+            "        AnimalOrSubtype::Animal(_) => {}\n"
+            '        _ => panic!("expected Animal variant"),\n'
+            "    }\n"
+            "}\n"
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn subtype_decodes_as_subtype() {\n"
+            f"    use {crate_ident}::{{Shelter, AnimalOrSubtype}};\n"
+            '    let yaml = "occupant:\\n  category: Dog\\n  name: Rex\\n  breed: lab\\n";\n'
+            '    let v: Shelter = serde_yml::from_str(yaml).expect("subtype decode");\n'
+            "    match v.occupant.expect(\"occupant\") {\n"
+            "        AnimalOrSubtype::Dog(_) => {}\n"
+            '        _ => panic!("expected Dog variant"),\n'
+            "    }\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "orsubtype_base"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "cargo test failed, likely due to a missing Rust toolchain:\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )
+
+
 def test_subproperty_of_generates_rust_enum(temp_dir):
     """Test that subproperty_of generates a Rust enum with slot descendants."""
     schema_yaml = textwrap.dedent(

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -1208,3 +1208,131 @@ def test_subproperty_of_cargo_check(temp_dir):
         pytest.fail(
             f"cargo check failed for subproperty_of schema.\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
         )
+
+
+_TYPE_DESIGNATOR_SCHEMA = textwrap.dedent(
+    """
+    id: https://example.org/rustgen/type_designator
+    name: rustgen_type_designator
+    prefixes:
+      ex: https://example.org/rustgen/
+      linkml: https://w3id.org/linkml/
+    default_prefix: ex
+    default_range: string
+    imports:
+      - linkml:types
+
+    classes:
+      Event:
+        tree_root: true
+        slots:
+          - category
+          - name
+        slot_usage:
+          category:
+            designates_type: true
+      EmploymentEvent:
+        is_a: Event
+        slots:
+          - employer
+      MedicalEvent:
+        is_a: Event
+        slots:
+          - diagnosis
+
+    slots:
+      category:
+        range: string
+      name:
+        range: string
+      employer:
+        range: string
+      diagnosis:
+        range: string
+    """
+)
+
+
+def test_rustgen_type_designator_emits_serde_tag(temp_dir):
+    """A ``designates_type`` slot on a class with subtypes produces an internally
+    tagged ``*OrSubtype`` enum (``#[serde(tag = ...)]``), not an untagged one.
+
+    Regression for two compounding bugs: ``type_designators`` was typed
+    ``dict[str, str]`` while the generator supplies ``list[str]`` (which crashed
+    generation with a ``ValidationError``), and the enum was built with a
+    ``type_designator_name`` kwarg that did not match the model field
+    ``type_designator_field`` (silently dropped, so the tag was never emitted).
+    """
+    schema_path = Path(temp_dir) / "rustgen_type_designator.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_file = Path(temp_dir) / "type_designator.rs"
+    gen = RustGenerator(
+        str(schema_path),
+        mode="file",
+        pyo3=False,
+        serde=True,
+        output=str(out_file),
+    )
+    # Generation itself must not raise (covers the dict[str, list[str]] crash).
+    gen.serialize(force=True)
+
+    contents = out_file.read_text(encoding="utf-8")
+
+    # The designator slot drives an internally tagged enum.
+    assert 'serde(tag = "category")' in contents
+    # And the fall-back untagged form is no longer used for the OrSubtype enum.
+    assert "serde(untagged)" not in contents
+    # Each subtype variant is renamed to the value carried by the designator.
+    assert 'serde(rename = "EmploymentEvent"' in contents
+    assert 'serde(rename = "MedicalEvent"' in contents
+
+
+def test_rustgen_type_designator_tagged_roundtrip(temp_dir):
+    """The tagged ``*OrSubtype`` enum discriminates variants by the designator
+    value and round-trips it through serde."""
+    schema_path = Path(temp_dir) / "rustgen_type_designator_rt.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_dir = _generate_rust_crate(str(schema_path), Path(temp_dir) / "type_designator_crate")
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "type_designator.rs").write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn tagged_discriminates_by_designator() {\n"
+            f"    use {crate_ident}::EventOrSubtype;\n"
+            '    let yaml = "category: MedicalEvent\\nname: x\\ndiagnosis: flu\\n";\n'
+            '    let value: EventOrSubtype = serde_yml::from_str(yaml).expect("decode tagged");\n'
+            "    match value {\n"
+            "        EventOrSubtype::MedicalEvent(_) => {}\n"
+            '        _ => panic!("expected MedicalEvent variant"),\n'
+            "    }\n"
+            '    let out = serde_yml::to_string(&value).expect("encode");\n'
+            '    assert!(out.contains("category: MedicalEvent"), "designator tag not round-tripped: {out}");\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "type_designator"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "cargo test failed, likely due to a missing Rust toolchain:\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -1023,6 +1023,132 @@ def test_rustgen_simple_dict_with_recursive_multivalued_sibling(temp_dir):
         )
 
 
+_ORSUBTYPE_BASE_SCHEMA = textwrap.dedent(
+    """
+    id: https://example.org/rustgen/orsubtype_base
+    name: rustgen_orsubtype_base
+    prefixes:
+      ex: https://example.org/rustgen/
+      linkml: https://w3id.org/linkml/
+    default_prefix: ex
+    default_range: string
+    imports:
+      - linkml:types
+
+    classes:
+      Animal:
+        slots:
+          - category
+          - name
+        slot_usage:
+          category:
+            designates_type: true
+      Dog:
+        is_a: Animal
+        slots:
+          - breed
+      Shelter:
+        tree_root: true
+        slots:
+          - occupant
+        slot_usage:
+          occupant:
+            inlined: true
+
+    slots:
+      category:
+        range: string
+      name:
+        range: string
+      breed:
+        range: string
+      occupant:
+        range: Animal
+    """
+)
+
+
+def test_rustgen_orsubtype_includes_concrete_base(temp_dir):
+    """A concrete base class is itself a variant of its ``*OrSubtype`` enum.
+
+    Regression: the enum was built from ``class_real_descendants`` (which excludes
+    the class itself), so a field ranged on a concrete base could not represent a
+    plain base instance — under untagged enums it was silently mis-decoded as an
+    arbitrary subtype, and under tagged enums it became an ``unknown variant`` error.
+    """
+    schema_path = Path(temp_dir) / "rustgen_orsubtype_base.yaml"
+    schema_path.write_text(_ORSUBTYPE_BASE_SCHEMA, encoding="utf-8")
+
+    out_file = Path(temp_dir) / "orsubtype_base.rs"
+    RustGenerator(str(schema_path), mode="file", pyo3=False, serde=True, output=str(out_file)).serialize(force=True)
+
+    contents = out_file.read_text(encoding="utf-8")
+    enum_block = contents[contents.index("enum AnimalOrSubtype") :].split("}", 1)[0]
+    # Both the subtype and the concrete base are variants; base is last.
+    assert "Dog(Dog)" in enum_block
+    assert "Animal(Animal)" in enum_block
+    assert enum_block.index("Dog(Dog)") < enum_block.index("Animal(Animal)")
+
+
+def test_rustgen_orsubtype_base_roundtrip(temp_dir):
+    """A plain concrete-base instance round-trips as the base variant, and a
+    subtype instance as the subtype variant (tagged by the designator)."""
+    schema_path = Path(temp_dir) / "rustgen_orsubtype_base_rt.yaml"
+    schema_path.write_text(_ORSUBTYPE_BASE_SCHEMA, encoding="utf-8")
+
+    out_dir = _generate_rust_crate(str(schema_path), Path(temp_dir) / "orsubtype_base_crate")
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "orsubtype_base.rs").write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn base_decodes_as_base() {\n"
+            f"    use {crate_ident}::{{Shelter, AnimalOrSubtype}};\n"
+            '    let yaml = "occupant:\\n  category: Animal\\n  name: Rex\\n";\n'
+            '    let v: Shelter = serde_yml::from_str(yaml).expect("plain base decode");\n'
+            '    match v.occupant.expect("occupant") {\n'
+            "        AnimalOrSubtype::Animal(_) => {}\n"
+            '        _ => panic!("expected Animal variant"),\n'
+            "    }\n"
+            "}\n"
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn subtype_decodes_as_subtype() {\n"
+            f"    use {crate_ident}::{{Shelter, AnimalOrSubtype}};\n"
+            '    let yaml = "occupant:\\n  category: Dog\\n  name: Rex\\n  breed: lab\\n";\n'
+            '    let v: Shelter = serde_yml::from_str(yaml).expect("subtype decode");\n'
+            '    match v.occupant.expect("occupant") {\n'
+            "        AnimalOrSubtype::Dog(_) => {}\n"
+            '        _ => panic!("expected Dog variant"),\n'
+            "    }\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "orsubtype_base"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "cargo test failed, likely due to a missing Rust toolchain:\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )
+
+
 def test_subproperty_of_generates_rust_enum(temp_dir):
     """Test that subproperty_of generates a Rust enum with slot descendants."""
     schema_yaml = textwrap.dedent(


### PR DESCRIPTION
(second of llm-found bugs of which i'm surprised i didn't find them myself)

## Summary

In the rust generator of linkml, for a class `Thing` with subtypes, we generate a `ThingOrSubtype` enum. This enum allows for compile-time and runtime polymorphism: every descendant of `Thing` is representable as a `ThingOrSubtype` , and `ThingOrSubtype` implements the `Thing` trait so it can be treated as such.

The bug was that we didn't include the base class `Thing` into this: so while you could represent every subclass as a `ThingOrSubtype` you couldn't represent `Thing` itself.

The fix is rather simple.

## How was this tested?

An extra unit test is added, first failing, then after the fix passing.

## Areas of uncertainty

N/A

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
