### PR TITLE
Make EnumDefinitionImpl instances hashable

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/utils/enumerations.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/enumerations.py
@@ -117,6 +117,16 @@ class EnumDefinitionImpl(YAMLRoot, metaclass=EnumDefinitionMeta):
         """The string representation of an enumerated value should be the code representing this value."""
         return self._code.text
 
+    def __hash__(self) -> int:
+        """Hash on the permissible value text.
+
+        ``YAMLRoot`` inherits ``__eq__`` from ``jsonasobj2`` without a matching
+        ``__hash__``, which leaves ``__hash__`` set to ``None`` and makes
+        instances unhashable.  Two equal enum values always share the same
+        permissible value text, so hashing on it stays consistent with equality.
+        """
+        return hash(self._code.text)
+
     def __repr__(self) -> str:
         rlist = [(f.name, getattr(self._code, f.name)) for f in fields(self._code)]
         return self.__class__.__name__ + "(" + ", ".join([f"{f[0]}={repr(f[1])}" for f in rlist if f[1]]) + ")"

--- a/tests/linkml_runtime/test_utils/test_enumerations.py
+++ b/tests/linkml_runtime/test_utils/test_enumerations.py
@@ -76,3 +76,17 @@ def test_construct_with_inherited_code(cls):
 def test_construct_with_own_code_on_grandchild():
     instance = _GrandchildEnum("C")
     assert str(instance) == "C"
+
+
+@pytest.mark.parametrize("cls", [_ParentEnum, _WrapperEnum, _GrandchildEnum])
+def test_enum_value_is_hashable(cls):
+    """Regression for https://github.com/linkml/linkml/issues/3590.
+
+    ``YAMLRoot`` inherited ``__eq__`` without ``__hash__``, so enum values were
+    unhashable and could not be used as keys when normalizing inlined-as-dict
+    slots.
+    """
+    value = cls("A")
+    assert hash(value) == hash(cls("A"))
+    assert {value, cls("A")} == {value}
+    assert {value: "x"}[cls("A")] == "x"


### PR DESCRIPTION
## Summary

Fixes #3590

`EnumDefinitionImpl` inherits `__eq__` from `jsonasobj2` (via `YAMLRoot`) but never defines `__hash__`, so Python sets `__hash__` to `None` and instances become unhashable. This breaks `_normalize_inlined()` in `yamlutils.py`, which adds enum-typed keys to a `set` for duplicate detection, with `TypeError: unhashable type`. The minimal reproducer from the issue (`hash(E("A"))`) also raises.

I added a `__hash__` that hashes on the permissible value text. Two equal enum values always share the same `_code.text`, so this stays consistent with the inherited equality and matches what `__str__` already returns.

## How was this tested?

Added a regression test in `tests/linkml_runtime/test_utils/test_enumerations.py` that checks the enum value is hashable, that equal values hash equally, and that it works as a set member and dict key. Confirmed the test fails on `main` (TypeError) and passes with this change. The existing tests in that module still pass.

## Areas of uncertainty

Hashing on `_code.text` (rather than including the class) is deliberate: cross-class enum values with the same code compare equal under the inherited `__eq__`, so folding in the class would break the equal-implies-equal-hash invariant.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
