### PR TITLE
Add linter rules for slot_group and in_subset referential integrity

### DIFF
--- a/packages/linkml/src/linkml/linter/config/datamodel/config.py
+++ b/packages/linkml/src/linkml/linter/config/datamodel/config.py
@@ -1,5 +1,5 @@
 # Auto generated from config.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-09-30T13:24:19
+# Generation date: 2026-06-26T12:49:40
 # Schema: linter-config
 #
 # id: https://w3id.org/linkml/linter/config
@@ -25,7 +25,7 @@ from rdflib import Namespace, URIRef
 from linkml_runtime.linkml_model.types import Boolean, String
 from linkml_runtime.utils.metamodelcore import Bool
 
-metamodel_version = "1.7.0"
+metamodel_version = "1.11.0"
 version = None
 
 # Namespaces
@@ -81,8 +81,10 @@ class Rules(YAMLRoot):
 
     canonical_prefixes: Optional[Union[dict, "CanonicalPrefixesConfig"]] = None
     no_empty_title: Optional[Union[dict, "NoEmptyTitleConfig"]] = None
+    no_invalid_slot_group: Optional[Union[dict, "RuleConfig"]] = None
     no_invalid_slot_usage: Optional[Union[dict, "RuleConfig"]] = None
     no_undeclared_slots: Optional[Union[dict, "RuleConfig"]] = None
+    no_undeclared_subsets: Optional[Union[dict, "RuleConfig"]] = None
     no_undeclared_ranges: Optional[Union[dict, "RuleConfig"]] = None
     no_xsd_int_type: Optional[Union[dict, "RuleConfig"]] = None
     one_identifier_per_class: Optional[Union[dict, "RuleConfig"]] = None
@@ -100,11 +102,17 @@ class Rules(YAMLRoot):
         if self.no_empty_title is not None and not isinstance(self.no_empty_title, NoEmptyTitleConfig):
             self.no_empty_title = NoEmptyTitleConfig(**as_dict(self.no_empty_title))
 
+        if self.no_invalid_slot_group is not None and not isinstance(self.no_invalid_slot_group, RuleConfig):
+            self.no_invalid_slot_group = RuleConfig(**as_dict(self.no_invalid_slot_group))
+
         if self.no_invalid_slot_usage is not None and not isinstance(self.no_invalid_slot_usage, RuleConfig):
             self.no_invalid_slot_usage = RuleConfig(**as_dict(self.no_invalid_slot_usage))
 
         if self.no_undeclared_slots is not None and not isinstance(self.no_undeclared_slots, RuleConfig):
             self.no_undeclared_slots = RuleConfig(**as_dict(self.no_undeclared_slots))
+
+        if self.no_undeclared_subsets is not None and not isinstance(self.no_undeclared_subsets, RuleConfig):
+            self.no_undeclared_subsets = RuleConfig(**as_dict(self.no_undeclared_subsets))
 
         if self.no_undeclared_ranges is not None and not isinstance(self.no_undeclared_ranges, RuleConfig):
             self.no_undeclared_ranges = RuleConfig(**as_dict(self.no_undeclared_ranges))
@@ -439,6 +447,15 @@ slots.rules__no_empty_title = Slot(
     range=Optional[Union[dict, NoEmptyTitleConfig]],
 )
 
+slots.rules__no_invalid_slot_group = Slot(
+    uri=LINTCFG.no_invalid_slot_group,
+    name="rules__no_invalid_slot_group",
+    curie=LINTCFG.curie("no_invalid_slot_group"),
+    model_uri=LINTCFG.rules__no_invalid_slot_group,
+    domain=None,
+    range=Optional[Union[dict, RuleConfig]],
+)
+
 slots.rules__no_invalid_slot_usage = Slot(
     uri=LINTCFG.no_invalid_slot_usage,
     name="rules__no_invalid_slot_usage",
@@ -453,6 +470,15 @@ slots.rules__no_undeclared_slots = Slot(
     name="rules__no_undeclared_slots",
     curie=LINTCFG.curie("no_undeclared_slots"),
     model_uri=LINTCFG.rules__no_undeclared_slots,
+    domain=None,
+    range=Optional[Union[dict, RuleConfig]],
+)
+
+slots.rules__no_undeclared_subsets = Slot(
+    uri=LINTCFG.no_undeclared_subsets,
+    name="rules__no_undeclared_subsets",
+    curie=LINTCFG.curie("no_undeclared_subsets"),
+    model_uri=LINTCFG.rules__no_undeclared_subsets,
     domain=None,
     range=Optional[Union[dict, RuleConfig]],
 )

--- a/packages/linkml/src/linkml/linter/config/datamodel/config.yaml
+++ b/packages/linkml/src/linkml/linter/config/datamodel/config.yaml
@@ -48,6 +48,11 @@ classes:
         description: >-
           Disallow empty titles on schema elements. Autofix will transform the element's
           name into a title.
+      no_invalid_slot_group:
+        range: RuleConfig
+        description: >-
+          Disallow `slot_group` references that do not resolve to a slot marked
+          `is_grouping_slot: true`. Not auto-fixable.
       no_invalid_slot_usage:
         range: RuleConfig
         description: >-
@@ -58,6 +63,11 @@ classes:
         description: >-
           Disallow the use of slots in class specifications if the name of the slot
           does not refer to an existing slot. Not auto-fixable.
+      no_undeclared_subsets:
+        range: RuleConfig
+        description: >-
+          Disallow `in_subset` references to subsets that are not declared in the
+          schema's `subsets` section. Not auto-fixable.
       no_undeclared_ranges:
         range: RuleConfig
         description: >-

--- a/packages/linkml/src/linkml/linter/config/default.yaml
+++ b/packages/linkml/src/linkml/linter/config/default.yaml
@@ -16,9 +16,13 @@ rules:
     exclude_type: []
   no_xsd_int_type:
     level: disabled
+  no_invalid_slot_group:
+    level: disabled
   no_invalid_slot_usage:
     level: disabled
   no_undeclared_slots:
+    level: disabled
+  no_undeclared_subsets:
     level: disabled
   no_undeclared_ranges:
     level: disabled

--- a/packages/linkml/src/linkml/linter/rules.py
+++ b/packages/linkml/src/linkml/linter/rules.py
@@ -27,6 +27,7 @@ from linkml_runtime.linkml_model import (
     EnumDefinition,
     EnumDefinitionName,
     SlotDefinition,
+    SlotDefinitionName,
     TypeDefinition,
     TypeDefinitionName,
 )
@@ -447,3 +448,79 @@ class CanonicalPrefixesRule(LinterRule):
                     f"'{prefix.prefix_reference}' instead of using prefix "
                     f"'{namespace_to_prefix[prefix.prefix_reference]}'"
                 )
+
+
+class NoInvalidSlotGroupRule(LinterRule):
+    """Disallow `slot_group` references that do not resolve to a grouping slot.
+
+    A slot may declare `slot_group: B` only if B is a defined slot and B is marked
+    `is_grouping_slot: true`. The LinkML metamodel gives `slot_group` the range
+    `slot_definition` but does not enforce that the referenced name resolves to a
+    declared slot, nor that the target is a grouping slot, so dangling or
+    non-grouping `slot_group` references pass silently. This rule is the
+    `slot_group` analogue of `no_undeclared_ranges`. Not auto-fixable.
+    """
+
+    id = "no_invalid_slot_group"
+
+    def check(self, schema_view: SchemaView, fix: bool = False) -> Iterable[LinterProblem]:
+        all_slots: dict[SlotDefinitionName, SlotDefinition] = schema_view.all_slots()
+
+        def check_slot(slot: SlotDefinition, descriptor: str) -> Iterable[LinterProblem]:
+            group = slot.slot_group
+            if not group:
+                return
+            if group not in all_slots:
+                yield LinterProblem(f"{descriptor} has slot_group '{group}' which is not a defined slot.")
+            elif not all_slots[group].is_grouping_slot:
+                yield LinterProblem(
+                    f"{descriptor} has slot_group '{group}' which is not marked 'is_grouping_slot: true'."
+                )
+
+        for slot_name, slot_def in all_slots.items():
+            yield from check_slot(slot_def, f"Slot '{slot_name}'")
+
+        for class_name, class_def in schema_view.all_classes().items():
+            for usage_name, usage in (class_def.slot_usage or {}).items():
+                yield from check_slot(usage, f"Class '{class_name}' slot_usage '{usage_name}'")
+
+
+class NoUndeclaredSubsetsRule(LinterRule):
+    """Disallow `in_subset` references to subsets not declared in the `subsets` section.
+
+    An element may declare `in_subset: S` only if S is a declared `SubsetDefinition`.
+    The LinkML metamodel gives `in_subset` the range `subset_definition` but does not
+    enforce that the referenced name resolves to a declared subset, so dangling
+    `in_subset` references pass silently. This rule is the `in_subset` analogue of
+    `no_undeclared_ranges`. Not auto-fixable.
+    """
+
+    id = "no_undeclared_subsets"
+
+    def check(self, schema_view: SchemaView, fix: bool = False) -> Iterable[LinterProblem]:
+        declared_subsets: set[str] = set(schema_view.all_subsets())
+
+        def check_element(element: Element, descriptor: str) -> Iterable[LinterProblem]:
+            for subset_name in getattr(element, "in_subset", None) or []:
+                if subset_name not in declared_subsets:
+                    yield LinterProblem(f"{descriptor} asserts membership in undeclared subset '{subset_name}'.")
+
+        # slots (includes attributes)
+        for slot_name, slot_def in schema_view.all_slots().items():
+            yield from check_element(slot_def, f"Slot '{slot_name}'")
+
+        # classes, plus their slot_usage overrides
+        for class_name, class_def in schema_view.all_classes().items():
+            yield from check_element(class_def, f"Class '{class_name}'")
+            for usage_name, usage in (class_def.slot_usage or {}).items():
+                yield from check_element(usage, f"Class '{class_name}' slot_usage '{usage_name}'")
+
+        # enums and their permissible values
+        for enum_name, enum_def in schema_view.all_enums().items():
+            yield from check_element(enum_def, f"Enum '{enum_name}'")
+            for pv_name, pv in (enum_def.permissible_values or {}).items():
+                yield from check_element(pv, f"Enum '{enum_name}' permissible value '{pv_name}'")
+
+        # types
+        for type_name, type_def in schema_view.all_types().items():
+            yield from check_element(type_def, f"Type '{type_name}'")

--- a/packages/linkml/src/linkml/linter/rules.py
+++ b/packages/linkml/src/linkml/linter/rules.py
@@ -464,6 +464,8 @@ class NoInvalidSlotGroupRule(LinterRule):
     id = "no_invalid_slot_group"
 
     def check(self, schema_view: SchemaView, fix: bool = False) -> Iterable[LinterProblem]:
+        # Lookup table for resolving slot_group targets. all_slots() is acceptable here
+        # because we only need to know whether a grouping slot of a given name exists.
         all_slots: dict[SlotDefinitionName, SlotDefinition] = schema_view.all_slots()
 
         def check_slot(slot: SlotDefinition, descriptor: str) -> Iterable[LinterProblem]:
@@ -477,10 +479,17 @@ class NoInvalidSlotGroupRule(LinterRule):
                     f"{descriptor} has slot_group '{group}' which is not marked 'is_grouping_slot: true'."
                 )
 
-        for slot_name, slot_def in all_slots.items():
+        # Iterate global slots, then each class's attributes and slot_usage separately.
+        # all_slots() de-duplicates attributes by name, so iterating it would miss
+        # slot_group on attributes that share a name across classes or override a global
+        # slot. attributes=False yields only the global slots; attributes are checked
+        # per class below, each in its own context.
+        for slot_name, slot_def in schema_view.all_slots(attributes=False).items():
             yield from check_slot(slot_def, f"Slot '{slot_name}'")
 
         for class_name, class_def in schema_view.all_classes().items():
+            for attr_name, attr in (class_def.attributes or {}).items():
+                yield from check_slot(attr, f"Class '{class_name}' attribute '{attr_name}'")
             for usage_name, usage in (class_def.slot_usage or {}).items():
                 yield from check_slot(usage, f"Class '{class_name}' slot_usage '{usage_name}'")
 
@@ -505,13 +514,19 @@ class NoUndeclaredSubsetsRule(LinterRule):
                 if subset_name not in declared_subsets:
                     yield LinterProblem(f"{descriptor} asserts membership in undeclared subset '{subset_name}'.")
 
-        # slots (includes attributes)
-        for slot_name, slot_def in schema_view.all_slots().items():
+        # Iterate global slots, then each class's attributes and slot_usage separately.
+        # all_slots() de-duplicates attributes by name, so iterating it would miss
+        # in_subset on attributes that share a name across classes or override a global
+        # slot. attributes=False yields only the global slots; attributes are checked
+        # per class below, each in its own context.
+        for slot_name, slot_def in schema_view.all_slots(attributes=False).items():
             yield from check_element(slot_def, f"Slot '{slot_name}'")
 
-        # classes, plus their slot_usage overrides
+        # classes, plus their attributes and slot_usage overrides
         for class_name, class_def in schema_view.all_classes().items():
             yield from check_element(class_def, f"Class '{class_name}'")
+            for attr_name, attr in (class_def.attributes or {}).items():
+                yield from check_element(attr, f"Class '{class_name}' attribute '{attr_name}'")
             for usage_name, usage in (class_def.slot_usage or {}).items():
                 yield from check_element(usage, f"Class '{class_name}' slot_usage '{usage_name}'")
 

--- a/tests/linkml/test_linter/test_rule_no_invalid_slot_group.py
+++ b/tests/linkml/test_linter/test_rule_no_invalid_slot_group.py
@@ -94,3 +94,23 @@ classes:
         problems[0].message
         == "Class 'SomeClass' slot_usage 'member_slot' has slot_group 'Not A Slot' which is not a defined slot."
     )
+
+
+def test_slot_group_on_class_attribute() -> None:
+    """slot_group on an inline attribute is checked, including one overriding a global slot name."""
+    test_schema = """id: http://example.org/test_slot_group
+name: test_slot_group
+slots:
+  member_slot:
+classes:
+  A:
+    attributes:
+      member_slot:
+        slot_group: Not A Slot
+"""
+    problems = check_schema(test_schema)
+    assert len(problems) == 1
+    assert (
+        problems[0].message
+        == "Class 'A' attribute 'member_slot' has slot_group 'Not A Slot' which is not a defined slot."
+    )

--- a/tests/linkml/test_linter/test_rule_no_invalid_slot_group.py
+++ b/tests/linkml/test_linter/test_rule_no_invalid_slot_group.py
@@ -1,0 +1,96 @@
+"""Tests of the linter's slot_group integrity rule."""
+
+from linkml.linter.config.datamodel.config import RuleConfig, RuleLevel
+from linkml.linter.linter import LinterProblem
+from linkml.linter.rules import NoInvalidSlotGroupRule
+from linkml_runtime.utils.schemaview import SchemaView
+
+
+def check_schema(test_schema: str) -> list[LinterProblem]:
+    """Check a schema using the NoInvalidSlotGroupRule linter.
+
+    :param test_schema: schema to test, as a string
+    :type test_schema: str
+    :return: list of linting problems discovered
+    :rtype: list[LinterProblem]
+    """
+    schema_view = SchemaView(test_schema)
+    config = RuleConfig(level=RuleLevel.error.text)
+
+    rule = NoInvalidSlotGroupRule(config)
+    return list(rule.check(schema_view, fix=False))
+
+
+def test_valid_slot_group() -> None:
+    """A slot_group that names a slot marked is_grouping_slot: true is valid."""
+    test_schema = """id: http://example.org/test_slot_group
+name: test_slot_group
+slots:
+  section_header:
+    is_grouping_slot: true
+  member_slot:
+    slot_group: section_header
+"""
+    assert not check_schema(test_schema)
+
+
+def test_no_slot_group() -> None:
+    """A slot with no slot_group produces no problems."""
+    test_schema = """id: http://example.org/test_slot_group
+name: test_slot_group
+slots:
+  plain_slot:
+"""
+    assert not check_schema(test_schema)
+
+
+def test_undefined_slot_group() -> None:
+    """A slot_group naming something that is not a defined slot is an error."""
+    test_schema = """id: http://example.org/test_slot_group
+name: test_slot_group
+slots:
+  member_slot:
+    slot_group: Not A Slot
+"""
+    problems = check_schema(test_schema)
+    assert len(problems) == 1
+    assert problems[0].message == "Slot 'member_slot' has slot_group 'Not A Slot' which is not a defined slot."
+
+
+def test_non_grouping_slot_group() -> None:
+    """A slot_group naming a defined slot that is not a grouping slot is an error."""
+    test_schema = """id: http://example.org/test_slot_group
+name: test_slot_group
+slots:
+  ordinary_slot:
+  member_slot:
+    slot_group: ordinary_slot
+"""
+    problems = check_schema(test_schema)
+    assert len(problems) == 1
+    assert (
+        problems[0].message
+        == "Slot 'member_slot' has slot_group 'ordinary_slot' which is not marked 'is_grouping_slot: true'."
+    )
+
+
+def test_slot_group_in_slot_usage() -> None:
+    """slot_group asserted in a class's slot_usage is also checked."""
+    test_schema = """id: http://example.org/test_slot_group
+name: test_slot_group
+slots:
+  member_slot:
+classes:
+  SomeClass:
+    slots:
+      - member_slot
+    slot_usage:
+      member_slot:
+        slot_group: Not A Slot
+"""
+    problems = check_schema(test_schema)
+    assert len(problems) == 1
+    assert (
+        problems[0].message
+        == "Class 'SomeClass' slot_usage 'member_slot' has slot_group 'Not A Slot' which is not a defined slot."
+    )

--- a/tests/linkml/test_linter/test_rule_no_undeclared_subsets.py
+++ b/tests/linkml/test_linter/test_rule_no_undeclared_subsets.py
@@ -1,0 +1,108 @@
+"""Tests of the linter's in_subset integrity rule."""
+
+from linkml.linter.config.datamodel.config import RuleConfig, RuleLevel
+from linkml.linter.linter import LinterProblem
+from linkml.linter.rules import NoUndeclaredSubsetsRule
+from linkml_runtime.utils.schemaview import SchemaView
+
+
+def check_schema(test_schema: str) -> list[LinterProblem]:
+    """Check a schema using the NoUndeclaredSubsetsRule linter.
+
+    :param test_schema: schema to test, as a string
+    :type test_schema: str
+    :return: list of linting problems discovered
+    :rtype: list[LinterProblem]
+    """
+    schema_view = SchemaView(test_schema)
+    config = RuleConfig(level=RuleLevel.error.text)
+
+    rule = NoUndeclaredSubsetsRule(config)
+    return list(rule.check(schema_view, fix=False))
+
+
+def test_valid_in_subset() -> None:
+    """in_subset that names a declared subset is valid."""
+    test_schema = """id: http://example.org/test_subsets
+name: test_subsets
+subsets:
+  a_subset:
+    description: a declared subset
+slots:
+  member_slot:
+    in_subset:
+      - a_subset
+"""
+    assert not check_schema(test_schema)
+
+
+def test_no_in_subset() -> None:
+    """A slot with no in_subset produces no problems."""
+    test_schema = """id: http://example.org/test_subsets
+name: test_subsets
+slots:
+  plain_slot:
+"""
+    assert not check_schema(test_schema)
+
+
+def test_undeclared_in_subset_on_slot() -> None:
+    """in_subset naming an undeclared subset is an error."""
+    test_schema = """id: http://example.org/test_subsets
+name: test_subsets
+slots:
+  member_slot:
+    in_subset:
+      - made_up_subset
+"""
+    problems = check_schema(test_schema)
+    assert len(problems) == 1
+    assert problems[0].message == "Slot 'member_slot' asserts membership in undeclared subset 'made_up_subset'."
+
+
+def test_undeclared_in_subset_on_class_and_enum() -> None:
+    """in_subset on classes, enums, and permissible values is checked."""
+    test_schema = """id: http://example.org/test_subsets
+name: test_subsets
+classes:
+  SomeClass:
+    in_subset:
+      - missing_class_subset
+enums:
+  SomeEnum:
+    in_subset:
+      - missing_enum_subset
+    permissible_values:
+      VALUE:
+        in_subset:
+          - missing_pv_subset
+"""
+    messages = sorted(p.message for p in check_schema(test_schema))
+    assert messages == [
+        "Class 'SomeClass' asserts membership in undeclared subset 'missing_class_subset'.",
+        "Enum 'SomeEnum' asserts membership in undeclared subset 'missing_enum_subset'.",
+        "Enum 'SomeEnum' permissible value 'VALUE' asserts membership in undeclared subset 'missing_pv_subset'.",
+    ]
+
+
+def test_undeclared_in_subset_in_slot_usage() -> None:
+    """in_subset asserted in a class's slot_usage is also checked."""
+    test_schema = """id: http://example.org/test_subsets
+name: test_subsets
+slots:
+  member_slot:
+classes:
+  SomeClass:
+    slots:
+      - member_slot
+    slot_usage:
+      member_slot:
+        in_subset:
+          - made_up_subset
+"""
+    problems = check_schema(test_schema)
+    assert len(problems) == 1
+    assert (
+        problems[0].message
+        == "Class 'SomeClass' slot_usage 'member_slot' asserts membership in undeclared subset 'made_up_subset'."
+    )

--- a/tests/linkml/test_linter/test_rule_no_undeclared_subsets.py
+++ b/tests/linkml/test_linter/test_rule_no_undeclared_subsets.py
@@ -106,3 +106,36 @@ classes:
         problems[0].message
         == "Class 'SomeClass' slot_usage 'member_slot' asserts membership in undeclared subset 'made_up_subset'."
     )
+
+
+def test_undeclared_in_subset_on_class_attributes() -> None:
+    """in_subset on inline attributes is checked per class.
+
+    Covers attributes that share a name across classes and an attribute that overrides
+    a globally declared slot name. all_slots() de-duplicates these by name, so this
+    guards against the rule silently skipping them.
+    """
+    test_schema = """id: http://example.org/test_subsets
+name: test_subsets
+slots:
+  shared:
+    in_subset:
+      - missing_global
+classes:
+  A:
+    attributes:
+      shared:
+        in_subset:
+          - missing_in_a
+  B:
+    attributes:
+      shared:
+        in_subset:
+          - missing_in_b
+"""
+    messages = sorted(p.message for p in check_schema(test_schema))
+    assert messages == [
+        "Class 'A' attribute 'shared' asserts membership in undeclared subset 'missing_in_a'.",
+        "Class 'B' attribute 'shared' asserts membership in undeclared subset 'missing_in_b'.",
+        "Slot 'shared' asserts membership in undeclared subset 'missing_global'.",
+    ]


### PR DESCRIPTION
Closes #3679.

## Problem

The linter checks that slot ranges resolve (`no_undeclared_ranges`, added in #2781 for #2254), but it does not check two other name references in the metamodel:

- `slot_group` has range `slot_definition`, but nothing verifies the named slot exists or that it is marked `is_grouping_slot: true`.
- `in_subset` has range `subset_definition`, but nothing verifies the named subset is declared in the `subsets` section.

Both pass silently today. A dangling `slot_group` or `in_subset` is a schema authoring error that no current rule catches. 

For context, enabling the `slot_group` rule against one production schema surfaced 21 dangling references that had accumulated in nmdc-schema.

## What this adds

Two rules, modeled directly on `NoUndeclaredRangesRule`:

- `no_invalid_slot_group`: a `slot_group` must resolve to a defined slot that is marked `is_grouping_slot: true`. Reports an undefined target and a defined but non-grouping target separately. Checks top-level slots and per-class `slot_usage`.
- `no_undeclared_subsets`: an `in_subset` value must name a subset declared in the `subsets` section. Checks slots and attributes, classes, `slot_usage`, enums, permissible values, and types.

Neither is auto-fixable.

## Design choices

- Both rules are `disabled` in `default.yaml`, consistent with the other rules.
- I did not add them to `recommended.yaml`. Adding a new error-level rule there would start failing existing schemas that extend `recommended` on a routine upgrade. Keeping them opt-in lets schemas adopt on their own schedule. Happy to add them to `recommended` if maintainers prefer, see the open question below.
- `config.py` was regenerated with `gen-python`, not hand-edited. That regen also refreshes a stale `metamodel_version` stamp (1.7.0 to 1.11.0); flagging it since it shows up in the diff but is unrelated to the rules.

## Open question

Should these graduate into `recommended` (and at what level, warning or error), or stay opt-in? I leaned opt-in to avoid a breaking change, but the range rule sets the precedent for putting referential-integrity checks in `recommended` at error level.

## Testing

- Two new test modules under `tests/linkml/test_linter/`, 10 cases covering valid references, undefined targets, non-grouping targets, undeclared subsets, and `slot_usage` overrides.
- Full linter suite passes (167 tests).
