### PR TITLE
Fix SchemaView get_uri

### DIFF
--- a/packages/linkml/src/linkml/generators/owlgen.py
+++ b/packages/linkml/src/linkml/generators/owlgen.py
@@ -1569,14 +1569,6 @@ class OwlSchemaGenerator(Generator):
         if native is None:
             # never use native unless type shadowing with objects is enabled
             native = self.type_objects
-        if native:
-            # UGLY HACK: Currently schemaview does not camelcase types
-            e = self.schemaview.get_element(tn, imports=True)
-            if e.from_schema is not None:
-                schema = next(sc for sc in self.schemaview.schema_map.values() if sc.id == e.from_schema)
-                pfx = schema.default_prefix
-                if pfx == "linkml":
-                    return URIRef(self.schemaview.expand_curie(f"{pfx}:{camelcase(tn)}"))
         t = self.schemaview.get_type(tn)
         expanded = self.schemaview.get_uri(t, expand=True, native=native)
         if expanded.startswith("xsd:"):

--- a/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
@@ -1378,13 +1378,32 @@ class SchemaView:
     ) -> str:
         """Return the CURIE or URI for a schema element.
 
-        If the schema defines a specific URI, this is used;
-        otherwise this is constructed from the default prefix combined with the element name.
+        If the schema declares a specific URI for the element (e.g. ``class_uri``,
+        ``slot_uri``, ``type.uri``, ``enum_uri``), that declared URI is used.
+        Otherwise — or when ``native=True`` — the *native* URI is constructed from
+        the schema's ``default_prefix`` combined with the normalized element name.
+
+        When ``native=True`` this method returns the element's ``definition_uri``
+        value (as a CURIE, or expanded to a full URI when ``expand=True``).  The
+        name-casing convention matches
+        :func:`linkml.utils.mergeutils.set_from_schema`:
+
+        * **Slots** – :func:`~linkml_runtime.utils.formatutils.underscore`
+        * **All other elements** (classes, types, enums, subsets) –
+          :func:`~linkml_runtime.utils.formatutils.camelcase`
+
+        When ``native=False`` (the default) the same casing is used for the native
+        fallback (applied when the element has no declared URI), but the element's
+        own declared URI takes precedence.
 
         :param element: name of schema element
         :param imports: include imports closure
-        :param native: return the native CURIE or URI rather than what is declared in the uri slot
-        :param expand: expand the CURIE to a URI; defaults to False
+        :param native: return the native URI (``definition_uri`` semantics) rather
+            than what is declared in the element's URI slot
+        :param expand: expand the result from a CURIE to a full URI;
+            defaults to ``False``
+        :param use_element_type: when constructing the native URI, insert the
+            element type as a path segment (e.g. ``core:class/TestClass``)
         :return: URI or CURIE as a string
         """
         e = self.get_element(element, imports=imports)
@@ -1397,13 +1416,15 @@ class SchemaView:
             e_name = underscore(e.name)
         elif isinstance(e, EnumDefinition):
             uri = e.enum_uri
-            e_name = e.name
+            e_name = camelcase(e.name)
         elif isinstance(e, TypeDefinition):
             uri = e.uri
-            e_name = underscore(e.name)
+            e_name = camelcase(e.name)
+        elif isinstance(e, SubsetDefinition):
+            uri = None
+            e_name = camelcase(e.name)
         else:
-            msg = f"Must be class or slot or type: {e}"
-            # should be a TypeError
+            msg = f"Must be class, slot, type, enum, or subset: {e}"
             raise ValueError(msg)
 
         if uri is None or native:

--- a/tests/linkml/test_biolink_model/__snapshots__/biolink.owl.ttl
+++ b/tests/linkml/test_biolink_model/__snapshots__/biolink.owl.ttl
@@ -110,7 +110,7 @@ biolink:AdministrativeEntity a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Agent a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "agent" ;
-	rdfs:subClassOf biolink:AdministrativeEntity , _:c14n1041 , _:c14n1107 , _:c14n1135 , _:c14n1142 , _:c14n1360 , _:c14n1739 , _:c14n238 , _:c14n276 , _:c14n704 , _:c14n870 , _:c14n95 ;
+	rdfs:subClassOf biolink:AdministrativeEntity , _:c14n1047 , _:c14n1111 , _:c14n1140 , _:c14n1147 , _:c14n1364 , _:c14n1742 , _:c14n241 , _:c14n279 , _:c14n706 , _:c14n874 , _:c14n95 ;
 	skos:altLabel "group" ;
 	skos:definition "person, group, organization or project that provides a piece of information (i.e. a knowledge association)" ;
 	skos:exactMatch dct:Agent , prov:Agent ;
@@ -154,7 +154,7 @@ biolink:AgentTypeEnum\#text_mining_agent a owl:Class , biolink:AgentTypeEnum ;
 	skos:editorialNote "The original statement in the source text is typically made by a human /  manual agent, but if a specific encoding of this knowledge is produced by a text-mining tool, it has an agent_type of 'text_mining_agent'. Examples of text mining agents include SemmedDB, and the Translator Text-Mining Knowledge Provider. Note that text-mining tools are prone to erroneous interpretation of  concepts and relationships, and can fail to provide important details  about the context in which the original knowledge was reported - so users should always consult the source text for a text-mined statement to assess its veracity and relevance." .
 biolink:AgentTypeEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "AgentTypeEnum" ;
-	owl:unionOf _:c14n232 ;
+	owl:unionOf _:c14n234 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:AgentTypeEnum\#automated_agent , biolink:AgentTypeEnum\#computational_model , biolink:AgentTypeEnum\#data_analysis_pipeline , biolink:AgentTypeEnum\#image_processing_agent , biolink:AgentTypeEnum\#manual_agent , biolink:AgentTypeEnum\#manual_validation_of_automated_agent , biolink:AgentTypeEnum\#not_provided , biolink:AgentTypeEnum\#text_mining_agent .
 biolink:AnatomicalEntity a owl:Class , linkml:ClassDefinition ;
@@ -167,16 +167,16 @@ biolink:AnatomicalEntity a owl:Class , linkml:ClassDefinition ;
 	skos:relatedMatch SNOMEDCT:123037004 .
 biolink:AnatomicalEntityToAnatomicalEntityAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "anatomical entity to anatomical entity association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1317 , _:c14n140 , _:c14n272 , _:c14n508 , _:c14n545 , _:c14n763 , _:c14n944 ;
+	rdfs:subClassOf biolink:Association , _:c14n1323 , _:c14n142 , _:c14n275 , _:c14n515 , _:c14n549 , _:c14n764 , _:c14n948 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "anatomical entity to anatomical entity ontogenic association" ;
-	rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation , _:c14n1373 , _:c14n156 , _:c14n1816 , _:c14n592 , _:c14n593 , _:c14n748 , _:c14n793 , _:c14n807 , _:c14n868 ;
+	rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation , _:c14n1377 , _:c14n158 , _:c14n1818 , _:c14n595 , _:c14n596 , _:c14n749 , _:c14n795 , _:c14n810 , _:c14n872 ;
 	skos:definition "A relationship between two anatomical entities where the relationship is ontogenic, i.e. the two entities are related by development. A number of different relationship types can be used to specify the precise nature of the relationship." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "anatomical entity to anatomical entity part of association" ;
-	rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation , _:c14n1010 , _:c14n1541 , _:c14n160 , _:c14n1610 , _:c14n1682 , _:c14n1879 , _:c14n668 , _:c14n874 , _:c14n995 ;
+	rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation , _:c14n1015 , _:c14n1545 , _:c14n1613 , _:c14n162 , _:c14n1686 , _:c14n1880 , _:c14n669 , _:c14n878 , _:c14n999 ;
 	skos:definition "A relationship between two anatomical entities where the relationship is mereological, i.e the two entities are related by parthood. This includes relationships between cellular components and cells, between cells and tissues, tissues and whole organisms" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Annotation a owl:Class , linkml:ClassDefinition ;
@@ -245,25 +245,25 @@ biolink:ApprovalStatusEnum\#regular_fda_approval a owl:Class , biolink:ApprovalS
 	skos:definition "Regular FDA Approval.  The last phase of drug approval is an ongoing one while the drug is on the marketplace. If a developer wants to change anything about the drug formulation or approve it for a new use, they must apply with the FDA. The FDA also frequently reviews the drug’s advertising and its manufacturing facility to make sure everything involved in its creation and marketing is in compliance with regulations." .
 biolink:ApprovalStatusEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "ApprovalStatusEnum" ;
-	owl:unionOf _:c14n775 ;
+	owl:unionOf _:c14n776 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:ApprovalStatusEnum\#discovery_and_development_phase , biolink:ApprovalStatusEnum\#fda_accelerated_approval , biolink:ApprovalStatusEnum\#fda_breakthrough_therapy , biolink:ApprovalStatusEnum\#fda_clinical_research_phase , biolink:ApprovalStatusEnum\#fda_clinical_research_phase_1 , biolink:ApprovalStatusEnum\#fda_clinical_research_phase_2 , biolink:ApprovalStatusEnum\#fda_clinical_research_phase_3 , biolink:ApprovalStatusEnum\#fda_clinical_research_phase_4 , biolink:ApprovalStatusEnum\#fda_fast_track , biolink:ApprovalStatusEnum\#fda_post_market_safety_review , biolink:ApprovalStatusEnum\#fda_priority_review , biolink:ApprovalStatusEnum\#fda_review_phase_4 , biolink:ApprovalStatusEnum\#post_approval_withdrawal , biolink:ApprovalStatusEnum\#preclinical_research_phase , biolink:ApprovalStatusEnum\#regular_fda_approval .
 biolink:Article a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "article" ;
-	rdfs:subClassOf biolink:Publication , _:c14n1046 , _:c14n1185 , _:c14n154 , _:c14n1555 , _:c14n1738 , _:c14n1903 , _:c14n224 , _:c14n540 , _:c14n67 , _:c14n776 , _:c14n859 , _:c14n877 ;
+	rdfs:subClassOf biolink:Publication , _:c14n1052 , _:c14n1190 , _:c14n1559 , _:c14n156 , _:c14n1741 , _:c14n1903 , _:c14n226 , _:c14n545 , _:c14n65 , _:c14n777 , _:c14n862 , _:c14n881 ;
 	skos:definition "a piece of writing on a particular topic presented as a stand-alone section of a larger publication" ;
 	skos:exactMatch fabio:article , SIO:000154 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Association a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "association" ;
-	rdfs:subClassOf biolink:Entity , _:c14n1011 , _:c14n1083 , _:c14n1108 , _:c14n1121 , _:c14n1122 , _:c14n1149 , _:c14n1151 , _:c14n1169 , _:c14n1190 , _:c14n1215 , _:c14n1229 , _:c14n1235 , _:c14n1263 , _:c14n1288 , _:c14n1323 , _:c14n1326 , _:c14n1341 , _:c14n1347 , _:c14n1356 , _:c14n1404 , _:c14n1411 , _:c14n1461 , _:c14n1468 , _:c14n1478 , _:c14n1494 , _:c14n1496 , _:c14n1498 , _:c14n1556 , _:c14n1613 , _:c14n163 , _:c14n1640 , _:c14n1645 , _:c14n1653 , _:c14n1665 , _:c14n170 , _:c14n173 , _:c14n1761 , _:c14n1763 , _:c14n1795 , _:c14n1807 , _:c14n1815 , _:c14n189 , _:c14n245 , _:c14n253 , _:c14n277 , _:c14n295 , _:c14n302 , _:c14n310 , _:c14n317 , _:c14n328 , _:c14n335 , _:c14n344 , _:c14n358 , _:c14n397 , _:c14n401 , _:c14n403 , _:c14n420 , _:c14n471 , _:c14n495 , _:c14n547 , _:c14n565 , _:c14n575 , _:c14n580 , _:c14n601 , _:c14n638 , _:c14n717 , _:c14n74 , _:c14n754 , _:c14n781 , _:c14n792 , _:c14n814 , _:c14n820 , _:c14n833 , _:c14n857 , _:c14n898 , _:c14n901 , _:c14n919 , _:c14n921 , _:c14n923 , _:c14n943 , _:c14n954 , _:c14n961 , _:c14n974 , _:c14n975 , _:c14n982 ;
+	rdfs:subClassOf biolink:Entity , _:c14n1016 , _:c14n1088 , _:c14n1112 , _:c14n1125 , _:c14n1126 , _:c14n1154 , _:c14n1156 , _:c14n1175 , _:c14n1195 , _:c14n1218 , _:c14n1233 , _:c14n1239 , _:c14n1268 , _:c14n1293 , _:c14n1330 , _:c14n1345 , _:c14n1351 , _:c14n1360 , _:c14n1409 , _:c14n1416 , _:c14n1457 , _:c14n1467 , _:c14n1474 , _:c14n1483 , _:c14n1499 , _:c14n1501 , _:c14n1503 , _:c14n1560 , _:c14n1616 , _:c14n1644 , _:c14n1649 , _:c14n165 , _:c14n1657 , _:c14n1669 , _:c14n173 , _:c14n176 , _:c14n1763 , _:c14n1765 , _:c14n1797 , _:c14n1809 , _:c14n1817 , _:c14n191 , _:c14n248 , _:c14n256 , _:c14n280 , _:c14n299 , _:c14n307 , _:c14n314 , _:c14n322 , _:c14n333 , _:c14n340 , _:c14n349 , _:c14n363 , _:c14n404 , _:c14n408 , _:c14n410 , _:c14n427 , _:c14n477 , _:c14n501 , _:c14n552 , _:c14n570 , _:c14n578 , _:c14n583 , _:c14n604 , _:c14n640 , _:c14n73 , _:c14n755 , _:c14n782 , _:c14n794 , _:c14n797 , _:c14n817 , _:c14n823 , _:c14n837 , _:c14n860 , _:c14n902 , _:c14n905 , _:c14n923 , _:c14n925 , _:c14n927 , _:c14n947 , _:c14n958 , _:c14n965 , _:c14n977 , _:c14n978 , _:c14n985 ;
 	skos:definition "A typed association between two entities, supported by evidence" ;
 	skos:exactMatch OBAN:association , rdf:Statement , owl:Axiom ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:note "This is roughly the model used by biolink and ontobio at the moment" .
 biolink:Attribute a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "attribute" ;
-	rdfs:subClassOf biolink:NamedThing , biolink:OntologyClass , _:c14n1016 , _:c14n128 , _:c14n1517 , _:c14n1588 , _:c14n1674 , _:c14n1713 , _:c14n186 , _:c14n200 , _:c14n231 , _:c14n490 , _:c14n566 , _:c14n625 , _:c14n798 , _:c14n878 ;
+	rdfs:subClassOf biolink:NamedThing , biolink:OntologyClass , _:c14n1021 , _:c14n130 , _:c14n1521 , _:c14n1591 , _:c14n1678 , _:c14n1716 , _:c14n188 , _:c14n202 , _:c14n233 , _:c14n283 , _:c14n304 , _:c14n496 , _:c14n628 , _:c14n801 ;
 	skos:definition "A property or characteristic of an entity. For example, an apple may have properties such as color, shape, age, crispiness. An environmental sample may have attributes such as depth, lat, long, material." ;
 	skos:exactMatch SIO:000614 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -281,7 +281,7 @@ biolink:Behavior a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch STY:T041 , STY:T054 , STY:T055 .
 biolink:BehaviorToBehavioralFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "behavior to behavioral feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , _:c14n1279 , _:c14n1762 , _:c14n223 , _:c14n234 , _:c14n582 , _:c14n709 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , _:c14n1284 , _:c14n1764 , _:c14n225 , _:c14n237 , _:c14n585 , _:c14n711 ;
 	skos:definition "An association between an mixture behavior and a behavioral feature manifested by the individual exhibited or has exhibited the behavior." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:BehavioralExposure a owl:Class , linkml:ClassDefinition ;
@@ -302,7 +302,7 @@ biolink:BehavioralOutcome a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:BiologicalEntity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "biological entity" ;
-	rdfs:subClassOf biolink:NamedThing , biolink:ThingWithTaxon , _:c14n301 ;
+	rdfs:subClassOf biolink:NamedThing , biolink:ThingWithTaxon , _:c14n306 ;
 	skos:altLabel "bioentity" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch STY:T050 , STY:T129 , SIO:010046 , WIKIDATA:Q28845870 .
@@ -315,9 +315,11 @@ biolink:BiologicalProcess a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:BiologicalProcessOrActivity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "biological process or activity" ;
-	rdfs:subClassOf biolink:BiologicalEntity , biolink:Occurrent , biolink:OntologyClass , _:c14n1030 , _:c14n1271 , _:c14n1615 , _:c14n1823 , _:c14n1912 , _:c14n697 , _:c14n837 , _:c14n953 , _:c14n981 ;
+	rdfs:subClassOf biolink:BiologicalEntity , biolink:Occurrent , biolink:OntologyClass , _:c14n1036 , _:c14n1276 , _:c14n1618 , _:c14n1824 , _:c14n1912 , _:c14n698 , _:c14n841 , _:c14n957 , _:c14n984 ;
 	skos:definition "Either an individual molecular activity, or a collection of causally connected molecular activities in a biological system." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:BiologicalSequence a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:String .
 biolink:BiologicalSex a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "biological sex" ;
 	rdfs:subClassOf biolink:Attribute ;
@@ -331,12 +333,12 @@ biolink:BioticExposure a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Book a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "book" ;
-	rdfs:subClassOf biolink:Publication , _:c14n1441 , _:c14n1721 , _:c14n1803 , _:c14n483 , _:c14n752 ;
+	rdfs:subClassOf biolink:Publication , _:c14n1446 , _:c14n1724 , _:c14n1805 , _:c14n489 , _:c14n753 ;
 	skos:definition "This class may rarely be instantiated except if use cases of a given knowledge graph support its utility." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:BookChapter a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "book chapter" ;
-	rdfs:subClassOf biolink:Publication , _:c14n1157 , _:c14n121 , _:c14n1784 , _:c14n1801 , _:c14n1806 , _:c14n1810 , _:c14n275 , _:c14n305 , _:c14n476 ;
+	rdfs:subClassOf biolink:Publication , _:c14n1163 , _:c14n121 , _:c14n1786 , _:c14n1803 , _:c14n1808 , _:c14n1812 , _:c14n278 , _:c14n309 , _:c14n482 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Case a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "case" ;
@@ -346,7 +348,7 @@ biolink:Case a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CaseToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "case to entity association mixin" ;
-	rdfs:subClassOf _:c14n1077 , _:c14n1105 , _:c14n1196 , _:c14n12 , _:c14n1438 , _:c14n1783 , _:c14n58 , _:c14n745 , _:c14n910 ;
+	rdfs:subClassOf _:c14n1082 , _:c14n1109 , _:c14n1201 , _:c14n128 , _:c14n1443 , _:c14n1785 , _:c14n56 , _:c14n746 , _:c14n914 ;
 	skos:definition "An abstract association for use where the case is the subject" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CaseToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
@@ -356,7 +358,7 @@ biolink:CaseToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition 
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CausalGeneToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "causal gene to disease association" ;
-	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1216 , _:c14n1709 , _:c14n1812 , _:c14n782 , _:c14n871 , _:c14n929 ;
+	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1219 , _:c14n1712 , _:c14n1814 , _:c14n783 , _:c14n875 , _:c14n934 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CausalMechanismQualifierEnum\#activation a owl:Class , biolink:CausalMechanismQualifierEnum ;
 	rdfs:label "activation" ;
@@ -446,7 +448,7 @@ biolink:CausalMechanismQualifierEnum\#transcriptional_regulation a owl:Class , b
 	skos:definition "A causal mechanism mediated by through the control of target gene transcription" .
 biolink:CausalMechanismQualifierEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "CausalMechanismQualifierEnum" ;
-	owl:unionOf _:c14n713 ;
+	owl:unionOf _:c14n716 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:CausalMechanismQualifierEnum\#activation , biolink:CausalMechanismQualifierEnum\#agonism , biolink:CausalMechanismQualifierEnum\#antagonism , biolink:CausalMechanismQualifierEnum\#antibody_inhibition , biolink:CausalMechanismQualifierEnum\#binding , biolink:CausalMechanismQualifierEnum\#inducer , biolink:CausalMechanismQualifierEnum\#inhibition , biolink:CausalMechanismQualifierEnum\#inverse_agonism , biolink:CausalMechanismQualifierEnum\#molecular_channel_blockage , biolink:CausalMechanismQualifierEnum\#molecular_channel_opening , biolink:CausalMechanismQualifierEnum\#negative_allosteric_modulation , biolink:CausalMechanismQualifierEnum\#positive_allosteric_modulation , biolink:CausalMechanismQualifierEnum\#potentiation , biolink:CausalMechanismQualifierEnum\#releasing_activity , biolink:CausalMechanismQualifierEnum\#signaling_mediated_control , biolink:CausalMechanismQualifierEnum\#stabilization , biolink:CausalMechanismQualifierEnum\#stimulation , biolink:CausalMechanismQualifierEnum\#transcriptional_regulation .
 biolink:Cell a owl:Class , linkml:ClassDefinition ;
@@ -461,16 +463,16 @@ biolink:CellLine a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CellLineAsAModelOfDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "cell line as a model of disease association" ;
-	rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation , biolink:EntityToDiseaseAssociationMixin , biolink:ModelToDiseaseAssociationMixin , _:c14n124 , _:c14n53 , _:c14n714 ;
+	rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation , biolink:EntityToDiseaseAssociationMixin , biolink:ModelToDiseaseAssociationMixin , _:c14n124 , _:c14n51 , _:c14n717 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "cell line to disease or phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:CellLineToEntityAssociationMixin , biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin , _:c14n1159 , _:c14n1464 , _:c14n365 ;
+	rdfs:subClassOf biolink:Association , biolink:CellLineToEntityAssociationMixin , biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin , _:c14n1165 , _:c14n1470 , _:c14n370 ;
 	skos:definition "An relationship between a cell line and a disease or a phenotype, where the cell line is derived from an individual with that disease or phenotype." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CellLineToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "cell line to entity association mixin" ;
-	rdfs:subClassOf _:c14n1069 , _:c14n1343 , _:c14n214 , _:c14n282 , _:c14n39 , _:c14n40 , _:c14n570 , _:c14n692 , _:c14n840 ;
+	rdfs:subClassOf _:c14n1074 , _:c14n1347 , _:c14n216 , _:c14n286 , _:c14n37 , _:c14n38 , _:c14n693 , _:c14n793 , _:c14n844 ;
 	skos:definition "An relationship between a cell line and another entity" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CellularComponent a owl:Class , linkml:ClassDefinition ;
@@ -488,12 +490,12 @@ biolink:CellularOrganism a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalAffectsGeneAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical affects gene association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1033 , _:c14n1047 , _:c14n1057 , _:c14n1131 , _:c14n1153 , _:c14n1179 , _:c14n119 , _:c14n1213 , _:c14n1231 , _:c14n1260 , _:c14n130 , _:c14n1316 , _:c14n1383 , _:c14n1387 , _:c14n14 , _:c14n1420 , _:c14n1458 , _:c14n1487 , _:c14n1497 , _:c14n151 , _:c14n153 , _:c14n1557 , _:c14n1566 , _:c14n1586 , _:c14n1612 , _:c14n1659 , _:c14n1757 , _:c14n1837 , _:c14n1848 , _:c14n1849 , _:c14n1898 , _:c14n195 , _:c14n235 , _:c14n26 , _:c14n271 , _:c14n326 , _:c14n34 , _:c14n352 , _:c14n393 , _:c14n41 , _:c14n463 , _:c14n492 , _:c14n496 , _:c14n514 , _:c14n52 , _:c14n543 , _:c14n600 , _:c14n76 , _:c14n784 , _:c14n808 , _:c14n839 , _:c14n913 , _:c14n977 , _:c14n992 ;
+	rdfs:subClassOf biolink:Association , _:c14n1039 , _:c14n1053 , _:c14n1063 , _:c14n1136 , _:c14n1158 , _:c14n1184 , _:c14n119 , _:c14n12 , _:c14n1216 , _:c14n1235 , _:c14n1265 , _:c14n132 , _:c14n1322 , _:c14n1387 , _:c14n1391 , _:c14n1425 , _:c14n1464 , _:c14n1492 , _:c14n1502 , _:c14n153 , _:c14n155 , _:c14n1561 , _:c14n1569 , _:c14n1589 , _:c14n1615 , _:c14n1663 , _:c14n1759 , _:c14n1838 , _:c14n1848 , _:c14n1849 , _:c14n1898 , _:c14n197 , _:c14n238 , _:c14n24 , _:c14n274 , _:c14n32 , _:c14n331 , _:c14n357 , _:c14n39 , _:c14n400 , _:c14n469 , _:c14n498 , _:c14n50 , _:c14n502 , _:c14n521 , _:c14n547 , _:c14n603 , _:c14n75 , _:c14n785 , _:c14n811 , _:c14n843 , _:c14n917 , _:c14n980 , _:c14n996 ;
 	skos:definition "Describes an effect that a chemical has on a gene or gene product (e.g. an impact of on its abundance, activity,localization, processing, expression, etc.)" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalEntity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical entity" ;
-	rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProduct , biolink:ChemicalEntityOrProteinOrPolypeptide , biolink:ChemicalOrDrugOrTreatment , biolink:NamedThing , biolink:PhysicalEssence , _:c14n1049 , _:c14n1274 , _:c14n1546 , _:c14n1572 , _:c14n1766 , _:c14n1782 , _:c14n249 , _:c14n35 , _:c14n37 , _:c14n562 , _:c14n674 , _:c14n780 , _:c14n93 ;
+	rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProduct , biolink:ChemicalEntityOrProteinOrPolypeptide , biolink:ChemicalOrDrugOrTreatment , biolink:NamedThing , biolink:PhysicalEssence , _:c14n1055 , _:c14n1279 , _:c14n1551 , _:c14n1576 , _:c14n1768 , _:c14n1784 , _:c14n252 , _:c14n33 , _:c14n35 , _:c14n567 , _:c14n675 , _:c14n781 , _:c14n93 ;
 	skos:broadMatch STY:T167 ;
 	skos:definition "A chemical entity is a physical entity that pertains to chemistry or biochemistry." ;
 	skos:exactMatch STY:T103 , <http://purl.obolibrary.org/obo/CHEBI_24431> , SIO:010004 , WIKIDATA:Q79529 ;
@@ -501,7 +503,7 @@ biolink:ChemicalEntity a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch STY:T123 , STY:T131 , WIKIDATA:Q43460564 .
 biolink:ChemicalEntityAssessesNamedThingAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical entity assesses named thing association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1013 , _:c14n1158 , _:c14n1363 , _:c14n1457 , _:c14n193 , _:c14n290 , _:c14n678 , _:c14n700 , _:c14n87 ;
+	rdfs:subClassOf biolink:Association , _:c14n1018 , _:c14n1164 , _:c14n1367 , _:c14n1463 , _:c14n195 , _:c14n294 , _:c14n679 , _:c14n702 , _:c14n86 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalEntityDerivativeEnum\#metabolite a owl:Class , biolink:ChemicalEntityDerivativeEnum ;
 	rdfs:label "metabolite" ;
@@ -516,7 +518,7 @@ biolink:ChemicalEntityOrGeneOrGeneProduct a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical entity or gene or gene product regulates gene association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1103 , _:c14n1234 , _:c14n1533 , _:c14n1649 , _:c14n1701 , _:c14n347 , _:c14n424 , _:c14n440 , _:c14n477 , _:c14n819 , _:c14n940 , _:c14n99 ;
+	rdfs:subClassOf biolink:Association , _:c14n1107 , _:c14n1238 , _:c14n1537 , _:c14n1653 , _:c14n1704 , _:c14n352 , _:c14n431 , _:c14n447 , _:c14n483 , _:c14n822 , _:c14n944 , _:c14n99 ;
 	skos:definition "A regulatory relationship between two genes" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalEntityOrProteinOrPolypeptide a owl:Class , linkml:ClassDefinition ;
@@ -525,24 +527,26 @@ biolink:ChemicalEntityOrProteinOrPolypeptide a owl:Class , linkml:ClassDefinitio
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalEntityToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical entity to entity association mixin" ;
-	rdfs:subClassOf _:c14n1339 , _:c14n1699 , _:c14n1775 , _:c14n1778 , _:c14n194 , _:c14n419 , _:c14n549 , _:c14n7 , _:c14n902 ;
+	rdfs:subClassOf _:c14n1343 , _:c14n1703 , _:c14n1777 , _:c14n1780 , _:c14n196 , _:c14n374 , _:c14n426 , _:c14n554 , _:c14n906 ;
 	skos:definition "An interaction between a chemical entity and another entity" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalExposure a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical exposure" ;
-	rdfs:subClassOf biolink:Attribute , biolink:ExposureEvent , _:c14n1262 , _:c14n1711 ;
+	rdfs:subClassOf biolink:Attribute , biolink:ExposureEvent , _:c14n1267 , _:c14n1714 ;
 	skos:definition "A chemical exposure is an intake of a particular chemical entity." ;
 	skos:exactMatch ECTO:9000000 , SIO:001399 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:ChemicalFormulaValue a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf _:c14n8 .
 biolink:ChemicalGeneInteractionAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical gene interaction association" ;
-	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , _:c14n1 , _:c14n1075 , _:c14n1203 , _:c14n1212 , _:c14n1236 , _:c14n1306 , _:c14n1436 , _:c14n1446 , _:c14n1454 , _:c14n1456 , _:c14n1542 , _:c14n158 , _:c14n164 , _:c14n1641 , _:c14n1666 , _:c14n1689 , _:c14n1756 , _:c14n1907 , _:c14n250 , _:c14n264 , _:c14n324 , _:c14n404 , _:c14n447 , _:c14n470 , _:c14n518 , _:c14n594 , _:c14n640 , _:c14n66 , _:c14n710 , _:c14n719 , _:c14n899 , _:c14n990 , _:c14n998 ;
+	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , _:c14n1 , _:c14n1002 , _:c14n1080 , _:c14n1207 , _:c14n1215 , _:c14n1240 , _:c14n1312 , _:c14n1441 , _:c14n1451 , _:c14n1460 , _:c14n1462 , _:c14n1546 , _:c14n160 , _:c14n1645 , _:c14n166 , _:c14n1670 , _:c14n1693 , _:c14n1758 , _:c14n1907 , _:c14n253 , _:c14n267 , _:c14n329 , _:c14n411 , _:c14n453 , _:c14n476 , _:c14n525 , _:c14n597 , _:c14n64 , _:c14n642 , _:c14n713 , _:c14n721 , _:c14n903 , _:c14n994 ;
 	skos:definition "describes a physical interaction between a chemical entity and a gene or gene product. Any biological or chemical effect resulting from such an interaction are out of scope, and covered by the ChemicalAffectsGeneAssociation type (e.g. impact of a chemical on the abundance, activity, structure, etc, of either participant in the interaction)" ;
 	skos:exactMatch SIO:001257 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalMixture a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical mixture" ;
-	rdfs:subClassOf biolink:ChemicalEntity , _:c14n1045 , _:c14n1365 , _:c14n1422 , _:c14n1466 , _:c14n1827 , _:c14n337 , _:c14n501 , _:c14n588 , _:c14n826 , _:c14n846 , _:c14n957 ;
+	rdfs:subClassOf biolink:ChemicalEntity , _:c14n1051 , _:c14n1369 , _:c14n1427 , _:c14n1472 , _:c14n1828 , _:c14n342 , _:c14n507 , _:c14n591 , _:c14n829 , _:c14n850 , _:c14n961 ;
 	skos:closeMatch dcid:ChemicalCompound ;
 	skos:definition "A chemical mixture is a chemical entity composed of two or more molecular entities." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
@@ -552,12 +556,12 @@ biolink:ChemicalOrDrugOrTreatment a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical or drug or treatment side effect disease or phenotypic feature association" ;
-	rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation , biolink:ChemicalToEntityAssociationMixin , biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin , _:c14n1063 , _:c14n1679 , _:c14n925 ;
+	rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation , biolink:ChemicalToEntityAssociationMixin , biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin , _:c14n1068 , _:c14n1683 , _:c14n929 ;
 	skos:definition "This association defines a relationship between a chemical or treatment (or procedure) and a disease or phenotypic feature where the disesae or phenotypic feature is a secondary, typically (but not always) undesirable effect." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical or drug or treatment to disease or phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin , biolink:EntityToFeatureOrDiseaseQualifiersMixin , _:c14n1695 , _:c14n176 , _:c14n1885 , _:c14n27 , _:c14n346 , _:c14n873 ;
+	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin , biolink:EntityToFeatureOrDiseaseQualifiersMixin , _:c14n1699 , _:c14n179 , _:c14n1887 , _:c14n25 , _:c14n351 , _:c14n877 ;
 	skos:definition "This association defines a relationship between a chemical or treatment (or procedure) and a disease or phenotypic feature where the disease or phenotypic feature is a secondary undesirable effect." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#analog_form a owl:Class , biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
@@ -583,7 +587,7 @@ biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#snp_form a owl:Class , bio
 	rdfs:subClassOf biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#polymorphic_form , biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum .
 biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "ChemicalOrGeneOrGeneProductFormOrVariantEnum" ;
-	owl:unionOf _:c14n613 ;
+	owl:unionOf _:c14n616 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#analog_form , biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#gain_of_function_variant_form , biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#genetic_variant_form , biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#loss_of_function_variant_form , biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#modified_form , biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#polymorphic_form , biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#snp_form .
 biolink:ChemicalRole a owl:Class , linkml:ClassDefinition ;
@@ -594,28 +598,28 @@ biolink:ChemicalRole a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalToChemicalAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical to chemical association" ;
-	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , _:c14n1101 , _:c14n1382 , _:c14n1410 , _:c14n1700 , _:c14n243 , _:c14n609 , _:c14n633 , _:c14n647 , _:c14n767 ;
+	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , _:c14n1105 , _:c14n1386 , _:c14n1415 , _:c14n236 , _:c14n246 , _:c14n612 , _:c14n636 , _:c14n648 , _:c14n768 ;
 	skos:definition "A relationship between two chemical entities. This can encompass actual interactions as well as temporal causal edges, e.g. one chemical converted to another." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalToChemicalDerivationAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical to chemical derivation association" ;
-	rdfs:subClassOf biolink:ChemicalToChemicalAssociation , _:c14n1110 , _:c14n1197 , _:c14n1214 , _:c14n15 , _:c14n1667 , _:c14n1813 , _:c14n325 , _:c14n36 , _:c14n430 , _:c14n794 , _:c14n968 ;
+	rdfs:subClassOf biolink:ChemicalToChemicalAssociation , _:c14n1114 , _:c14n1202 , _:c14n1217 , _:c14n13 , _:c14n1671 , _:c14n1815 , _:c14n330 , _:c14n34 , _:c14n437 , _:c14n796 , _:c14n972 ;
 	skos:definition "A causal relationship between two chemical entities, where the subject represents the upstream entity and the object represents the downstream. For any such association there is an implicit reaction: IF R has-input C1 AND R has-output C2 AND R enabled-by P AND R type Reaction THEN C1 derives-into C2 catalyst qualifier P" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical to disease or phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin , _:c14n1525 , _:c14n1591 , _:c14n928 ;
+	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin , _:c14n1529 , _:c14n1594 , _:c14n933 ;
 	skos:definition "An interaction between a chemical entity and a phenotype or disease, where the presence of the chemical gives rise to or exacerbates the phenotype." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch SIO:000993 .
 biolink:ChemicalToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical to entity association mixin" ;
-	rdfs:subClassOf biolink:ChemicalEntityToEntityAssociationMixin , _:c14n1012 , _:c14n1068 , _:c14n1346 , _:c14n1527 , _:c14n1611 , _:c14n1906 , _:c14n236 , _:c14n256 , _:c14n879 ;
+	rdfs:subClassOf biolink:ChemicalEntityToEntityAssociationMixin , _:c14n1017 , _:c14n1073 , _:c14n1349 , _:c14n1531 , _:c14n1614 , _:c14n1906 , _:c14n239 , _:c14n259 , _:c14n882 ;
 	skos:definition "An interaction between a chemical entity and another entity" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ChemicalToPathwayAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "chemical to pathway association" ;
-	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , _:c14n1186 , _:c14n1585 , _:c14n1654 , _:c14n1858 , _:c14n24 , _:c14n768 ;
+	rdfs:subClassOf biolink:Association , biolink:ChemicalToEntityAssociationMixin , _:c14n1191 , _:c14n1588 , _:c14n1658 , _:c14n1858 , _:c14n22 , _:c14n769 ;
 	skos:definition "An interaction between a chemical entity and a biological process or pathway." ;
 	skos:exactMatch SIO:001250 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -644,7 +648,7 @@ biolink:ClinicalApprovalStatusEnum\#post_approval_withdrawal a owl:Class , bioli
 	rdfs:subClassOf biolink:ClinicalApprovalStatusEnum\#not_approved_for_condition , biolink:ClinicalApprovalStatusEnum .
 biolink:ClinicalApprovalStatusEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "ClinicalApprovalStatusEnum" ;
-	owl:unionOf _:c14n439 ;
+	owl:unionOf _:c14n446 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:ClinicalApprovalStatusEnum\#approved_for_condition , biolink:ClinicalApprovalStatusEnum\#fda_approved_for_condition , biolink:ClinicalApprovalStatusEnum\#not_approved_for_condition , biolink:ClinicalApprovalStatusEnum\#not_provided , biolink:ClinicalApprovalStatusEnum\#off_label_use , biolink:ClinicalApprovalStatusEnum\#post_approval_withdrawal .
 biolink:ClinicalAttribute a owl:Class , linkml:ClassDefinition ;
@@ -666,7 +670,7 @@ biolink:ClinicalEntity a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ClinicalFinding a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "clinical finding" ;
-	rdfs:subClassOf biolink:PhenotypicFeature , _:c14n262 , _:c14n414 ;
+	rdfs:subClassOf biolink:PhenotypicFeature , _:c14n265 , _:c14n421 ;
 	skos:definition "this category is currently considered broad enough to tag clinical lab measurements and other biological attributes taken as 'clinical traits' with some statistical score, for example, a p value in genetic associations." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ClinicalIntervention a owl:Class , linkml:ClassDefinition ;
@@ -675,7 +679,7 @@ biolink:ClinicalIntervention a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ClinicalMeasurement a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "clinical measurement" ;
-	rdfs:subClassOf biolink:ClinicalAttribute , _:c14n55 , _:c14n70 , _:c14n90 ;
+	rdfs:subClassOf biolink:ClinicalAttribute , _:c14n53 , _:c14n69 , _:c14n90 ;
 	skos:definition "A clinical measurement is a special kind of attribute which results from a laboratory observation from a subject individual or sample. Measurements can be connected to their subject by the 'has attribute' slot." ;
 	skos:exactMatch EFO:0001444 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -730,12 +734,12 @@ biolink:ConfidenceLevel a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ContributorAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "contributor association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1100 , _:c14n1182 , _:c14n1492 , _:c14n1791 , _:c14n1901 , _:c14n1910 , _:c14n273 , _:c14n299 , _:c14n369 , _:c14n485 , _:c14n672 ;
+	rdfs:subClassOf biolink:Association , _:c14n1104 , _:c14n1187 , _:c14n1497 , _:c14n1793 , _:c14n1901 , _:c14n1910 , _:c14n276 , _:c14n303 , _:c14n375 , _:c14n491 , _:c14n673 ;
 	skos:definition "Any association between an entity (such as a publication) and various agents that contribute to its realisation" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:CorrelatedGeneToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "correlated gene to disease association" ;
-	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1764 , _:c14n1873 , _:c14n689 , _:c14n787 , _:c14n895 , _:c14n960 ;
+	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1766 , _:c14n1873 , _:c14n690 , _:c14n788 , _:c14n899 , _:c14n964 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Dataset a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "dataset" ;
@@ -745,18 +749,18 @@ biolink:Dataset a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DatasetDistribution a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "dataset distribution" ;
-	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1191 , _:c14n1491 , _:c14n643 ;
+	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1196 , _:c14n1496 , _:c14n644 ;
 	skos:definition "an item that holds distribution level information about a dataset." ;
 	skos:exactMatch dcat:Distribution ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DatasetSummary a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "dataset summary" ;
-	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1415 , _:c14n1614 , _:c14n306 , _:c14n568 , _:c14n905 , _:c14n937 ;
+	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1420 , _:c14n1617 , _:c14n310 , _:c14n572 , _:c14n909 , _:c14n941 ;
 	skos:definition "an item that holds summary level information about a dataset." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DatasetVersion a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "dataset version" ;
-	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1052 , _:c14n1201 , _:c14n1238 , _:c14n1427 , _:c14n1443 , _:c14n1884 , _:c14n478 , _:c14n624 , _:c14n769 ;
+	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1058 , _:c14n1205 , _:c14n1242 , _:c14n1432 , _:c14n1448 , _:c14n1886 , _:c14n484 , _:c14n627 , _:c14n770 ;
 	skos:definition "an item that holds version level information about a dataset." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Device a owl:Class , linkml:ClassDefinition ;
@@ -791,7 +795,7 @@ biolink:DirectionQualifierEnum\#upregulated a owl:Class , biolink:DirectionQuali
 	skos:narrowMatch RO:0002629 , RO:0004032 , RO:0004034 .
 biolink:DirectionQualifierEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "DirectionQualifierEnum" ;
-	owl:unionOf _:c14n835 ;
+	owl:unionOf _:c14n839 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:DirectionQualifierEnum\#decreased , biolink:DirectionQualifierEnum\#downregulated , biolink:DirectionQualifierEnum\#increased , biolink:DirectionQualifierEnum\#upregulated .
 biolink:Disease a owl:Class , linkml:ClassDefinition ;
@@ -821,21 +825,21 @@ biolink:DiseaseOrPhenotypicFeatureOutcome a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "disease or phenotypic feature to entity association mixin" ;
-	rdfs:subClassOf _:c14n1204 , _:c14n1379 , _:c14n1748 , _:c14n1872 , _:c14n581 , _:c14n596 , _:c14n663 , _:c14n972 , _:c14n993 ;
+	rdfs:subClassOf _:c14n1208 , _:c14n1383 , _:c14n1872 , _:c14n584 , _:c14n599 , _:c14n664 , _:c14n870 , _:c14n976 , _:c14n997 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "disease or phenotypic feature to genetic inheritance association" ;
-	rdfs:subClassOf biolink:Association , biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin , _:c14n1225 , _:c14n1338 , _:c14n1742 , _:c14n240 , _:c14n599 , _:c14n729 ;
+	rdfs:subClassOf biolink:Association , biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin , _:c14n1229 , _:c14n1342 , _:c14n1745 , _:c14n243 , _:c14n602 , _:c14n730 ;
 	skos:definition "An association between either a disease or a phenotypic feature and its mode of (genetic) inheritance." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DiseaseOrPhenotypicFeatureToLocationAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "disease or phenotypic feature to location association" ;
-	rdfs:subClassOf biolink:Association , biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin , _:c14n1115 , _:c14n587 , _:c14n694 ;
+	rdfs:subClassOf biolink:Association , biolink:DiseaseOrPhenotypicFeatureToEntityAssociationMixin , _:c14n1119 , _:c14n590 , _:c14n695 ;
 	skos:definition "An association between either a disease or a phenotypic feature and an anatomical entity, where the disease/feature manifests in that site." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DiseaseToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "disease to entity association mixin" ;
-	rdfs:subClassOf _:c14n1536 , _:c14n1702 , _:c14n1712 , _:c14n284 , _:c14n355 , _:c14n446 , _:c14n809 , _:c14n853 , _:c14n887 ;
+	rdfs:subClassOf _:c14n1540 , _:c14n1705 , _:c14n1715 , _:c14n288 , _:c14n360 , _:c14n812 , _:c14n856 , _:c14n892 , _:c14n986 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DiseaseToExposureEventAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "disease to exposure event association" ;
@@ -844,7 +848,7 @@ biolink:DiseaseToExposureEventAssociation a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DiseaseToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "disease to phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:DiseaseToEntityAssociationMixin , biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:FrequencyQuantifier , _:c14n146 , _:c14n1594 , _:c14n1892 , _:c14n554 , _:c14n646 , _:c14n671 , _:c14n796 , _:c14n836 , _:c14n851 ;
+	rdfs:subClassOf biolink:Association , biolink:DiseaseToEntityAssociationMixin , biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:FrequencyQuantifier , _:c14n148 , _:c14n1597 , _:c14n1892 , _:c14n559 , _:c14n647 , _:c14n672 , _:c14n799 , _:c14n840 , _:c14n854 ;
 	skos:closeMatch dcid:DiseaseSymptomAssociation ;
 	skos:definition "An association between a disease and a phenotypic feature in which the phenotypic feature is associated with the disease in some way." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -867,7 +871,7 @@ biolink:DrugAvailabilityEnum\#prescription a owl:Class , biolink:DrugAvailabilit
 	skos:definition "chemical entity is available by prescription." .
 biolink:DrugAvailabilityEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "DrugAvailabilityEnum" ;
-	owl:unionOf _:c14n1551 ;
+	owl:unionOf _:c14n1556 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:DrugAvailabilityEnum\#over_the_counter , biolink:DrugAvailabilityEnum\#prescription .
 biolink:DrugDeliveryEnum\#absorption_through_the_skin a owl:Class , biolink:DrugDeliveryEnum ;
@@ -884,7 +888,7 @@ biolink:DrugDeliveryEnum\#oral a owl:Class , biolink:DrugDeliveryEnum ;
 	rdfs:subClassOf biolink:DrugDeliveryEnum .
 biolink:DrugDeliveryEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "DrugDeliveryEnum" ;
-	owl:unionOf _:c14n1829 ;
+	owl:unionOf _:c14n1830 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:DrugDeliveryEnum\#absorption_through_the_skin , biolink:DrugDeliveryEnum\#inhalation , biolink:DrugDeliveryEnum\#intravenous_injection , biolink:DrugDeliveryEnum\#oral .
 biolink:DrugExposure a owl:Class , linkml:ClassDefinition ;
@@ -903,12 +907,12 @@ biolink:DrugLabel a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DrugToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "drug to entity association mixin" ;
-	rdfs:subClassOf biolink:ChemicalEntityToEntityAssociationMixin , _:c14n113 , _:c14n1239 , _:c14n1445 , _:c14n1459 , _:c14n1589 , _:c14n378 , _:c14n542 , _:c14n585 , _:c14n822 ;
+	rdfs:subClassOf biolink:ChemicalEntityToEntityAssociationMixin , _:c14n113 , _:c14n1243 , _:c14n1450 , _:c14n1465 , _:c14n1592 , _:c14n320 , _:c14n384 , _:c14n588 , _:c14n825 ;
 	skos:definition "An interaction between a drug and another entity" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:DrugToGeneAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "drug to gene association" ;
-	rdfs:subClassOf biolink:Association , biolink:DrugToEntityAssociationMixin , _:c14n1856 , _:c14n522 , _:c14n843 ;
+	rdfs:subClassOf biolink:Association , biolink:DrugToEntityAssociationMixin , _:c14n1856 , _:c14n529 , _:c14n847 ;
 	skos:definition "An interaction between a drug and a gene or gene product." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:relatedMatch SIO:001257 .
@@ -935,53 +939,53 @@ biolink:DruggableGeneCategoryEnum\#tdark a owl:Class , biolink:DruggableGeneCate
 	skos:definition "These are targets about which virtually nothing is known. They do not have known drug or small molecule activities that satisfy the activity thresholds detailed below AND satisfy two or more of the following criteria: A PubMed text-mining score from Jensen Lab less than 5, greater than or equal TO 3 Gene RIFs, or less than or equal to 50 Antibodies available according to http://antibodypedia.com." .
 biolink:DruggableGeneCategoryEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "DruggableGeneCategoryEnum" ;
-	owl:unionOf _:c14n1460 ;
+	owl:unionOf _:c14n1466 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:DruggableGeneCategoryEnum\#tbio , biolink:DruggableGeneCategoryEnum\#tchem , biolink:DruggableGeneCategoryEnum\#tclin , biolink:DruggableGeneCategoryEnum\#tdark .
 biolink:DruggableGeneToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "druggable gene to disease association" ;
-	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1087 , _:c14n1090 , _:c14n1706 , _:c14n659 , _:c14n765 , _:c14n810 , _:c14n842 , _:c14n984 ;
+	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1092 , _:c14n1095 , _:c14n1709 , _:c14n661 , _:c14n766 , _:c14n813 , _:c14n846 , _:c14n988 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Entity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity" ;
-	rdfs:subClassOf _:c14n1000 , _:c14n1126 , _:c14n1408 , _:c14n1462 , _:c14n1607 , _:c14n1639 , _:c14n1656 , _:c14n1703 , _:c14n182 , _:c14n1839 , _:c14n185 , _:c14n1857 , _:c14n1859 , _:c14n303 , _:c14n311 , _:c14n437 , _:c14n527 , _:c14n589 , _:c14n606 , _:c14n615 , _:c14n676 , _:c14n888 ;
+	rdfs:subClassOf _:c14n1004 , _:c14n1130 , _:c14n1131 , _:c14n1413 , _:c14n1468 , _:c14n1574 , _:c14n1610 , _:c14n1643 , _:c14n1660 , _:c14n1706 , _:c14n1840 , _:c14n1857 , _:c14n1859 , _:c14n187 , _:c14n315 , _:c14n444 , _:c14n592 , _:c14n609 , _:c14n618 , _:c14n659 , _:c14n677 , _:c14n893 ;
 	skos:definition "Root Biolink Model class for all things and informational relationships, real or imagined." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EntityToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity to disease association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1080 , _:c14n515 , _:c14n683 , _:c14n686 , _:c14n757 , _:c14n994 ;
+	rdfs:subClassOf biolink:Association , _:c14n1085 , _:c14n522 , _:c14n684 , _:c14n687 , _:c14n758 , _:c14n998 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EntityToDiseaseAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity to disease association mixin" ;
-	rdfs:subClassOf biolink:EntityToFeatureOrDiseaseQualifiersMixin , _:c14n1918 , _:c14n380 , _:c14n462 ;
+	rdfs:subClassOf biolink:EntityToFeatureOrDiseaseQualifiersMixin , _:c14n1918 , _:c14n386 , _:c14n468 ;
 	skos:definition "mixin class for any association whose object (target node) is a disease" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EntityToDiseaseOrPhenotypicFeatureAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity to disease or phenotypic feature association mixin" ;
-	rdfs:subClassOf _:c14n1124 , _:c14n1252 , _:c14n1423 , _:c14n1655 , _:c14n1683 , _:c14n1844 , _:c14n708 , _:c14n734 , _:c14n766 ;
+	rdfs:subClassOf _:c14n1128 , _:c14n1257 , _:c14n1428 , _:c14n1536 , _:c14n1659 , _:c14n1687 , _:c14n710 , _:c14n735 , _:c14n767 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EntityToExposureEventAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity to exposure event association mixin" ;
-	rdfs:subClassOf _:c14n1048 , _:c14n1421 , _:c14n166 , _:c14n1891 , _:c14n287 , _:c14n348 , _:c14n357 , _:c14n773 , _:c14n81 ;
+	rdfs:subClassOf _:c14n1027 , _:c14n1054 , _:c14n1426 , _:c14n168 , _:c14n291 , _:c14n353 , _:c14n362 , _:c14n774 , _:c14n80 ;
 	skos:definition "An association between some entity and an exposure event." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EntityToFeatureOrDiseaseQualifiersMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity to feature or disease qualifiers mixin" ;
-	rdfs:subClassOf biolink:FrequencyQualifierMixin , _:c14n1019 , _:c14n1073 , _:c14n1223 , _:c14n1401 , _:c14n1488 , _:c14n1592 , _:c14n1647 , _:c14n1691 , _:c14n1751 , _:c14n1841 , _:c14n1914 , _:c14n360 , _:c14n388 , _:c14n422 , _:c14n517 , _:c14n541 , _:c14n584 , _:c14n969 ;
+	rdfs:subClassOf biolink:FrequencyQualifierMixin , _:c14n1024 , _:c14n1078 , _:c14n1227 , _:c14n1406 , _:c14n1493 , _:c14n1595 , _:c14n1651 , _:c14n1695 , _:c14n1753 , _:c14n1842 , _:c14n1914 , _:c14n365 , _:c14n394 , _:c14n429 , _:c14n524 , _:c14n546 , _:c14n587 , _:c14n973 ;
 	skos:definition "Qualifiers for entity to disease or phenotype associations." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EntityToOutcomeAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity to outcome association mixin" ;
-	rdfs:subClassOf _:c14n1261 , _:c14n1473 , _:c14n1483 , _:c14n1617 , _:c14n239 , _:c14n558 , _:c14n756 , _:c14n791 , _:c14n986 ;
+	rdfs:subClassOf _:c14n1266 , _:c14n1488 , _:c14n1620 , _:c14n170 , _:c14n242 , _:c14n563 , _:c14n757 , _:c14n792 , _:c14n990 ;
 	skos:definition "An association between some entity and an outcome" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EntityToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity to phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1195 , _:c14n1398 , _:c14n1663 , _:c14n557 , _:c14n623 , _:c14n703 ;
+	rdfs:subClassOf biolink:Association , _:c14n1200 , _:c14n1403 , _:c14n1667 , _:c14n562 , _:c14n626 , _:c14n705 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EntityToPhenotypicFeatureAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "entity to phenotypic feature association mixin" ;
-	rdfs:subClassOf biolink:EntityToFeatureOrDiseaseQualifiersMixin , biolink:FrequencyQuantifier , _:c14n106 , _:c14n1099 , _:c14n1297 , _:c14n1389 , _:c14n1489 , _:c14n1521 , _:c14n1698 , _:c14n1707 , _:c14n1800 , _:c14n1853 , _:c14n1916 , _:c14n192 , _:c14n209 , _:c14n252 , _:c14n255 , _:c14n396 , _:c14n456 , _:c14n620 , _:c14n712 , _:c14n77 , _:c14n906 , _:c14n941 , _:c14n958 , _:c14n976 ;
+	rdfs:subClassOf biolink:EntityToFeatureOrDiseaseQualifiersMixin , biolink:FrequencyQuantifier , _:c14n106 , _:c14n1221 , _:c14n1303 , _:c14n1393 , _:c14n1494 , _:c14n1525 , _:c14n1702 , _:c14n1710 , _:c14n1802 , _:c14n1853 , _:c14n1916 , _:c14n194 , _:c14n211 , _:c14n255 , _:c14n258 , _:c14n403 , _:c14n462 , _:c14n623 , _:c14n715 , _:c14n76 , _:c14n910 , _:c14n945 , _:c14n962 , _:c14n979 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:EnvironmentalExposure a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "environmental exposure" ;
@@ -1011,7 +1015,7 @@ biolink:EpidemiologicalOutcome a owl:Class , linkml:ClassDefinition ;
 	skos:relatedMatch <http://purl.obolibrary.org/obo/NCIT_C19291> .
 biolink:EpigenomicEntity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "epigenomic entity" ;
-	rdfs:subClassOf _:c14n288 , _:c14n660 , _:c14n824 ;
+	rdfs:subClassOf _:c14n1335 , _:c14n292 , _:c14n827 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Event a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "event" ;
@@ -1034,24 +1038,24 @@ biolink:Exon a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ExonToTranscriptRelationship a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "exon to transcript relationship" ;
-	rdfs:subClassOf biolink:SequenceFeatureRelationship , _:c14n1102 , _:c14n1132 , _:c14n1514 , _:c14n1662 , _:c14n384 , _:c14n416 ;
+	rdfs:subClassOf biolink:SequenceFeatureRelationship , _:c14n1106 , _:c14n1137 , _:c14n1518 , _:c14n1666 , _:c14n390 , _:c14n423 ;
 	skos:definition "A transcript is formed from multiple exons" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ExposureEvent a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "exposure event" ;
-	rdfs:subClassOf biolink:OntologyClass , _:c14n1174 , _:c14n330 , _:c14n849 ;
+	rdfs:subClassOf biolink:OntologyClass , _:c14n1179 , _:c14n1881 , _:c14n335 ;
 	skos:altLabel "experimental condition" , "exposure" ;
 	skos:definition "A (possibly time bounded) incidence of a feature of the environment of an organism that influences one or more phenotypic features of that organism, potentially mediated by genes" ;
 	skos:exactMatch <http://purl.obolibrary.org/obo/XCO_0000000> ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ExposureEventToOutcomeAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "exposure event to outcome association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToOutcomeAssociationMixin , _:c14n1528 , _:c14n1624 , _:c14n1851 , _:c14n382 , _:c14n817 , _:c14n989 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToOutcomeAssociationMixin , _:c14n1162 , _:c14n1628 , _:c14n1851 , _:c14n388 , _:c14n820 , _:c14n993 ;
 	skos:definition "An association between an exposure event and an outcome." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ExposureEventToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "exposure event to phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , _:c14n1280 , _:c14n2 , _:c14n25 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , _:c14n1285 , _:c14n2 , _:c14n23 ;
 	skos:definition "Any association between an environment and a phenotypic feature, where being in the environment influences the phenotype." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:FDAIDAAdverseEventEnum\#life_threatening_adverse_event a owl:Class , biolink:FDAIDAAdverseEventEnum ;
@@ -1072,7 +1076,7 @@ biolink:FDAIDAAdverseEventEnum\#unexpected_adverse_event a owl:Class , biolink:F
 	skos:definition "An adverse event or suspected adverse reaction is considered 'unexpected' if it is not listed in the investigator brochure or is not listed at the specificity or severity that has been observed; or, if an investigator brochure is not required or available, is not consistent with the risk information described in the general investigational plan or elsewhere in the current application, as amended. For example, under this definition, hepatic necrosis would be unexpected (by virtue of greater severity) if the investigator brochure referred only to elevated hepatic enzymes or hepatitis. Similarly, cerebral thromboembolism and cerebral vasculitis would be unexpected (by virtue of greater specificity) if the investigator brochure listed only cerebral vascular accidents. 'Unexpected', as used in this definition, also refers to adverse events or suspected adverse reactions that are mentioned in the investigator brochure as occurring with a class of drugs or as anticipated from the pharmacological properties of the drug, but are not specifically mentioned as occurring with the particular drug under investigation." .
 biolink:FDAIDAAdverseEventEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "FDAIDAAdverseEventEnum" ;
-	owl:unionOf _:c14n920 ;
+	owl:unionOf _:c14n924 ;
 	skos:definition "please consult with the FDA guidelines as proposed in this document: https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfcfr/cfrsearch.cfm?fr=312.32" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:FDAIDAAdverseEventEnum\#life_threatening_adverse_event , biolink:FDAIDAAdverseEventEnum\#serious_adverse_event , biolink:FDAIDAAdverseEventEnum\#suspected_adverse_reaction , biolink:FDAIDAAdverseEventEnum\#unexpected_adverse_event .
@@ -1083,7 +1087,7 @@ biolink:FDA_adverse_event_level a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:FeatureOrDiseaseQualifiersToEntityMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "feature or disease qualifiers to entity mixin" ;
-	rdfs:subClassOf biolink:FrequencyQualifierMixin , _:c14n1118 , _:c14n1129 , _:c14n1176 , _:c14n132 , _:c14n1395 , _:c14n1400 , _:c14n1558 , _:c14n1650 , _:c14n1690 , _:c14n1835 , _:c14n222 , _:c14n412 , _:c14n499 , _:c14n567 , _:c14n963 ;
+	rdfs:subClassOf biolink:FrequencyQualifierMixin , _:c14n1122 , _:c14n1134 , _:c14n1181 , _:c14n134 , _:c14n1400 , _:c14n1405 , _:c14n1562 , _:c14n1654 , _:c14n1694 , _:c14n1836 , _:c14n224 , _:c14n419 , _:c14n505 , _:c14n571 , _:c14n967 ;
 	skos:definition "Qualifiers for disease or phenotype to entity associations." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Food a owl:Class , linkml:ClassDefinition ;
@@ -1098,16 +1102,18 @@ biolink:FoodAdditive a owl:Class , linkml:ClassDefinition ;
 	skos:relatedMatch <http://purl.obolibrary.org/obo/CHEBI_64047> .
 biolink:FrequencyQualifierMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "frequency qualifier mixin" ;
-	rdfs:subClassOf _:c14n1180 , _:c14n1205 , _:c14n1265 , _:c14n1370 , _:c14n1506 , _:c14n1509 , _:c14n1597 , _:c14n28 , _:c14n304 , _:c14n320 , _:c14n801 , _:c14n834 ;
+	rdfs:subClassOf _:c14n1185 , _:c14n1270 , _:c14n1374 , _:c14n1397 , _:c14n1511 , _:c14n1600 , _:c14n26 , _:c14n308 , _:c14n325 , _:c14n804 , _:c14n838 , _:c14n88 ;
 	skos:definition "Qualifier for frequency type associations" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:FrequencyQuantifier a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "frequency quantifier" ;
-	rdfs:subClassOf biolink:RelationshipQuantifier , _:c14n1023 , _:c14n1054 , _:c14n1065 , _:c14n1136 , _:c14n1228 , _:c14n1292 , _:c14n1376 , _:c14n1627 , _:c14n266 , _:c14n453 , _:c14n97 , _:c14n991 ;
+	rdfs:subClassOf biolink:RelationshipQuantifier , _:c14n1029 , _:c14n1060 , _:c14n1070 , _:c14n1141 , _:c14n1232 , _:c14n1297 , _:c14n1380 , _:c14n1631 , _:c14n269 , _:c14n459 , _:c14n97 , _:c14n995 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:FrequencyValue a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:String .
 biolink:FunctionalAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "functional association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1062 , _:c14n212 , _:c14n528 , _:c14n553 , _:c14n569 , _:c14n597 ;
+	rdfs:subClassOf biolink:Association , _:c14n1067 , _:c14n214 , _:c14n534 , _:c14n558 , _:c14n573 , _:c14n600 ;
 	skos:definition "An association between a macromolecular machine mixin (gene, gene product or complex of gene products) and either a molecular activity, a biological process or a cellular location in which a function is executed." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Fungus a owl:Class , linkml:ClassDefinition ;
@@ -1119,7 +1125,7 @@ biolink:Fungus a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch <http://purl.obolibrary.org/obo/FOODON_03315605> , <http://purl.obolibrary.org/obo/NCBITaxon_1670606> .
 biolink:Gene a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene" ;
-	rdfs:subClassOf biolink:BiologicalEntity , biolink:ChemicalEntityOrGeneOrGeneProduct , biolink:GeneOrGeneProduct , biolink:GenomicEntity , biolink:OntologyClass , biolink:PhysicalEssence , _:c14n1476 , _:c14n1618 , _:c14n221 , _:c14n48 , _:c14n816 ;
+	rdfs:subClassOf biolink:BiologicalEntity , biolink:ChemicalEntityOrGeneOrGeneProduct , biolink:GeneOrGeneProduct , biolink:GenomicEntity , biolink:OntologyClass , biolink:PhysicalEssence , _:c14n1481 , _:c14n1621 , _:c14n223 , _:c14n46 , _:c14n819 ;
 	skos:broadMatch <http://purl.obolibrary.org/obo/NCIT_C45822> ;
 	skos:definition "A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene locus may include regulatory regions, transcribed regions and/or other functional sequence regions." ;
 	skos:exactMatch <http://purl.obolibrary.org/obo/SO_0000704> , SIO:010035 , dcid:Gene , WIKIDATA:Q7187 ;
@@ -1127,16 +1133,16 @@ biolink:Gene a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch bioschemas:gene .
 biolink:GeneAffectsChemicalAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene affects chemical association" ;
-	rdfs:subClassOf biolink:Association , _:c14n101 , _:c14n114 , _:c14n1162 , _:c14n117 , _:c14n1269 , _:c14n1272 , _:c14n1273 , _:c14n1283 , _:c14n1287 , _:c14n1298 , _:c14n1309 , _:c14n1366 , _:c14n1504 , _:c14n1507 , _:c14n1519 , _:c14n1569 , _:c14n1582 , _:c14n1630 , _:c14n1675 , _:c14n1681 , _:c14n1734 , _:c14n1737 , _:c14n1747 , _:c14n1758 , _:c14n1776 , _:c14n1792 , _:c14n1794 , _:c14n1818 , _:c14n184 , _:c14n1877 , _:c14n1886 , _:c14n1888 , _:c14n1895 , _:c14n1900 , _:c14n1913 , _:c14n247 , _:c14n267 , _:c14n292 , _:c14n293 , _:c14n391 , _:c14n454 , _:c14n466 , _:c14n469 , _:c14n489 , _:c14n550 , _:c14n611 , _:c14n64 , _:c14n644 , _:c14n648 , _:c14n654 , _:c14n749 , _:c14n815 , _:c14n865 , _:c14n886 , _:c14n94 , _:c14n955 , _:c14n979 ;
+	rdfs:subClassOf biolink:Association , _:c14n101 , _:c14n114 , _:c14n1168 , _:c14n117 , _:c14n1274 , _:c14n1277 , _:c14n1278 , _:c14n1288 , _:c14n1292 , _:c14n1304 , _:c14n1315 , _:c14n1370 , _:c14n1509 , _:c14n1512 , _:c14n1523 , _:c14n1572 , _:c14n1585 , _:c14n1634 , _:c14n1679 , _:c14n1685 , _:c14n1737 , _:c14n1740 , _:c14n1750 , _:c14n1760 , _:c14n1778 , _:c14n1794 , _:c14n1796 , _:c14n1820 , _:c14n186 , _:c14n1878 , _:c14n1888 , _:c14n1889 , _:c14n1895 , _:c14n1900 , _:c14n1913 , _:c14n250 , _:c14n270 , _:c14n296 , _:c14n297 , _:c14n397 , _:c14n460 , _:c14n472 , _:c14n475 , _:c14n495 , _:c14n555 , _:c14n614 , _:c14n62 , _:c14n645 , _:c14n649 , _:c14n655 , _:c14n750 , _:c14n818 , _:c14n868 , _:c14n890 , _:c14n94 , _:c14n959 , _:c14n982 ;
 	skos:definition "Describes an effect that a gene or gene product has on a chemical entity (e.g. an impact of on its abundance, activity, localization, processing, transport, etc.)" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneAsAModelOfDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene as a model of disease association" ;
-	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseAssociation , biolink:ModelToDiseaseAssociationMixin , _:c14n1499 , _:c14n368 , _:c14n845 ;
+	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseAssociation , biolink:ModelToDiseaseAssociationMixin , _:c14n1504 , _:c14n373 , _:c14n849 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneExpressionMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene expression mixin" ;
-	rdfs:subClassOf _:c14n1053 , _:c14n1160 , _:c14n1199 , _:c14n1270 , _:c14n1565 , _:c14n1575 , _:c14n1846 , _:c14n210 , _:c14n450 , _:c14n564 , _:c14n679 , _:c14n947 ;
+	rdfs:subClassOf _:c14n1059 , _:c14n1166 , _:c14n1204 , _:c14n1275 , _:c14n1568 , _:c14n1579 , _:c14n1846 , _:c14n212 , _:c14n456 , _:c14n569 , _:c14n680 , _:c14n951 ;
 	skos:definition "Observed gene expression intensity, context (site, stage) and associated phenotypic status within which the expression occurs." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneFamily a owl:Class , linkml:ClassDefinition ;
@@ -1149,12 +1155,12 @@ biolink:GeneFamily a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch <http://purl.obolibrary.org/obo/NCIT_C20130> , SIO:001380 , WIKIDATA:Q417841 .
 biolink:GeneGroupingMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene grouping mixin" ;
-	rdfs:subClassOf _:c14n503 , _:c14n657 ;
+	rdfs:subClassOf _:c14n510 , _:c14n658 ;
 	skos:definition "any grouping of multiple genes or gene products" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneHasVariantThatContributesToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene has variant that contributes to disease association" ;
-	rdfs:subClassOf biolink:GeneToDiseaseAssociation , _:c14n1256 , _:c14n1448 , _:c14n1475 , _:c14n1553 , _:c14n1633 , _:c14n1868 , _:c14n327 , _:c14n386 , _:c14n521 , _:c14n612 , _:c14n751 , _:c14n965 ;
+	rdfs:subClassOf biolink:GeneToDiseaseAssociation , _:c14n1261 , _:c14n1453 , _:c14n1480 , _:c14n1557 , _:c14n1637 , _:c14n1868 , _:c14n332 , _:c14n392 , _:c14n528 , _:c14n615 , _:c14n752 , _:c14n969 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneOrGeneProduct a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene or gene product" ;
@@ -1326,7 +1332,7 @@ biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#uptake a owl:Class , biolin
 	rdfs:subClassOf biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#transport , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum .
 biolink:GeneOrGeneProductOrChemicalEntityAspectEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "GeneOrGeneProductOrChemicalEntityAspectEnum" ;
-	owl:unionOf _:c14n821 ;
+	owl:unionOf _:c14n824 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ADP-ribosylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#absorption , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#abundance , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#acetylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#activity , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#activity_or_abundance , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#acylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#aggregation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#alkylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#amination , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#carbamoylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#carboxylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#cleavage , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#degradation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ethylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#expression , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#farnesylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#folding , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#geranoylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glucuronidation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glutathionylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glycation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glycosylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#hydrolysis , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#hydroxylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#interaction , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#lipidation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#localization , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#metabolic_processing , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#methylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#molecular_interaction , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#molecular_modification , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#mutation_rate , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#myristoylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#n_linked_glycosylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#nitrosation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#nucleotidylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#o_linked_glycosylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#oxidation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#palmitoylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#phosphorylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#prenylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#reduction , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#release , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ribosylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#secretion , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#splicing , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#stability , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#sulfation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#sumoylation , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#synthesis , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#transport , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ubiquitination , biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#uptake .
 biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#3_prime_utr a owl:Class , biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
@@ -1352,7 +1358,7 @@ biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#promoter a owl:Class , bio
 	rdfs:subClassOf biolink:GeneOrGeneProductOrChemicalPartQualifierEnum .
 biolink:GeneOrGeneProductOrChemicalPartQualifierEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "GeneOrGeneProductOrChemicalPartQualifierEnum" ;
-	owl:unionOf _:c14n1348 ;
+	owl:unionOf _:c14n1352 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#3_prime_utr , biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#5_prime_utr , biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#enhancer , biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#exon , biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#intron , biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#polya_tail , biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#promoter .
 biolink:GeneProductIsoformMixin a owl:Class , linkml:ClassDefinition ;
@@ -1362,79 +1368,79 @@ biolink:GeneProductIsoformMixin a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneProductMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene product mixin" ;
-	rdfs:subClassOf biolink:GeneOrGeneProduct , _:c14n1552 , _:c14n392 , _:c14n827 , _:c14n863 ;
+	rdfs:subClassOf biolink:GeneOrGeneProduct , _:c14n399 , _:c14n551 , _:c14n830 , _:c14n866 ;
 	skos:definition "The functional molecular product of a single gene locus. Gene products are either proteins or functional RNA molecules." ;
 	skos:exactMatch <http://purl.obolibrary.org/obo/GENO_0000907> , <http://purl.obolibrary.org/obo/NCIT_C26548> , WIKIDATA:Q424689 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneRegulatesGeneAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene regulates gene association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1071 , _:c14n1112 , _:c14n1232 , _:c14n1344 , _:c14n1378 , _:c14n1522 , _:c14n1688 , _:c14n1854 , _:c14n1890 , _:c14n196 , _:c14n213 , _:c14n283 , _:c14n298 , _:c14n376 , _:c14n434 , _:c14n455 , _:c14n586 , _:c14n682 , _:c14n723 , _:c14n84 , _:c14n951 ;
+	rdfs:subClassOf biolink:Association , _:c14n1076 , _:c14n1116 , _:c14n1236 , _:c14n1348 , _:c14n1382 , _:c14n1526 , _:c14n1692 , _:c14n1854 , _:c14n1891 , _:c14n198 , _:c14n215 , _:c14n287 , _:c14n302 , _:c14n382 , _:c14n441 , _:c14n461 , _:c14n589 , _:c14n683 , _:c14n725 , _:c14n83 , _:c14n955 ;
 	skos:definition "Describes a regulatory relationship between two genes or gene products." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to disease association" ;
-	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseOrPhenotypicFeatureAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1165 , _:c14n1321 , _:c14n1452 , _:c14n1455 , _:c14n1730 , _:c14n175 ;
+	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GeneToDiseaseOrPhenotypicFeatureAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1171 , _:c14n1327 , _:c14n1458 , _:c14n1461 , _:c14n1733 , _:c14n178 ;
 	skos:closeMatch dcid:DiseaseGeneAssociation ;
 	skos:exactMatch SIO:000983 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:note "NCIT:R176 refers to the inverse relationship" .
 biolink:GeneToDiseaseOrPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to disease or phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:GeneToEntityAssociationMixin , _:c14n1038 , _:c14n1141 , _:c14n1206 , _:c14n1285 , _:c14n1299 , _:c14n1416 , _:c14n150 , _:c14n159 , _:c14n1632 , _:c14n1788 , _:c14n1870 , _:c14n332 , _:c14n534 , _:c14n616 , _:c14n701 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:GeneToEntityAssociationMixin , _:c14n1044 , _:c14n1146 , _:c14n1209 , _:c14n1290 , _:c14n1305 , _:c14n1421 , _:c14n152 , _:c14n161 , _:c14n1636 , _:c14n1790 , _:c14n1870 , _:c14n337 , _:c14n539 , _:c14n619 , _:c14n703 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch WBVocab:Gene-Phenotype-Association , SIO:000983 , dcid:DiseaseGeneAssociation ;
 	skos:note "NCIT:R176 refers to the inverse relationship" , "for use in describing the affect that the loss of function of a gene can have on exacerbating or ameliorating a symptom/phenotype" , "if the relationship of the statement using this predicate is statistical in nature, please use `associated with likelihood` or one of its children." .
 biolink:GeneToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to entity association mixin" ;
-	rdfs:subClassOf _:c14n1155 , _:c14n1248 , _:c14n1310 , _:c14n1516 , _:c14n152 , _:c14n168 , _:c14n452 , _:c14n903 , _:c14n973 ;
+	rdfs:subClassOf _:c14n1160 , _:c14n1253 , _:c14n1316 , _:c14n1520 , _:c14n154 , _:c14n171 , _:c14n398 , _:c14n458 , _:c14n907 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToExpressionSiteAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to expression site association" ;
 	rdfs:seeAlso <https://github.com/monarch-initiative/ingest-artifacts/tree/master/sources/BGee> ;
-	rdfs:subClassOf biolink:Association , _:c14n1003 , _:c14n1150 , _:c14n1188 , _:c14n120 , _:c14n1329 , _:c14n1537 , _:c14n1831 , _:c14n1865 , _:c14n279 , _:c14n364 , _:c14n806 , _:c14n838 , _:c14n844 , _:c14n86 , _:c14n890 ;
+	rdfs:subClassOf biolink:Association , _:c14n1008 , _:c14n1155 , _:c14n1193 , _:c14n120 , _:c14n1333 , _:c14n1541 , _:c14n1832 , _:c14n1865 , _:c14n282 , _:c14n369 , _:c14n809 , _:c14n842 , _:c14n848 , _:c14n85 , _:c14n895 ;
 	skos:definition "An association between a gene and a gene expression site, possibly qualified by stage/timing info." ;
 	skos:editorialNote "TBD: introduce subclasses for distinction between wild-type and experimental conditions?" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToGeneAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to gene association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1031 , _:c14n148 , _:c14n1505 , _:c14n1515 , _:c14n19 , _:c14n699 , _:c14n71 ;
+	rdfs:subClassOf biolink:Association , _:c14n1037 , _:c14n150 , _:c14n1510 , _:c14n1519 , _:c14n17 , _:c14n70 , _:c14n701 ;
 	skos:altLabel "molecular or genetic interaction" ;
 	skos:definition "abstract parent class for different kinds of gene-gene or gene product to gene product relationships. Includes homology and interaction." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToGeneCoexpressionAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to gene coexpression association" ;
-	rdfs:subClassOf biolink:GeneExpressionMixin , biolink:GeneToGeneAssociation , _:c14n1380 , _:c14n143 , _:c14n698 ;
+	rdfs:subClassOf biolink:GeneExpressionMixin , biolink:GeneToGeneAssociation , _:c14n1384 , _:c14n145 , _:c14n700 ;
 	skos:definition "Indicates that two genes are co-expressed, generally under the same conditions." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToGeneFamilyAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to gene family association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1119 , _:c14n1172 , _:c14n1686 , _:c14n1808 , _:c14n1894 , _:c14n226 , _:c14n429 , _:c14n511 , _:c14n740 ;
+	rdfs:subClassOf biolink:Association , _:c14n1123 , _:c14n1178 , _:c14n1690 , _:c14n1810 , _:c14n1894 , _:c14n228 , _:c14n436 , _:c14n518 , _:c14n741 ;
 	skos:definition "Set membership of a gene in a family of genes related by common evolutionary ancestry usually inferred by sequence comparisons. The genes in a given family generally share common sequence motifs which generally map onto shared gene product structure-function relationships." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToGeneHomologyAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to gene homology association" ;
-	rdfs:subClassOf biolink:GeneToGeneAssociation , _:c14n1027 , _:c14n1084 , _:c14n1554 , _:c14n1670 , _:c14n1725 , _:c14n285 , _:c14n407 , _:c14n473 , _:c14n544 ;
+	rdfs:subClassOf biolink:GeneToGeneAssociation , _:c14n1033 , _:c14n1089 , _:c14n1558 , _:c14n1674 , _:c14n1728 , _:c14n289 , _:c14n414 , _:c14n479 , _:c14n548 ;
 	skos:definition "A homology association between two genes. May be orthology (in which case the species of subject and object should differ) or paralogy (in which case the species may be the same)" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToGeneProductRelationship a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to gene product relationship" ;
-	rdfs:subClassOf biolink:SequenceFeatureRelationship , _:c14n1024 , _:c14n1029 , _:c14n1258 , _:c14n133 , _:c14n219 , _:c14n294 , _:c14n333 , _:c14n399 , _:c14n482 ;
+	rdfs:subClassOf biolink:SequenceFeatureRelationship , _:c14n1030 , _:c14n1035 , _:c14n1263 , _:c14n135 , _:c14n221 , _:c14n298 , _:c14n338 , _:c14n406 , _:c14n488 ;
 	skos:definition "A gene is transcribed and potentially translated to a gene product" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToGoTermAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to go term association" ;
-	rdfs:subClassOf biolink:FunctionalAssociation , _:c14n1092 , _:c14n1535 , _:c14n1802 , _:c14n1909 , _:c14n632 , _:c14n724 ;
+	rdfs:subClassOf biolink:FunctionalAssociation , _:c14n1097 , _:c14n1539 , _:c14n1804 , _:c14n1909 , _:c14n635 , _:c14n726 ;
 	skos:altLabel "functional association" ;
 	skos:exactMatch WBVocab:Gene-GO-Association ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToPathwayAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to pathway association" ;
-	rdfs:subClassOf biolink:Association , biolink:GeneToEntityAssociationMixin , _:c14n1014 , _:c14n1403 , _:c14n17 , _:c14n33 , _:c14n406 , _:c14n983 ;
+	rdfs:subClassOf biolink:Association , biolink:GeneToEntityAssociationMixin , _:c14n1019 , _:c14n1408 , _:c14n15 , _:c14n31 , _:c14n413 , _:c14n987 ;
 	skos:definition "An interaction between a gene or gene product and a biological process or pathway." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "gene to phenotypic feature association" ;
-	rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:GeneToDiseaseOrPhenotypicFeatureAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1577 , _:c14n1760 , _:c14n1833 , _:c14n725 , _:c14n896 , _:c14n962 ;
+	rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:GeneToDiseaseOrPhenotypicFeatureAssociation , biolink:GeneToEntityAssociationMixin , _:c14n1580 , _:c14n1762 , _:c14n1834 , _:c14n727 , _:c14n900 , _:c14n966 ;
 	skos:exactMatch WBVocab:Gene-Phenotype-Association ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeneticInheritance a owl:Class , linkml:ClassDefinition ;
@@ -1459,54 +1465,54 @@ biolink:GenomicBackgroundExposure a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GenomicEntity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genomic entity" ;
-	rdfs:subClassOf _:c14n531 , _:c14n69 , _:c14n869 ;
+	rdfs:subClassOf _:c14n1874 , _:c14n67 , _:c14n873 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch STY:T028 , <http://purl.obolibrary.org/obo/GENO_0000897> .
 biolink:GenomicSequenceLocalization a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genomic sequence localization" ;
-	rdfs:subClassOf biolink:SequenceAssociation , _:c14n1006 , _:c14n1055 , _:c14n1152 , _:c14n1318 , _:c14n1409 , _:c14n149 , _:c14n1529 , _:c14n1629 , _:c14n1697 , _:c14n1741 , _:c14n1749 , _:c14n180 , _:c14n1809 , _:c14n1871 , _:c14n1883 , _:c14n428 , _:c14n457 , _:c14n732 , _:c14n85 , _:c14n861 , _:c14n872 , _:c14n884 , _:c14n966 , _:c14n997 ;
+	rdfs:subClassOf biolink:SequenceAssociation , _:c14n1001 , _:c14n1011 , _:c14n1061 , _:c14n1157 , _:c14n1324 , _:c14n1414 , _:c14n151 , _:c14n1532 , _:c14n1633 , _:c14n1701 , _:c14n1744 , _:c14n1751 , _:c14n1811 , _:c14n183 , _:c14n1871 , _:c14n1885 , _:c14n435 , _:c14n463 , _:c14n733 , _:c14n84 , _:c14n864 , _:c14n876 , _:c14n887 , _:c14n970 ;
 	skos:broadMatch dcid:Chromosome ;
 	skos:definition "A relationship between a sequence feature and a nucleic acid entity it is localized to. The reference entity may be a chromosome, chromosome region or information entity such as a contig." ;
 	skos:exactMatch dcid:GenomeAnnotation ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Genotype a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genotype" ;
-	rdfs:subClassOf biolink:BiologicalEntity , biolink:GenomicEntity , biolink:OntologyClass , biolink:PhysicalEssence , _:c14n125 , _:c14n1313 , _:c14n912 ;
+	rdfs:subClassOf biolink:BiologicalEntity , biolink:GenomicEntity , biolink:OntologyClass , biolink:PhysicalEssence , _:c14n125 , _:c14n1319 , _:c14n916 ;
 	skos:definition "An information content entity that describes a genome by specifying the total variation in genomic sequence and/or gene expression, relative to some established background" ;
 	skos:exactMatch <http://purl.obolibrary.org/obo/GENO_0000536> , SIO:001079 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:note "Consider renaming as genotypic entity" .
 biolink:GenotypeAsAModelOfDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genotype as a model of disease association" ;
-	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GenotypeToDiseaseAssociation , biolink:ModelToDiseaseAssociationMixin , _:c14n147 , _:c14n183 , _:c14n738 ;
+	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:GenotypeToDiseaseAssociation , biolink:ModelToDiseaseAssociationMixin , _:c14n149 , _:c14n185 , _:c14n739 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GenotypeToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genotype to disease association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToDiseaseAssociationMixin , biolink:GenotypeToEntityAssociationMixin , _:c14n1111 , _:c14n118 , _:c14n1350 , _:c14n1568 , _:c14n167 , _:c14n1729 , _:c14n343 , _:c14n413 , _:c14n73 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToDiseaseAssociationMixin , biolink:GenotypeToEntityAssociationMixin , _:c14n1115 , _:c14n118 , _:c14n1354 , _:c14n1571 , _:c14n169 , _:c14n1732 , _:c14n348 , _:c14n420 , _:c14n72 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:note "TODO decide no how to model pathogenicity" .
 biolink:GenotypeToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genotype to entity association mixin" ;
-	rdfs:subClassOf _:c14n1056 , _:c14n1094 , _:c14n1449 , _:c14n1772 , _:c14n205 , _:c14n309 , _:c14n38 , _:c14n80 , _:c14n894 ;
+	rdfs:subClassOf _:c14n1062 , _:c14n1099 , _:c14n1454 , _:c14n1774 , _:c14n207 , _:c14n313 , _:c14n36 , _:c14n79 , _:c14n889 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GenotypeToGeneAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genotype to gene association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1098 , _:c14n1324 , _:c14n1340 , _:c14n1386 , _:c14n1402 , _:c14n1548 , _:c14n1609 , _:c14n635 , _:c14n938 ;
+	rdfs:subClassOf biolink:Association , _:c14n1103 , _:c14n1328 , _:c14n1344 , _:c14n1390 , _:c14n1407 , _:c14n1553 , _:c14n1612 , _:c14n637 , _:c14n942 ;
 	skos:definition "Any association between a genotype and a gene. The genotype have have multiple variants in that gene or a single one. There is no assumption of cardinality" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GenotypeToGenotypePartAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genotype to genotype part association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1104 , _:c14n1296 , _:c14n1406 , _:c14n1417 , _:c14n1418 , _:c14n1902 , _:c14n307 , _:c14n465 , _:c14n525 ;
+	rdfs:subClassOf biolink:Association , _:c14n1108 , _:c14n1302 , _:c14n1411 , _:c14n1422 , _:c14n1423 , _:c14n1902 , _:c14n311 , _:c14n471 , _:c14n532 ;
 	skos:definition "Any association between one genotype and a genotypic entity that is a sub-component of it" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GenotypeToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genotype to phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:GenotypeToEntityAssociationMixin , _:c14n1237 , _:c14n1485 , _:c14n207 , _:c14n467 , _:c14n736 , _:c14n96 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:GenotypeToEntityAssociationMixin , _:c14n1241 , _:c14n1490 , _:c14n209 , _:c14n473 , _:c14n737 , _:c14n96 ;
 	skos:definition "Any association between one genotype and a phenotypic feature, where having the genotype confers the phenotype, either in isolation or through environment" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GenotypeToVariantAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "genotype to variant association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1187 , _:c14n1241 , _:c14n1353 , _:c14n1578 , _:c14n1616 , _:c14n1759 , _:c14n535 , _:c14n690 , _:c14n935 ;
+	rdfs:subClassOf biolink:Association , _:c14n1192 , _:c14n1246 , _:c14n1357 , _:c14n1581 , _:c14n1619 , _:c14n1761 , _:c14n540 , _:c14n691 , _:c14n940 ;
 	skos:definition "Any association between a genotype and a sequence variant." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GenotypicSex a owl:Class , linkml:ClassDefinition ;
@@ -1524,13 +1530,13 @@ biolink:GeographicExposure a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch dcid:IceStoremEvent , dcid:LakeEffectSnowEvent , dcid:LandslideEvent , dcid:MarineDenseFogEvent , dcid:MarineLighteningEvent , dcid:MarineStrongWindEvent , dcid:MarineThunderstormWindEvent , dcid:StormEvent , dcid:StormSurgeTideEvent , dcid:StrongWindEvent , dcid:ThunderstormWindEvent , dcid:TornadoEvent , dcid:TropicalDepressionEvent , dcid:WinterStoremEvent .
 biolink:GeographicLocation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "geographic location" ;
-	rdfs:subClassOf biolink:PlanetaryEntity , _:c14n1025 , _:c14n1863 , _:c14n201 , _:c14n400 , _:c14n779 , _:c14n999 ;
+	rdfs:subClassOf biolink:PlanetaryEntity , _:c14n1003 , _:c14n1031 , _:c14n1863 , _:c14n203 , _:c14n407 , _:c14n780 ;
 	skos:definition "a location that can be described in lat/long coordinates" ;
 	skos:exactMatch STY:T083 , UMLSSG:GEOG ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GeographicLocationAtTime a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "geographic location at time" ;
-	rdfs:subClassOf biolink:GeographicLocation , _:c14n1560 , _:c14n1694 , _:c14n811 ;
+	rdfs:subClassOf biolink:GeographicLocation , _:c14n1245 , _:c14n1698 , _:c14n814 ;
 	skos:definition "a location that can be described in lat/long coordinates, for a particular time" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:GrossAnatomicalStructure a owl:Class , linkml:ClassDefinition ;
@@ -1572,7 +1578,7 @@ biolink:IndividualOrganism a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch foaf:Person , WIKIDATA:Q795052 .
 biolink:InformationContentEntity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "information content entity" ;
-	rdfs:subClassOf biolink:NamedThing , _:c14n1007 , _:c14n1078 , _:c14n1284 , _:c14n1381 , _:c14n1393 , _:c14n1726 , _:c14n1840 , _:c14n1908 , _:c14n546 , _:c14n574 , _:c14n739 , _:c14n800 , _:c14n931 ;
+	rdfs:subClassOf biolink:NamedThing , _:c14n1012 , _:c14n1083 , _:c14n1289 , _:c14n1385 , _:c14n1398 , _:c14n1729 , _:c14n1841 , _:c14n1908 , _:c14n550 , _:c14n577 , _:c14n740 , _:c14n803 , _:c14n936 ;
 	skos:altLabel "information artefact" , "information entity" , "information" ;
 	skos:definition "a piece of information that typically describes some topic of discourse or is used as support." ;
 	skos:exactMatch IAO:0000030 ;
@@ -1580,7 +1586,7 @@ biolink:InformationContentEntity a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch STY:T077 , STY:T078 , STY:T079 , STY:T080 , STY:T081 , STY:T082 , STY:T089 , STY:T102 , STY:T169 , STY:T171 , STY:T185 , UMLSSG:CONC .
 biolink:InformationContentEntityToNamedThingAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "information content entity to named thing association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1549 , _:c14n1606 , _:c14n1919 , _:c14n208 , _:c14n230 , _:c14n322 , _:c14n383 , _:c14n603 , _:c14n918 ;
+	rdfs:subClassOf biolink:Association , _:c14n1554 , _:c14n1609 , _:c14n1919 , _:c14n210 , _:c14n232 , _:c14n327 , _:c14n389 , _:c14n606 , _:c14n922 ;
 	skos:definition "association between a named thing and a information content entity where the specific context of the relationship between that named thing and the publication is unknown. For example, model organisms databases often capture the knowledge that a gene is found in a journal article, but not specifically the context in which that gene was documented in the article. In these cases, this association with the accompanying predicate 'mentions' could be used. Conversely, for more specific associations (like 'gene to disease association', the publication should be captured as an edge property)." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Invertebrate a owl:Class , linkml:ClassDefinition ;
@@ -1590,6 +1596,8 @@ biolink:Invertebrate a owl:Class , linkml:ClassDefinition ;
 	skos:exactMatch STY:T011 , <http://purl.obolibrary.org/obo/FOODON_00002452> , <http://purl.obolibrary.org/obo/NCIT_C14228> , <http://purl.obolibrary.org/obo/OMIT_0008565> ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:relatedMatch <http://purl.obolibrary.org/obo/NCBITaxon_1767184> .
+biolink:IriType a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:Uriorcurie .
 biolink:JournalArticle a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "journal article" ;
 	rdfs:subClassOf biolink:Article ;
@@ -1631,9 +1639,11 @@ biolink:KnowledgeLevelEnum\#statistical_association a owl:Class , biolink:Knowle
 	skos:editorialNote "Such statements report the direct results of some statistical analysis. Their scope is limited tp the cohort/dataset interrogated in the analysis, and they do not make broader claims or draw  more meaningful conclusions about the domain of discourse. Note however that such Statistical  Associations can be used as evidence to support a more pointed/precise Prediction or Assertion  of knowledge. For example, e.g. a Statistical Association between 'Metformin Prescription' and 'Diabetes Diagnosis' in EHR records could support a Prediction that 'Metformin treats Diabetes',  or 'Metformin causes Diabetes'. This 'treats' edge may have a knowledge_level of 'Prediction',  but the provider could use the 'evidence_type' edge property to indicate that this prediction is  based on a 'Statistical Association'. Because Statistical Associations directly report analysis-specific  results, we can consider them to be inherently true statements, whose broader utility is dependent on  subsequent generalization of the reported result to a broader population, and/or interpretation of the  result as support for a more meaningful statements about the domain of discourse." .
 biolink:KnowledgeLevelEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "KnowledgeLevelEnum" ;
-	owl:unionOf _:c14n1538 ;
+	owl:unionOf _:c14n1542 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:KnowledgeLevelEnum\#knowledge_assertion , biolink:KnowledgeLevelEnum\#logical_entailment , biolink:KnowledgeLevelEnum\#not_provided , biolink:KnowledgeLevelEnum\#observation , biolink:KnowledgeLevelEnum\#prediction , biolink:KnowledgeLevelEnum\#statistical_association .
+biolink:LabelType a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:String .
 biolink:LifeStage a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "life stage" ;
 	rdfs:subClassOf biolink:OrganismalEntity ;
@@ -1651,7 +1661,7 @@ biolink:LogicalInterpretationEnum\#inverse_all_some a owl:Class , biolink:Logica
 	rdfs:subClassOf biolink:LogicalInterpretationEnum .
 biolink:LogicalInterpretationEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "LogicalInterpretationEnum" ;
-	owl:unionOf _:c14n1720 ;
+	owl:unionOf _:c14n1723 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values os:AllSomeInterpretation , os:SomeSomeInterpretation , biolink:LogicalInterpretationEnum\#inverse_all_some .
 biolink:MacromolecularComplex a owl:Class , linkml:ClassDefinition ;
@@ -1662,27 +1672,27 @@ biolink:MacromolecularComplex a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MacromolecularMachineMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "macromolecular machine mixin" ;
-	rdfs:subClassOf _:c14n1358 , _:c14n1620 , _:c14n3 ;
+	rdfs:subClassOf _:c14n1362 , _:c14n1623 , _:c14n68 ;
 	skos:definition "A union of gene locus, gene product, and macromolecular complex. These are the basic units of function in a cell. They either carry out individual biological activities, or they encode molecules which do this." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MacromolecularMachineToBiologicalProcessAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "macromolecular machine to biological process association" ;
-	rdfs:subClassOf biolink:FunctionalAssociation , biolink:MacromolecularMachineToEntityAssociationMixin , _:c14n1268 , _:c14n1642 , _:c14n1685 ;
+	rdfs:subClassOf biolink:FunctionalAssociation , biolink:MacromolecularMachineToEntityAssociationMixin , _:c14n1273 , _:c14n1646 , _:c14n1689 ;
 	skos:definition "A functional association between a macromolecular machine (gene, gene product or complex) and a biological process or pathway (as represented in the GO biological process branch), where the entity carries out some part of the process, regulates it, or acts upstream of it." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MacromolecularMachineToCellularComponentAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "macromolecular machine to cellular component association" ;
-	rdfs:subClassOf biolink:FunctionalAssociation , biolink:MacromolecularMachineToEntityAssociationMixin , _:c14n1471 , _:c14n1562 , _:c14n1595 ;
+	rdfs:subClassOf biolink:FunctionalAssociation , biolink:MacromolecularMachineToEntityAssociationMixin , _:c14n1477 , _:c14n1565 , _:c14n1598 ;
 	skos:definition "A functional association between a macromolecular machine (gene, gene product or complex) and a cellular component (as represented in the GO cellular component branch), where the entity carries out its function in the cellular component." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MacromolecularMachineToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "macromolecular machine to entity association mixin" ;
-	rdfs:subClassOf _:c14n1200 , _:c14n1584 , _:c14n1661 , _:c14n188 , _:c14n417 , _:c14n498 , _:c14n583 , _:c14n666 , _:c14n786 , _:c14n831 , _:c14n922 , _:c14n950 ;
+	rdfs:subClassOf _:c14n127 , _:c14n1587 , _:c14n1665 , _:c14n190 , _:c14n424 , _:c14n504 , _:c14n586 , _:c14n667 , _:c14n787 , _:c14n835 , _:c14n926 , _:c14n954 ;
 	skos:definition "an association which has a macromolecular machine mixin as a subject" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MacromolecularMachineToMolecularActivityAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "macromolecular machine to molecular activity association" ;
-	rdfs:subClassOf biolink:FunctionalAssociation , biolink:MacromolecularMachineToEntityAssociationMixin , _:c14n1036 , _:c14n1780 , _:c14n685 ;
+	rdfs:subClassOf biolink:FunctionalAssociation , biolink:MacromolecularMachineToEntityAssociationMixin , _:c14n1042 , _:c14n1782 , _:c14n686 ;
 	skos:definition "A functional association between a macromolecular machine (gene, gene product or complex) and a molecular activity (as represented in the GO molecular function branch), where the entity carries out the activity, or contributes to its execution." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Mammal a owl:Class , linkml:ClassDefinition ;
@@ -1693,7 +1703,7 @@ biolink:Mammal a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MappingCollection a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "mapping collection" ;
-	rdfs:subClassOf _:c14n774 , _:c14n88 ;
+	rdfs:subClassOf _:c14n775 , _:c14n87 ;
 	skos:definition "A collection of deprecated mappings." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MaterialSample a owl:Class , linkml:ClassDefinition ;
@@ -1705,7 +1715,7 @@ biolink:MaterialSample a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MaterialSampleDerivationAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "material sample derivation association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1091 , _:c14n1531 , _:c14n1736 , _:c14n1887 , _:c14n334 , _:c14n617 , _:c14n627 , _:c14n705 , _:c14n759 ;
+	rdfs:subClassOf biolink:Association , _:c14n1096 , _:c14n1534 , _:c14n1739 , _:c14n339 , _:c14n620 , _:c14n630 , _:c14n707 , _:c14n760 , _:c14n833 ;
 	skos:definition "An association between a material sample and the material entity from which it is derived." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
@@ -1715,7 +1725,7 @@ biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation a owl:Class , link
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MaterialSampleToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "material sample to entity association mixin" ;
-	rdfs:subClassOf _:c14n1305 , _:c14n1333 , _:c14n1407 , _:c14n1477 , _:c14n1796 , _:c14n263 , _:c14n449 , _:c14n509 , _:c14n61 ;
+	rdfs:subClassOf _:c14n1311 , _:c14n1412 , _:c14n1482 , _:c14n1547 , _:c14n1798 , _:c14n266 , _:c14n455 , _:c14n516 , _:c14n59 ;
 	skos:definition "An association between a material sample and something." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MicroRNA a owl:Class , linkml:ClassDefinition ;
@@ -1725,12 +1735,12 @@ biolink:MicroRNA a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ModelToDiseaseAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "model to disease association mixin" ;
-	rdfs:subClassOf _:c14n1082 , _:c14n1173 , _:c14n169 , _:c14n1790 , _:c14n371 , _:c14n45 , _:c14n642 , _:c14n760 , _:c14n828 ;
+	rdfs:subClassOf _:c14n1087 , _:c14n1691 , _:c14n172 , _:c14n1792 , _:c14n377 , _:c14n43 , _:c14n643 , _:c14n761 , _:c14n831 ;
 	skos:definition "This mixin is used for any association class for which the subject (source node) plays the role of a 'model', in that it recapitulates some features of the disease in a way that is useful for studying the disease outside a patient carrying the disease" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MolecularActivity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "molecular activity" ;
-	rdfs:subClassOf biolink:BiologicalProcessOrActivity , biolink:Occurrent , biolink:OntologyClass , _:c14n104 , _:c14n115 , _:c14n1154 , _:c14n1282 , _:c14n1374 , _:c14n1608 , _:c14n1750 , _:c14n20 , _:c14n608 ;
+	rdfs:subClassOf biolink:BiologicalProcessOrActivity , biolink:Occurrent , biolink:OntologyClass , _:c14n104 , _:c14n115 , _:c14n1159 , _:c14n1287 , _:c14n1378 , _:c14n1611 , _:c14n1752 , _:c14n18 , _:c14n611 ;
 	skos:altLabel "molecular event" , "molecular function" , "reaction" ;
 	skos:broadMatch STY:T045 ;
 	skos:definition "An execution of a molecular function carried out by a gene product or macromolecular complex." ;
@@ -1738,22 +1748,22 @@ biolink:MolecularActivity a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MolecularActivityToChemicalEntityAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "molecular activity to chemical entity association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1177 , _:c14n1183 , _:c14n1413 , _:c14n1440 , _:c14n56 , _:c14n789 ;
+	rdfs:subClassOf biolink:Association , _:c14n1182 , _:c14n1188 , _:c14n1418 , _:c14n1445 , _:c14n54 , _:c14n790 ;
 	skos:definition "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MolecularActivityToMolecularActivityAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "molecular activity to molecular activity association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1168 , _:c14n1233 , _:c14n1354 , _:c14n1470 , _:c14n1799 , _:c14n803 ;
+	rdfs:subClassOf biolink:Association , _:c14n1174 , _:c14n1237 , _:c14n1358 , _:c14n1476 , _:c14n1801 , _:c14n806 ;
 	skos:definition "Added in response to capturing relationship between microbiome activities as measured via measurements of blood analytes as collected via blood and stool samples" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MolecularActivityToPathwayAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "molecular activity to pathway association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1300 , _:c14n1367 , _:c14n1472 , _:c14n16 , _:c14n1743 , _:c14n1754 , _:c14n1843 , _:c14n684 , _:c14n728 ;
+	rdfs:subClassOf biolink:Association , _:c14n1306 , _:c14n1371 , _:c14n14 , _:c14n1478 , _:c14n1746 , _:c14n1756 , _:c14n1844 , _:c14n685 , _:c14n729 ;
 	skos:definition "Association that holds the relationship between a reaction and the pathway it participates in." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:MolecularEntity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "molecular entity" ;
-	rdfs:subClassOf biolink:ChemicalEntity , _:c14n1250 , _:c14n610 , _:c14n860 ;
+	rdfs:subClassOf biolink:ChemicalEntity , _:c14n1255 , _:c14n613 , _:c14n863 ;
 	skos:definition "A molecular entity is a chemical entity composed of individual or covalently bonded atoms." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch STY:T085 , STY:T088 , <http://purl.obolibrary.org/obo/CHEBI_23367> , bioschemas:MolecularEntity .
@@ -1769,14 +1779,16 @@ biolink:MortalityOutcome a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:NamedThing a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "named thing" ;
-	rdfs:subClassOf biolink:Entity , _:c14n1039 , _:c14n1337 , _:c14n1434 , _:c14n1600 , _:c14n1687 , _:c14n1717 , _:c14n460 , _:c14n634 , _:c14n731 , _:c14n747 , _:c14n932 ;
+	rdfs:subClassOf biolink:Entity , _:c14n1045 , _:c14n1301 , _:c14n1341 , _:c14n1439 , _:c14n1603 , _:c14n1720 , _:c14n466 , _:c14n732 , _:c14n748 , _:c14n932 , _:c14n937 ;
 	skos:definition "a databased entity or concept/class" ;
 	skos:exactMatch STY:T071 , <http://purl.obolibrary.org/obo/BFO_0000001> , dcid:Thing , UMLSSG:OBJC , WIKIDATA:Q35120 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "named thing associated with likelihood of named thing association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1093 , _:c14n1106 , _:c14n1134 , _:c14n1145 , _:c14n1295 , _:c14n1331 , _:c14n1490 , _:c14n155 , _:c14n1576 , _:c14n1636 , _:c14n1860 , _:c14n1876 , _:c14n373 , _:c14n458 , _:c14n47 , _:c14n551 , _:c14n6 , _:c14n604 , _:c14n651 , _:c14n665 , _:c14n669 , _:c14n695 , _:c14n889 , _:c14n980 ;
+	rdfs:subClassOf biolink:Association , _:c14n1098 , _:c14n1110 , _:c14n1139 , _:c14n1150 , _:c14n1300 , _:c14n1336 , _:c14n1495 , _:c14n157 , _:c14n1640 , _:c14n1860 , _:c14n1877 , _:c14n379 , _:c14n45 , _:c14n464 , _:c14n5 , _:c14n509 , _:c14n556 , _:c14n607 , _:c14n652 , _:c14n666 , _:c14n670 , _:c14n696 , _:c14n894 , _:c14n983 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:NarrativeText a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:String .
 biolink:NoncodingRNAProduct a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "noncoding RNA product" ;
 	rdfs:subClassOf biolink:RNAProduct ;
@@ -1822,7 +1834,7 @@ biolink:Onset a owl:Class , linkml:ClassDefinition ;
 biolink:OntologyClass a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "ontology class" ;
 	rdfs:seeAlso <https://github.com/biolink/biolink-model/issues/486> ;
-	rdfs:subClassOf _:c14n1453 , _:c14n1897 , _:c14n338 ;
+	rdfs:subClassOf _:c14n1459 , _:c14n1897 , _:c14n343 ;
 	skos:definition "a concept or class in an ontology, vocabulary or thesaurus. Note that nodes in a biolink compatible KG can be considered both instances of biolink classes, and OWL classes in their own right. In general you should not need to use this class directly. Instead, use the appropriate biolink class. For example, for the GO concept of endocytosis (GO:0006897), use bl:BiologicalProcess as the type." ;
 	skos:exactMatch schema1:Class , owl:Class ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
@@ -1835,7 +1847,7 @@ biolink:OrganismAttribute a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:OrganismTaxon a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organism taxon" ;
-	rdfs:subClassOf biolink:NamedThing , _:c14n1249 , _:c14n1437 , _:c14n945 ;
+	rdfs:subClassOf biolink:NamedThing , _:c14n1254 , _:c14n1442 , _:c14n949 ;
 	skos:altLabel "taxon" , "taxonomic classification" ;
 	skos:definition "A classification of a set of organisms. Example instances: NCBITaxon:9606 (Homo sapiens), NCBITaxon:2 (Bacteria). Can also be used to represent strains or subspecies." ;
 	skos:exactMatch STY:T001 , bioschemas:Taxon , WIKIDATA:Q16521 ;
@@ -1843,42 +1855,42 @@ biolink:OrganismTaxon a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch dcid:BiologicalSpecies .
 biolink:OrganismTaxonToEntityAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organism taxon to entity association" ;
-	rdfs:subClassOf _:c14n1060 , _:c14n109 , _:c14n1508 , _:c14n260 , _:c14n261 , _:c14n312 , _:c14n563 , _:c14n602 , _:c14n652 ;
+	rdfs:subClassOf _:c14n109 , _:c14n1513 , _:c14n263 , _:c14n264 , _:c14n316 , _:c14n568 , _:c14n605 , _:c14n653 , _:c14n712 ;
 	skos:definition "An association between an organism taxon and another entity" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:OrganismTaxonToEnvironmentAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organism taxon to environment association" ;
-	rdfs:subClassOf biolink:Association , biolink:OrganismTaxonToEntityAssociation , _:c14n1230 , _:c14n141 , _:c14n1646 , _:c14n1793 , _:c14n315 , _:c14n318 , _:c14n825 , _:c14n91 , _:c14n924 ;
+	rdfs:subClassOf biolink:Association , biolink:OrganismTaxonToEntityAssociation , _:c14n1234 , _:c14n143 , _:c14n1650 , _:c14n1795 , _:c14n319 , _:c14n323 , _:c14n828 , _:c14n91 , _:c14n928 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:OrganismTaxonToOrganismTaxonAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organism taxon to organism taxon association" ;
-	rdfs:subClassOf biolink:Association , biolink:OrganismTaxonToEntityAssociation , _:c14n1133 , _:c14n1290 , _:c14n607 , _:c14n777 , _:c14n778 , _:c14n795 , _:c14n818 ;
+	rdfs:subClassOf biolink:Association , biolink:OrganismTaxonToEntityAssociation , _:c14n1138 , _:c14n1295 , _:c14n610 , _:c14n778 , _:c14n779 , _:c14n798 , _:c14n821 ;
 	skos:definition "A relationship between two organism taxon nodes" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:OrganismTaxonToOrganismTaxonInteraction a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organism taxon to organism taxon interaction" ;
-	rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation , _:c14n1281 , _:c14n1286 , _:c14n1677 , _:c14n1704 , _:c14n341 , _:c14n389 , _:c14n390 , _:c14n436 , _:c14n54 , _:c14n72 , _:c14n790 , _:c14n900 ;
+	rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation , _:c14n1286 , _:c14n1291 , _:c14n1681 , _:c14n1707 , _:c14n346 , _:c14n395 , _:c14n396 , _:c14n443 , _:c14n52 , _:c14n71 , _:c14n791 , _:c14n904 ;
 	skos:definition "An interaction relationship between two taxa. This may be a symbiotic relationship (encompassing mutualism and parasitism), or it may be non-symbiotic. Example: plague transmitted_by flea; cattle domesticated_by Homo sapiens; plague infects Homo sapiens" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:OrganismTaxonToOrganismTaxonSpecialization a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organism taxon to organism taxon specialization" ;
-	rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation , _:c14n100 , _:c14n1482 , _:c14n1581 , _:c14n1671 , _:c14n1866 , _:c14n494 , _:c14n595 , _:c14n645 , _:c14n691 ;
+	rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation , _:c14n100 , _:c14n1487 , _:c14n1584 , _:c14n1675 , _:c14n1866 , _:c14n500 , _:c14n598 , _:c14n646 , _:c14n692 ;
 	skos:definition "A child-parent relationship between two taxa. For example: Homo sapiens subclass_of Homo" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:OrganismToOrganismAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organism to organism association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1352 , _:c14n1414 , _:c14n1523 , _:c14n1652 , _:c14n18 , _:c14n181 ;
+	rdfs:subClassOf biolink:Association , _:c14n1356 , _:c14n1419 , _:c14n1527 , _:c14n16 , _:c14n1656 , _:c14n184 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:OrganismalEntity a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organismal entity" ;
-	rdfs:subClassOf biolink:BiologicalEntity , biolink:SubjectOfInvestigation , _:c14n1266 , _:c14n1732 , _:c14n1869 ;
+	rdfs:subClassOf biolink:BiologicalEntity , biolink:SubjectOfInvestigation , _:c14n1271 , _:c14n1735 , _:c14n1869 ;
 	skos:definition "A named entity that is either a part of an organism, a whole organism, population or clade of organisms, excluding chemical entities" ;
 	skos:exactMatch <http://purl.obolibrary.org/obo/CARO_0001010> , UMLSSG:LIVB , WIKIDATA:Q7239 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch STY:T008 .
 biolink:OrganismalEntityAsAModelOfDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "organismal entity as a model of disease association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToDiseaseAssociationMixin , biolink:ModelToDiseaseAssociationMixin , _:c14n191 , _:c14n630 , _:c14n735 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToDiseaseAssociationMixin , biolink:ModelToDiseaseAssociationMixin , _:c14n193 , _:c14n633 , _:c14n736 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Outcome a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "outcome" ;
@@ -1886,13 +1898,13 @@ biolink:Outcome a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:PairwiseGeneToGeneInteraction a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "pairwise gene to gene interaction" ;
-	rdfs:subClassOf biolink:GeneToGeneAssociation , _:c14n1573 , _:c14n726 , _:c14n864 ;
+	rdfs:subClassOf biolink:GeneToGeneAssociation , _:c14n1577 , _:c14n728 , _:c14n867 ;
 	skos:definition "An interaction between two genes or two gene products. May be physical (e.g. protein binding) or genetic (between genes). May be symmetric (e.g. protein interaction) or directed (e.g. phosphorylation)" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch dcid:ProteinProteinInteraction .
 biolink:PairwiseMolecularInteraction a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "pairwise molecular interaction" ;
-	rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction , _:c14n103 , _:c14n1161 , _:c14n1218 , _:c14n1302 , _:c14n136 , _:c14n1431 , _:c14n1433 , _:c14n1735 , _:c14n1836 , _:c14n21 , _:c14n225 , _:c14n526 , _:c14n571 , _:c14n914 , _:c14n959 ;
+	rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction , _:c14n103 , _:c14n1167 , _:c14n1222 , _:c14n1308 , _:c14n138 , _:c14n1436 , _:c14n1438 , _:c14n1738 , _:c14n1837 , _:c14n19 , _:c14n227 , _:c14n533 , _:c14n574 , _:c14n918 , _:c14n963 ;
 	skos:definition "An interaction at the molecular level between two physical entities" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Patent a owl:Class , linkml:ClassDefinition ;
@@ -1951,6 +1963,8 @@ biolink:Pathway a owl:Class , linkml:ClassDefinition ;
 	skos:exactMatch <http://purl.obolibrary.org/obo/PW_0000001> , WIKIDATA:Q4915012 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch <http://purl.obolibrary.org/obo/GO_0007165> , SIO:010526 .
+biolink:PercentageFrequencyValue a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:Double .
 biolink:PhaseEnum\#0 a owl:Class , biolink:PhaseEnum ;
 	rdfs:label "0" ;
 	rdfs:subClassOf biolink:PhaseEnum .
@@ -1962,7 +1976,7 @@ biolink:PhaseEnum\#2 a owl:Class , biolink:PhaseEnum ;
 	rdfs:subClassOf biolink:PhaseEnum .
 biolink:PhaseEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "PhaseEnum" ;
-	owl:unionOf _:c14n1002 ;
+	owl:unionOf _:c14n1007 ;
 	skos:definition "phase" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:PhaseEnum\#0 , biolink:PhaseEnum\#1 , biolink:PhaseEnum\#2 .
@@ -1985,11 +1999,11 @@ biolink:PhenotypicFeature a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch STY:T184 , STY:T190 , <http://purl.obolibrary.org/obo/APO_0000017> , <http://purl.obolibrary.org/obo/FBcv_0001347> , FYPO:0000001 , <http://purl.obolibrary.org/obo/HP_0000118> , <http://purl.obolibrary.org/obo/MP_0000001> , <http://purl.obolibrary.org/obo/TO_0000387> , <http://purl.obolibrary.org/obo/WBPhenotype_0000886> , XPO:00000000 , <http://purl.obolibrary.org/obo/ZP_00000000> , WIKIDATA:Q169872 , WIKIDATA:Q25203551 .
 biolink:PhenotypicFeatureToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "phenotypic feature to disease association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToDiseaseAssociationMixin , biolink:PhenotypicFeatureToEntityAssociationMixin , _:c14n257 , _:c14n4 , _:c14n755 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToDiseaseAssociationMixin , biolink:PhenotypicFeatureToEntityAssociationMixin , _:c14n260 , _:c14n3 , _:c14n756 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:PhenotypicFeatureToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "phenotypic feature to entity association mixin" ;
-	rdfs:subClassOf biolink:FeatureOrDiseaseQualifiersToEntityMixin , biolink:FrequencyQuantifier , _:c14n107 , _:c14n1085 , _:c14n1680 , _:c14n217 , _:c14n350 , _:c14n513 ;
+	rdfs:subClassOf biolink:FeatureOrDiseaseQualifiersToEntityMixin , biolink:FrequencyQuantifier , _:c14n107 , _:c14n1090 , _:c14n1684 , _:c14n219 , _:c14n355 , _:c14n520 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:PhenotypicFeatureToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "phenotypic feature to phenotypic feature association" ;
@@ -2057,7 +2071,7 @@ biolink:PopulationOfIndividualOrganisms a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:PopulationToPopulationAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "population to population association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1004 , _:c14n1175 , _:c14n1320 , _:c14n1745 , _:c14n1752 , _:c14n1819 , _:c14n1850 , _:c14n59 , _:c14n949 ;
+	rdfs:subClassOf biolink:Association , _:c14n1009 , _:c14n1180 , _:c14n1326 , _:c14n1748 , _:c14n1754 , _:c14n1821 , _:c14n1850 , _:c14n57 , _:c14n953 ;
 	skos:definition "An association between a two populations" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:PosttranslationalModification a owl:Class , linkml:ClassDefinition ;
@@ -2067,9 +2081,11 @@ biolink:PosttranslationalModification a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:PredicateMapping a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "predicate mapping" ;
-	rdfs:subClassOf _:c14n1079 , _:c14n1097 , _:c14n1120 , _:c14n1140 , _:c14n1144 , _:c14n1193 , _:c14n1210 , _:c14n1240 , _:c14n1243 , _:c14n126 , _:c14n1304 , _:c14n1319 , _:c14n1322 , _:c14n1375 , _:c14n1377 , _:c14n1390 , _:c14n1396 , _:c14n1405 , _:c14n1545 , _:c14n1550 , _:c14n1598 , _:c14n1657 , _:c14n1668 , _:c14n1684 , _:c14n1692 , _:c14n1727 , _:c14n1746 , _:c14n1842 , _:c14n1875 , _:c14n215 , _:c14n233 , _:c14n241 , _:c14n248 , _:c14n258 , _:c14n268 , _:c14n281 , _:c14n300 , _:c14n316 , _:c14n319 , _:c14n331 , _:c14n374 , _:c14n410 , _:c14n451 , _:c14n461 , _:c14n497 , _:c14n50 , _:c14n504 , _:c14n516 , _:c14n520 , _:c14n57 , _:c14n591 , _:c14n614 , _:c14n618 , _:c14n636 , _:c14n658 , _:c14n670 , _:c14n675 , _:c14n743 , _:c14n771 , _:c14n78 , _:c14n856 , _:c14n916 , _:c14n930 ;
+	rdfs:subClassOf _:c14n1005 , _:c14n1084 , _:c14n1102 , _:c14n1124 , _:c14n1145 , _:c14n1149 , _:c14n1198 , _:c14n1213 , _:c14n1244 , _:c14n1248 , _:c14n126 , _:c14n1310 , _:c14n1325 , _:c14n1379 , _:c14n1381 , _:c14n1394 , _:c14n1401 , _:c14n1410 , _:c14n1550 , _:c14n1555 , _:c14n1601 , _:c14n1661 , _:c14n1672 , _:c14n1688 , _:c14n1696 , _:c14n1730 , _:c14n1749 , _:c14n1843 , _:c14n1876 , _:c14n217 , _:c14n235 , _:c14n244 , _:c14n251 , _:c14n261 , _:c14n271 , _:c14n285 , _:c14n305 , _:c14n321 , _:c14n324 , _:c14n336 , _:c14n380 , _:c14n417 , _:c14n457 , _:c14n467 , _:c14n48 , _:c14n503 , _:c14n511 , _:c14n523 , _:c14n527 , _:c14n55 , _:c14n594 , _:c14n617 , _:c14n621 , _:c14n638 , _:c14n660 , _:c14n671 , _:c14n676 , _:c14n744 , _:c14n77 , _:c14n772 , _:c14n859 , _:c14n920 , _:c14n935 ;
 	skos:definition "A deprecated predicate mapping object contains the deprecated predicate and an example of the rewiring that should be done to use a qualified statement in its place." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:PredicateType a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:Uriorcurie .
 biolink:PreprintPublication a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "preprint publication" ;
 	rdfs:subClassOf biolink:Publication ;
@@ -2085,7 +2101,7 @@ biolink:Procedure a owl:Class , linkml:ClassDefinition ;
 	skos:narrowMatch STY:T059 , STY:T060 , STY:T061 , STY:T063 .
 biolink:ProcessRegulatesProcessAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "process regulates process association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1050 , _:c14n1070 , _:c14n1345 , _:c14n1631 , _:c14n1767 , _:c14n536 , _:c14n667 , _:c14n693 , _:c14n720 ;
+	rdfs:subClassOf biolink:Association , _:c14n1056 , _:c14n1075 , _:c14n1350 , _:c14n1635 , _:c14n1769 , _:c14n541 , _:c14n668 , _:c14n694 , _:c14n722 ;
 	skos:definition "Describes a regulatory relationship between two genes or gene products." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ProcessedMaterial a owl:Class , linkml:ClassDefinition ;
@@ -2122,16 +2138,18 @@ biolink:ProteinIsoform a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Publication a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "publication" ;
-	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1219 , _:c14n1267 , _:c14n1276 , _:c14n1351 , _:c14n1368 , _:c14n144 , _:c14n1601 , _:c14n1637 , _:c14n1676 , _:c14n1785 , _:c14n203 , _:c14n354 , _:c14n421 , _:c14n464 , _:c14n673 , _:c14n677 , _:c14n733 , _:c14n8 , _:c14n823 , _:c14n89 , _:c14n927 ;
+	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1223 , _:c14n1272 , _:c14n1281 , _:c14n1355 , _:c14n1372 , _:c14n146 , _:c14n1604 , _:c14n1641 , _:c14n1680 , _:c14n1787 , _:c14n205 , _:c14n359 , _:c14n428 , _:c14n470 , _:c14n6 , _:c14n674 , _:c14n678 , _:c14n734 , _:c14n826 , _:c14n89 , _:c14n931 ;
 	skos:definition "Any ‘published’ piece of information. Publications are considered broadly to include any document or document part made available in print or on the web - which may include scientific journal issues, individual articles, and books - as well as things like pre-prints, white papers, patents, drug labels, web pages, protocol documents,  and even a part of a publication if of significant knowledge scope (e.g. a figure, figure legend, or section highlighted by NLP)." ;
 	skos:exactMatch IAO:0000311 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch STY:T170 , IAO:0000013 .
 biolink:QuantityValue a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "quantity value" ;
-	rdfs:subClassOf biolink:Annotation , _:c14n1432 , _:c14n1543 , _:c14n229 , _:c14n448 , _:c14n555 , _:c14n641 ;
+	rdfs:subClassOf biolink:Annotation , _:c14n1437 , _:c14n1548 , _:c14n1625 , _:c14n231 , _:c14n454 , _:c14n560 ;
 	skos:definition "A value of an attribute that is quantitative and measurable, expressed as a combination of a unit and a numeric value" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:Quotient a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:Double .
 biolink:RNAProduct a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "RNA product" ;
 	rdfs:subClassOf biolink:GeneProductMixin , biolink:Transcript ;
@@ -2156,7 +2174,7 @@ biolink:ReactionDirectionEnum\#right_to_left a owl:Class , biolink:ReactionDirec
 	rdfs:subClassOf biolink:ReactionDirectionEnum .
 biolink:ReactionDirectionEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "ReactionDirectionEnum" ;
-	owl:unionOf _:c14n631 ;
+	owl:unionOf _:c14n634 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:ReactionDirectionEnum\#bidirectional , biolink:ReactionDirectionEnum\#left_to_right , biolink:ReactionDirectionEnum\#neutral , biolink:ReactionDirectionEnum\#right_to_left .
 biolink:ReactionSideEnum\#left a owl:Class , biolink:ReactionSideEnum ;
@@ -2167,16 +2185,16 @@ biolink:ReactionSideEnum\#right a owl:Class , biolink:ReactionSideEnum ;
 	rdfs:subClassOf biolink:ReactionSideEnum .
 biolink:ReactionSideEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "ReactionSideEnum" ;
-	owl:unionOf _:c14n1773 ;
+	owl:unionOf _:c14n1775 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:ReactionSideEnum\#left , biolink:ReactionSideEnum\#right .
 biolink:ReactionToCatalystAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "reaction to catalyst association" ;
-	rdfs:subClassOf biolink:ReactionToParticipantAssociation , _:c14n1166 , _:c14n172 , _:c14n523 ;
+	rdfs:subClassOf biolink:ReactionToParticipantAssociation , _:c14n1172 , _:c14n175 , _:c14n530 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ReactionToParticipantAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "reaction to participant association" ;
-	rdfs:subClassOf biolink:ChemicalToChemicalAssociation , _:c14n1032 , _:c14n1061 , _:c14n111 , _:c14n138 , _:c14n1394 , _:c14n1503 , _:c14n387 , _:c14n696 , _:c14n758 , _:c14n855 , _:c14n911 , _:c14n926 ;
+	rdfs:subClassOf biolink:ChemicalToChemicalAssociation , _:c14n1038 , _:c14n1066 , _:c14n111 , _:c14n1399 , _:c14n140 , _:c14n1508 , _:c14n393 , _:c14n697 , _:c14n759 , _:c14n858 , _:c14n915 , _:c14n930 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ReagentTargetedGene a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "reagent targeted gene" ;
@@ -2235,7 +2253,7 @@ biolink:ResearchPhaseEnum\#pre_clinical_research_phase a owl:Class , biolink:Res
 	skos:editorialNote "DrugBank calls this 'experimental'." .
 biolink:ResearchPhaseEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "ResearchPhaseEnum" ;
-	owl:unionOf _:c14n1765 ;
+	owl:unionOf _:c14n1767 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:ResearchPhaseEnum\#clinical_trial_phase , biolink:ResearchPhaseEnum\#clinical_trial_phase_1 , biolink:ResearchPhaseEnum\#clinical_trial_phase_2 , biolink:ResearchPhaseEnum\#clinical_trial_phase_3 , biolink:ResearchPhaseEnum\#clinical_trial_phase_4 , biolink:ResearchPhaseEnum\#not_provided , biolink:ResearchPhaseEnum\#pre_clinical_research_phase .
 biolink:ResourceRoleEnum\#aggregator_knowledge_source a owl:Class , biolink:ResourceRoleEnum ;
@@ -2255,7 +2273,7 @@ biolink:ResourceRoleEnum a owl:Class , linkml:EnumDefinition ;
 	linkml:permissible_values biolink:ResourceRoleEnum\#aggregator_knowledge_source , biolink:ResourceRoleEnum\#primary_knowledge_source , biolink:ResourceRoleEnum\#supporting_data_source .
 biolink:RetrievalSource a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "retrieval source" ;
-	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1042 , _:c14n1171 , _:c14n1178 , _:c14n1275 , _:c14n1540 , _:c14n1728 , _:c14n468 , _:c14n486 , _:c14n559 , _:c14n560 , _:c14n656 ;
+	rdfs:subClassOf biolink:InformationContentEntity , _:c14n1048 , _:c14n1177 , _:c14n1183 , _:c14n1280 , _:c14n1544 , _:c14n1731 , _:c14n474 , _:c14n492 , _:c14n564 , _:c14n565 , _:c14n657 ;
 	skos:definition "Provides information about how a particular InformationResource served as a source from which knowledge expressed in an Edge, or data used to generate this knowledge, was retrieved." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:SensitivityQuantifier a owl:Class , linkml:ClassDefinition ;
@@ -2277,19 +2295,19 @@ biolink:SequenceEnum\#na a owl:Class , biolink:SequenceEnum ;
 	skos:definition "nucleic acid" .
 biolink:SequenceEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "SequenceEnum" ;
-	owl:unionOf _:c14n372 ;
+	owl:unionOf _:c14n378 ;
 	skos:definition "type of sequence" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:SequenceEnum\#aa , biolink:SequenceEnum\#na .
 biolink:SequenceFeatureRelationship a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "sequence feature relationship" ;
-	rdfs:subClassOf biolink:Association , _:c14n1081 , _:c14n1451 , _:c14n1625 , _:c14n1672 , _:c14n1911 , _:c14n63 ;
+	rdfs:subClassOf biolink:Association , _:c14n1086 , _:c14n1456 , _:c14n1629 , _:c14n1676 , _:c14n1911 , _:c14n61 ;
 	skos:definition "For example, a particular exon is part of a particular transcript or gene" ;
 	skos:exactMatch CHADO:feature_relationship ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:SequenceVariant a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "sequence variant" ;
-	rdfs:subClassOf biolink:BiologicalEntity , biolink:GenomicEntity , biolink:OntologyClass , biolink:PhysicalEssence , _:c14n1005 , _:c14n1130 , _:c14n1143 , _:c14n1430 , _:c14n1450 , _:c14n532 , _:c14n605 , _:c14n942 ;
+	rdfs:subClassOf biolink:BiologicalEntity , biolink:GenomicEntity , biolink:OntologyClass , biolink:PhysicalEssence , _:c14n1010 , _:c14n1135 , _:c14n1148 , _:c14n1435 , _:c14n1455 , _:c14n537 , _:c14n608 , _:c14n946 ;
 	skos:altLabel "allele" ;
 	skos:closeMatch <http://purl.obolibrary.org/obo/GENO_0000002> , <http://purl.obolibrary.org/obo/SO_0001060> , SIO:010277 , dcid:Allele , VMC:Allele ;
 	skos:definition "A sequence_variant is a non exact copy of a sequence_feature or genome exhibiting one or more sequence_alteration." ;
@@ -2298,13 +2316,13 @@ biolink:SequenceVariant a owl:Class , linkml:ClassDefinition ;
 	skos:note "This class is for modeling the specific state at a locus. A single DBSNP rs ID could correspond to more than one sequence variants (e.g CIViC:1252 and CIViC:1253, two distinct BRCA2 alleles for rs28897743)" .
 biolink:SequenceVariantModulatesTreatmentAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "sequence variant modulates treatment association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1634 , _:c14n1768 , _:c14n32 , _:c14n579 , _:c14n805 , _:c14n847 ;
+	rdfs:subClassOf biolink:Association , _:c14n1638 , _:c14n1770 , _:c14n30 , _:c14n582 , _:c14n808 , _:c14n851 ;
 	skos:definition "An association between a sequence variant and a treatment or health intervention. The treatment object itself encompasses both the disease and the drug used." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:note "An alternate way to model the same information could be via a qualifier" .
 biolink:Serial a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "serial" ;
-	rdfs:subClassOf biolink:Publication , _:c14n1181 , _:c14n1307 , _:c14n1312 , _:c14n1332 , _:c14n161 , _:c14n179 , _:c14n1905 , _:c14n370 , _:c14n444 , _:c14n681 , _:c14n753 , _:c14n82 , _:c14n907 , _:c14n952 ;
+	rdfs:subClassOf biolink:Publication , _:c14n1186 , _:c14n1313 , _:c14n1318 , _:c14n1337 , _:c14n163 , _:c14n182 , _:c14n1905 , _:c14n376 , _:c14n451 , _:c14n682 , _:c14n754 , _:c14n81 , _:c14n911 , _:c14n956 ;
 	skos:altLabel "journal" ;
 	skos:definition "This class may rarely be instantiated except if use cases of a given knowledge graph support its utility." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -2341,7 +2359,7 @@ biolink:SocioeconomicAttribute a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:SocioeconomicExposure a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "socioeconomic exposure" ;
-	rdfs:subClassOf biolink:Attribute , biolink:ExposureEvent , _:c14n1113 , _:c14n1128 ;
+	rdfs:subClassOf biolink:Attribute , biolink:ExposureEvent , _:c14n1117 , _:c14n1133 ;
 	skos:definition "A socioeconomic exposure is a factor relating to social and financial status of an affected individual (e.g. poverty)." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:SocioeconomicOutcome a owl:Class , linkml:ClassDefinition ;
@@ -2371,7 +2389,7 @@ biolink:StrandEnum\#- a owl:Class , biolink:StrandEnum ;
 	skos:definition "Unstranded" .
 biolink:StrandEnum a owl:Class , linkml:EnumDefinition ;
 	rdfs:label "StrandEnum" ;
-	owl:unionOf _:c14n134 ;
+	owl:unionOf _:c14n136 ;
 	skos:definition "strand" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	linkml:permissible_values biolink:StrandEnum\#\%2B , biolink:StrandEnum\#\%3F , biolink:StrandEnum\#- , <https://w3id.org/biolink/vocab/StrandEnum#.> .
@@ -2391,7 +2409,7 @@ biolink:StudyPopulation a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:StudyResult a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "study result" ;
-	rdfs:subClassOf biolink:InformationContentEntity , _:c14n415 ;
+	rdfs:subClassOf biolink:InformationContentEntity , _:c14n422 ;
 	skos:definition "A collection of data items from a study that are about a particular study subject or experimental unit (the 'focus' of the Result) - optionally with context/provenance metadata that may be relevant to the interpretation of this data as evidence." ;
 	skos:editorialNote "The data/metadata included in a Study Result object are typically a subset of data from a larger study data set, that are selected by a curator because they may be useful as evidence for deriving knowledge about a specific focus of the study. The notion of a 'study' here is defined broadly to include any research activity at any scale that is aimed at generating knowledge or hypotheses. This may include a single assay or computational analyses, or a larger scale clinical trial or experimental research investigation." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -2406,9 +2424,11 @@ biolink:SubjectOfInvestigation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "subject of investigation" ;
 	skos:definition "An entity that has the role of being studied in an investigation, study, or experiment" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:SymbolType a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:String .
 biolink:TaxonToTaxonAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "taxon to taxon association" ;
-	rdfs:subClassOf biolink:Association , _:c14n1117 , _:c14n1137 , _:c14n1539 , _:c14n1643 , _:c14n68 , _:c14n880 ;
+	rdfs:subClassOf biolink:Association , _:c14n1121 , _:c14n1142 , _:c14n1543 , _:c14n1647 , _:c14n66 , _:c14n883 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:TaxonomicRank a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "taxonomic rank" ;
@@ -2423,9 +2443,11 @@ biolink:TextMiningResult a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:ThingWithTaxon a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "thing with taxon" ;
-	rdfs:subClassOf _:c14n0 , _:c14n1051 , _:c14n1059 , _:c14n524 , _:c14n727 , _:c14n832 ;
+	rdfs:subClassOf _:c14n0 , _:c14n1057 , _:c14n1065 , _:c14n531 , _:c14n699 , _:c14n836 ;
 	skos:definition "A mixin that can be used on any entity that can be taxonomically classified. This includes individual organisms; genes, their products and other molecular entities; body parts; biological processes" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:TimeType a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:Time .
 biolink:Transcript a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "transcript" ;
 	rdfs:subClassOf biolink:BiologicalEntity ;
@@ -2434,7 +2456,7 @@ biolink:Transcript a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:TranscriptToGeneRelationship a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "transcript to gene relationship" ;
-	rdfs:subClassOf biolink:SequenceFeatureRelationship , _:c14n1220 , _:c14n1474 , _:c14n1520 , _:c14n423 , _:c14n484 , _:c14n506 ;
+	rdfs:subClassOf biolink:SequenceFeatureRelationship , _:c14n1224 , _:c14n1479 , _:c14n1524 , _:c14n430 , _:c14n490 , _:c14n513 ;
 	skos:definition "A gene is a collection of transcripts" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:TranscriptionFactorBindingSite a owl:Class , linkml:ClassDefinition ;
@@ -2446,42 +2468,44 @@ biolink:TranscriptionFactorBindingSite a owl:Class , linkml:ClassDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Treatment a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "treatment" ;
-	rdfs:subClassOf biolink:ChemicalOrDrugOrTreatment , biolink:ExposureEvent , biolink:NamedThing , _:c14n174 , _:c14n187 , _:c14n339 , _:c14n49 , _:c14n83 , _:c14n917 ;
+	rdfs:subClassOf biolink:ChemicalOrDrugOrTreatment , biolink:ExposureEvent , biolink:NamedThing , _:c14n177 , _:c14n189 , _:c14n344 , _:c14n47 , _:c14n82 , _:c14n921 ;
 	skos:altLabel "medical action" , "medical intervention" ;
 	skos:broadMatch MAXO:0000058 ;
 	skos:definition "A treatment is targeted at a disease or phenotype and may involve multiple drug 'exposures', medical devices and/or procedures" ;
 	skos:exactMatch <http://purl.obolibrary.org/obo/OGMS_0000090> , SIO:001398 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
+biolink:Unit a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf linkml:String .
 biolink:VariantAsAModelOfDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "variant as a model of disease association" ;
-	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:ModelToDiseaseAssociationMixin , biolink:VariantToDiseaseAssociation , _:c14n1001 , _:c14n206 , _:c14n308 ;
+	rdfs:subClassOf biolink:EntityToDiseaseAssociationMixin , biolink:ModelToDiseaseAssociationMixin , biolink:VariantToDiseaseAssociation , _:c14n1006 , _:c14n208 , _:c14n312 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:VariantToDiseaseAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "variant to disease association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToDiseaseAssociationMixin , biolink:VariantToEntityAssociationMixin , _:c14n1392 , _:c14n142 , _:c14n1593 , _:c14n269 , _:c14n361 , _:c14n43 , _:c14n639 , _:c14n650 , _:c14n867 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToDiseaseAssociationMixin , biolink:VariantToEntityAssociationMixin , _:c14n1396 , _:c14n144 , _:c14n1596 , _:c14n272 , _:c14n366 , _:c14n41 , _:c14n641 , _:c14n651 , _:c14n871 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:note "TODO decide no how to model pathogenicity" .
 biolink:VariantToEntityAssociationMixin a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "variant to entity association mixin" ;
-	rdfs:subClassOf _:c14n1064 , _:c14n1072 , _:c14n1245 , _:c14n1355 , _:c14n1372 , _:c14n1467 , _:c14n1821 , _:c14n359 , _:c14n561 ;
+	rdfs:subClassOf _:c14n1069 , _:c14n1077 , _:c14n1250 , _:c14n1359 , _:c14n1376 , _:c14n1473 , _:c14n364 , _:c14n566 , _:c14n891 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:VariantToGeneAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "variant to gene association" ;
-	rdfs:subClassOf biolink:Association , biolink:VariantToEntityAssociationMixin , _:c14n1277 , _:c14n1334 , _:c14n1425 , _:c14n1651 , _:c14n1874 , _:c14n75 ;
+	rdfs:subClassOf biolink:Association , biolink:VariantToEntityAssociationMixin , _:c14n1282 , _:c14n1338 , _:c14n1430 , _:c14n1655 , _:c14n1875 , _:c14n74 ;
 	skos:definition "An association between a variant and a gene, where the variant has a genetic association with the gene (i.e. is in linkage disequilibrium)" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:VariantToGeneExpressionAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "variant to gene expression association" ;
-	rdfs:subClassOf biolink:GeneExpressionMixin , biolink:VariantToGeneAssociation , _:c14n1867 , _:c14n1881 , _:c14n431 ;
+	rdfs:subClassOf biolink:GeneExpressionMixin , biolink:VariantToGeneAssociation , _:c14n1867 , _:c14n1883 , _:c14n438 ;
 	skos:definition "An association between a variant and expression of a gene (i.e. e-QTL)" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:VariantToPhenotypicFeatureAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "variant to phenotypic feature association" ;
-	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:VariantToEntityAssociationMixin , _:c14n1289 , _:c14n1862 , _:c14n313 ;
+	rdfs:subClassOf biolink:Association , biolink:EntityToPhenotypicFeatureAssociationMixin , biolink:VariantToEntityAssociationMixin , _:c14n1294 , _:c14n1862 , _:c14n317 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:VariantToPopulationAssociation a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "variant to population association" ;
-	rdfs:subClassOf biolink:Association , biolink:FrequencyQualifierMixin , biolink:FrequencyQuantifier , biolink:VariantToEntityAssociationMixin , _:c14n1146 , _:c14n1242 , _:c14n1301 , _:c14n1325 , _:c14n1336 , _:c14n1518 , _:c14n1561 , _:c14n1580 , _:c14n1604 , _:c14n1644 , _:c14n1731 , _:c14n1755 , _:c14n1774 , _:c14n1787 , _:c14n892 ;
+	rdfs:subClassOf biolink:Association , biolink:FrequencyQualifierMixin , biolink:FrequencyQuantifier , biolink:VariantToEntityAssociationMixin , _:c14n1151 , _:c14n1247 , _:c14n1307 , _:c14n1329 , _:c14n1340 , _:c14n1522 , _:c14n1564 , _:c14n1583 , _:c14n1607 , _:c14n1648 , _:c14n1734 , _:c14n1757 , _:c14n1776 , _:c14n1789 , _:c14n897 ;
 	skos:definition "An association between a variant and a population, where the variant has particular frequency in the population" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:Vertebrate a owl:Class , linkml:ClassDefinition ;
@@ -2818,8 +2842,6 @@ biolink:biological_role_mixin a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:definition "A role played by the chemical entity or part thereof within a biological context." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch <http://purl.obolibrary.org/obo/CHEBI_24432> .
-biolink:biological_sequence a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:String .
 biolink:biomarker_for a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:ChemicalEntityOrGeneOrGeneProduct ;
 	rdfs:label "biomarker for" ;
@@ -2925,8 +2947,6 @@ biolink:chemical_entity_or_drug_or_treatment a owl:ObjectProperty , linkml:SlotD
 	rdfs:label "chemical entity or drug or treatment" ;
 	skos:definition "A union of chemical entities and children, and drug or treatment." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
-biolink:chemical_formula_value a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf _:c14n936 .
 biolink:chemical_role_mixin a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "chemical role mixin" ;
 	skos:definition "A role played by the chemical entity or part thereof within a chemical context." ;
@@ -3211,7 +3231,7 @@ biolink:derives_into a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:description a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "description" ;
-	rdfs:range biolink:narrative_text ;
+	rdfs:range biolink:NarrativeText ;
 	skos:altLabel "definition" ;
 	skos:definition "a human-readable description of an entity" ;
 	skos:exactMatch IAO:0000115 , skos:definitions ;
@@ -3444,16 +3464,14 @@ biolink:format a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:frequency_qualifier a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "frequency qualifier" ;
-	rdfs:range biolink:frequency_value ;
+	rdfs:range biolink:FrequencyValue ;
 	rdfs:subPropertyOf biolink:qualifier ;
 	skos:definition "a qualifier used in a phenotypic association to state how frequent the phenotype is observed in the subject" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
-biolink:frequency_value a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:String .
 biolink:full_name a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:NamedThing ;
 	rdfs:label "full name" ;
-	rdfs:range biolink:label_type ;
+	rdfs:range biolink:LabelType ;
 	rdfs:subPropertyOf biolink:node_property ;
 	skos:definition "a long-form human readable name for a thing" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3570,7 +3588,7 @@ biolink:has_author a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:has_biological_sequence a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "has biological sequence" ;
-	rdfs:range biolink:biological_sequence ;
+	rdfs:range biolink:BiologicalSequence ;
 	rdfs:subPropertyOf biolink:node_property ;
 	skos:definition "connects a genomic feature to its sequence" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -3590,7 +3608,7 @@ biolink:has_catalyst a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:has_chemical_formula a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "has chemical formula" ;
-	rdfs:range biolink:chemical_formula_value ;
+	rdfs:range biolink:ChemicalFormulaValue ;
 	rdfs:subPropertyOf biolink:node_property ;
 	skos:definition "description of chemical compound based on element symbols" ;
 	skos:exactMatch WIKIDATA_PROPERTY:P274 ;
@@ -4086,7 +4104,7 @@ biolink:has_total a owl:ObjectProperty , linkml:SlotDefinition ;
 biolink:has_unit a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:QuantityValue ;
 	rdfs:label "has unit" ;
-	rdfs:range biolink:unit ;
+	rdfs:range biolink:Unit ;
 	skos:closeMatch UO-PROPERTY:is_unit_of , EFO:0001697 ;
 	skos:definition "connects a quantity value to a unit" ;
 	skos:exactMatch IAO:0000039 , qud:unit ;
@@ -4205,7 +4223,7 @@ biolink:in_taxon a owl:ObjectProperty , linkml:SlotDefinition ;
 biolink:in_taxon_label a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:ThingWithTaxon ;
 	rdfs:label "in taxon label" ;
-	rdfs:range biolink:label_type ;
+	rdfs:range biolink:LabelType ;
 	rdfs:subPropertyOf biolink:node_property ;
 	skos:definition "The human readable scientific name for the taxon of the entity." ;
 	skos:exactMatch WIKIDATA_PROPERTY:P225 ;
@@ -4271,12 +4289,10 @@ biolink:interbase_coordinate a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:iri a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "iri" ;
-	rdfs:range biolink:iri_type ;
+	rdfs:range biolink:IriType ;
 	skos:definition "An IRI for an entity. This is determined by the id using expansion rules." ;
 	skos:exactMatch WIKIDATA_PROPERTY:P854 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
-biolink:iri_type a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:Uriorcurie .
 biolink:is_active_ingredient_of a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:MolecularEntity ;
 	rdfs:label "is active ingredient of" ;
@@ -4481,8 +4497,6 @@ biolink:knowledge_source a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:closeMatch pav:providedBy ;
 	skos:definition "An Information Resource from which the knowledge expressed in an Association was retrieved, directly or indirectly. This can be any resource through which the knowledge passed on its way to its currently serialized form. In practice, implementers should use one of the more specific subtypes of this generic property." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
-biolink:label_type a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:String .
 biolink:lacks_part a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "lacks part" ;
 	rdfs:subPropertyOf biolink:related_to_at_instance_level ;
@@ -4675,14 +4689,12 @@ biolink:models_demonstrating_benefits_for a owl:ObjectProperty , linkml:SlotDefi
 biolink:name a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:Entity ;
 	rdfs:label "name" ;
-	rdfs:range biolink:label_type ;
+	rdfs:range biolink:LabelType ;
 	skos:altLabel "display name" , "label" , "title" ;
 	skos:definition "A human-readable name for an attribute or entity." ;
 	skos:exactMatch gff3:Name , gpi:DB_Object_Name ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch dct:title , WIKIDATA_PROPERTY:P1476 .
-biolink:narrative_text a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:String .
 biolink:narrow_match a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "narrow match" ;
 	rdfs:subPropertyOf biolink:related_to_at_concept_level ;
@@ -4940,8 +4952,6 @@ biolink:participates_in a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:exactMatch <http://purl.obolibrary.org/obo/BFO_0000056> , RO:0000056 ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch <http://identifiers.org/drugbank/pathway> , <http://identifiers.org/hmdb/in_pathway> , LOINC:is_given_pharmaceutical_substance_for , <http://purl.obolibrary.org/obo/NCIT_R130> , <http://purl.obolibrary.org/obo/NCIT_R131> , <http://purl.obolibrary.org/obo/NCIT_R37> , <http://purl.obolibrary.org/obo/NCIT_R51> , <http://purl.obolibrary.org/obo/NCIT_R53> , <http://purl.obolibrary.org/obo/OBI_0000295> , RO:0002216 , RO:0002505 , <http://purl.obolibrary.org/obo/SNOMED_has_direct_device> .
-biolink:percentage_frequency_value a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:Double .
 biolink:phase a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:CodingSequence ;
 	rdfs:label "phase" ;
@@ -5019,7 +5029,7 @@ biolink:precedes a owl:ObjectProperty , linkml:SlotDefinition ;
 biolink:predicate a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:Association ;
 	rdfs:label "predicate" ;
-	rdfs:range biolink:predicate_type ;
+	rdfs:range biolink:PredicateType ;
 	rdfs:subPropertyOf biolink:association_slot ;
 	skos:definition "A high-level grouping for the relationship type. AKA minimal predicate. This is analogous to category for nodes." ;
 	skos:editorialNote "Has a value from the Biolink related_to hierarchy. In RDF,  this corresponds to rdf:predicate and in Neo4j this corresponds to the relationship type. The convention is for an edge label in snake_case form. For example, biolink:related_to, biolink:causes, biolink:treats" ;
@@ -5030,8 +5040,6 @@ biolink:predicate_mappings a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:range biolink:PredicateMapping ;
 	skos:definition "A collection of relationships that are not used in biolink, but have biolink patterns that can be used to replace them.  This is a temporary slot to help with the transition to the fully qualified predicate model in Biolink3." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
-biolink:predicate_type a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:Uriorcurie .
 biolink:predisposes_to_condition a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:ChemicalOrDrugOrTreatment ;
 	rdfs:label "predisposes to condition" ;
@@ -5150,8 +5158,6 @@ biolink:quantifier_qualifier a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:definition "A measurable quantity for the object of the association" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> ;
 	skos:narrowMatch <http://identifiers.org/umls/measures> , LOINC:analyzes , LOINC:measured_by , LOINC:property_of , SEMMEDDB:MEASURES .
-biolink:quotient a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:Double .
 biolink:reaction_balanced a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "reaction balanced" ;
 	rdfs:range linkml:Boolean ;
@@ -5666,12 +5672,10 @@ biolink:symbol a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:definition "Symbol for a particular thing" ;
 	skos:exactMatch gpi:DB_Object_Symbol , AGRKB:symbol ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
-biolink:symbol_type a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:String .
 biolink:synonym a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:NamedThing ;
 	rdfs:label "synonym" ;
-	rdfs:range biolink:label_type ;
+	rdfs:range biolink:LabelType ;
 	rdfs:subPropertyOf biolink:node_property ;
 	skos:altLabel "alias" ;
 	skos:definition "Alternate human-readable names for a thing" ;
@@ -5680,7 +5684,7 @@ biolink:synonym a owl:ObjectProperty , linkml:SlotDefinition ;
 biolink:systematic_synonym a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:domain biolink:NamedThing ;
 	rdfs:label "systematic synonym" ;
-	rdfs:range biolink:label_type ;
+	rdfs:range biolink:LabelType ;
 	rdfs:subPropertyOf biolink:node_property ;
 	skos:definition "more commonly used for gene symbols in yeast" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5701,7 +5705,7 @@ biolink:taxon_of a owl:ObjectProperty , linkml:SlotDefinition ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
 biolink:temporal_context_qualifier a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "temporal context qualifier" ;
-	rdfs:range biolink:time_type ;
+	rdfs:range biolink:TimeType ;
 	rdfs:subPropertyOf biolink:qualifier ;
 	skos:definition "a constraint of time placed upon the truth value of an association. for time intervales, use temporal interval qualifier." ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5734,11 +5738,9 @@ biolink:tested_by_preclinical_trials_of a owl:ObjectProperty , linkml:SlotDefini
 	rdfs:subPropertyOf biolink:subject_of_treatment_application_or_study_for_treatment_by , biolink:treated_in_studies_by ;
 	owl:inverseOf biolink:in_preclinical_trials_for ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
-biolink:time_type a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:Time .
 biolink:timepoint a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "timepoint" ;
-	rdfs:range biolink:time_type ;
+	rdfs:range biolink:TimeType ;
 	skos:altLabel "duration" ;
 	skos:definition "a point in time" ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
@@ -5840,8 +5842,6 @@ biolink:type a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "type" ;
 	skos:exactMatch gff3:type , gpi:DB_Object_Type ;
 	skos:inScheme <https://w3id.org/biolink/biolink-model> .
-biolink:unit a owl:Class , linkml:TypeDefinition ;
-	rdfs:subClassOf linkml:String .
 biolink:update_date a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "update date" ;
 	rdfs:range linkml:Date ;
@@ -5911,2821 +5911,2821 @@ _:c14n1 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:anatomical_context_qualifier .
 _:c14n10 a owl:Restriction ;
-	rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation ;
+	rdfs:subClassOf biolink:WebPage ;
 	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation .
+	owl:someValuesFrom biolink:WebPage .
 _:c14n100 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
 _:c14n1000 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:description .
+	rdfs:subClassOf biolink:RNAProductIsoform ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:RNAProductIsoform .
 _:c14n1001 a owl:Restriction ;
-	owl:maxCardinality 1 ;
+	owl:allValuesFrom biolink:NucleicAcidEntity ;
+	owl:onProperty biolink:object .
+_:c14n1002 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalEntity ;
 	owl:onProperty biolink:subject .
-_:c14n1002 rdf:first biolink:PhaseEnum\#0 ;
-	rdf:rest _:c14n1076 .
 _:c14n1003 a owl:Restriction ;
-	owl:allValuesFrom biolink:LifeStage ;
-	owl:onProperty biolink:stage_qualifier .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:latitude .
 _:c14n1004 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:description .
 _:c14n1005 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:has_biological_sequence .
-_:c14n1006 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
+	owl:allValuesFrom biolink:PredicateType ;
 	owl:onProperty biolink:predicate .
-_:c14n1007 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:format .
-_:c14n1008 rdf:first biolink:ClinicalApprovalStatusEnum\#not_approved_for_condition ;
-	rdf:rest _:c14n1660 .
+_:c14n1006 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1007 rdf:first biolink:PhaseEnum\#0 ;
+	rdf:rest _:c14n1081 .
+_:c14n1008 a owl:Restriction ;
+	owl:allValuesFrom biolink:LifeStage ;
+	owl:onProperty biolink:stage_qualifier .
 _:c14n1009 a owl:Restriction ;
-	rdfs:subClassOf biolink:DatasetSummary ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:DatasetSummary .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
 _:c14n101 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_context_qualifier .
 _:c14n1010 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:has_biological_sequence .
+_:c14n1011 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1012 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:format .
+_:c14n1013 rdf:first biolink:ClinicalApprovalStatusEnum\#not_approved_for_condition ;
+	rdf:rest _:c14n1664 .
+_:c14n1014 a owl:Restriction ;
+	rdfs:subClassOf biolink:DatasetSummary ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:DatasetSummary .
+_:c14n1015 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1011 a owl:Restriction ;
+_:c14n1016 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:qualifiers .
-_:c14n1012 a owl:Restriction ;
+_:c14n1017 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1013 a owl:Restriction ;
+_:c14n1018 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1014 a owl:Restriction ;
+_:c14n1019 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1015 a owl:Restriction ;
-	rdfs:subClassOf biolink:ClinicalFinding ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ClinicalFinding .
-_:c14n1016 a owl:Restriction ;
-	owl:allValuesFrom biolink:OntologyClass ;
-	owl:onProperty biolink:has_attribute_type .
-_:c14n1017 a owl:Restriction ;
-	rdfs:subClassOf biolink:DiseaseToExposureEventAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:DiseaseToExposureEventAssociation .
-_:c14n1018 a owl:Restriction ;
-	rdfs:subClassOf biolink:Polypeptide ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Polypeptide .
-_:c14n1019 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_aspect_qualifier .
 _:c14n102 a owl:Restriction ;
 	rdfs:subClassOf biolink:BehavioralExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:BehavioralExposure .
 _:c14n1020 a owl:Restriction ;
+	rdfs:subClassOf biolink:ClinicalFinding ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ClinicalFinding .
+_:c14n1021 a owl:Restriction ;
+	owl:allValuesFrom biolink:OntologyClass ;
+	owl:onProperty biolink:has_attribute_type .
+_:c14n1022 a owl:Restriction ;
+	rdfs:subClassOf biolink:DiseaseToExposureEventAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:DiseaseToExposureEventAssociation .
+_:c14n1023 a owl:Restriction ;
+	rdfs:subClassOf biolink:Polypeptide ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Polypeptide .
+_:c14n1024 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n1025 a owl:Restriction ;
 	rdfs:subClassOf biolink:TranscriptToGeneRelationship ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:TranscriptToGeneRelationship .
-_:c14n1021 rdf:first biolink:ReactionDirectionEnum\#bidirectional ;
-	rdf:rest _:c14n1147 .
-_:c14n1022 rdf:first biolink:Genotype ;
-	rdf:rest _:c14n1838 .
-_:c14n1023 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_count .
-_:c14n1024 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneProductMixin ;
-	owl:onProperty biolink:object .
-_:c14n1025 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:longitude .
-_:c14n1026 a owl:Restriction ;
-	rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:PairwiseGeneToGeneInteraction .
+_:c14n1026 rdf:first biolink:ReactionDirectionEnum\#bidirectional ;
+	rdf:rest _:c14n1152 .
 _:c14n1027 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:subject .
-_:c14n1028 a owl:Restriction ;
-	rdfs:subClassOf biolink:ReactionToCatalystAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ReactionToCatalystAssociation .
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n1028 rdf:first biolink:Genotype ;
+	rdf:rest _:c14n1839 .
 _:c14n1029 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:has_count .
 _:c14n103 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1030 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneProductMixin ;
+	owl:onProperty biolink:object .
+_:c14n1031 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:longitude .
+_:c14n1032 a owl:Restriction ;
+	rdfs:subClassOf biolink:PairwiseGeneToGeneInteraction ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:PairwiseGeneToGeneInteraction .
+_:c14n1033 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:subject .
+_:c14n1034 a owl:Restriction ;
+	rdfs:subClassOf biolink:ReactionToCatalystAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ReactionToCatalystAssociation .
+_:c14n1035 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1036 a owl:Restriction ;
 	owl:allValuesFrom biolink:PhysicalEntity ;
 	owl:onProperty biolink:enabled_by .
-_:c14n1031 a owl:Restriction ;
+_:c14n1037 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1032 a owl:Restriction ;
+_:c14n1038 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:stoichiometry .
-_:c14n1033 a owl:Restriction ;
+_:c14n1039 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n1034 rdf:first biolink:SequenceEnum\#aa ;
-	rdf:rest rdf:nil .
-_:c14n1035 a owl:Restriction ;
-	rdfs:subClassOf biolink:CorrelatedGeneToDiseaseAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:CorrelatedGeneToDiseaseAssociation .
-_:c14n1036 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1037 rdf:first biolink:SequenceVariant ;
-	rdf:rest _:c14n1811 .
-_:c14n1038 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1039 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:full_name .
 _:c14n104 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:enabled_by .
-_:c14n1040 rdf:first biolink:OrganismalEntity ;
-	rdf:rest _:c14n42 .
+_:c14n1040 rdf:first biolink:SequenceEnum\#aa ;
+	rdf:rest rdf:nil .
 _:c14n1041 a owl:Restriction ;
+	rdfs:subClassOf biolink:CorrelatedGeneToDiseaseAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:CorrelatedGeneToDiseaseAssociation .
+_:c14n1042 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1043 rdf:first biolink:SequenceVariant ;
+	rdf:rest _:c14n1813 .
+_:c14n1044 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1045 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:full_name .
+_:c14n1046 rdf:first biolink:OrganismalEntity ;
+	rdf:rest _:c14n40 .
+_:c14n1047 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:id .
-_:c14n1042 a owl:Restriction ;
+_:c14n1048 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:xref .
-_:c14n1043 a owl:Restriction ;
+_:c14n1049 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneticInheritance ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneticInheritance .
-_:c14n1044 a owl:Restriction ;
+_:c14n105 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase ;
+	rdf:rest _:c14n1627 .
+_:c14n1050 a owl:Restriction ;
 	rdfs:subClassOf biolink:Onset ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Onset .
-_:c14n1045 a owl:Restriction ;
+_:c14n1051 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:highest_FDA_approval_status .
-_:c14n1046 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:iso_abbreviation .
-_:c14n1047 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n1048 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:subject .
-_:c14n1049 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:available_from .
-_:c14n105 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase ;
-	rdf:rest _:c14n1623 .
-_:c14n1050 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1051 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:in_taxon_label .
 _:c14n1052 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:ingest_date .
+	owl:onProperty biolink:iso_abbreviation .
 _:c14n1053 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:stage_qualifier .
+	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
 _:c14n1054 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_count .
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:subject .
 _:c14n1055 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:start_interbase_coordinate .
+	owl:onProperty biolink:available_from .
 _:c14n1056 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n1057 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:species_context_qualifier .
+	owl:onProperty biolink:in_taxon_label .
 _:c14n1058 a owl:Restriction ;
-	rdfs:subClassOf biolink:Serial ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Serial .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:ingest_date .
 _:c14n1059 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:in_taxon .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:stage_qualifier .
 _:c14n106 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:anatomical_context_qualifier .
 _:c14n1060 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_count .
 _:c14n1061 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:start_interbase_coordinate .
+_:c14n1062 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1063 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:species_context_qualifier .
+_:c14n1064 a owl:Restriction ;
+	rdfs:subClassOf biolink:Serial ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Serial .
+_:c14n1065 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:in_taxon .
+_:c14n1066 a owl:Restriction ;
 	owl:allValuesFrom biolink:ReactionDirectionEnum ;
 	owl:onProperty biolink:reaction_direction .
-_:c14n1062 a owl:Restriction ;
+_:c14n1067 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1063 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1064 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1065 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_quotient .
-_:c14n1066 a owl:Restriction ;
-	rdfs:subClassOf biolink:GeneToExpressionSiteAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:GeneToExpressionSiteAssociation .
-_:c14n1067 rdf:first biolink:ApprovalStatusEnum\#fda_priority_review ;
-	rdf:rest _:c14n441 .
 _:c14n1068 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
 _:c14n1069 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:predicate .
 _:c14n107 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1070 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:has_quotient .
 _:c14n1071 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:qualified_predicate .
-_:c14n1072 a owl:Restriction ;
+	rdfs:subClassOf biolink:GeneToExpressionSiteAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:GeneToExpressionSiteAssociation .
+_:c14n1072 rdf:first biolink:ApprovalStatusEnum\#fda_priority_review ;
+	rdf:rest _:c14n448 .
+_:c14n1073 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1074 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1073 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:qualified_predicate .
-_:c14n1074 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#interaction ;
-	rdf:rest _:c14n98 .
 _:c14n1075 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1076 rdf:first biolink:PhaseEnum\#1 ;
-	rdf:rest _:c14n1123 .
+	owl:onProperty biolink:predicate .
+_:c14n1076 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:qualified_predicate .
 _:c14n1077 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1078 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:license .
-_:c14n1079 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_part_qualifier .
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:qualified_predicate .
+_:c14n1079 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#interaction ;
+	rdf:rest _:c14n98 .
 _:c14n108 rdf:first biolink:LifeStage ;
-	rdf:rest _:c14n1603 .
+	rdf:rest _:c14n1606 .
 _:c14n1080 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:max_research_phase .
-_:c14n1081 a owl:Restriction ;
-	owl:allValuesFrom biolink:NucleicAcidEntity ;
 	owl:onProperty biolink:object .
+_:c14n1081 rdf:first biolink:PhaseEnum\#1 ;
+	rdf:rest _:c14n1127 .
 _:c14n1082 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:object .
 _:c14n1083 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty biolink:negated .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:license .
 _:c14n1084 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_part_qualifier .
 _:c14n1085 a owl:Restriction ;
-	owl:allValuesFrom biolink:PhenotypicFeature ;
-	owl:onProperty biolink:subject .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:max_research_phase .
 _:c14n1086 a owl:Restriction ;
-	rdfs:subClassOf biolink:IndividualOrganism ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:IndividualOrganism .
+	owl:allValuesFrom biolink:NucleicAcidEntity ;
+	owl:onProperty biolink:object .
 _:c14n1087 a owl:Restriction ;
-	owl:minCardinality 1 ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1088 a owl:Restriction ;
-	rdfs:subClassOf biolink:Hospitalization ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Hospitalization .
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty biolink:negated .
 _:c14n1089 a owl:Restriction ;
-	rdfs:subClassOf biolink:Device ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Device .
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
 _:c14n109 a owl:Restriction ;
 	owl:allValuesFrom biolink:OrganismTaxon ;
 	owl:onProperty biolink:subject .
 _:c14n1090 a owl:Restriction ;
-	owl:allValuesFrom biolink:DruggableGeneCategoryEnum ;
-	owl:onProperty biolink:has_evidence .
+	owl:allValuesFrom biolink:PhenotypicFeature ;
+	owl:onProperty biolink:subject .
 _:c14n1091 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	rdfs:subClassOf biolink:IndividualOrganism ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:IndividualOrganism .
 _:c14n1092 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1093 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:object .
+	rdfs:subClassOf biolink:Hospitalization ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Hospitalization .
 _:c14n1094 a owl:Restriction ;
+	rdfs:subClassOf biolink:Device ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Device .
+_:c14n1095 a owl:Restriction ;
+	owl:allValuesFrom biolink:DruggableGeneCategoryEnum ;
+	owl:onProperty biolink:has_evidence .
+_:c14n1096 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1097 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1095 rdf:first biolink:RetrievalSource ;
-	rdf:rest _:c14n715 .
-_:c14n1096 a owl:Restriction ;
+_:c14n1098 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:object .
+_:c14n1099 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n11 a owl:Restriction ;
+	rdfs:subClassOf biolink:BiologicalSex ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:BiologicalSex .
+_:c14n110 rdf:first biolink:DirectionQualifierEnum\#downregulated ;
+	rdf:rest rdf:nil .
+_:c14n1100 rdf:first biolink:RetrievalSource ;
+	rdf:rest _:c14n718 .
+_:c14n1101 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenotypeToVariantAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenotypeToVariantAssociation .
-_:c14n1097 a owl:Restriction ;
+_:c14n1102 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_context_qualifier .
-_:c14n1098 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1099 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n11 a owl:Restriction ;
-	rdfs:subClassOf biolink:WebPage ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:WebPage .
-_:c14n110 rdf:first biolink:DirectionQualifierEnum\#downregulated ;
-	rdf:rest rdf:nil .
-_:c14n1100 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1101 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntity ;
-	owl:onProperty biolink:object .
-_:c14n1102 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
 _:c14n1103 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
 _:c14n1104 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:object .
 _:c14n1105 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
+	owl:allValuesFrom biolink:ChemicalEntity ;
 	owl:onProperty biolink:object .
 _:c14n1106 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:population_context_qualifier .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n1107 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:address .
-_:c14n1108 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:qualifier .
-_:c14n1109 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ubiquitination ;
-	rdf:rest _:c14n198 .
+	owl:onProperty biolink:predicate .
+_:c14n1108 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1109 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:object .
 _:c14n111 a owl:Restriction ;
 	owl:allValuesFrom biolink:MolecularEntity ;
 	owl:onProperty biolink:subject .
 _:c14n1110 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:population_context_qualifier .
+_:c14n1111 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:address .
+_:c14n1112 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:qualifier .
+_:c14n1113 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ubiquitination ;
+	rdf:rest _:c14n200 .
+_:c14n1114 a owl:Restriction ;
 	owl:allValuesFrom biolink:ChemicalEntity ;
 	owl:onProperty biolink:object .
-_:c14n1111 a owl:Restriction ;
+_:c14n1115 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1112 a owl:Restriction ;
+_:c14n1116 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1113 a owl:Restriction ;
+_:c14n1117 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:has_attribute .
-_:c14n1114 a owl:Restriction ;
+_:c14n1118 a owl:Restriction ;
 	rdfs:subClassOf biolink:NoncodingRNAProduct ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:NoncodingRNAProduct .
-_:c14n1115 a owl:Restriction ;
+_:c14n1119 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:object .
-_:c14n1116 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#localization ;
-	rdf:rest _:c14n662 .
-_:c14n1117 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1118 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n1119 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n112 a owl:Restriction ;
 	rdfs:subClassOf biolink:DiagnosticAid ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DiagnosticAid .
-_:c14n1120 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_form_or_variant_qualifier .
+_:c14n1120 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#localization ;
+	rdf:rest _:c14n663 .
 _:c14n1121 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:type .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
 _:c14n1122 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:retrieval_source_ids .
-_:c14n1123 rdf:first biolink:PhaseEnum\#2 ;
-	rdf:rest rdf:nil .
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n1123 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
 _:c14n1124 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:object_form_or_variant_qualifier .
 _:c14n1125 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:type .
+_:c14n1126 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:retrieval_source_ids .
+_:c14n1127 rdf:first biolink:PhaseEnum\#2 ;
+	rdf:rest rdf:nil .
+_:c14n1128 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1129 a owl:Restriction ;
 	rdfs:subClassOf biolink:PhysiologicalProcess ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PhysiologicalProcess .
-_:c14n1126 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:deprecated .
-_:c14n1127 a owl:Restriction ;
-	rdfs:subClassOf biolink:ObservedExpectedFrequencyAnalysisResult ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ObservedExpectedFrequencyAnalysisResult .
-_:c14n1128 a owl:Restriction ;
-	owl:allValuesFrom biolink:SocioeconomicAttribute ;
-	owl:onProperty biolink:has_attribute .
-_:c14n1129 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:object_aspect_qualifier .
 _:c14n113 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
 _:c14n1130 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_gene .
+	owl:onProperty biolink:deprecated .
 _:c14n1131 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:species_context_qualifier .
+	owl:allValuesFrom biolink:LabelType ;
+	owl:onProperty biolink:name .
 _:c14n1132 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
+	rdfs:subClassOf biolink:ObservedExpectedFrequencyAnalysisResult ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ObservedExpectedFrequencyAnalysisResult .
 _:c14n1133 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom biolink:SocioeconomicAttribute ;
+	owl:onProperty biolink:has_attribute .
 _:c14n1134 a owl:Restriction ;
-	owl:minCardinality 0 ;
+	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:object_aspect_qualifier .
 _:c14n1135 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:address .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_gene .
 _:c14n1136 a owl:Restriction ;
-	owl:allValuesFrom linkml:Integer ;
-	owl:onProperty biolink:has_total .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:species_context_qualifier .
 _:c14n1137 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1138 rdf:first biolink:ApprovalStatusEnum\#fda_fast_track ;
-	rdf:rest _:c14n296 .
+_:c14n1138 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
 _:c14n1139 a owl:Restriction ;
-	rdfs:subClassOf biolink:ConceptCountAnalysisResult ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ConceptCountAnalysisResult .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_aspect_qualifier .
 _:c14n114 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:qualified_predicate .
 _:c14n1140 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:mapped_predicate .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:address .
 _:c14n1141 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_aspect_qualifier .
+	owl:allValuesFrom linkml:Integer ;
+	owl:onProperty biolink:has_total .
 _:c14n1142 a owl:Restriction ;
-	owl:allValuesFrom linkml:Uriorcurie ;
-	owl:onProperty biolink:affiliation .
-_:c14n1143 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:id .
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:subject .
+_:c14n1143 rdf:first biolink:ApprovalStatusEnum\#fda_fast_track ;
+	rdf:rest _:c14n300 .
 _:c14n1144 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:narrow_match .
+	rdfs:subClassOf biolink:ConceptCountAnalysisResult ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ConceptCountAnalysisResult .
 _:c14n1145 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_aspect_qualifier .
+	owl:onProperty biolink:mapped_predicate .
 _:c14n1146 a owl:Restriction ;
-	owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
-	owl:onProperty biolink:object .
-_:c14n1147 rdf:first biolink:ReactionDirectionEnum\#neutral ;
-	rdf:rest rdf:nil .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_aspect_qualifier .
+_:c14n1147 a owl:Restriction ;
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty biolink:affiliation .
 _:c14n1148 a owl:Restriction ;
-	rdfs:subClassOf biolink:ConfidenceLevel ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ConfidenceLevel .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:id .
 _:c14n1149 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:narrow_match .
 _:c14n115 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_input .
 _:c14n1150 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_aspect_qualifier .
 _:c14n1151 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:object_namespace .
-_:c14n1152 a owl:Restriction ;
-	owl:allValuesFrom biolink:NucleicAcidEntity ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
+	owl:onProperty biolink:object .
+_:c14n1152 rdf:first biolink:ReactionDirectionEnum\#neutral ;
+	rdf:rest rdf:nil .
 _:c14n1153 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-	owl:onProperty biolink:object_form_or_variant_qualifier .
+	rdfs:subClassOf biolink:ConfidenceLevel ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ConfidenceLevel .
 _:c14n1154 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_output .
+	owl:onProperty biolink:object .
 _:c14n1155 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1156 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:object_namespace .
+_:c14n1157 a owl:Restriction ;
+	owl:allValuesFrom biolink:NucleicAcidEntity ;
+	owl:onProperty biolink:subject .
+_:c14n1158 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+	owl:onProperty biolink:object_form_or_variant_qualifier .
+_:c14n1159 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:has_output .
+_:c14n116 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#splicing ;
+	rdf:rest _:c14n58 .
+_:c14n1160 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1156 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#aggregation ;
-	rdf:rest _:c14n1074 .
-_:c14n1157 a owl:Restriction ;
+_:c14n1161 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#aggregation ;
+	rdf:rest _:c14n1079 .
+_:c14n1162 a owl:Restriction ;
+	owl:allValuesFrom biolink:TimeType ;
+	owl:onProperty biolink:temporal_context_qualifier .
+_:c14n1163 a owl:Restriction ;
 	owl:allValuesFrom linkml:Uriorcurie ;
 	owl:onProperty biolink:published_in .
-_:c14n1158 a owl:Restriction ;
+_:c14n1164 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1159 a owl:Restriction ;
+_:c14n1165 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n116 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#splicing ;
-	rdf:rest _:c14n60 .
-_:c14n1160 a owl:Restriction ;
+_:c14n1166 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:expression_site .
-_:c14n1161 a owl:Restriction ;
+_:c14n1167 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1162 a owl:Restriction ;
+_:c14n1168 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n1163 rdf:first biolink:CausalMechanismQualifierEnum\#stabilization ;
-	rdf:rest _:c14n626 .
-_:c14n1164 a owl:Restriction ;
-	rdfs:subClassOf biolink:VariantToPopulationAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:VariantToPopulationAssociation .
-_:c14n1165 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1166 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1167 a owl:Restriction ;
-	rdfs:subClassOf biolink:NucleicAcidEntity ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:NucleicAcidEntity .
-_:c14n1168 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1169 a owl:Restriction ;
-	owl:allValuesFrom linkml:Float ;
-	owl:onProperty biolink:p_value .
+_:c14n1169 rdf:first biolink:CausalMechanismQualifierEnum\#stabilization ;
+	rdf:rest _:c14n629 .
 _:c14n117 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_part_qualifier .
-_:c14n1170 rdf:first biolink:IndividualOrganism ;
-	rdf:rest _:c14n108 .
+_:c14n1170 a owl:Restriction ;
+	rdfs:subClassOf biolink:VariantToPopulationAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:VariantToPopulationAssociation .
 _:c14n1171 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1172 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1173 a owl:Restriction ;
+	rdfs:subClassOf biolink:NucleicAcidEntity ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:NucleicAcidEntity .
+_:c14n1174 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1175 a owl:Restriction ;
+	owl:allValuesFrom linkml:Float ;
+	owl:onProperty biolink:p_value .
+_:c14n1176 rdf:first biolink:IndividualOrganism ;
+	rdf:rest _:c14n108 .
+_:c14n1177 a owl:Restriction ;
 	owl:allValuesFrom biolink:ResourceRoleEnum ;
 	owl:onProperty biolink:resource_role .
-_:c14n1172 a owl:Restriction ;
+_:c14n1178 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n1173 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n1174 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:timepoint .
-_:c14n1175 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1176 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n1177 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntity ;
-	owl:onProperty biolink:object .
-_:c14n1178 a owl:Restriction ;
-	owl:allValuesFrom linkml:Uriorcurie ;
-	owl:onProperty biolink:upstream_resource_ids .
 _:c14n1179 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_direction_qualifier .
+	owl:onProperty biolink:timepoint .
 _:c14n118 a owl:Restriction ;
 	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:object .
 _:c14n1180 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:frequency_qualifier .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n1181 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:id .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_aspect_qualifier .
 _:c14n1182 a owl:Restriction ;
-	owl:allValuesFrom biolink:Agent ;
+	owl:allValuesFrom biolink:ChemicalEntity ;
 	owl:onProperty biolink:object .
 _:c14n1183 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty biolink:upstream_resource_ids .
 _:c14n1184 a owl:Restriction ;
-	rdfs:subClassOf biolink:MaterialSample ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:MaterialSample .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_direction_qualifier .
 _:c14n1185 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:volume .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:frequency_qualifier .
 _:c14n1186 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntity ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:id .
 _:c14n1187 a owl:Restriction ;
-	owl:allValuesFrom biolink:SequenceVariant ;
+	owl:allValuesFrom biolink:Agent ;
 	owl:onProperty biolink:object .
 _:c14n1188 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1189 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase_4 ;
-	rdf:rest _:c14n1255 .
+_:c14n1189 a owl:Restriction ;
+	rdfs:subClassOf biolink:MaterialSample ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:MaterialSample .
 _:c14n119 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:anatomical_context_qualifier .
 _:c14n1190 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:volume .
+_:c14n1191 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalEntity ;
+	owl:onProperty biolink:subject .
+_:c14n1192 a owl:Restriction ;
+	owl:allValuesFrom biolink:SequenceVariant ;
+	owl:onProperty biolink:object .
+_:c14n1193 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1194 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase_4 ;
+	rdf:rest _:c14n1260 .
+_:c14n1195 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1191 a owl:Restriction ;
+_:c14n1196 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:distribution_download_url .
-_:c14n1192 a owl:Restriction ;
+_:c14n1197 a owl:Restriction ;
 	rdfs:subClassOf biolink:InformationContentEntity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:InformationContentEntity .
-_:c14n1193 a owl:Restriction ;
+_:c14n1198 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:species_context_qualifier .
-_:c14n1194 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#secretion ;
-	rdf:rest _:c14n1524 .
-_:c14n1195 a owl:Restriction ;
-	owl:allValuesFrom biolink:ClinicalApprovalStatusEnum ;
-	owl:onProperty biolink:clinical_approval_status .
-_:c14n1196 a owl:Restriction ;
-	owl:allValuesFrom biolink:Case ;
-	owl:onProperty biolink:subject .
-_:c14n1197 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1198 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#farnesylation ;
-	rdf:rest _:c14n1439 .
-_:c14n1199 a owl:Restriction ;
-	owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
-	owl:onProperty biolink:phenotypic_state .
+_:c14n1199 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#secretion ;
+	rdf:rest _:c14n1528 .
 _:c14n12 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:anatomical_context_qualifier .
 _:c14n120 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
 _:c14n1200 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
+	owl:allValuesFrom biolink:ClinicalApprovalStatusEnum ;
+	owl:onProperty biolink:clinical_approval_status .
 _:c14n1201 a owl:Restriction ;
-	owl:allValuesFrom biolink:Dataset ;
-	owl:onProperty biolink:has_dataset .
-_:c14n1202 rdf:first biolink:ConfidenceLevel ;
-	rdf:rest _:c14n381 .
-_:c14n1203 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-	owl:onProperty biolink:object_form_or_variant_qualifier .
+	owl:allValuesFrom biolink:Case ;
+	owl:onProperty biolink:subject .
+_:c14n1202 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1203 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#farnesylation ;
+	rdf:rest _:c14n1444 .
 _:c14n1204 a owl:Restriction ;
 	owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:phenotypic_state .
 _:c14n1205 a owl:Restriction ;
-	owl:allValuesFrom biolink:frequency_value ;
-	owl:onProperty biolink:frequency_qualifier .
-_:c14n1206 a owl:Restriction ;
+	owl:allValuesFrom biolink:Dataset ;
+	owl:onProperty biolink:has_dataset .
+_:c14n1206 rdf:first biolink:ConfidenceLevel ;
+	rdf:rest _:c14n387 .
+_:c14n1207 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+	owl:onProperty biolink:object_form_or_variant_qualifier .
+_:c14n1208 a owl:Restriction ;
+	owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
+	owl:onProperty biolink:subject .
+_:c14n1209 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n1207 a owl:Restriction ;
-	rdfs:subClassOf biolink:Behavior ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Behavior .
-_:c14n1208 rdf:first biolink:FDAIDAAdverseEventEnum\#unexpected_adverse_event ;
-	rdf:rest rdf:nil .
-_:c14n1209 rdf:first biolink:TextMiningResult ;
-	rdf:rest rdf:nil .
 _:c14n121 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:chapter .
 _:c14n1210 a owl:Restriction ;
+	rdfs:subClassOf biolink:Behavior ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Behavior .
+_:c14n1211 rdf:first biolink:FDAIDAAdverseEventEnum\#unexpected_adverse_event ;
+	rdf:rest rdf:nil .
+_:c14n1212 rdf:first biolink:TextMiningResult ;
+	rdf:rest rdf:nil .
+_:c14n1213 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:mapped_predicate .
-_:c14n1211 a owl:Restriction ;
+_:c14n1214 a owl:Restriction ;
 	rdfs:subClassOf biolink:FunctionalAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:FunctionalAssociation .
-_:c14n1212 a owl:Restriction ;
+_:c14n1215 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1213 a owl:Restriction ;
+_:c14n1216 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n1214 a owl:Restriction ;
+_:c14n1217 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1215 a owl:Restriction ;
+_:c14n1218 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_category .
-_:c14n1216 a owl:Restriction ;
+_:c14n1219 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1217 rdf:first biolink:DruggableGeneCategoryEnum\#tchem ;
-	rdf:rest _:c14n375 .
-_:c14n1218 a owl:Restriction ;
-	owl:allValuesFrom biolink:MolecularEntity ;
-	owl:onProperty biolink:subject .
-_:c14n1219 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:mesh_terms .
 _:c14n122 a owl:Restriction ;
 	rdfs:subClassOf biolink:DrugToGeneInteractionExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DrugToGeneInteractionExposure .
-_:c14n1220 a owl:Restriction ;
+_:c14n1220 rdf:first biolink:DruggableGeneCategoryEnum\#tchem ;
+	rdf:rest _:c14n381 .
+_:c14n1221 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n1222 a owl:Restriction ;
+	owl:allValuesFrom biolink:MolecularEntity ;
+	owl:onProperty biolink:subject .
+_:c14n1223 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:mesh_terms .
+_:c14n1224 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1221 a owl:Restriction ;
+_:c14n1225 a owl:Restriction ;
 	rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureExposure .
-_:c14n1222 rdf:first biolink:ReactionSideEnum\#right ;
+_:c14n1226 rdf:first biolink:ReactionSideEnum\#right ;
 	rdf:rest rdf:nil .
-_:c14n1223 a owl:Restriction ;
+_:c14n1227 a owl:Restriction ;
 	owl:allValuesFrom biolink:DirectionQualifierEnum ;
 	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n1224 a owl:Restriction ;
+_:c14n1228 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneToDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneToDiseaseAssociation .
-_:c14n1225 a owl:Restriction ;
+_:c14n1229 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneticInheritance ;
 	owl:onProperty biolink:object .
-_:c14n1226 rdf:first biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
-	rdf:rest _:c14n1486 .
-_:c14n1227 a owl:Restriction ;
-	rdfs:subClassOf biolink:SequenceVariant ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:SequenceVariant .
-_:c14n1228 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_total .
-_:c14n1229 a owl:Restriction ;
-	owl:allValuesFrom biolink:OntologyClass ;
-	owl:onProperty biolink:subject_category .
 _:c14n123 a owl:Restriction ;
 	rdfs:subClassOf biolink:PreprintPublication ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PreprintPublication .
-_:c14n1230 a owl:Restriction ;
+_:c14n1230 rdf:first biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
+	rdf:rest _:c14n1491 .
+_:c14n1231 a owl:Restriction ;
+	rdfs:subClassOf biolink:SequenceVariant ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:SequenceVariant .
+_:c14n1232 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_total .
+_:c14n1233 a owl:Restriction ;
+	owl:allValuesFrom biolink:OntologyClass ;
+	owl:onProperty biolink:subject_category .
+_:c14n1234 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1231 a owl:Restriction ;
+_:c14n1235 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_form_or_variant_qualifier .
-_:c14n1232 a owl:Restriction ;
+_:c14n1236 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1233 a owl:Restriction ;
+_:c14n1237 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1234 a owl:Restriction ;
+_:c14n1238 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n1235 a owl:Restriction ;
+_:c14n1239 a owl:Restriction ;
 	owl:allValuesFrom biolink:EvidenceType ;
 	owl:onProperty biolink:has_evidence .
-_:c14n1236 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:object_context_qualifier .
-_:c14n1237 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1238 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:ingest_date .
-_:c14n1239 a owl:Restriction ;
-	owl:allValuesFrom biolink:Drug ;
-	owl:onProperty biolink:subject .
 _:c14n124 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1240 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_direction_qualifier .
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:object_context_qualifier .
 _:c14n1241 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1242 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
+_:c14n1242 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:ingest_date .
 _:c14n1243 a owl:Restriction ;
+	owl:allValuesFrom biolink:Drug ;
+	owl:onProperty biolink:subject .
+_:c14n1244 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_direction_qualifier .
+_:c14n1245 a owl:Restriction ;
+	owl:allValuesFrom biolink:TimeType ;
+	owl:onProperty biolink:timepoint .
+_:c14n1246 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1247 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1248 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_part_qualifier .
-_:c14n1244 a owl:Restriction ;
+_:c14n1249 a owl:Restriction ;
 	rdfs:subClassOf biolink:ClinicalTrial ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ClinicalTrial .
-_:c14n1245 a owl:Restriction ;
-	owl:allValuesFrom biolink:SequenceVariant ;
-	owl:onProperty biolink:subject .
-_:c14n1246 a owl:Restriction ;
-	rdfs:subClassOf biolink:EnvironmentalProcess ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:EnvironmentalProcess .
-_:c14n1247 a owl:Restriction ;
-	rdfs:subClassOf biolink:BiologicalEntity ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:BiologicalEntity .
-_:c14n1248 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1249 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_taxonomic_rank .
 _:c14n125 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_zygosity .
 _:c14n1250 a owl:Restriction ;
+	owl:allValuesFrom biolink:SequenceVariant ;
+	owl:onProperty biolink:subject .
+_:c14n1251 a owl:Restriction ;
+	rdfs:subClassOf biolink:EnvironmentalProcess ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:EnvironmentalProcess .
+_:c14n1252 a owl:Restriction ;
+	rdfs:subClassOf biolink:BiologicalEntity ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:BiologicalEntity .
+_:c14n1253 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1254 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:has_taxonomic_rank .
+_:c14n1255 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:is_metabolite .
-_:c14n1251 a owl:Restriction ;
+_:c14n1256 a owl:Restriction ;
 	rdfs:subClassOf biolink:SocioeconomicAttribute ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:SocioeconomicAttribute .
-_:c14n1252 a owl:Restriction ;
+_:c14n1257 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1253 rdf:first biolink:StrandEnum\#- ;
-	rdf:rest _:c14n1264 .
-_:c14n1254 a owl:Restriction ;
+_:c14n1258 rdf:first biolink:StrandEnum\#- ;
+	rdf:rest _:c14n1269 .
+_:c14n1259 a owl:Restriction ;
 	rdfs:subClassOf biolink:FoodAdditive ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:FoodAdditive .
-_:c14n1255 rdf:first biolink:ResearchPhaseEnum\#not_provided ;
-	rdf:rest rdf:nil .
-_:c14n1256 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1257 a owl:Restriction ;
-	rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonAssociation .
-_:c14n1258 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1259 rdf:first biolink:DrugDeliveryEnum\#intravenous_injection ;
-	rdf:rest rdf:nil .
 _:c14n126 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_context_qualifier .
-_:c14n1260 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:object_context_qualifier .
+_:c14n1260 rdf:first biolink:ResearchPhaseEnum\#not_provided ;
+	rdf:rest rdf:nil .
 _:c14n1261 a owl:Restriction ;
-	owl:allValuesFrom biolink:Outcome ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1262 a owl:Restriction ;
+	rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonAssociation .
+_:c14n1263 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1264 rdf:first biolink:DrugDeliveryEnum\#intravenous_injection ;
+	rdf:rest rdf:nil .
+_:c14n1265 a owl:Restriction ;
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:object_context_qualifier .
+_:c14n1266 a owl:Restriction ;
+	owl:allValuesFrom biolink:Outcome ;
+	owl:onProperty biolink:object .
+_:c14n1267 a owl:Restriction ;
 	owl:allValuesFrom biolink:QuantityValue ;
 	owl:onProperty biolink:has_quantitative_value .
-_:c14n1263 a owl:Restriction ;
+_:c14n1268 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:knowledge_level .
-_:c14n1264 rdf:first <https://w3id.org/biolink/vocab/StrandEnum#.> ;
-	rdf:rest _:c14n661 .
-_:c14n1265 a owl:Restriction ;
+_:c14n1269 rdf:first <https://w3id.org/biolink/vocab/StrandEnum#.> ;
+	rdf:rest _:c14n662 .
+_:c14n127 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n1270 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1266 owl:unionOf _:c14n1291 .
-_:c14n1267 a owl:Restriction ;
+_:c14n1271 owl:unionOf _:c14n1296 .
+_:c14n1272 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:id .
-_:c14n1268 a owl:Restriction ;
+_:c14n1273 a owl:Restriction ;
 	owl:allValuesFrom biolink:BiologicalProcess ;
 	owl:onProperty biolink:object .
-_:c14n1269 a owl:Restriction ;
+_:c14n1274 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n127 a owl:Restriction ;
+_:c14n1275 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:phenotypic_state .
+_:c14n1276 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_output .
+_:c14n1277 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_direction_qualifier .
+_:c14n1278 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1279 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:max_tolerated_dose .
+_:c14n128 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n1280 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:resource_role .
+_:c14n1281 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:summary .
+_:c14n1282 a owl:Restriction ;
+	owl:allValuesFrom biolink:Gene ;
+	owl:onProperty biolink:object .
+_:c14n1283 rdf:first biolink:ApprovalStatusEnum\#fda_accelerated_approval ;
+	rdf:rest _:c14n1072 .
+_:c14n1284 a owl:Restriction ;
+	owl:allValuesFrom biolink:Behavior ;
+	owl:onProperty biolink:subject .
+_:c14n1285 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1286 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1287 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_output .
+_:c14n1288 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:species_context_qualifier .
+_:c14n1289 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:license .
+_:c14n129 a owl:Restriction ;
 	rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonInteraction ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonInteraction .
-_:c14n1270 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:phenotypic_state .
-_:c14n1271 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_output .
-_:c14n1272 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n1273 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n1274 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:max_tolerated_dose .
-_:c14n1275 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:resource_role .
-_:c14n1276 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:summary .
-_:c14n1277 a owl:Restriction ;
-	owl:allValuesFrom biolink:Gene ;
-	owl:onProperty biolink:object .
-_:c14n1278 rdf:first biolink:ApprovalStatusEnum\#fda_accelerated_approval ;
-	rdf:rest _:c14n1067 .
-_:c14n1279 a owl:Restriction ;
-	owl:allValuesFrom biolink:Behavior ;
-	owl:onProperty biolink:subject .
-_:c14n128 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_qualitative_value .
-_:c14n1280 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1281 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n1282 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_output .
-_:c14n1283 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:species_context_qualifier .
-_:c14n1284 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:license .
-_:c14n1285 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1286 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:subject .
-_:c14n1287 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_derivative_qualifier .
-_:c14n1288 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1289 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n129 a owl:Restriction ;
-	rdfs:subClassOf biolink:ChemicalEntityAssessesNamedThingAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ChemicalEntityAssessesNamedThingAssociation .
 _:c14n1290 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1291 rdf:first biolink:AnatomicalEntity ;
-	rdf:rest _:c14n1830 .
+_:c14n1291 a owl:Restriction ;
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:subject .
 _:c14n1292 a owl:Restriction ;
-	owl:allValuesFrom linkml:Double ;
-	owl:onProperty biolink:has_quotient .
-_:c14n1293 rdf:first biolink:ResourceRoleEnum\#aggregator_knowledge_source ;
-	rdf:rest _:c14n137 .
-_:c14n1294 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#snp_form ;
-	rdf:rest _:c14n426 .
-_:c14n1295 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n1296 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_derivative_qualifier .
+_:c14n1293 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1297 a owl:Restriction ;
-	owl:allValuesFrom biolink:PhenotypicFeature ;
-	owl:onProperty biolink:object .
-_:c14n1298 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n1299 a owl:Restriction ;
+	owl:onProperty biolink:subject .
+_:c14n1294 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n13 a owl:Restriction ;
-	rdfs:subClassOf biolink:BiologicalSex ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:BiologicalSex .
-_:c14n130 a owl:Restriction ;
+_:c14n1295 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1300 a owl:Restriction ;
-	owl:allValuesFrom biolink:Pathway ;
 	owl:onProperty biolink:object .
+_:c14n1296 rdf:first biolink:AnatomicalEntity ;
+	rdf:rest _:c14n1831 .
+_:c14n1297 a owl:Restriction ;
+	owl:allValuesFrom linkml:Double ;
+	owl:onProperty biolink:has_quotient .
+_:c14n1298 rdf:first biolink:ResourceRoleEnum\#aggregator_knowledge_source ;
+	rdf:rest _:c14n139 .
+_:c14n1299 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#snp_form ;
+	rdf:rest _:c14n433 .
+_:c14n13 a owl:Restriction ;
+	owl:allValuesFrom biolink:MacromolecularMachineMixin ;
+	owl:onProperty biolink:catalyst_qualifier .
+_:c14n130 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:has_qualitative_value .
+_:c14n1300 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:subject_aspect_qualifier .
 _:c14n1301 a owl:Restriction ;
-	owl:allValuesFrom biolink:SequenceVariant ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom biolink:LabelType ;
+	owl:onProperty biolink:synonym .
 _:c14n1302 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:object .
 _:c14n1303 a owl:Restriction ;
+	owl:allValuesFrom biolink:PhenotypicFeature ;
+	owl:onProperty biolink:object .
+_:c14n1304 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_aspect_qualifier .
+_:c14n1305 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1306 a owl:Restriction ;
+	owl:allValuesFrom biolink:Pathway ;
+	owl:onProperty biolink:object .
+_:c14n1307 a owl:Restriction ;
+	owl:allValuesFrom biolink:SequenceVariant ;
+	owl:onProperty biolink:subject .
+_:c14n1308 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1309 a owl:Restriction ;
 	rdfs:subClassOf biolink:Fungus ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Fungus .
-_:c14n1304 a owl:Restriction ;
+_:c14n131 a owl:Restriction ;
+	rdfs:subClassOf biolink:ChemicalEntityAssessesNamedThingAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ChemicalEntityAssessesNamedThingAssociation .
+_:c14n1310 a owl:Restriction ;
 	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:narrow_match .
-_:c14n1305 a owl:Restriction ;
+_:c14n1311 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1306 a owl:Restriction ;
+_:c14n1312 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
 	owl:onProperty biolink:subject_part_qualifier .
-_:c14n1307 a owl:Restriction ;
+_:c14n1313 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:id .
-_:c14n1308 rdf:first biolink:Exon ;
-	rdf:rest _:c14n799 .
-_:c14n1309 a owl:Restriction ;
+_:c14n1314 rdf:first biolink:Exon ;
+	rdf:rest _:c14n802 .
+_:c14n1315 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n131 rdf:first biolink:KnowledgeLevelEnum\#observation ;
-	rdf:rest _:c14n1481 .
-_:c14n1310 a owl:Restriction ;
+_:c14n1316 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n1311 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#carboxylation ;
+_:c14n1317 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#carboxylation ;
 	rdf:rest rdf:nil .
-_:c14n1312 a owl:Restriction ;
+_:c14n1318 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:iso_abbreviation .
-_:c14n1313 a owl:Restriction ;
+_:c14n1319 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_zygosity .
-_:c14n1314 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#gain_of_function_variant_form ;
-	rdf:rest _:c14n841 .
-_:c14n1315 a owl:Restriction ;
+_:c14n132 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1320 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#gain_of_function_variant_form ;
+	rdf:rest _:c14n845 .
+_:c14n1321 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneAsAModelOfDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneAsAModelOfDiseaseAssociation .
-_:c14n1316 a owl:Restriction ;
+_:c14n1322 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n1317 owl:unionOf _:c14n1226 .
-_:c14n1318 a owl:Restriction ;
+_:c14n1323 owl:unionOf _:c14n1230 .
+_:c14n1324 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:strand .
-_:c14n1319 a owl:Restriction ;
+_:c14n1325 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n132 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n1320 a owl:Restriction ;
+_:c14n1326 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1321 a owl:Restriction ;
+_:c14n1327 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1322 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n1323 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n1324 a owl:Restriction ;
+_:c14n1328 a owl:Restriction ;
 	owl:allValuesFrom biolink:Genotype ;
 	owl:onProperty biolink:subject .
-_:c14n1325 a owl:Restriction ;
+_:c14n1329 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_total .
-_:c14n1326 a owl:Restriction ;
+_:c14n133 rdf:first biolink:KnowledgeLevelEnum\#observation ;
+	rdf:rest _:c14n1486 .
+_:c14n1330 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:knowledge_source .
-_:c14n1327 a owl:Restriction ;
+_:c14n1331 a owl:Restriction ;
 	rdfs:subClassOf biolink:Book ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Book .
-_:c14n1328 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#absorption ;
-	rdf:rest _:c14n1156 .
-_:c14n1329 a owl:Restriction ;
+_:c14n1332 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#absorption ;
+	rdf:rest _:c14n1161 .
+_:c14n1333 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:quantifier_qualifier .
-_:c14n133 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1330 a owl:Restriction ;
+_:c14n1334 a owl:Restriction ;
 	rdfs:subClassOf biolink:BiologicalProcess ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:BiologicalProcess .
-_:c14n1331 a owl:Restriction ;
+_:c14n1335 a owl:Restriction ;
+	owl:allValuesFrom biolink:BiologicalSequence ;
+	owl:onProperty biolink:has_biological_sequence .
+_:c14n1336 a owl:Restriction ;
 	owl:allValuesFrom biolink:OntologyClass ;
 	owl:onProperty biolink:object_context_qualifier .
-_:c14n1332 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:volume .
-_:c14n1333 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n1334 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n1335 a owl:Restriction ;
-	rdfs:subClassOf biolink:BehavioralFeature ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:BehavioralFeature .
-_:c14n1336 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:has_quotient .
 _:c14n1337 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:provided_by .
+	owl:onProperty biolink:volume .
 _:c14n1338 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
 _:c14n1339 a owl:Restriction ;
+	rdfs:subClassOf biolink:BehavioralFeature ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:BehavioralFeature .
+_:c14n134 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n1340 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:has_quotient .
+_:c14n1341 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:provided_by .
+_:c14n1342 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1343 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n134 rdf:first biolink:StrandEnum\#\%2B ;
-	rdf:rest _:c14n1253 .
-_:c14n1340 a owl:Restriction ;
+_:c14n1344 a owl:Restriction ;
 	owl:allValuesFrom biolink:Gene ;
 	owl:onProperty biolink:object .
-_:c14n1341 a owl:Restriction ;
+_:c14n1345 a owl:Restriction ;
 	owl:allValuesFrom biolink:KnowledgeLevelEnum ;
 	owl:onProperty biolink:knowledge_level .
-_:c14n1342 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#sumoylation ;
-	rdf:rest _:c14n1109 .
-_:c14n1343 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1344 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:qualified_predicate .
-_:c14n1345 a owl:Restriction ;
-	owl:allValuesFrom biolink:BiologicalProcess ;
-	owl:onProperty biolink:object .
-_:c14n1346 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
+_:c14n1346 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#sumoylation ;
+	rdf:rest _:c14n1113 .
 _:c14n1347 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:agent_type .
-_:c14n1348 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#3_prime_utr ;
-	rdf:rest _:c14n537 .
+	owl:onProperty biolink:predicate .
+_:c14n1348 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:qualified_predicate .
 _:c14n1349 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n135 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1350 a owl:Restriction ;
+	owl:allValuesFrom biolink:BiologicalProcess ;
+	owl:onProperty biolink:object .
+_:c14n1351 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:agent_type .
+_:c14n1352 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#3_prime_utr ;
+	rdf:rest _:c14n542 .
+_:c14n1353 a owl:Restriction ;
 	rdfs:subClassOf biolink:Pathway ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Pathway .
-_:c14n135 rdf:first biolink:ReactionDirectionEnum\#right_to_left ;
-	rdf:rest _:c14n1021 .
-_:c14n1350 a owl:Restriction ;
+_:c14n1354 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n1351 a owl:Restriction ;
+_:c14n1355 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:summary .
-_:c14n1352 a owl:Restriction ;
+_:c14n1356 a owl:Restriction ;
 	owl:allValuesFrom biolink:IndividualOrganism ;
 	owl:onProperty biolink:object .
-_:c14n1353 a owl:Restriction ;
+_:c14n1357 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1354 a owl:Restriction ;
+_:c14n1358 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1355 a owl:Restriction ;
+_:c14n1359 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1356 a owl:Restriction ;
+_:c14n136 rdf:first biolink:StrandEnum\#\%2B ;
+	rdf:rest _:c14n1258 .
+_:c14n1360 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:original_subject .
-_:c14n1357 rdf:first biolink:DruggableGeneCategoryEnum\#tbio ;
-	rdf:rest _:c14n1217 .
-_:c14n1358 a owl:Restriction ;
+_:c14n1361 rdf:first biolink:DruggableGeneCategoryEnum\#tbio ;
+	rdf:rest _:c14n1220 .
+_:c14n1362 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:name .
-_:c14n1359 a owl:Restriction ;
+_:c14n1363 a owl:Restriction ;
 	rdfs:subClassOf biolink:ReagentTargetedGene ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ReagentTargetedGene .
-_:c14n136 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n1360 a owl:Restriction ;
+_:c14n1364 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:name .
-_:c14n1361 rdf:first biolink:DrugDeliveryEnum\#oral ;
-	rdf:rest _:c14n1744 .
-_:c14n1362 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#activity ;
-	rdf:rest _:c14n1781 .
-_:c14n1363 a owl:Restriction ;
+_:c14n1365 rdf:first biolink:DrugDeliveryEnum\#oral ;
+	rdf:rest _:c14n1747 .
+_:c14n1366 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#activity ;
+	rdf:rest _:c14n1783 .
+_:c14n1367 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n1364 a owl:Restriction ;
+_:c14n1368 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChiSquaredAnalysisResult ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChiSquaredAnalysisResult .
-_:c14n1365 a owl:Restriction ;
+_:c14n1369 a owl:Restriction ;
 	owl:allValuesFrom biolink:DrugDeliveryEnum ;
 	owl:onProperty biolink:routes_of_delivery .
-_:c14n1366 a owl:Restriction ;
+_:c14n137 rdf:first biolink:ReactionDirectionEnum\#right_to_left ;
+	rdf:rest _:c14n1026 .
+_:c14n1370 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
 	owl:onProperty biolink:subject_part_qualifier .
-_:c14n1367 a owl:Restriction ;
+_:c14n1371 a owl:Restriction ;
 	owl:allValuesFrom biolink:MolecularActivity ;
 	owl:onProperty biolink:subject .
-_:c14n1368 a owl:Restriction ;
+_:c14n1372 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:name .
-_:c14n1369 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase_1 ;
-	rdf:rest _:c14n395 .
-_:c14n137 rdf:first biolink:ResourceRoleEnum\#supporting_data_source ;
-	rdf:rest rdf:nil .
-_:c14n1370 a owl:Restriction ;
+_:c14n1373 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase_1 ;
+	rdf:rest _:c14n402 .
+_:c14n1374 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n1371 a owl:Restriction ;
+_:c14n1375 a owl:Restriction ;
 	rdfs:subClassOf biolink:MolecularActivityToChemicalEntityAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:MolecularActivityToChemicalEntityAssociation .
-_:c14n1372 a owl:Restriction ;
+_:c14n1376 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1373 a owl:Restriction ;
+_:c14n1377 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1374 a owl:Restriction ;
+_:c14n1378 a owl:Restriction ;
 	owl:allValuesFrom biolink:MolecularEntity ;
 	owl:onProperty biolink:has_output .
-_:c14n1375 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n1376 a owl:Restriction ;
-	owl:allValuesFrom linkml:Integer ;
-	owl:onProperty biolink:has_count .
-_:c14n1377 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:qualified_predicate .
-_:c14n1378 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n1379 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:subject_derivative_qualifier .
 _:c14n138 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:reaction_side .
-_:c14n1380 a owl:Restriction ;
-	owl:minCardinality 1 ;
+	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
+_:c14n1380 a owl:Restriction ;
+	owl:allValuesFrom linkml:Integer ;
+	owl:onProperty biolink:has_count .
 _:c14n1381 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:creation_date .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:qualified_predicate .
 _:c14n1382 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1383 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_context_qualifier .
-_:c14n1384 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#mutation_rate ;
-	rdf:rest _:c14n1845 .
-_:c14n1385 rdf:first biolink:NucleicAcidSequenceMotif ;
-	rdf:rest _:c14n1512 .
+	owl:onProperty biolink:subject .
+_:c14n1384 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1385 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:creation_date .
 _:c14n1386 a owl:Restriction ;
-	owl:maxCardinality 1 ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1387 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1388 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#polya_tail ;
-	rdf:rest _:c14n1570 .
-_:c14n1389 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:subject .
-_:c14n139 rdf:first biolink:DatasetVersion ;
-	rdf:rest _:c14n946 .
+	owl:onProperty biolink:subject_context_qualifier .
+_:c14n1388 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#mutation_rate ;
+	rdf:rest _:c14n1845 .
+_:c14n1389 rdf:first biolink:NucleicAcidSequenceMotif ;
+	rdf:rest _:c14n1516 .
+_:c14n139 rdf:first biolink:ResourceRoleEnum\#supporting_data_source ;
+	rdf:rest rdf:nil .
 _:c14n1390 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:exact_match .
+	owl:onProperty biolink:subject .
 _:c14n1391 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1392 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#polya_tail ;
+	rdf:rest _:c14n1573 .
+_:c14n1393 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:subject .
+_:c14n1394 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:exact_match .
+_:c14n1395 a owl:Restriction ;
 	rdfs:subClassOf biolink:NucleosomeModification ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:NucleosomeModification .
-_:c14n1392 a owl:Restriction ;
+_:c14n1396 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1393 a owl:Restriction ;
+_:c14n1397 a owl:Restriction ;
+	owl:allValuesFrom biolink:FrequencyValue ;
+	owl:onProperty biolink:frequency_qualifier .
+_:c14n1398 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:rights .
-_:c14n1394 a owl:Restriction ;
+_:c14n1399 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1395 a owl:Restriction ;
+_:c14n14 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n140 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:reaction_side .
+_:c14n1400 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n1396 a owl:Restriction ;
+_:c14n1401 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n1397 a owl:Restriction ;
+_:c14n1402 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalEntityOrGeneOrGeneProductRegulatesGeneAssociation .
-_:c14n1398 a owl:Restriction ;
+_:c14n1403 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:max_research_phase .
-_:c14n1399 a owl:Restriction ;
+_:c14n1404 a owl:Restriction ;
 	rdfs:subClassOf biolink:NucleicAcidSequenceMotif ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:NucleicAcidSequenceMotif .
-_:c14n14 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n140 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1400 a owl:Restriction ;
+_:c14n1405 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:qualified_predicate .
-_:c14n1401 a owl:Restriction ;
+_:c14n1406 a owl:Restriction ;
 	owl:allValuesFrom biolink:DirectionQualifierEnum ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n1402 a owl:Restriction ;
+_:c14n1407 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1403 a owl:Restriction ;
+_:c14n1408 a owl:Restriction ;
 	owl:allValuesFrom biolink:Pathway ;
 	owl:onProperty biolink:object .
-_:c14n1404 a owl:Restriction ;
+_:c14n1409 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:knowledge_source .
-_:c14n1405 a owl:Restriction ;
+_:c14n141 rdf:first biolink:DatasetVersion ;
+	rdf:rest _:c14n950 .
+_:c14n1410 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_context_qualifier .
-_:c14n1406 a owl:Restriction ;
+_:c14n1411 a owl:Restriction ;
 	owl:allValuesFrom biolink:Genotype ;
 	owl:onProperty biolink:subject .
-_:c14n1407 a owl:Restriction ;
+_:c14n1412 a owl:Restriction ;
 	owl:allValuesFrom biolink:MaterialSample ;
 	owl:onProperty biolink:subject .
-_:c14n1408 a owl:Restriction ;
+_:c14n1413 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:category .
-_:c14n1409 a owl:Restriction ;
+_:c14n1414 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:phase .
-_:c14n141 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1410 a owl:Restriction ;
+_:c14n1415 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1411 a owl:Restriction ;
+_:c14n1416 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:primary_knowledge_source .
-_:c14n1412 rdf:first biolink:ChiSquaredAnalysisResult ;
-	rdf:rest _:c14n1567 .
-_:c14n1413 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1414 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1415 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:source_logo .
-_:c14n1416 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
-	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n1417 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+_:c14n1417 rdf:first biolink:ChiSquaredAnalysisResult ;
+	rdf:rest _:c14n1570 .
 _:c14n1418 a owl:Restriction ;
-	owl:minCardinality 1 ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1419 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n142 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1420 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:source_logo .
+_:c14n1421 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
+	owl:onProperty biolink:subject_aspect_qualifier .
+_:c14n1422 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1423 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1424 a owl:Restriction ;
 	rdfs:subClassOf biolink:VariantToGeneExpressionAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:VariantToGeneExpressionAssociation .
-_:c14n142 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1420 a owl:Restriction ;
+_:c14n1425 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n1421 a owl:Restriction ;
+_:c14n1426 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1422 a owl:Restriction ;
+_:c14n1427 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:is_supplement .
-_:c14n1423 a owl:Restriction ;
+_:c14n1428 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1424 a owl:Restriction ;
+_:c14n1429 a owl:Restriction ;
 	rdfs:subClassOf biolink:OrganismTaxon ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:OrganismTaxon .
-_:c14n1425 a owl:Restriction ;
+_:c14n143 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1426 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#phosphorylation ;
-	rdf:rest _:c14n65 .
-_:c14n1427 a owl:Restriction ;
+_:c14n1430 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1431 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#phosphorylation ;
+	rdf:rest _:c14n63 .
+_:c14n1432 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_distribution .
-_:c14n1428 a owl:Restriction ;
+_:c14n1433 a owl:Restriction ;
 	rdfs:subClassOf biolink:MolecularEntity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:MolecularEntity .
-_:c14n1429 a owl:Restriction ;
+_:c14n1434 a owl:Restriction ;
 	rdfs:subClassOf biolink:StudyPopulation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:StudyPopulation .
-_:c14n143 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n1430 a owl:Restriction ;
+_:c14n1435 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:id .
-_:c14n1431 a owl:Restriction ;
+_:c14n1436 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:id .
-_:c14n1432 a owl:Restriction ;
+_:c14n1437 a owl:Restriction ;
 	owl:allValuesFrom linkml:Double ;
 	owl:onProperty biolink:has_numeric_value .
-_:c14n1433 a owl:Restriction ;
+_:c14n1438 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:interacting_molecules_category .
-_:c14n1434 a owl:Restriction ;
+_:c14n1439 a owl:Restriction ;
 	owl:allValuesFrom linkml:Uriorcurie ;
 	owl:onProperty biolink:xref .
-_:c14n1435 a owl:Restriction ;
+_:c14n144 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1440 a owl:Restriction ;
 	rdfs:subClassOf biolink:OrganismalEntityAsAModelOfDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:OrganismalEntityAsAModelOfDiseaseAssociation .
-_:c14n1436 a owl:Restriction ;
+_:c14n1441 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n1437 a owl:Restriction ;
+_:c14n1442 a owl:Restriction ;
 	owl:allValuesFrom biolink:TaxonomicRank ;
 	owl:onProperty biolink:has_taxonomic_rank .
-_:c14n1438 a owl:Restriction ;
+_:c14n1443 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1439 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#geranoylation ;
-	rdf:rest _:c14n881 .
-_:c14n144 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:publication_type .
-_:c14n1440 a owl:Restriction ;
+_:c14n1444 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#geranoylation ;
+	rdf:rest _:c14n884 .
+_:c14n1445 a owl:Restriction ;
 	owl:allValuesFrom biolink:MolecularActivity ;
 	owl:onProperty biolink:subject .
-_:c14n1441 a owl:Restriction ;
+_:c14n1446 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:type .
-_:c14n1442 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#prenylation ;
-	rdf:rest _:c14n394 .
-_:c14n1443 a owl:Restriction ;
+_:c14n1447 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#prenylation ;
+	rdf:rest _:c14n401 .
+_:c14n1448 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:ingest_date .
-_:c14n1444 a owl:Restriction ;
+_:c14n1449 a owl:Restriction ;
 	rdfs:subClassOf biolink:ClinicalMeasurement ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ClinicalMeasurement .
-_:c14n1445 a owl:Restriction ;
+_:c14n145 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1450 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n1446 a owl:Restriction ;
+_:c14n1451 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_context_qualifier .
-_:c14n1447 a owl:Restriction ;
+_:c14n1452 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneToGeneHomologyAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneToGeneHomologyAssociation .
-_:c14n1448 a owl:Restriction ;
+_:c14n1453 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1449 a owl:Restriction ;
+_:c14n1454 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n145 a owl:Restriction ;
-	rdfs:subClassOf biolink:Drug ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Drug .
-_:c14n1450 a owl:Restriction ;
+_:c14n1455 a owl:Restriction ;
 	owl:allValuesFrom biolink:Gene ;
 	owl:onProperty biolink:has_gene .
-_:c14n1451 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1452 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1453 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:id .
-_:c14n1454 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n1455 a owl:Restriction ;
-	owl:allValuesFrom biolink:Disease ;
-	owl:onProperty biolink:object .
 _:c14n1456 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n1457 a owl:Restriction ;
-	owl:maxCardinality 1 ;
+	owl:allValuesFrom biolink:PredicateType ;
 	owl:onProperty biolink:predicate .
 _:c14n1458 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1459 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:id .
+_:c14n146 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:publication_type .
+_:c14n1460 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
+_:c14n1461 a owl:Restriction ;
+	owl:allValuesFrom biolink:Disease ;
+	owl:onProperty biolink:object .
+_:c14n1462 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1463 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1459 a owl:Restriction ;
+_:c14n1464 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1465 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n146 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:onset_qualifier .
-_:c14n1460 rdf:first biolink:DruggableGeneCategoryEnum\#tclin ;
-	rdf:rest _:c14n1357 .
-_:c14n1461 a owl:Restriction ;
+_:c14n1466 rdf:first biolink:DruggableGeneCategoryEnum\#tclin ;
+	rdf:rest _:c14n1361 .
+_:c14n1467 a owl:Restriction ;
 	owl:allValuesFrom biolink:AgentTypeEnum ;
 	owl:onProperty biolink:agent_type .
-_:c14n1462 a owl:Restriction ;
+_:c14n1468 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:iri .
-_:c14n1463 a owl:Restriction ;
+_:c14n1469 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenomicBackgroundExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenomicBackgroundExposure .
-_:c14n1464 a owl:Restriction ;
+_:c14n147 a owl:Restriction ;
+	rdfs:subClassOf biolink:Drug ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Drug .
+_:c14n1470 a owl:Restriction ;
 	owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
 	owl:onProperty biolink:subject .
-_:c14n1465 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#hydrolysis ;
-	rdf:rest _:c14n711 .
-_:c14n1466 a owl:Restriction ;
+_:c14n1471 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#hydrolysis ;
+	rdf:rest _:c14n714 .
+_:c14n1472 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:routes_of_delivery .
-_:c14n1467 a owl:Restriction ;
+_:c14n1473 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n1468 a owl:Restriction ;
+_:c14n1474 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:negated .
-_:c14n1469 a owl:Restriction ;
+_:c14n1475 a owl:Restriction ;
 	rdfs:subClassOf biolink:Mammal ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Mammal .
-_:c14n147 a owl:Restriction ;
-	owl:allValuesFrom biolink:Genotype ;
-	owl:onProperty biolink:subject .
-_:c14n1470 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1471 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1472 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n1473 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n1474 a owl:Restriction ;
-	owl:allValuesFrom biolink:Gene ;
-	owl:onProperty biolink:object .
-_:c14n1475 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
 _:c14n1476 a owl:Restriction ;
-	owl:allValuesFrom linkml:Uriorcurie ;
-	owl:onProperty biolink:xref .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n1477 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1478 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1479 a owl:Restriction ;
+	owl:allValuesFrom biolink:Gene ;
+	owl:onProperty biolink:object .
+_:c14n148 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:onset_qualifier .
+_:c14n1480 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
+_:c14n1481 a owl:Restriction ;
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty biolink:xref .
+_:c14n1482 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1483 a owl:Restriction ;
 	owl:allValuesFrom biolink:OntologyClass ;
 	owl:onProperty biolink:qualifiers .
-_:c14n1479 a owl:Restriction ;
+_:c14n1484 a owl:Restriction ;
 	rdfs:subClassOf biolink:Cohort ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Cohort .
-_:c14n148 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:subject .
-_:c14n1480 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glycosylation ;
+_:c14n1485 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glycosylation ;
 	rdf:rest _:c14n1899 .
-_:c14n1481 rdf:first biolink:KnowledgeLevelEnum\#not_provided ;
-	rdf:rest rdf:nil .
-_:c14n1482 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:subject .
-_:c14n1483 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1484 rdf:first biolink:AgentTypeEnum\#image_processing_agent ;
-	rdf:rest _:c14n286 .
-_:c14n1485 a owl:Restriction ;
-	owl:allValuesFrom biolink:Genotype ;
-	owl:onProperty biolink:subject .
-_:c14n1486 rdf:first biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation ;
+_:c14n1486 rdf:first biolink:KnowledgeLevelEnum\#not_provided ;
 	rdf:rest rdf:nil .
 _:c14n1487 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_context_qualifier .
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:subject .
 _:c14n1488 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n1489 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
+_:c14n1489 rdf:first biolink:AgentTypeEnum\#image_processing_agent ;
+	rdf:rest _:c14n290 .
 _:c14n149 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:start_interbase_coordinate .
+	owl:allValuesFrom biolink:Genotype ;
+	owl:onProperty biolink:subject .
 _:c14n1490 a owl:Restriction ;
+	owl:allValuesFrom biolink:Genotype ;
+	owl:onProperty biolink:subject .
+_:c14n1491 rdf:first biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation ;
+	rdf:rest rdf:nil .
+_:c14n1492 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_context_qualifier .
+_:c14n1493 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_direction_qualifier .
+_:c14n1494 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1495 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:subject .
-_:c14n1491 a owl:Restriction ;
+_:c14n1496 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:distribution_download_url .
-_:c14n1492 a owl:Restriction ;
+_:c14n1497 a owl:Restriction ;
 	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:qualifiers .
-_:c14n1493 a owl:Restriction ;
+_:c14n1498 a owl:Restriction ;
 	rdfs:subClassOf biolink:Case ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Case .
-_:c14n1494 a owl:Restriction ;
+_:c14n1499 a owl:Restriction ;
 	owl:allValuesFrom biolink:RetrievalSource ;
 	owl:onProperty biolink:retrieval_source_ids .
-_:c14n1495 rdf:first biolink:CellLine ;
-	rdf:rest _:c14n1814 .
-_:c14n1496 a owl:Restriction ;
+_:c14n15 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n150 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:subject .
+_:c14n1500 rdf:first biolink:CellLine ;
+	rdf:rest _:c14n1816 .
+_:c14n1501 a owl:Restriction ;
 	owl:allValuesFrom biolink:OntologyClass ;
 	owl:onProperty biolink:object_category_closure .
-_:c14n1497 a owl:Restriction ;
+_:c14n1502 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:causal_mechanism_qualifier .
-_:c14n1498 a owl:Restriction ;
+_:c14n1503 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:negated .
-_:c14n1499 a owl:Restriction ;
+_:c14n1504 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n15 a owl:Restriction ;
-	owl:allValuesFrom biolink:MacromolecularMachineMixin ;
-	owl:onProperty biolink:catalyst_qualifier .
-_:c14n150 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n1500 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#modified_form ;
-	rdf:rest _:c14n297 .
-_:c14n1501 a owl:Restriction ;
+_:c14n1505 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#modified_form ;
+	rdf:rest _:c14n301 .
+_:c14n1506 a owl:Restriction ;
 	rdfs:subClassOf biolink:PathologicalAnatomicalExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PathologicalAnatomicalExposure .
-_:c14n1502 rdf:first biolink:CausalMechanismQualifierEnum\#antibody_inhibition ;
-	rdf:rest _:c14n804 .
-_:c14n1503 a owl:Restriction ;
+_:c14n1507 rdf:first biolink:CausalMechanismQualifierEnum\#antibody_inhibition ;
+	rdf:rest _:c14n807 .
+_:c14n1508 a owl:Restriction ;
 	owl:allValuesFrom biolink:ReactionSideEnum ;
 	owl:onProperty biolink:reaction_side .
-_:c14n1504 a owl:Restriction ;
+_:c14n1509 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1505 owl:unionOf _:c14n1510 .
-_:c14n1506 a owl:Restriction ;
+_:c14n151 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:start_interbase_coordinate .
+_:c14n1510 owl:unionOf _:c14n1514 .
+_:c14n1511 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1507 a owl:Restriction ;
+_:c14n1512 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1508 a owl:Restriction ;
+_:c14n1513 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n1509 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n151 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1510 rdf:first biolink:GeneToGeneCoexpressionAssociation ;
-	rdf:rest _:c14n162 .
-_:c14n1511 rdf:first biolink:AgentTypeEnum\#data_analysis_pipeline ;
-	rdf:rest _:c14n730 .
-_:c14n1512 rdf:first biolink:NucleosomeModification ;
-	rdf:rest _:c14n1040 .
-_:c14n1513 a owl:Restriction ;
+_:c14n1514 rdf:first biolink:GeneToGeneCoexpressionAssociation ;
+	rdf:rest _:c14n164 .
+_:c14n1515 rdf:first biolink:AgentTypeEnum\#data_analysis_pipeline ;
+	rdf:rest _:c14n731 .
+_:c14n1516 rdf:first biolink:NucleosomeModification ;
+	rdf:rest _:c14n1046 .
+_:c14n1517 a owl:Restriction ;
 	rdfs:subClassOf biolink:ProcessedMaterial ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ProcessedMaterial .
-_:c14n1514 a owl:Restriction ;
+_:c14n1518 a owl:Restriction ;
 	owl:allValuesFrom biolink:Transcript ;
 	owl:onProperty biolink:object .
-_:c14n1515 a owl:Restriction ;
+_:c14n1519 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1516 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1517 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:name .
-_:c14n1518 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_quotient .
-_:c14n1519 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_aspect_qualifier .
 _:c14n152 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:subject_aspect_qualifier .
 _:c14n1520 a owl:Restriction ;
-	owl:maxCardinality 1 ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1521 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:name .
+_:c14n1522 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_quotient .
+_:c14n1523 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n1524 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1525 a owl:Restriction ;
 	owl:allValuesFrom linkml:Uriorcurie ;
 	owl:onProperty biolink:subject_specialization_qualifier .
-_:c14n1522 a owl:Restriction ;
+_:c14n1526 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n1523 a owl:Restriction ;
+_:c14n1527 a owl:Restriction ;
 	owl:allValuesFrom biolink:IndividualOrganism ;
 	owl:onProperty biolink:subject .
-_:c14n1524 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#uptake ;
+_:c14n1528 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#uptake ;
 	rdf:rest _:c14n116 .
-_:c14n1525 a owl:Restriction ;
+_:c14n1529 a owl:Restriction ;
 	owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
 	owl:onProperty biolink:object .
-_:c14n1526 a owl:Restriction ;
+_:c14n153 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1530 a owl:Restriction ;
 	rdfs:subClassOf biolink:OrganismTaxonToEnvironmentAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:OrganismTaxonToEnvironmentAssociation .
-_:c14n1527 a owl:Restriction ;
+_:c14n1531 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1528 a owl:Restriction ;
-	owl:allValuesFrom biolink:time_type ;
-	owl:onProperty biolink:temporal_context_qualifier .
-_:c14n1529 a owl:Restriction ;
+_:c14n1532 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:genome_build .
-_:c14n153 a owl:Restriction ;
-	owl:allValuesFrom biolink:DirectionQualifierEnum ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n1530 rdf:first biolink:NamedThing ;
+_:c14n1533 rdf:first biolink:NamedThing ;
 	rdf:rest rdf:nil .
-_:c14n1531 a owl:Restriction ;
+_:c14n1534 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1532 rdf:first biolink:ProteinFamily ;
-	rdf:rest _:c14n577 .
-_:c14n1533 a owl:Restriction ;
+_:c14n1535 rdf:first biolink:ProteinFamily ;
+	rdf:rest _:c14n580 .
+_:c14n1536 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n1537 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1534 a owl:Restriction ;
+_:c14n1538 a owl:Restriction ;
 	rdfs:subClassOf biolink:Vertebrate ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Vertebrate .
-_:c14n1535 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1536 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1537 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:stage_qualifier .
-_:c14n1538 rdf:first biolink:KnowledgeLevelEnum\#knowledge_assertion ;
-	rdf:rest _:c14n1769 .
 _:c14n1539 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:subject .
 _:c14n154 a owl:Restriction ;
-	owl:allValuesFrom linkml:Uriorcurie ;
-	owl:onProperty biolink:published_in .
-_:c14n1540 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:upstream_resource_ids .
-_:c14n1541 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1542 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_context_qualifier .
+_:c14n1540 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1541 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:stage_qualifier .
+_:c14n1542 rdf:first biolink:KnowledgeLevelEnum\#knowledge_assertion ;
+	rdf:rest _:c14n1771 .
 _:c14n1543 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_unit .
+	owl:onProperty biolink:object .
 _:c14n1544 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:upstream_resource_ids .
+_:c14n1545 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1546 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_context_qualifier .
+_:c14n1547 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n1548 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:has_unit .
+_:c14n1549 a owl:Restriction ;
 	rdfs:subClassOf biolink:Exon ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Exon .
-_:c14n1545 a owl:Restriction ;
+_:c14n155 a owl:Restriction ;
+	owl:allValuesFrom biolink:DirectionQualifierEnum ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n1550 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n1546 a owl:Restriction ;
+_:c14n1551 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:is_toxic .
-_:c14n1547 a owl:Restriction ;
+_:c14n1552 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalToChemicalAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalToChemicalAssociation .
-_:c14n1548 a owl:Restriction ;
+_:c14n1553 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1549 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n155 a owl:Restriction ;
-	owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
-	owl:onProperty biolink:population_context_qualifier .
-_:c14n1550 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:causal_mechanism_qualifier .
-_:c14n1551 rdf:first biolink:DrugAvailabilityEnum\#over_the_counter ;
-	rdf:rest _:c14n398 .
-_:c14n1552 a owl:Restriction ;
-	owl:allValuesFrom biolink:label_type ;
-	owl:onProperty biolink:synonym .
-_:c14n1553 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
 _:c14n1554 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1555 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:causal_mechanism_qualifier .
+_:c14n1556 rdf:first biolink:DrugAvailabilityEnum\#over_the_counter ;
+	rdf:rest _:c14n405 .
+_:c14n1557 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n1558 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1559 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:iso_abbreviation .
-_:c14n1556 a owl:Restriction ;
+_:c14n156 a owl:Restriction ;
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty biolink:published_in .
+_:c14n1560 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_label_closure .
-_:c14n1557 a owl:Restriction ;
+_:c14n1561 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
 	owl:onProperty biolink:subject_part_qualifier .
-_:c14n1558 a owl:Restriction ;
+_:c14n1562 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:qualified_predicate .
-_:c14n1559 a owl:Restriction ;
+_:c14n1563 a owl:Restriction ;
 	rdfs:subClassOf biolink:BehaviorToBehavioralFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:BehaviorToBehavioralFeatureAssociation .
-_:c14n156 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:subject .
-_:c14n1560 a owl:Restriction ;
-	owl:allValuesFrom biolink:time_type ;
-	owl:onProperty biolink:timepoint .
-_:c14n1561 a owl:Restriction ;
+_:c14n1564 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_count .
-_:c14n1562 a owl:Restriction ;
+_:c14n1565 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1563 a owl:Restriction ;
+_:c14n1566 a owl:Restriction ;
 	rdfs:subClassOf biolink:NamedThing ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:NamedThing .
-_:c14n1564 rdf:first biolink:CausalMechanismQualifierEnum\#signaling_mediated_control ;
-	rdf:rest _:c14n1163 .
-_:c14n1565 a owl:Restriction ;
+_:c14n1567 rdf:first biolink:CausalMechanismQualifierEnum\#signaling_mediated_control ;
+	rdf:rest _:c14n1169 .
+_:c14n1568 a owl:Restriction ;
 	owl:allValuesFrom biolink:OntologyClass ;
 	owl:onProperty biolink:quantifier_qualifier .
-_:c14n1566 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_part_qualifier .
-_:c14n1567 rdf:first biolink:ConceptCountAnalysisResult ;
-	rdf:rest _:c14n379 .
-_:c14n1568 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
 _:c14n1569 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_form_or_variant_qualifier .
+	owl:onProperty biolink:object_part_qualifier .
 _:c14n157 a owl:Restriction ;
-	rdfs:subClassOf biolink:GeneToGeneFamilyAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:GeneToGeneFamilyAssociation .
-_:c14n1570 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#promoter ;
-	rdf:rest _:c14n1635 .
-_:c14n1571 rdf:first biolink:PairwiseGeneToGeneInteraction ;
-	rdf:rest rdf:nil .
+	owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
+	owl:onProperty biolink:population_context_qualifier .
+_:c14n1570 rdf:first biolink:ConceptCountAnalysisResult ;
+	rdf:rest _:c14n385 .
+_:c14n1571 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
 _:c14n1572 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_form_or_variant_qualifier .
+_:c14n1573 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#promoter ;
+	rdf:rest _:c14n1639 .
+_:c14n1574 a owl:Restriction ;
+	owl:allValuesFrom biolink:IriType ;
+	owl:onProperty biolink:iri .
+_:c14n1575 rdf:first biolink:PairwiseGeneToGeneInteraction ;
+	rdf:rest rdf:nil .
+_:c14n1576 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:max_tolerated_dose .
-_:c14n1573 a owl:Restriction ;
+_:c14n1577 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1574 rdf:first biolink:RelativeFrequencyAnalysisResult ;
-	rdf:rest _:c14n1209 .
-_:c14n1575 a owl:Restriction ;
+_:c14n1578 rdf:first biolink:RelativeFrequencyAnalysisResult ;
+	rdf:rest _:c14n1212 .
+_:c14n1579 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:phenotypic_state .
-_:c14n1576 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n1577 a owl:Restriction ;
+_:c14n158 a owl:Restriction ;
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:subject .
+_:c14n1580 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1578 a owl:Restriction ;
+_:c14n1581 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1579 a owl:Restriction ;
+_:c14n1582 a owl:Restriction ;
 	rdfs:subClassOf biolink:CellLineAsAModelOfDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:CellLineAsAModelOfDiseaseAssociation .
-_:c14n158 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_context_qualifier .
-_:c14n1580 a owl:Restriction ;
+_:c14n1583 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_quotient .
-_:c14n1581 a owl:Restriction ;
+_:c14n1584 a owl:Restriction ;
 	owl:allValuesFrom biolink:OrganismTaxon ;
 	owl:onProperty biolink:object .
-_:c14n1582 a owl:Restriction ;
+_:c14n1585 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n1583 a owl:Restriction ;
+_:c14n1586 a owl:Restriction ;
 	rdfs:subClassOf biolink:AdministrativeEntity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:AdministrativeEntity .
-_:c14n1584 a owl:Restriction ;
+_:c14n1587 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1585 a owl:Restriction ;
+_:c14n1588 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1586 a owl:Restriction ;
+_:c14n1589 a owl:Restriction ;
 	owl:allValuesFrom biolink:OrganismTaxon ;
 	owl:onProperty biolink:species_context_qualifier .
-_:c14n1587 a owl:Restriction ;
+_:c14n159 a owl:Restriction ;
+	rdfs:subClassOf biolink:GeneToGeneFamilyAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:GeneToGeneFamilyAssociation .
+_:c14n1590 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeographicExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeographicExposure .
-_:c14n1588 a owl:Restriction ;
+_:c14n1591 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:iri .
-_:c14n1589 a owl:Restriction ;
+_:c14n1592 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n159 a owl:Restriction ;
-	owl:allValuesFrom biolink:DirectionQualifierEnum ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n1590 a owl:Restriction ;
+_:c14n1593 a owl:Restriction ;
 	rdfs:subClassOf biolink:ProcessRegulatesProcessAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ProcessRegulatesProcessAssociation .
-_:c14n1591 a owl:Restriction ;
+_:c14n1594 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1592 a owl:Restriction ;
+_:c14n1595 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n1593 a owl:Restriction ;
+_:c14n1596 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1594 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1595 a owl:Restriction ;
-	owl:allValuesFrom biolink:CellularComponent ;
-	owl:onProperty biolink:object .
-_:c14n1596 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glutathionylation ;
-	rdf:rest _:c14n788 .
 _:c14n1597 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1598 a owl:Restriction ;
+	owl:allValuesFrom biolink:CellularComponent ;
+	owl:onProperty biolink:object .
+_:c14n1599 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glutathionylation ;
+	rdf:rest _:c14n789 .
+_:c14n16 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n160 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_context_qualifier .
+_:c14n1600 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1601 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n1599 a owl:Restriction ;
+_:c14n1602 a owl:Restriction ;
 	rdfs:subClassOf biolink:CellularOrganism ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:CellularOrganism .
-_:c14n16 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n160 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1600 a owl:Restriction ;
+_:c14n1603 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:xref .
-_:c14n1601 a owl:Restriction ;
+_:c14n1604 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:pages .
-_:c14n1602 a owl:Restriction ;
+_:c14n1605 a owl:Restriction ;
 	rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToLocationAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToLocationAssociation .
-_:c14n1603 rdf:first biolink:PopulationOfIndividualOrganisms ;
-	rdf:rest _:c14n530 .
-_:c14n1604 a owl:Restriction ;
+_:c14n1606 rdf:first biolink:PopulationOfIndividualOrganisms ;
+	rdf:rest _:c14n536 .
+_:c14n1607 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1605 a owl:Restriction ;
+_:c14n1608 a owl:Restriction ;
 	rdfs:subClassOf biolink:PathologicalAnatomicalStructure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PathologicalAnatomicalStructure .
-_:c14n1606 a owl:Restriction ;
+_:c14n1609 a owl:Restriction ;
 	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:subject .
-_:c14n1607 a owl:Restriction ;
+_:c14n161 a owl:Restriction ;
+	owl:allValuesFrom biolink:DirectionQualifierEnum ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n1610 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_attribute .
-_:c14n1608 a owl:Restriction ;
+_:c14n1611 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_input .
-_:c14n1609 a owl:Restriction ;
+_:c14n1612 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n161 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:volume .
-_:c14n1610 a owl:Restriction ;
+_:c14n1613 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:object .
-_:c14n1611 a owl:Restriction ;
+_:c14n1614 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1612 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n1613 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:p_value .
-_:c14n1614 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:source_logo .
 _:c14n1615 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:enabled_by .
+	owl:onProperty biolink:anatomical_context_qualifier .
 _:c14n1616 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:p_value .
+_:c14n1617 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:source_logo .
+_:c14n1618 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:enabled_by .
+_:c14n1619 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n1617 a owl:Restriction ;
+_:c14n162 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1618 a owl:Restriction ;
+_:c14n1620 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1621 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:symbol .
-_:c14n1619 a owl:Restriction ;
+_:c14n1622 a owl:Restriction ;
 	rdfs:subClassOf biolink:Human ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Human .
-_:c14n162 rdf:first biolink:GeneToGeneHomologyAssociation ;
-	rdf:rest _:c14n1571 .
-_:c14n1620 a owl:Restriction ;
+_:c14n1623 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:name .
-_:c14n1621 rdf:first biolink:ClinicalApprovalStatusEnum\#not_provided ;
+_:c14n1624 rdf:first biolink:ClinicalApprovalStatusEnum\#not_provided ;
 	rdf:rest rdf:nil .
-_:c14n1622 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#n_linked_glycosylation ;
-	rdf:rest _:c14n349 .
-_:c14n1623 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase_1 ;
-	rdf:rest _:c14n653 .
-_:c14n1624 a owl:Restriction ;
+_:c14n1625 a owl:Restriction ;
+	owl:allValuesFrom biolink:Unit ;
+	owl:onProperty biolink:has_unit .
+_:c14n1626 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#n_linked_glycosylation ;
+	rdf:rest _:c14n354 .
+_:c14n1627 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase_1 ;
+	rdf:rest _:c14n654 .
+_:c14n1628 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:temporal_context_qualifier .
-_:c14n1625 a owl:Restriction ;
+_:c14n1629 a owl:Restriction ;
 	owl:allValuesFrom biolink:NucleicAcidEntity ;
 	owl:onProperty biolink:subject .
-_:c14n1626 a owl:Restriction ;
+_:c14n163 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:volume .
+_:c14n1630 a owl:Restriction ;
 	rdfs:subClassOf biolink:Phenomenon ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Phenomenon .
-_:c14n1627 a owl:Restriction ;
+_:c14n1631 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_quotient .
-_:c14n1628 rdf:first biolink:FDAIDAAdverseEventEnum\#suspected_adverse_reaction ;
-	rdf:rest _:c14n1208 .
-_:c14n1629 a owl:Restriction ;
+_:c14n1632 rdf:first biolink:FDAIDAAdverseEventEnum\#suspected_adverse_reaction ;
+	rdf:rest _:c14n1211 .
+_:c14n1633 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:end_interbase_coordinate .
-_:c14n163 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_namespace .
-_:c14n1630 a owl:Restriction ;
+_:c14n1634 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:species_context_qualifier .
-_:c14n1631 a owl:Restriction ;
+_:c14n1635 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1632 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1633 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1634 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1635 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#enhancer ;
-	rdf:rest _:c14n487 .
 _:c14n1636 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_aspect_qualifier .
+	owl:onProperty biolink:predicate .
 _:c14n1637 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1638 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1639 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#enhancer ;
+	rdf:rest _:c14n493 .
+_:c14n164 rdf:first biolink:GeneToGeneHomologyAssociation ;
+	rdf:rest _:c14n1575 .
+_:c14n1640 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n1641 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:publication_type .
-_:c14n1638 a owl:Restriction ;
+_:c14n1642 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneFamily ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneFamily .
-_:c14n1639 a owl:Restriction ;
+_:c14n1643 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:id .
-_:c14n164 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:subject_context_qualifier .
-_:c14n1640 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:original_object .
-_:c14n1641 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n1642 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1643 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:object .
 _:c14n1644 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:has_total .
+	owl:onProperty biolink:original_object .
 _:c14n1645 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_category_closure .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_derivative_qualifier .
 _:c14n1646 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:object .
 _:c14n1647 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:qualified_predicate .
-_:c14n1648 rdf:first biolink:OrganismTaxonToOrganismTaxonInteraction ;
-	rdf:rest _:c14n850 .
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:object .
+_:c14n1648 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:has_total .
 _:c14n1649 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_category_closure .
 _:c14n165 a owl:Restriction ;
-	rdfs:subClassOf biolink:Treatment ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Treatment .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_namespace .
 _:c14n1650 a owl:Restriction ;
-	owl:allValuesFrom biolink:DirectionQualifierEnum ;
-	owl:onProperty biolink:object_direction_qualifier .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
 _:c14n1651 a owl:Restriction ;
 	owl:maxCardinality 1 ;
+	owl:onProperty biolink:qualified_predicate .
+_:c14n1652 rdf:first biolink:OrganismTaxonToOrganismTaxonInteraction ;
+	rdf:rest _:c14n853 .
+_:c14n1653 a owl:Restriction ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1652 a owl:Restriction ;
+_:c14n1654 a owl:Restriction ;
+	owl:allValuesFrom biolink:DirectionQualifierEnum ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n1655 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1656 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1653 a owl:Restriction ;
+_:c14n1657 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:category .
-_:c14n1654 a owl:Restriction ;
+_:c14n1658 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1655 a owl:Restriction ;
+_:c14n1659 a owl:Restriction ;
 	owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
 	owl:onProperty biolink:object .
-_:c14n1656 a owl:Restriction ;
+_:c14n166 a owl:Restriction ;
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:subject_context_qualifier .
+_:c14n1660 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty biolink:deprecated .
-_:c14n1657 a owl:Restriction ;
+_:c14n1661 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n1658 a owl:Restriction ;
+_:c14n1662 a owl:Restriction ;
 	rdfs:subClassOf biolink:VariantToGeneAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:VariantToGeneAssociation .
-_:c14n1659 a owl:Restriction ;
+_:c14n1663 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_context_qualifier .
-_:c14n166 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1660 rdf:first biolink:ClinicalApprovalStatusEnum\#post_approval_withdrawal ;
-	rdf:rest _:c14n190 .
-_:c14n1661 a owl:Restriction ;
+_:c14n1664 rdf:first biolink:ClinicalApprovalStatusEnum\#post_approval_withdrawal ;
+	rdf:rest _:c14n192 .
+_:c14n1665 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1662 a owl:Restriction ;
+_:c14n1666 a owl:Restriction ;
 	owl:allValuesFrom biolink:Exon ;
 	owl:onProperty biolink:subject .
-_:c14n1663 a owl:Restriction ;
+_:c14n1667 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:max_research_phase .
-_:c14n1664 a owl:Restriction ;
+_:c14n1668 a owl:Restriction ;
 	rdfs:subClassOf biolink:PhenotypicFeature ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PhenotypicFeature .
-_:c14n1665 a owl:Restriction ;
+_:c14n1669 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_category .
-_:c14n1666 a owl:Restriction ;
+_:c14n167 a owl:Restriction ;
+	rdfs:subClassOf biolink:Treatment ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Treatment .
+_:c14n1670 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_part_qualifier .
-_:c14n1667 a owl:Restriction ;
+_:c14n1671 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1668 a owl:Restriction ;
+_:c14n1672 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:object_context_qualifier .
-_:c14n1669 a owl:Restriction ;
+_:c14n1673 a owl:Restriction ;
 	rdfs:subClassOf biolink:VariantToDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:VariantToDiseaseAssociation .
-_:c14n167 a owl:Restriction ;
-	owl:allValuesFrom owl:Thing ;
-	owl:onProperty biolink:subject .
-_:c14n1670 a owl:Restriction ;
+_:c14n1674 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:object .
-_:c14n1671 a owl:Restriction ;
+_:c14n1675 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1672 a owl:Restriction ;
+_:c14n1676 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1673 a owl:Restriction ;
+_:c14n1677 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenotypeToGeneAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenotypeToGeneAssociation .
-_:c14n1674 a owl:Restriction ;
+_:c14n1678 a owl:Restriction ;
 	owl:allValuesFrom biolink:QuantityValue ;
 	owl:onProperty biolink:has_quantitative_value .
-_:c14n1675 a owl:Restriction ;
+_:c14n1679 a owl:Restriction ;
 	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
 	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n1676 a owl:Restriction ;
+_:c14n168 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1680 a owl:Restriction ;
 	owl:allValuesFrom linkml:Uriorcurie ;
 	owl:onProperty biolink:mesh_terms .
-_:c14n1677 a owl:Restriction ;
+_:c14n1681 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:associated_environmental_context .
-_:c14n1678 rdf:first biolink:Publication ;
-	rdf:rest _:c14n1095 .
-_:c14n1679 a owl:Restriction ;
+_:c14n1682 rdf:first biolink:Publication ;
+	rdf:rest _:c14n1100 .
+_:c14n1683 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n168 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:subject .
-_:c14n1680 a owl:Restriction ;
+_:c14n1684 a owl:Restriction ;
 	owl:allValuesFrom biolink:BiologicalSex ;
 	owl:onProperty biolink:sex_qualifier .
-_:c14n1681 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1682 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:subject .
-_:c14n1683 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1684 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:mapped_predicate .
 _:c14n1685 a owl:Restriction ;
-	owl:maxCardinality 1 ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1686 a owl:Restriction ;
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:subject .
+_:c14n1687 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1687 a owl:Restriction ;
-	owl:allValuesFrom biolink:label_type ;
-	owl:onProperty biolink:synonym .
 _:c14n1688 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:mapped_predicate .
 _:c14n1689 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n169 a owl:Restriction ;
-	owl:minCardinality 1 ;
+	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:subject .
 _:c14n1690 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:qualified_predicate .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
 _:c14n1691 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:disease_context_qualifier .
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
 _:c14n1692 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
+	owl:onProperty biolink:subject .
 _:c14n1693 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1694 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:qualified_predicate .
+_:c14n1695 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:disease_context_qualifier .
+_:c14n1696 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
+_:c14n1697 a owl:Restriction ;
 	rdfs:subClassOf biolink:Patent ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Patent .
-_:c14n1694 a owl:Restriction ;
+_:c14n1698 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:timepoint .
-_:c14n1695 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1696 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#carbamoylation ;
-	rdf:rest _:c14n1896 .
-_:c14n1697 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1698 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:sex_qualifier .
 _:c14n1699 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n17 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n170 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:original_subject .
-_:c14n1700 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
 	owl:onProperty biolink:predicate .
+_:c14n17 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n170 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n1700 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#carbamoylation ;
+	rdf:rest _:c14n1896 .
 _:c14n1701 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:subject .
 _:c14n1702 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:sex_qualifier .
 _:c14n1703 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:description .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n1704 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1705 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1706 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:description .
+_:c14n1707 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1708 a owl:Restriction ;
 	rdfs:subClassOf biolink:Agent ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Agent .
-_:c14n1706 a owl:Restriction ;
+_:c14n1709 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1707 a owl:Restriction ;
+_:c14n171 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:subject .
+_:c14n1710 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n1708 a owl:Restriction ;
+_:c14n1711 a owl:Restriction ;
 	rdfs:subClassOf biolink:MacromolecularComplex ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:MacromolecularComplex .
-_:c14n1709 a owl:Restriction ;
+_:c14n1712 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n171 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase_3 ;
-	rdf:rest _:c14n829 .
-_:c14n1710 a owl:Restriction ;
+_:c14n1713 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneToDiseaseOrPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneToDiseaseOrPhenotypicFeatureAssociation .
-_:c14n1711 a owl:Restriction ;
+_:c14n1714 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_quantitative_value .
-_:c14n1712 a owl:Restriction ;
+_:c14n1715 a owl:Restriction ;
 	owl:allValuesFrom biolink:Disease ;
 	owl:onProperty biolink:subject .
-_:c14n1713 a owl:Restriction ;
+_:c14n1716 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:has_qualitative_value .
-_:c14n1714 a owl:Restriction ;
+_:c14n1717 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneToPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneToPhenotypicFeatureAssociation .
-_:c14n1715 rdf:first biolink:CausalMechanismQualifierEnum\#positive_allosteric_modulation ;
-	rdf:rest _:c14n362 .
-_:c14n1716 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#synthesis ;
-	rdf:rest _:c14n289 .
-_:c14n1717 a owl:Restriction ;
+_:c14n1718 rdf:first biolink:CausalMechanismQualifierEnum\#positive_allosteric_modulation ;
+	rdf:rest _:c14n367 .
+_:c14n1719 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#synthesis ;
+	rdf:rest _:c14n293 .
+_:c14n172 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1720 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:category .
-_:c14n1718 a owl:Restriction ;
+_:c14n1721 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenotypicSex ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenotypicSex .
-_:c14n1719 rdf:first biolink:KnowledgeLevelEnum\#prediction ;
-	rdf:rest _:c14n9 .
-_:c14n172 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1720 rdf:first os:SomeSomeInterpretation ;
-	rdf:rest _:c14n934 .
-_:c14n1721 a owl:Restriction ;
+_:c14n1722 rdf:first biolink:KnowledgeLevelEnum\#prediction ;
+	rdf:rest _:c14n7 .
+_:c14n1723 rdf:first os:SomeSomeInterpretation ;
+	rdf:rest _:c14n939 .
+_:c14n1724 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:type .
-_:c14n1722 a owl:Restriction ;
+_:c14n1725 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenotypeToGenotypePartAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenotypeToGenotypePartAssociation .
-_:c14n1723 a owl:Restriction ;
+_:c14n1726 a owl:Restriction ;
 	rdfs:subClassOf biolink:DiseaseToPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DiseaseToPhenotypicFeatureAssociation .
-_:c14n1724 a owl:Restriction ;
+_:c14n1727 a owl:Restriction ;
 	rdfs:subClassOf biolink:MolecularActivity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:MolecularActivity .
-_:c14n1725 a owl:Restriction ;
+_:c14n1728 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1726 a owl:Restriction ;
+_:c14n1729 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:format .
-_:c14n1727 a owl:Restriction ;
+_:c14n173 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:original_subject .
+_:c14n1730 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:qualified_predicate .
-_:c14n1728 a owl:Restriction ;
+_:c14n1731 a owl:Restriction ;
 	owl:allValuesFrom linkml:Uriorcurie ;
 	owl:onProperty biolink:xref .
-_:c14n1729 a owl:Restriction ;
+_:c14n1732 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n173 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_namespace .
-_:c14n1730 a owl:Restriction ;
+_:c14n1733 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n1731 a owl:Restriction ;
+_:c14n1734 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:has_count .
-_:c14n1732 a owl:Restriction ;
+_:c14n1735 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_attribute .
-_:c14n1733 rdf:first biolink:ApprovalStatusEnum\#preclinical_research_phase ;
-	rdf:rest _:c14n254 .
-_:c14n1734 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_part_qualifier .
-_:c14n1735 a owl:Restriction ;
-	owl:allValuesFrom biolink:OntologyClass ;
-	owl:onProperty biolink:interacting_molecules_category .
-_:c14n1736 a owl:Restriction ;
-	owl:allValuesFrom biolink:MaterialSample ;
-	owl:onProperty biolink:subject .
+_:c14n1736 rdf:first biolink:ApprovalStatusEnum\#preclinical_research_phase ;
+	rdf:rest _:c14n257 .
 _:c14n1737 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_derivative_qualifier .
+	owl:onProperty biolink:subject_part_qualifier .
 _:c14n1738 a owl:Restriction ;
+	owl:allValuesFrom biolink:OntologyClass ;
+	owl:onProperty biolink:interacting_molecules_category .
+_:c14n1739 a owl:Restriction ;
+	owl:allValuesFrom biolink:MaterialSample ;
+	owl:onProperty biolink:subject .
+_:c14n174 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase_3 ;
+	rdf:rest _:c14n832 .
+_:c14n1740 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_derivative_qualifier .
+_:c14n1741 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:issue .
-_:c14n1739 a owl:Restriction ;
+_:c14n1742 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:address .
-_:c14n174 a owl:Restriction ;
-	owl:allValuesFrom biolink:Drug ;
-	owl:onProperty biolink:has_drug .
-_:c14n1740 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#amination ;
-	rdf:rest _:c14n1696 .
-_:c14n1741 a owl:Restriction ;
+_:c14n1743 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#amination ;
+	rdf:rest _:c14n1700 .
+_:c14n1744 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1742 a owl:Restriction ;
+_:c14n1745 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1743 a owl:Restriction ;
+_:c14n1746 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1744 rdf:first biolink:DrugDeliveryEnum\#absorption_through_the_skin ;
-	rdf:rest _:c14n1259 .
-_:c14n1745 a owl:Restriction ;
+_:c14n1747 rdf:first biolink:DrugDeliveryEnum\#absorption_through_the_skin ;
+	rdf:rest _:c14n1264 .
+_:c14n1748 a owl:Restriction ;
 	owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
 	owl:onProperty biolink:object .
-_:c14n1746 a owl:Restriction ;
+_:c14n1749 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n1747 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:causal_mechanism_qualifier .
-_:c14n1748 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n1749 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
 _:c14n175 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1750 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:causal_mechanism_qualifier .
+_:c14n1751 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1752 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:enabled_by .
-_:c14n1751 a owl:Restriction ;
+_:c14n1753 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n1752 a owl:Restriction ;
+_:c14n1754 a owl:Restriction ;
 	owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
 	owl:onProperty biolink:subject .
-_:c14n1753 a owl:Restriction ;
+_:c14n1755 a owl:Restriction ;
 	rdfs:subClassOf biolink:ProteinDomain ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ProteinDomain .
-_:c14n1754 a owl:Restriction ;
+_:c14n1756 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1755 a owl:Restriction ;
+_:c14n1757 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1756 a owl:Restriction ;
+_:c14n1758 a owl:Restriction ;
 	owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
 	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n1757 a owl:Restriction ;
+_:c14n1759 a owl:Restriction ;
 	owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
 	owl:onProperty biolink:causal_mechanism_qualifier .
-_:c14n1758 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:qualified_predicate .
-_:c14n1759 a owl:Restriction ;
-	owl:allValuesFrom biolink:Genotype ;
-	owl:onProperty biolink:subject .
 _:c14n176 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:FDA_adverse_event_level .
+	owl:onProperty biolink:object_namespace .
 _:c14n1760 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:qualified_predicate .
 _:c14n1761 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:object .
+	owl:allValuesFrom biolink:Genotype ;
+	owl:onProperty biolink:subject .
 _:c14n1762 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1763 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:original_predicate .
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:object .
 _:c14n1764 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1765 rdf:first biolink:ResearchPhaseEnum\#pre_clinical_research_phase ;
-	rdf:rest _:c14n105 .
+	owl:onProperty biolink:object .
+_:c14n1765 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:original_predicate .
 _:c14n1766 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n1767 rdf:first biolink:ResearchPhaseEnum\#pre_clinical_research_phase ;
+	rdf:rest _:c14n105 .
+_:c14n1768 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty biolink:is_toxic .
-_:c14n1767 a owl:Restriction ;
+_:c14n1769 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1768 a owl:Restriction ;
+_:c14n177 a owl:Restriction ;
+	owl:allValuesFrom biolink:Drug ;
+	owl:onProperty biolink:has_drug .
+_:c14n1770 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1769 rdf:first biolink:KnowledgeLevelEnum\#logical_entailment ;
-	rdf:rest _:c14n1719 .
-_:c14n177 a owl:Restriction ;
-	rdfs:subClassOf biolink:OrganismalEntity ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:OrganismalEntity .
-_:c14n1770 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#lipidation ;
-	rdf:rest _:c14n1198 .
-_:c14n1771 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#acylation ;
-	rdf:rest _:c14n218 .
-_:c14n1772 a owl:Restriction ;
+_:c14n1771 rdf:first biolink:KnowledgeLevelEnum\#logical_entailment ;
+	rdf:rest _:c14n1722 .
+_:c14n1772 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#lipidation ;
+	rdf:rest _:c14n1203 .
+_:c14n1773 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#acylation ;
+	rdf:rest _:c14n220 .
+_:c14n1774 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n1773 rdf:first biolink:ReactionSideEnum\#left ;
-	rdf:rest _:c14n1222 .
-_:c14n1774 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1775 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
+_:c14n1775 rdf:first biolink:ReactionSideEnum\#left ;
+	rdf:rest _:c14n1226 .
 _:c14n1776 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n1777 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#nucleotidylation ;
-	rdf:rest _:c14n1426 .
+	owl:onProperty biolink:object .
+_:c14n1777 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
 _:c14n1778 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_derivative_qualifier .
+_:c14n1779 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#nucleotidylation ;
+	rdf:rest _:c14n1431 .
+_:c14n178 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1780 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n1779 a owl:Restriction ;
+_:c14n1781 a owl:Restriction ;
 	rdfs:subClassOf biolink:OrganismToOrganismAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:OrganismToOrganismAssociation .
-_:c14n178 a owl:Restriction ;
-	rdfs:subClassOf biolink:ChemicalToPathwayAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ChemicalToPathwayAssociation .
-_:c14n1780 a owl:Restriction ;
+_:c14n1782 a owl:Restriction ;
 	owl:allValuesFrom biolink:MolecularActivity ;
 	owl:onProperty biolink:object .
-_:c14n1781 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#expression ;
-	rdf:rest _:c14n1716 .
-_:c14n1782 a owl:Restriction ;
+_:c14n1783 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#expression ;
+	rdf:rest _:c14n1719 .
+_:c14n1784 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:max_tolerated_dose .
-_:c14n1783 a owl:Restriction ;
+_:c14n1785 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1784 a owl:Restriction ;
+_:c14n1786 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:volume .
-_:c14n1785 a owl:Restriction ;
+_:c14n1787 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:id .
-_:c14n1786 a owl:Restriction ;
+_:c14n1788 a owl:Restriction ;
 	rdfs:subClassOf biolink:DrugLabel ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DrugLabel .
-_:c14n1787 a owl:Restriction ;
+_:c14n1789 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_count .
-_:c14n1788 a owl:Restriction ;
+_:c14n179 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:FDA_adverse_event_level .
+_:c14n1790 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n1789 a owl:Restriction ;
+_:c14n1791 a owl:Restriction ;
 	rdfs:subClassOf biolink:MolecularMixture ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:MolecularMixture .
-_:c14n179 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:volume .
-_:c14n1790 a owl:Restriction ;
+_:c14n1792 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1791 a owl:Restriction ;
+_:c14n1793 a owl:Restriction ;
 	owl:allValuesFrom biolink:InformationContentEntity ;
 	owl:onProperty biolink:subject .
-_:c14n1792 a owl:Restriction ;
+_:c14n1794 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
 	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n1793 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n1794 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:species_context_qualifier .
 _:c14n1795 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
 _:c14n1796 a owl:Restriction ;
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:species_context_qualifier .
+_:c14n1797 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n1798 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1797 a owl:Restriction ;
+_:c14n1799 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenotypeToPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenotypeToPhenotypicFeatureAssociation .
-_:c14n1798 a owl:Restriction ;
+_:c14n18 a owl:Restriction ;
+	owl:allValuesFrom biolink:MacromolecularMachineMixin ;
+	owl:onProperty biolink:enabled_by .
+_:c14n180 a owl:Restriction ;
+	rdfs:subClassOf biolink:OrganismalEntity ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:OrganismalEntity .
+_:c14n1800 a owl:Restriction ;
 	rdfs:subClassOf biolink:OrganismAttribute ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:OrganismAttribute .
-_:c14n1799 a owl:Restriction ;
+_:c14n1801 a owl:Restriction ;
 	owl:allValuesFrom biolink:MolecularActivity ;
 	owl:onProperty biolink:subject .
-_:c14n18 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n180 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:end_interbase_coordinate .
-_:c14n1800 a owl:Restriction ;
+_:c14n1802 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_specialization_qualifier .
-_:c14n1801 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:volume .
-_:c14n1802 a owl:Restriction ;
-	owl:allValuesFrom biolink:OntologyClass ;
-	owl:onProperty biolink:object .
 _:c14n1803 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:id .
+	owl:onProperty biolink:volume .
 _:c14n1804 a owl:Restriction ;
+	owl:allValuesFrom biolink:OntologyClass ;
+	owl:onProperty biolink:object .
+_:c14n1805 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:id .
+_:c14n1806 a owl:Restriction ;
 	rdfs:subClassOf biolink:SiRNA ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:SiRNA .
-_:c14n1805 a owl:Restriction ;
+_:c14n1807 a owl:Restriction ;
 	rdfs:subClassOf biolink:ReactionToParticipantAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ReactionToParticipantAssociation .
-_:c14n1806 a owl:Restriction ;
+_:c14n1808 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:volume .
-_:c14n1807 a owl:Restriction ;
+_:c14n1809 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_category .
-_:c14n1808 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n1809 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:start_interbase_coordinate .
 _:c14n181 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	rdfs:subClassOf biolink:ChemicalToPathwayAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ChemicalToPathwayAssociation .
 _:c14n1810 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:chapter .
-_:c14n1811 rdf:first biolink:Transcript ;
-	rdf:rest rdf:nil .
+	owl:onProperty biolink:object .
+_:c14n1811 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:start_interbase_coordinate .
 _:c14n1812 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:chapter .
+_:c14n1813 rdf:first biolink:Transcript ;
+	rdf:rest rdf:nil .
+_:c14n1814 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n1813 a owl:Restriction ;
+_:c14n1815 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:catalyst_qualifier .
-_:c14n1814 rdf:first biolink:CellularOrganism ;
-	rdf:rest _:c14n1170 .
-_:c14n1815 a owl:Restriction ;
+_:c14n1816 rdf:first biolink:CellularOrganism ;
+	rdf:rest _:c14n1176 .
+_:c14n1817 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:object_label_closure .
-_:c14n1816 a owl:Restriction ;
+_:c14n1818 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n1817 rdf:first biolink:PosttranslationalModification ;
-	rdf:rest _:c14n30 .
-_:c14n1818 a owl:Restriction ;
+_:c14n1819 rdf:first biolink:PosttranslationalModification ;
+	rdf:rest _:c14n28 .
+_:c14n182 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:volume .
+_:c14n1820 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_context_qualifier .
-_:c14n1819 a owl:Restriction ;
+_:c14n1821 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n182 a owl:Restriction ;
-	owl:allValuesFrom biolink:narrative_text ;
-	owl:onProperty biolink:description .
-_:c14n1820 a owl:Restriction ;
+_:c14n1822 a owl:Restriction ;
 	rdfs:subClassOf biolink:BioticExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:BioticExposure .
-_:c14n1821 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n1822 a owl:Restriction ;
+_:c14n1823 a owl:Restriction ;
 	rdfs:subClassOf biolink:SequenceFeatureRelationship ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:SequenceFeatureRelationship .
-_:c14n1823 a owl:Restriction ;
+_:c14n1824 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_output .
-_:c14n1824 a owl:Restriction ;
+_:c14n1825 a owl:Restriction ;
 	rdfs:subClassOf biolink:EntityToDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:EntityToDiseaseAssociation .
-_:c14n1825 a owl:Restriction ;
+_:c14n1826 a owl:Restriction ;
 	rdfs:subClassOf biolink:RNAProduct ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:RNAProduct .
-_:c14n1826 a owl:Restriction ;
+_:c14n1827 a owl:Restriction ;
 	rdfs:subClassOf biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation .
-_:c14n1827 a owl:Restriction ;
+_:c14n1828 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:drug_regulatory_status_world_wide .
-_:c14n1828 a owl:Restriction ;
+_:c14n1829 a owl:Restriction ;
 	rdfs:subClassOf biolink:ExposureEventToPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ExposureEventToPhenotypicFeatureAssociation .
-_:c14n1829 rdf:first biolink:DrugDeliveryEnum\#inhalation ;
-	rdf:rest _:c14n1361 .
 _:c14n183 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n1830 rdf:first biolink:Bacterium ;
-	rdf:rest _:c14n1495 .
-_:c14n1831 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:end_interbase_coordinate .
+_:c14n1830 rdf:first biolink:DrugDeliveryEnum\#inhalation ;
+	rdf:rest _:c14n1365 .
+_:c14n1831 rdf:first biolink:Bacterium ;
+	rdf:rest _:c14n1500 .
+_:c14n1832 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:quantifier_qualifier .
-_:c14n1832 a owl:Restriction ;
+_:c14n1833 a owl:Restriction ;
 	rdfs:subClassOf biolink:Gene ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Gene .
-_:c14n1833 a owl:Restriction ;
+_:c14n1834 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n1834 a owl:Restriction ;
+_:c14n1835 a owl:Restriction ;
 	rdfs:subClassOf biolink:CellularComponent ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:CellularComponent .
-_:c14n1835 a owl:Restriction ;
+_:c14n1836 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n1836 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
 _:c14n1837 a owl:Restriction ;
 	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1838 a owl:Restriction ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n1838 rdf:first biolink:Haplotype ;
-	rdf:rest _:c14n323 .
-_:c14n1839 a owl:Restriction ;
+_:c14n1839 rdf:first biolink:Haplotype ;
+	rdf:rest _:c14n328 .
+_:c14n184 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n1840 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:deprecated .
-_:c14n184 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_form_or_variant_qualifier .
-_:c14n1840 a owl:Restriction ;
+_:c14n1841 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:rights .
-_:c14n1841 a owl:Restriction ;
+_:c14n1842 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n1842 a owl:Restriction ;
+_:c14n1843 a owl:Restriction ;
 	owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
 	owl:onProperty biolink:causal_mechanism_qualifier .
-_:c14n1843 a owl:Restriction ;
+_:c14n1844 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1844 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
 _:c14n1845 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#stability ;
-	rdf:rest _:c14n314 .
+	rdf:rest _:c14n318 .
 _:c14n1846 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:expression_site .
@@ -8740,8 +8740,8 @@ _:c14n1849 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_part_qualifier .
 _:c14n185 a owl:Restriction ;
-	owl:allValuesFrom linkml:Uriorcurie ;
-	owl:onProperty biolink:category .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
 _:c14n1850 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
@@ -8775,13 +8775,13 @@ _:c14n1859 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:type .
 _:c14n186 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:has_attribute_type .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_form_or_variant_qualifier .
 _:c14n1860 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_aspect_qualifier .
 _:c14n1861 rdf:first biolink:ResourceRoleEnum\#primary_knowledge_source ;
-	rdf:rest _:c14n1293 .
+	rdf:rest _:c14n1298 .
 _:c14n1862 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
@@ -8789,7 +8789,7 @@ _:c14n1863 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:latitude .
 _:c14n1864 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#cleavage ;
-	rdf:rest _:c14n1465 .
+	rdf:rest _:c14n1471 .
 _:c14n1865 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
@@ -8806,8 +8806,8 @@ _:c14n1869 a owl:Restriction ;
 	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:has_attribute .
 _:c14n187 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_procedure .
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty biolink:category .
 _:c14n1870 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
@@ -8821,70 +8821,70 @@ _:c14n1873 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n1874 a owl:Restriction ;
+	owl:allValuesFrom biolink:BiologicalSequence ;
+	owl:onProperty biolink:has_biological_sequence .
+_:c14n1875 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1875 a owl:Restriction ;
+_:c14n1876 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:object_derivative_qualifier .
-_:c14n1876 a owl:Restriction ;
+_:c14n1877 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n1877 a owl:Restriction ;
+_:c14n1878 a owl:Restriction ;
 	owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
 	owl:onProperty biolink:object_derivative_qualifier .
-_:c14n1878 a owl:Restriction ;
+_:c14n1879 a owl:Restriction ;
 	rdfs:subClassOf biolink:Disease ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Disease .
-_:c14n1879 a owl:Restriction ;
+_:c14n188 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:has_attribute_type .
+_:c14n1880 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n188 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:species_context_qualifier .
-_:c14n1880 a owl:Restriction ;
+_:c14n1881 a owl:Restriction ;
+	owl:allValuesFrom biolink:TimeType ;
+	owl:onProperty biolink:timepoint .
+_:c14n1882 a owl:Restriction ;
 	rdfs:subClassOf biolink:SequenceAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:SequenceAssociation .
-_:c14n1881 a owl:Restriction ;
+_:c14n1883 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n1882 rdf:first biolink:DirectionQualifierEnum\#decreased ;
+_:c14n1884 rdf:first biolink:DirectionQualifierEnum\#decreased ;
 	rdf:rest _:c14n110 .
-_:c14n1883 a owl:Restriction ;
+_:c14n1885 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n1884 a owl:Restriction ;
+_:c14n1886 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_distribution .
-_:c14n1885 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n1886 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_derivative_qualifier .
 _:c14n1887 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
+	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
 _:c14n1888 a owl:Restriction ;
 	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_derivative_qualifier .
+_:c14n1889 a owl:Restriction ;
+	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_context_qualifier .
-_:c14n1889 rdf:first biolink:AgentTypeEnum\#automated_agent ;
-	rdf:rest _:c14n1511 .
 _:c14n189 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:aggregator_knowledge_source .
-_:c14n1890 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_procedure .
+_:c14n1890 rdf:first biolink:AgentTypeEnum\#automated_agent ;
+	rdf:rest _:c14n1515 .
+_:c14n1891 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:species_context_qualifier .
-_:c14n1891 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
 _:c14n1892 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n1893 rdf:first biolink:CodingSequence ;
-	rdf:rest _:c14n5 .
+	rdf:rest _:c14n4 .
 _:c14n1894 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
@@ -8892,7 +8892,7 @@ _:c14n1895 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:anatomical_context_qualifier .
 _:c14n1896 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ethylation ;
-	rdf:rest _:c14n1596 .
+	rdf:rest _:c14n1599 .
 _:c14n1897 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:id .
@@ -8900,12 +8900,13 @@ _:c14n1898 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_aspect_qualifier .
 _:c14n1899 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glucuronidation ;
-	rdf:rest _:c14n1622 .
+	rdf:rest _:c14n1626 .
 _:c14n19 a owl:Restriction ;
-	owl:minCardinality 1 ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n190 rdf:first biolink:ClinicalApprovalStatusEnum\#off_label_use ;
-	rdf:rest _:c14n1621 .
+_:c14n190 a owl:Restriction ;
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:species_context_qualifier .
 _:c14n1900 a owl:Restriction ;
 	owl:allValuesFrom biolink:ChemicalEntity ;
 	owl:onProperty biolink:object .
@@ -8938,8 +8939,8 @@ _:c14n1909 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n191 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismalEntity ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:aggregator_knowledge_source .
 _:c14n1910 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:qualifiers .
@@ -8970,1522 +8971,1520 @@ _:c14n1918 a owl:Restriction ;
 _:c14n1919 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n192 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:disease_context_qualifier .
+_:c14n192 rdf:first biolink:ClinicalApprovalStatusEnum\#off_label_use ;
+	rdf:rest _:c14n1624 .
 _:c14n193 a owl:Restriction ;
-	owl:minCardinality 1 ;
+	owl:allValuesFrom biolink:OrganismalEntity ;
 	owl:onProperty biolink:subject .
 _:c14n194 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:disease_context_qualifier .
+_:c14n195 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n196 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n195 a owl:Restriction ;
+_:c14n197 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_context_qualifier .
-_:c14n196 a owl:Restriction ;
+_:c14n198 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n197 a owl:Restriction ;
+_:c14n199 a owl:Restriction ;
 	rdfs:subClassOf biolink:ExposureEventToOutcomeAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ExposureEventToOutcomeAssociation .
-_:c14n198 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#oxidation ;
-	rdf:rest _:c14n474 .
-_:c14n199 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#abundance ;
-	rdf:rest _:c14n1362 .
 _:c14n2 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n20 a owl:Restriction ;
-	owl:allValuesFrom biolink:MacromolecularMachineMixin ;
-	owl:onProperty biolink:enabled_by .
-_:c14n200 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_quantitative_value .
-_:c14n201 a owl:Restriction ;
-	owl:allValuesFrom linkml:Float ;
-	owl:onProperty biolink:latitude .
-_:c14n202 a owl:Restriction ;
-	rdfs:subClassOf biolink:CaseToPhenotypicFeatureAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:CaseToPhenotypicFeatureAssociation .
-_:c14n203 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:authors .
-_:c14n204 a owl:Restriction ;
-	rdfs:subClassOf biolink:Snv ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Snv .
-_:c14n205 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n206 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n207 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n208 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n209 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:sex_qualifier .
-_:c14n21 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n210 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:expression_site .
-_:c14n211 a owl:Restriction ;
-	rdfs:subClassOf biolink:MacromolecularMachineToCellularComponentAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:MacromolecularMachineToCellularComponentAssociation .
-_:c14n212 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n213 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n214 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n215 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n216 rdf:first biolink:GeneFamily ;
-	rdf:rest _:c14n459 .
-_:c14n217 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:sex_qualifier .
-_:c14n218 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#alkylation ;
-	rdf:rest _:c14n1740 .
-_:c14n219 a owl:Restriction ;
-	owl:allValuesFrom biolink:Gene ;
-	owl:onProperty biolink:subject .
-_:c14n22 a owl:Restriction ;
 	rdfs:subClassOf biolink:VariantAsAModelOfDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:VariantAsAModelOfDiseaseAssociation .
-_:c14n220 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#hydroxylation ;
-	rdf:rest _:c14n1770 .
-_:c14n221 a owl:Restriction ;
+_:c14n200 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#oxidation ;
+	rdf:rest _:c14n480 .
+_:c14n201 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#abundance ;
+	rdf:rest _:c14n1366 .
+_:c14n202 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_quantitative_value .
+_:c14n203 a owl:Restriction ;
+	owl:allValuesFrom linkml:Float ;
+	owl:onProperty biolink:latitude .
+_:c14n204 a owl:Restriction ;
+	rdfs:subClassOf biolink:CaseToPhenotypicFeatureAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:CaseToPhenotypicFeatureAssociation .
+_:c14n205 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:authors .
+_:c14n206 a owl:Restriction ;
+	rdfs:subClassOf biolink:Snv ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Snv .
+_:c14n207 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:symbol .
-_:c14n222 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n223 a owl:Restriction ;
+	owl:onProperty biolink:subject .
+_:c14n208 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n224 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:volume .
-_:c14n225 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:interacting_molecules_category .
-_:c14n226 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n227 a owl:Restriction ;
-	rdfs:subClassOf biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation .
-_:c14n228 a owl:Restriction ;
-	rdfs:subClassOf biolink:DrugExposure ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:DrugExposure .
-_:c14n229 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_numeric_value .
-_:c14n23 a owl:Restriction ;
+_:c14n209 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n21 a owl:Restriction ;
 	rdfs:subClassOf biolink:PhenotypicQuality ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PhenotypicQuality .
-_:c14n230 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
+_:c14n210 a owl:Restriction ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n231 a owl:Restriction ;
+_:c14n211 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_qualitative_value .
-_:c14n232 rdf:first biolink:AgentTypeEnum\#manual_agent ;
-	rdf:rest _:c14n1889 .
-_:c14n233 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n234 a owl:Restriction ;
+	owl:onProperty biolink:sex_qualifier .
+_:c14n212 a owl:Restriction ;
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:expression_site .
+_:c14n213 a owl:Restriction ;
+	rdfs:subClassOf biolink:MacromolecularMachineToCellularComponentAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:MacromolecularMachineToCellularComponentAssociation .
+_:c14n214 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
+_:c14n215 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n216 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n217 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n218 rdf:first biolink:GeneFamily ;
+	rdf:rest _:c14n465 .
+_:c14n219 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:sex_qualifier .
+_:c14n22 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n220 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#alkylation ;
+	rdf:rest _:c14n1743 .
+_:c14n221 a owl:Restriction ;
+	owl:allValuesFrom biolink:Gene ;
+	owl:onProperty biolink:subject .
+_:c14n222 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#hydroxylation ;
+	rdf:rest _:c14n1772 .
+_:c14n223 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:symbol .
+_:c14n224 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_direction_qualifier .
+_:c14n225 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n226 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:volume .
+_:c14n227 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:interacting_molecules_category .
+_:c14n228 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n229 a owl:Restriction ;
+	rdfs:subClassOf biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:MaterialSampleToDiseaseOrPhenotypicFeatureAssociation .
+_:c14n23 a owl:Restriction ;
+	owl:allValuesFrom biolink:ExposureEvent ;
+	owl:onProperty biolink:subject .
+_:c14n230 a owl:Restriction ;
+	rdfs:subClassOf biolink:DrugExposure ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:DrugExposure .
+_:c14n231 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:has_numeric_value .
+_:c14n232 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n233 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_qualitative_value .
+_:c14n234 rdf:first biolink:AgentTypeEnum\#manual_agent ;
+	rdf:rest _:c14n1890 .
 _:c14n235 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:qualified_predicate .
+	owl:onProperty biolink:object_direction_qualifier .
 _:c14n236 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n237 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n238 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:qualified_predicate .
+_:c14n239 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n237 a owl:Restriction ;
+_:c14n24 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_aspect_qualifier .
+_:c14n240 a owl:Restriction ;
 	rdfs:subClassOf biolink:Association ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Association .
-_:c14n238 a owl:Restriction ;
+_:c14n241 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:id .
-_:c14n239 a owl:Restriction ;
+_:c14n242 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n24 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n240 a owl:Restriction ;
+_:c14n243 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n241 a owl:Restriction ;
+_:c14n244 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n242 a owl:Restriction ;
+_:c14n245 a owl:Restriction ;
 	rdfs:subClassOf biolink:DruggableGeneToDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DruggableGeneToDiseaseAssociation .
-_:c14n243 a owl:Restriction ;
+_:c14n246 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n244 a owl:Restriction ;
+_:c14n247 a owl:Restriction ;
 	rdfs:subClassOf biolink:ClinicalCourse ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ClinicalCourse .
-_:c14n245 a owl:Restriction ;
+_:c14n248 a owl:Restriction ;
 	owl:allValuesFrom linkml:Uriorcurie ;
 	owl:onProperty biolink:original_predicate .
-_:c14n246 rdf:first biolink:AgentTypeEnum\#text_mining_agent ;
-	rdf:rest _:c14n1484 .
-_:c14n247 a owl:Restriction ;
+_:c14n249 rdf:first biolink:AgentTypeEnum\#text_mining_agent ;
+	rdf:rest _:c14n1489 .
+_:c14n25 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n250 a owl:Restriction ;
 	owl:allValuesFrom biolink:DirectionQualifierEnum ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n248 a owl:Restriction ;
+_:c14n251 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:qualified_predicate .
-_:c14n249 a owl:Restriction ;
+_:c14n252 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:trade_name .
-_:c14n25 a owl:Restriction ;
-	owl:allValuesFrom biolink:ExposureEvent ;
-	owl:onProperty biolink:subject .
-_:c14n250 a owl:Restriction ;
+_:c14n253 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_form_or_variant_qualifier .
-_:c14n251 a owl:Restriction ;
+_:c14n254 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneToGeneProductRelationship ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneToGeneProductRelationship .
-_:c14n252 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n253 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:agent_type .
-_:c14n254 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase ;
-	rdf:rest _:c14n875 .
 _:c14n255 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:predicate .
 _:c14n256 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:agent_type .
+_:c14n257 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase ;
+	rdf:rest _:c14n879 .
+_:c14n258 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n259 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n257 a owl:Restriction ;
+_:c14n26 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n260 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n258 a owl:Restriction ;
+_:c14n261 a owl:Restriction ;
 	owl:allValuesFrom biolink:OrganismTaxon ;
 	owl:onProperty biolink:species_context_qualifier .
-_:c14n259 a owl:Restriction ;
+_:c14n262 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalToChemicalDerivationAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalToChemicalDerivationAssociation .
-_:c14n26 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n260 a owl:Restriction ;
+_:c14n263 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n261 a owl:Restriction ;
+_:c14n264 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n262 a owl:Restriction ;
+_:c14n265 a owl:Restriction ;
 	owl:allValuesFrom biolink:ClinicalAttribute ;
 	owl:onProperty biolink:has_attribute .
-_:c14n263 a owl:Restriction ;
+_:c14n266 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n264 a owl:Restriction ;
+_:c14n267 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n265 a owl:Restriction ;
+_:c14n268 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalEntity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalEntity .
-_:c14n266 a owl:Restriction ;
+_:c14n269 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_total .
-_:c14n267 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:subject .
-_:c14n268 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n269 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n27 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n270 a owl:Restriction ;
-	rdfs:subClassOf biolink:ClinicalEntity ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ClinicalEntity .
-_:c14n271 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:object .
-_:c14n272 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:object .
-_:c14n273 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n274 a owl:Restriction ;
-	rdfs:subClassOf biolink:CausalGeneToDiseaseAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:CausalGeneToDiseaseAssociation .
-_:c14n275 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:published_in .
-_:c14n276 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:id .
-_:c14n277 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:adjusted_p_value .
-_:c14n278 a owl:Restriction ;
-	rdfs:subClassOf biolink:MacromolecularMachineToMolecularActivityAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:MacromolecularMachineToMolecularActivityAssociation .
-_:c14n279 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n28 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n280 a owl:Restriction ;
-	rdfs:subClassOf biolink:GeneRegulatesGeneAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:GeneRegulatesGeneAssociation .
-_:c14n281 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:subject_part_qualifier .
-_:c14n282 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n283 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:species_context_qualifier .
-_:c14n284 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n285 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n286 rdf:first biolink:AgentTypeEnum\#manual_validation_of_automated_agent ;
-	rdf:rest _:c14n858 .
-_:c14n287 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n288 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_biological_sequence .
-_:c14n289 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#degradation ;
-	rdf:rest _:c14n1864 .
-_:c14n29 a owl:Restriction ;
 	rdfs:subClassOf biolink:Publication ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Publication .
-_:c14n290 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n291 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#intron ;
-	rdf:rest rdf:nil .
-_:c14n292 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_context_qualifier .
-_:c14n293 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n294 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n295 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:timepoint .
-_:c14n296 rdf:first biolink:ApprovalStatusEnum\#fda_breakthrough_therapy ;
-	rdf:rest _:c14n1278 .
-_:c14n297 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#loss_of_function_variant_form ;
-	rdf:rest _:c14n1314 .
-_:c14n298 a owl:Restriction ;
-	owl:allValuesFrom biolink:DirectionQualifierEnum ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n299 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n3 a owl:Restriction ;
-	owl:allValuesFrom biolink:symbol_type ;
-	owl:onProperty biolink:name .
-_:c14n30 rdf:first biolink:ProteinDomain ;
-	rdf:rest _:c14n1532 .
-_:c14n300 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:narrow_match .
-_:c14n301 owl:unionOf _:c14n785 .
-_:c14n302 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:type .
-_:c14n303 a owl:Restriction ;
-	owl:allValuesFrom biolink:label_type ;
-	owl:onProperty biolink:name .
-_:c14n304 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:frequency_qualifier .
-_:c14n305 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:chapter .
-_:c14n306 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:source_web_page .
-_:c14n307 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n308 a owl:Restriction ;
-	owl:allValuesFrom biolink:SequenceVariant ;
+_:c14n270 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n309 a owl:Restriction ;
+_:c14n271 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_derivative_qualifier .
+_:c14n272 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n273 a owl:Restriction ;
+	rdfs:subClassOf biolink:ClinicalEntity ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ClinicalEntity .
+_:c14n274 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:object .
+_:c14n275 a owl:Restriction ;
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:object .
+_:c14n276 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n277 a owl:Restriction ;
+	rdfs:subClassOf biolink:CausalGeneToDiseaseAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:CausalGeneToDiseaseAssociation .
+_:c14n278 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:published_in .
+_:c14n279 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:id .
+_:c14n28 rdf:first biolink:ProteinDomain ;
+	rdf:rest _:c14n1535 .
+_:c14n280 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:adjusted_p_value .
+_:c14n281 a owl:Restriction ;
+	rdfs:subClassOf biolink:MacromolecularMachineToMolecularActivityAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:MacromolecularMachineToMolecularActivityAssociation .
+_:c14n282 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n31 a owl:Restriction ;
+_:c14n283 a owl:Restriction ;
+	owl:allValuesFrom biolink:IriType ;
+	owl:onProperty biolink:iri .
+_:c14n284 a owl:Restriction ;
+	rdfs:subClassOf biolink:GeneRegulatesGeneAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:GeneRegulatesGeneAssociation .
+_:c14n285 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:subject_part_qualifier .
+_:c14n286 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n287 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:species_context_qualifier .
+_:c14n288 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n289 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n29 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalAffectsGeneAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalAffectsGeneAssociation .
-_:c14n310 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:primary_knowledge_source .
-_:c14n311 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:name .
-_:c14n312 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n313 a owl:Restriction ;
-	owl:allValuesFrom biolink:SequenceVariant ;
-	owl:onProperty biolink:subject .
-_:c14n314 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#folding ;
-	rdf:rest _:c14n1116 .
-_:c14n315 a owl:Restriction ;
-	owl:allValuesFrom owl:Thing ;
-	owl:onProperty biolink:object .
-_:c14n316 a owl:Restriction ;
-	owl:allValuesFrom owl:Thing ;
-	owl:onProperty biolink:exact_match .
-_:c14n317 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:subject_closure .
-_:c14n318 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n319 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_part_qualifier .
-_:c14n32 a owl:Restriction ;
-	owl:allValuesFrom biolink:Treatment ;
-	owl:onProperty biolink:object .
-_:c14n320 a owl:Restriction ;
+_:c14n290 rdf:first biolink:AgentTypeEnum\#manual_validation_of_automated_agent ;
+	rdf:rest _:c14n861 .
+_:c14n291 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
+_:c14n292 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:has_biological_sequence .
+_:c14n293 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#degradation ;
+	rdf:rest _:c14n1864 .
+_:c14n294 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n295 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#intron ;
+	rdf:rest rdf:nil .
+_:c14n296 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_context_qualifier .
+_:c14n297 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
+_:c14n298 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n299 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:timepoint .
+_:c14n3 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n30 a owl:Restriction ;
+	owl:allValuesFrom biolink:Treatment ;
+	owl:onProperty biolink:object .
+_:c14n300 rdf:first biolink:ApprovalStatusEnum\#fda_breakthrough_therapy ;
+	rdf:rest _:c14n1283 .
+_:c14n301 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#loss_of_function_variant_form ;
+	rdf:rest _:c14n1320 .
+_:c14n302 a owl:Restriction ;
+	owl:allValuesFrom biolink:DirectionQualifierEnum ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n303 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n304 a owl:Restriction ;
+	owl:allValuesFrom biolink:LabelType ;
+	owl:onProperty biolink:name .
+_:c14n305 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:narrow_match .
+_:c14n306 owl:unionOf _:c14n786 .
+_:c14n307 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:type .
+_:c14n308 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:frequency_qualifier .
+_:c14n309 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:chapter .
+_:c14n31 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n310 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:source_web_page .
+_:c14n311 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n312 a owl:Restriction ;
+	owl:allValuesFrom biolink:SequenceVariant ;
+	owl:onProperty biolink:subject .
+_:c14n313 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n314 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:primary_knowledge_source .
+_:c14n315 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:name .
+_:c14n316 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n317 a owl:Restriction ;
+	owl:allValuesFrom biolink:SequenceVariant ;
+	owl:onProperty biolink:subject .
+_:c14n318 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#folding ;
+	rdf:rest _:c14n1120 .
+_:c14n319 a owl:Restriction ;
+	owl:allValuesFrom owl:Thing ;
+	owl:onProperty biolink:object .
+_:c14n32 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n320 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
 _:c14n321 a owl:Restriction ;
+	owl:allValuesFrom owl:Thing ;
+	owl:onProperty biolink:exact_match .
+_:c14n322 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:subject_closure .
+_:c14n323 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n324 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_part_qualifier .
+_:c14n325 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n326 a owl:Restriction ;
 	rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityAssociation .
-_:c14n322 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n323 rdf:first biolink:MacromolecularComplex ;
-	rdf:rest _:c14n1385 .
-_:c14n324 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n325 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n326 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:causal_mechanism_qualifier .
 _:c14n327 a owl:Restriction ;
 	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n328 rdf:first biolink:MacromolecularComplex ;
+	rdf:rest _:c14n1389 .
+_:c14n329 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:anatomical_context_qualifier .
+_:c14n33 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:trade_name .
+_:c14n330 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n331 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:causal_mechanism_qualifier .
+_:c14n332 a owl:Restriction ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n328 a owl:Restriction ;
+_:c14n333 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_label_closure .
-_:c14n329 a owl:Restriction ;
+_:c14n334 a owl:Restriction ;
 	rdfs:subClassOf biolink:EnvironmentalFeature ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:EnvironmentalFeature .
-_:c14n33 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n330 a owl:Restriction ;
+_:c14n335 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:timepoint .
-_:c14n331 a owl:Restriction ;
+_:c14n336 a owl:Restriction ;
 	owl:allValuesFrom biolink:DirectionQualifierEnum ;
 	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n332 a owl:Restriction ;
+_:c14n337 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n333 a owl:Restriction ;
+_:c14n338 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n334 a owl:Restriction ;
+_:c14n339 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n335 a owl:Restriction ;
+_:c14n34 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n340 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n336 a owl:Restriction ;
+_:c14n341 a owl:Restriction ;
 	rdfs:subClassOf biolink:Genome ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Genome .
-_:c14n337 a owl:Restriction ;
+_:c14n342 a owl:Restriction ;
 	owl:allValuesFrom biolink:ApprovalStatusEnum ;
 	owl:onProperty biolink:drug_regulatory_status_world_wide .
-_:c14n338 a owl:Restriction ;
+_:c14n343 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:id .
-_:c14n339 a owl:Restriction ;
+_:c14n344 a owl:Restriction ;
 	owl:allValuesFrom biolink:Device ;
 	owl:onProperty biolink:has_device .
-_:c14n34 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
-	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n340 a owl:Restriction ;
+_:c14n345 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentToDiseaseOrPhenotypicFeatureAssociation .
-_:c14n341 a owl:Restriction ;
+_:c14n346 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:associated_environmental_context .
-_:c14n342 rdf:first biolink:CausalMechanismQualifierEnum\#releasing_activity ;
+_:c14n347 rdf:first biolink:CausalMechanismQualifierEnum\#releasing_activity ;
 	rdf:rest rdf:nil .
-_:c14n343 a owl:Restriction ;
+_:c14n348 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n344 a owl:Restriction ;
+_:c14n349 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:timepoint .
-_:c14n345 rdf:first biolink:StudyVariable ;
+_:c14n35 a owl:Restriction ;
+	owl:allValuesFrom biolink:DrugAvailabilityEnum ;
+	owl:onProperty biolink:available_from .
+_:c14n350 rdf:first biolink:StudyVariable ;
 	rdf:rest rdf:nil .
-_:c14n346 a owl:Restriction ;
+_:c14n351 a owl:Restriction ;
 	owl:allValuesFrom biolink:FDAIDAAdverseEventEnum ;
 	owl:onProperty biolink:FDA_adverse_event_level .
-_:c14n347 a owl:Restriction ;
+_:c14n352 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n348 a owl:Restriction ;
+_:c14n353 a owl:Restriction ;
 	owl:allValuesFrom biolink:ExposureEvent ;
 	owl:onProperty biolink:object .
-_:c14n349 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#o_linked_glycosylation ;
-	rdf:rest _:c14n220 .
-_:c14n35 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:trade_name .
-_:c14n350 a owl:Restriction ;
+_:c14n354 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#o_linked_glycosylation ;
+	rdf:rest _:c14n222 .
+_:c14n355 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:sex_qualifier .
-_:c14n351 a owl:Restriction ;
+_:c14n356 a owl:Restriction ;
 	rdfs:subClassOf biolink:PosttranslationalModification ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PosttranslationalModification .
-_:c14n352 a owl:Restriction ;
+_:c14n357 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
 	owl:onProperty biolink:object_part_qualifier .
-_:c14n353 rdf:first biolink:CausalMechanismQualifierEnum\#molecular_channel_opening ;
-	rdf:rest _:c14n1715 .
-_:c14n354 a owl:Restriction ;
+_:c14n358 rdf:first biolink:CausalMechanismQualifierEnum\#molecular_channel_opening ;
+	rdf:rest _:c14n1718 .
+_:c14n359 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:keywords .
-_:c14n355 a owl:Restriction ;
+_:c14n36 a owl:Restriction ;
+	owl:allValuesFrom biolink:Genotype ;
+	owl:onProperty biolink:subject .
+_:c14n360 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n356 a owl:Restriction ;
+_:c14n361 a owl:Restriction ;
 	rdfs:subClassOf biolink:SeverityValue ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:SeverityValue .
-_:c14n357 a owl:Restriction ;
+_:c14n362 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n358 a owl:Restriction ;
+_:c14n363 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:original_predicate .
-_:c14n359 a owl:Restriction ;
+_:c14n364 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n36 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n360 a owl:Restriction ;
+_:c14n365 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n361 a owl:Restriction ;
+_:c14n366 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n362 rdf:first biolink:CausalMechanismQualifierEnum\#potentiation ;
-	rdf:rest _:c14n435 .
-_:c14n363 rdf:first biolink:CausalMechanismQualifierEnum\#inhibition ;
-	rdf:rest _:c14n1502 .
-_:c14n364 a owl:Restriction ;
+_:c14n367 rdf:first biolink:CausalMechanismQualifierEnum\#potentiation ;
+	rdf:rest _:c14n442 .
+_:c14n368 rdf:first biolink:CausalMechanismQualifierEnum\#inhibition ;
+	rdf:rest _:c14n1507 .
+_:c14n369 a owl:Restriction ;
 	owl:allValuesFrom biolink:OntologyClass ;
 	owl:onProperty biolink:quantifier_qualifier .
-_:c14n365 a owl:Restriction ;
+_:c14n37 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n366 a owl:Restriction ;
+_:c14n370 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n371 a owl:Restriction ;
 	rdfs:subClassOf biolink:TranscriptionFactorBindingSite ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:TranscriptionFactorBindingSite .
-_:c14n367 rdf:first biolink:ObservedExpectedFrequencyAnalysisResult ;
-	rdf:rest _:c14n1574 .
-_:c14n368 a owl:Restriction ;
+_:c14n372 rdf:first biolink:ObservedExpectedFrequencyAnalysisResult ;
+	rdf:rest _:c14n1578 .
+_:c14n373 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n369 a owl:Restriction ;
+_:c14n374 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n375 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n37 a owl:Restriction ;
-	owl:allValuesFrom biolink:DrugAvailabilityEnum ;
-	owl:onProperty biolink:available_from .
-_:c14n370 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:issue .
-_:c14n371 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n372 rdf:first biolink:SequenceEnum\#na ;
-	rdf:rest _:c14n1034 .
-_:c14n373 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_context_qualifier .
-_:c14n374 a owl:Restriction ;
-	owl:allValuesFrom biolink:DirectionQualifierEnum ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n375 rdf:first biolink:DruggableGeneCategoryEnum\#tdark ;
-	rdf:rest rdf:nil .
 _:c14n376 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:qualified_predicate .
+	owl:onProperty biolink:issue .
 _:c14n377 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n378 rdf:first biolink:SequenceEnum\#na ;
+	rdf:rest _:c14n1040 .
+_:c14n379 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_context_qualifier .
+_:c14n38 a owl:Restriction ;
+	owl:allValuesFrom biolink:CellLine ;
+	owl:onProperty biolink:subject .
+_:c14n380 a owl:Restriction ;
+	owl:allValuesFrom biolink:DirectionQualifierEnum ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n381 rdf:first biolink:DruggableGeneCategoryEnum\#tdark ;
+	rdf:rest rdf:nil .
+_:c14n382 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:qualified_predicate .
+_:c14n383 a owl:Restriction ;
 	rdfs:subClassOf biolink:Plant ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Plant .
-_:c14n378 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n379 rdf:first biolink:LogOddsAnalysisResult ;
-	rdf:rest _:c14n367 .
-_:c14n38 a owl:Restriction ;
-	owl:allValuesFrom biolink:Genotype ;
-	owl:onProperty biolink:subject .
-_:c14n380 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n381 rdf:first biolink:Dataset ;
-	rdf:rest _:c14n44 .
-_:c14n382 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:population_context_qualifier .
-_:c14n383 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n384 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n385 a owl:Restriction ;
-	rdfs:subClassOf biolink:Zygosity ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Zygosity .
+_:c14n385 rdf:first biolink:LogOddsAnalysisResult ;
+	rdf:rest _:c14n372 .
 _:c14n386 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n387 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n388 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n389 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n39 a owl:Restriction ;
+	owl:onProperty biolink:object .
+_:c14n387 rdf:first biolink:Dataset ;
+	rdf:rest _:c14n42 .
+_:c14n388 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:population_context_qualifier .
+_:c14n389 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
+_:c14n39 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
 _:c14n390 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n391 a owl:Restriction ;
+	rdfs:subClassOf biolink:Zygosity ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Zygosity .
+_:c14n392 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
+_:c14n393 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n392 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:xref .
-_:c14n393 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_part_qualifier .
-_:c14n394 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#methylation ;
-	rdf:rest _:c14n744 .
-_:c14n395 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase_2 ;
-	rdf:rest _:c14n171 .
+_:c14n394 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_direction_qualifier .
+_:c14n395 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
 _:c14n396 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:subject .
 _:c14n397 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:original_object .
-_:c14n398 rdf:first biolink:DrugAvailabilityEnum\#prescription ;
-	rdf:rest rdf:nil .
+	owl:onProperty biolink:subject .
+_:c14n398 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
 _:c14n399 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:xref .
+_:c14n4 rdf:first biolink:DiseaseOrPhenotypicFeature ;
+	rdf:rest _:c14n1314 .
+_:c14n40 rdf:first biolink:Polypeptide ;
+	rdf:rest _:c14n1819 .
+_:c14n400 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_part_qualifier .
+_:c14n401 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#methylation ;
+	rdf:rest _:c14n745 .
+_:c14n402 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase_2 ;
+	rdf:rest _:c14n174 .
+_:c14n403 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n404 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:original_object .
+_:c14n405 rdf:first biolink:DrugAvailabilityEnum\#prescription ;
+	rdf:rest rdf:nil .
+_:c14n406 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n4 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n40 a owl:Restriction ;
-	owl:allValuesFrom biolink:CellLine ;
-	owl:onProperty biolink:subject .
-_:c14n400 a owl:Restriction ;
+_:c14n407 a owl:Restriction ;
 	owl:allValuesFrom linkml:Float ;
 	owl:onProperty biolink:longitude .
-_:c14n401 a owl:Restriction ;
+_:c14n408 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:qualifier .
-_:c14n402 a owl:Restriction ;
+_:c14n409 a owl:Restriction ;
 	rdfs:subClassOf biolink:AnatomicalEntity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:AnatomicalEntity .
-_:c14n403 a owl:Restriction ;
+_:c14n41 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n410 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_category_closure .
-_:c14n404 a owl:Restriction ;
+_:c14n411 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:object .
-_:c14n405 a owl:Restriction ;
+_:c14n412 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeographicLocationAtTime ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeographicLocationAtTime .
-_:c14n406 a owl:Restriction ;
+_:c14n413 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n407 a owl:Restriction ;
+_:c14n414 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n408 a owl:Restriction ;
+_:c14n415 a owl:Restriction ;
 	rdfs:subClassOf biolink:PlanetaryEntity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PlanetaryEntity .
-_:c14n409 a owl:Restriction ;
+_:c14n416 a owl:Restriction ;
 	rdfs:subClassOf biolink:Transcript ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Transcript .
-_:c14n41 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n410 a owl:Restriction ;
+_:c14n417 a owl:Restriction ;
 	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:broad_match .
-_:c14n411 a owl:Restriction ;
+_:c14n418 a owl:Restriction ;
 	rdfs:subClassOf biolink:ContributorAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ContributorAssociation .
-_:c14n412 a owl:Restriction ;
+_:c14n419 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n413 a owl:Restriction ;
+_:c14n42 rdf:first biolink:DatasetDistribution ;
+	rdf:rest _:c14n439 .
+_:c14n420 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n414 a owl:Restriction ;
+_:c14n421 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_attribute .
-_:c14n415 owl:unionOf _:c14n1412 .
-_:c14n416 a owl:Restriction ;
+_:c14n422 owl:unionOf _:c14n1417 .
+_:c14n423 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n417 a owl:Restriction ;
+_:c14n424 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n418 a owl:Restriction ;
+_:c14n425 a owl:Restriction ;
 	rdfs:subClassOf biolink:MolecularActivityToPathwayAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:MolecularActivityToPathwayAssociation .
-_:c14n419 a owl:Restriction ;
+_:c14n426 a owl:Restriction ;
 	owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n42 rdf:first biolink:Polypeptide ;
-	rdf:rest _:c14n1817 .
-_:c14n420 a owl:Restriction ;
+_:c14n427 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:subject .
-_:c14n421 a owl:Restriction ;
+_:c14n428 a owl:Restriction ;
 	owl:allValuesFrom biolink:Agent ;
 	owl:onProperty biolink:authors .
-_:c14n422 a owl:Restriction ;
+_:c14n429 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n423 a owl:Restriction ;
-	owl:allValuesFrom biolink:Transcript ;
-	owl:onProperty biolink:subject .
-_:c14n424 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n425 a owl:Restriction ;
-	rdfs:subClassOf biolink:BiologicalProcessOrActivity ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:BiologicalProcessOrActivity .
-_:c14n426 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#analog_form ;
-	rdf:rest rdf:nil .
-_:c14n427 a owl:Restriction ;
-	rdfs:subClassOf biolink:MaterialSampleDerivationAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:MaterialSampleDerivationAssociation .
-_:c14n428 a owl:Restriction ;
-	owl:allValuesFrom biolink:PhaseEnum ;
-	owl:onProperty biolink:phase .
-_:c14n429 a owl:Restriction ;
-	owl:allValuesFrom biolink:Gene ;
-	owl:onProperty biolink:subject .
 _:c14n43 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n430 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntity ;
+	owl:allValuesFrom biolink:Transcript ;
 	owl:onProperty biolink:subject .
 _:c14n431 a owl:Restriction ;
-	owl:maxCardinality 1 ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n432 rdf:first biolink:DatasetSummary ;
-	rdf:rest _:c14n139 .
-_:c14n433 rdf:first biolink:ClinicalApprovalStatusEnum\#fda_approved_for_condition ;
-	rdf:rest _:c14n1008 .
+_:c14n432 a owl:Restriction ;
+	rdfs:subClassOf biolink:BiologicalProcessOrActivity ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:BiologicalProcessOrActivity .
+_:c14n433 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#analog_form ;
+	rdf:rest rdf:nil .
 _:c14n434 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n435 rdf:first biolink:CausalMechanismQualifierEnum\#activation ;
-	rdf:rest _:c14n970 .
+	rdfs:subClassOf biolink:MaterialSampleDerivationAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:MaterialSampleDerivationAssociation .
+_:c14n435 a owl:Restriction ;
+	owl:allValuesFrom biolink:PhaseEnum ;
+	owl:onProperty biolink:phase .
 _:c14n436 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:allValuesFrom biolink:Gene ;
+	owl:onProperty biolink:subject .
 _:c14n437 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:type .
+	owl:allValuesFrom biolink:ChemicalEntity ;
+	owl:onProperty biolink:subject .
 _:c14n438 a owl:Restriction ;
-	rdfs:subClassOf biolink:Virus ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Virus .
-_:c14n439 rdf:first biolink:ClinicalApprovalStatusEnum\#approved_for_condition ;
-	rdf:rest _:c14n433 .
-_:c14n44 rdf:first biolink:DatasetDistribution ;
-	rdf:rest _:c14n432 .
-_:c14n440 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n441 rdf:first biolink:ApprovalStatusEnum\#regular_fda_approval ;
-	rdf:rest _:c14n988 .
-_:c14n442 rdf:first biolink:CausalMechanismQualifierEnum\#agonism ;
-	rdf:rest _:c14n353 .
-_:c14n443 a owl:Restriction ;
-	rdfs:subClassOf biolink:MicroRNA ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:MicroRNA .
-_:c14n444 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:issue .
-_:c14n445 a owl:Restriction ;
-	rdfs:subClassOf biolink:CellLine ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:CellLine .
-_:c14n446 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n447 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_part_qualifier .
-_:c14n448 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_unit .
-_:c14n449 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n45 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n450 a owl:Restriction ;
-	owl:allValuesFrom biolink:LifeStage ;
-	owl:onProperty biolink:stage_qualifier .
-_:c14n451 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:broad_match .
-_:c14n452 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n453 a owl:Restriction ;
-	owl:allValuesFrom linkml:Double ;
-	owl:onProperty biolink:has_percentage .
-_:c14n454 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:qualified_predicate .
-_:c14n455 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n456 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n457 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:strand .
-_:c14n458 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n459 rdf:first biolink:GeneticInheritance ;
-	rdf:rest _:c14n628 .
-_:c14n46 a owl:Restriction ;
+_:c14n439 rdf:first biolink:DatasetSummary ;
+	rdf:rest _:c14n141 .
+_:c14n44 a owl:Restriction ;
 	rdfs:subClassOf biolink:MolecularActivityToMolecularActivityAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:MolecularActivityToMolecularActivityAssociation .
-_:c14n460 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:synonym .
-_:c14n461 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_context_qualifier .
-_:c14n462 a owl:Restriction ;
-	owl:allValuesFrom biolink:Disease ;
-	owl:onProperty biolink:object .
-_:c14n463 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
-	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n464 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:name .
-_:c14n465 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n466 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_part_qualifier .
-_:c14n467 a owl:Restriction ;
+_:c14n440 rdf:first biolink:ClinicalApprovalStatusEnum\#fda_approved_for_condition ;
+	rdf:rest _:c14n1013 .
+_:c14n441 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n442 rdf:first biolink:CausalMechanismQualifierEnum\#activation ;
+	rdf:rest _:c14n974 .
+_:c14n443 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n468 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:resource_id .
-_:c14n469 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n47 a owl:Restriction ;
+_:c14n444 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:type .
+_:c14n445 a owl:Restriction ;
+	rdfs:subClassOf biolink:Virus ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Virus .
+_:c14n446 rdf:first biolink:ClinicalApprovalStatusEnum\#approved_for_condition ;
+	rdf:rest _:c14n440 .
+_:c14n447 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n448 rdf:first biolink:ApprovalStatusEnum\#regular_fda_approval ;
+	rdf:rest _:c14n992 .
+_:c14n449 rdf:first biolink:CausalMechanismQualifierEnum\#agonism ;
+	rdf:rest _:c14n358 .
+_:c14n45 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_context_qualifier .
+_:c14n450 a owl:Restriction ;
+	rdfs:subClassOf biolink:MicroRNA ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:MicroRNA .
+_:c14n451 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:issue .
+_:c14n452 a owl:Restriction ;
+	rdfs:subClassOf biolink:CellLine ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:CellLine .
+_:c14n453 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_part_qualifier .
+_:c14n454 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_unit .
+_:c14n455 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n456 a owl:Restriction ;
+	owl:allValuesFrom biolink:LifeStage ;
+	owl:onProperty biolink:stage_qualifier .
+_:c14n457 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:broad_match .
+_:c14n458 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n459 a owl:Restriction ;
+	owl:allValuesFrom linkml:Double ;
+	owl:onProperty biolink:has_percentage .
+_:c14n46 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:xref .
+_:c14n460 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:qualified_predicate .
+_:c14n461 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n462 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:anatomical_context_qualifier .
+_:c14n463 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:strand .
+_:c14n464 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n465 rdf:first biolink:GeneticInheritance ;
+	rdf:rest _:c14n631 .
+_:c14n466 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:synonym .
+_:c14n467 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_context_qualifier .
+_:c14n468 a owl:Restriction ;
+	owl:allValuesFrom biolink:Disease ;
+	owl:onProperty biolink:object .
+_:c14n469 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalEntityDerivativeEnum ;
+	owl:onProperty biolink:subject_derivative_qualifier .
+_:c14n47 a owl:Restriction ;
+	owl:allValuesFrom biolink:Procedure ;
+	owl:onProperty biolink:has_procedure .
 _:c14n470 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:name .
+_:c14n471 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n472 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_part_qualifier .
+_:c14n473 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n474 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:resource_id .
+_:c14n475 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
+_:c14n476 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_form_or_variant_qualifier .
-_:c14n471 a owl:Restriction ;
+_:c14n477 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:qualifier .
-_:c14n472 a owl:Restriction ;
+_:c14n478 a owl:Restriction ;
 	rdfs:subClassOf biolink:DatasetDistribution ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DatasetDistribution .
-_:c14n473 a owl:Restriction ;
+_:c14n479 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n474 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#reduction ;
-	rdf:rest _:c14n1311 .
-_:c14n475 a owl:Restriction ;
+_:c14n48 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n480 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#reduction ;
+	rdf:rest _:c14n1317 .
+_:c14n481 a owl:Restriction ;
 	rdfs:subClassOf biolink:PhenotypicFeatureToDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PhenotypicFeatureToDiseaseAssociation .
-_:c14n476 a owl:Restriction ;
+_:c14n482 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:published_in .
-_:c14n477 a owl:Restriction ;
+_:c14n483 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:object .
-_:c14n478 a owl:Restriction ;
+_:c14n484 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_dataset .
-_:c14n479 a owl:Restriction ;
+_:c14n485 a owl:Restriction ;
 	rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityPartOfAssociation .
-_:c14n48 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:xref .
-_:c14n480 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ADP-ribosylation ;
-	rdf:rest _:c14n552 .
-_:c14n481 a owl:Restriction ;
+_:c14n486 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ADP-ribosylation ;
+	rdf:rest _:c14n557 .
+_:c14n487 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneToGeneAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneToGeneAssociation .
-_:c14n482 a owl:Restriction ;
+_:c14n488 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n483 a owl:Restriction ;
+_:c14n489 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:id .
-_:c14n484 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n485 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n486 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:upstream_resource_ids .
-_:c14n487 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#exon ;
-	rdf:rest _:c14n291 .
-_:c14n488 a owl:Restriction ;
-	rdfs:subClassOf biolink:LogOddsAnalysisResult ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:LogOddsAnalysisResult .
-_:c14n489 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
-	owl:onProperty biolink:object_aspect_qualifier .
 _:c14n49 a owl:Restriction ;
-	owl:allValuesFrom biolink:Procedure ;
-	owl:onProperty biolink:has_procedure .
-_:c14n490 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:iri .
-_:c14n491 a owl:Restriction ;
-	rdfs:subClassOf biolink:Activity ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Activity .
-_:c14n492 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntity ;
-	owl:onProperty biolink:subject .
-_:c14n493 rdf:first biolink:CommonDataElement ;
-	rdf:rest _:c14n1202 .
-_:c14n494 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n495 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_label_closure .
-_:c14n496 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_part_qualifier .
-_:c14n497 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n498 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n499 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n5 rdf:first biolink:DiseaseOrPhenotypicFeature ;
-	rdf:rest _:c14n1308 .
-_:c14n50 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n500 a owl:Restriction ;
-	rdfs:subClassOf biolink:SmallMolecule ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:SmallMolecule .
-_:c14n501 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:is_supplement .
-_:c14n502 a owl:Restriction ;
-	rdfs:subClassOf biolink:TaxonToTaxonAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:TaxonToTaxonAssociation .
-_:c14n503 a owl:Restriction ;
-	owl:allValuesFrom biolink:Gene ;
-	owl:onProperty biolink:has_gene_or_gene_product .
-_:c14n504 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_derivative_qualifier .
-_:c14n505 a owl:Restriction ;
-	rdfs:subClassOf biolink:SequenceVariantModulatesTreatmentAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:SequenceVariantModulatesTreatmentAssociation .
-_:c14n506 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n507 a owl:Restriction ;
-	rdfs:subClassOf biolink:Event ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:Event .
-_:c14n508 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:subject .
-_:c14n509 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n51 a owl:Restriction ;
 	rdfs:subClassOf biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:CellLineToDiseaseOrPhenotypicFeatureAssociation .
+_:c14n490 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n491 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n492 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:upstream_resource_ids .
+_:c14n493 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#exon ;
+	rdf:rest _:c14n295 .
+_:c14n494 a owl:Restriction ;
+	rdfs:subClassOf biolink:LogOddsAnalysisResult ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:LogOddsAnalysisResult .
+_:c14n495 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n496 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:iri .
+_:c14n497 a owl:Restriction ;
+	rdfs:subClassOf biolink:Activity ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Activity .
+_:c14n498 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalEntity ;
+	owl:onProperty biolink:subject .
+_:c14n499 rdf:first biolink:CommonDataElement ;
+	rdf:rest _:c14n1206 .
+_:c14n5 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n50 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_derivative_qualifier .
+_:c14n500 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n501 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_label_closure .
+_:c14n502 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_part_qualifier .
+_:c14n503 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_aspect_qualifier .
+_:c14n504 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n505 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_aspect_qualifier .
+_:c14n506 a owl:Restriction ;
+	rdfs:subClassOf biolink:SmallMolecule ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:SmallMolecule .
+_:c14n507 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:is_supplement .
+_:c14n508 a owl:Restriction ;
+	rdfs:subClassOf biolink:TaxonToTaxonAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:TaxonToTaxonAssociation .
+_:c14n509 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n51 a owl:Restriction ;
+	owl:allValuesFrom biolink:CellLine ;
+	owl:onProperty biolink:subject .
 _:c14n510 a owl:Restriction ;
+	owl:allValuesFrom biolink:Gene ;
+	owl:onProperty biolink:has_gene_or_gene_product .
+_:c14n511 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_derivative_qualifier .
+_:c14n512 a owl:Restriction ;
+	rdfs:subClassOf biolink:SequenceVariantModulatesTreatmentAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:SequenceVariantModulatesTreatmentAssociation .
+_:c14n513 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n514 a owl:Restriction ;
+	rdfs:subClassOf biolink:Event ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:Event .
+_:c14n515 a owl:Restriction ;
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:subject .
+_:c14n516 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n517 a owl:Restriction ;
 	rdfs:subClassOf biolink:EnvironmentalExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:EnvironmentalExposure .
-_:c14n511 a owl:Restriction ;
+_:c14n518 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneFamily ;
 	owl:onProperty biolink:object .
-_:c14n512 a owl:Restriction ;
+_:c14n519 a owl:Restriction ;
 	rdfs:subClassOf biolink:MacromolecularMachineToBiologicalProcessAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:MacromolecularMachineToBiologicalProcessAssociation .
-_:c14n513 a owl:Restriction ;
+_:c14n52 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n520 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n514 a owl:Restriction ;
+_:c14n521 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:subject_context_qualifier .
-_:c14n515 a owl:Restriction ;
+_:c14n522 a owl:Restriction ;
 	owl:allValuesFrom biolink:ResearchPhaseEnum ;
 	owl:onProperty biolink:max_research_phase .
-_:c14n516 a owl:Restriction ;
+_:c14n523 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:broad_match .
-_:c14n517 a owl:Restriction ;
+_:c14n524 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:disease_context_qualifier .
-_:c14n518 a owl:Restriction ;
+_:c14n525 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_part_qualifier .
-_:c14n519 a owl:Restriction ;
+_:c14n526 a owl:Restriction ;
 	rdfs:subClassOf biolink:BookChapter ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:BookChapter .
-_:c14n52 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n520 a owl:Restriction ;
+_:c14n527 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_context_qualifier .
-_:c14n521 a owl:Restriction ;
+_:c14n528 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n522 a owl:Restriction ;
+_:c14n529 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n523 a owl:Restriction ;
+_:c14n53 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:has_attribute_type .
+_:c14n530 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:object .
-_:c14n524 a owl:Restriction ;
+_:c14n531 a owl:Restriction ;
 	owl:allValuesFrom biolink:OrganismTaxon ;
 	owl:onProperty biolink:in_taxon .
-_:c14n525 a owl:Restriction ;
+_:c14n532 a owl:Restriction ;
 	owl:allValuesFrom biolink:Genotype ;
 	owl:onProperty biolink:object .
-_:c14n526 a owl:Restriction ;
+_:c14n533 a owl:Restriction ;
 	owl:allValuesFrom biolink:MolecularEntity ;
 	owl:onProperty biolink:object .
-_:c14n527 a owl:Restriction ;
-	owl:allValuesFrom biolink:iri_type ;
-	owl:onProperty biolink:iri .
-_:c14n528 a owl:Restriction ;
+_:c14n534 a owl:Restriction ;
 	owl:allValuesFrom biolink:OntologyClass ;
 	owl:onProperty biolink:object .
-_:c14n529 a owl:Restriction ;
+_:c14n535 a owl:Restriction ;
 	rdfs:subClassOf biolink:PairwiseMolecularInteraction ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PairwiseMolecularInteraction .
-_:c14n53 a owl:Restriction ;
-	owl:allValuesFrom biolink:CellLine ;
-	owl:onProperty biolink:subject .
-_:c14n530 rdf:first biolink:Virus ;
+_:c14n536 rdf:first biolink:Virus ;
 	rdf:rest rdf:nil .
-_:c14n531 a owl:Restriction ;
-	owl:allValuesFrom biolink:biological_sequence ;
-	owl:onProperty biolink:has_biological_sequence .
-_:c14n532 a owl:Restriction ;
+_:c14n537 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_biological_sequence .
-_:c14n533 a owl:Restriction ;
+_:c14n538 a owl:Restriction ;
 	rdfs:subClassOf biolink:Food ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Food .
-_:c14n534 a owl:Restriction ;
+_:c14n539 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n535 a owl:Restriction ;
+_:c14n54 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n540 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n536 a owl:Restriction ;
+_:c14n541 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n537 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#5_prime_utr ;
-	rdf:rest _:c14n1388 .
-_:c14n538 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase_3 ;
-	rdf:rest _:c14n1189 .
-_:c14n539 a owl:Restriction ;
+_:c14n542 rdf:first biolink:GeneOrGeneProductOrChemicalPartQualifierEnum\#5_prime_utr ;
+	rdf:rest _:c14n1392 .
+_:c14n543 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase_3 ;
+	rdf:rest _:c14n1194 .
+_:c14n544 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalRole ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalRole .
-_:c14n54 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n540 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:issue .
-_:c14n541 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_direction_qualifier .
-_:c14n542 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n543 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n544 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
 _:c14n545 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:issue .
 _:c14n546 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n547 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_direction_qualifier .
+_:c14n548 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n549 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n55 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:causal_mechanism_qualifier .
+_:c14n550 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:rights .
-_:c14n547 a owl:Restriction ;
+_:c14n551 a owl:Restriction ;
+	owl:allValuesFrom biolink:LabelType ;
+	owl:onProperty biolink:synonym .
+_:c14n552 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_closure .
-_:c14n548 a owl:Restriction ;
+_:c14n553 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneToGeneCoexpressionAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneToGeneCoexpressionAssociation .
-_:c14n549 a owl:Restriction ;
+_:c14n554 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n55 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_attribute_type .
-_:c14n550 a owl:Restriction ;
+_:c14n555 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n551 a owl:Restriction ;
+_:c14n556 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:population_context_qualifier .
-_:c14n552 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#sulfation ;
-	rdf:rest _:c14n1342 .
-_:c14n553 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n554 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:onset_qualifier .
-_:c14n555 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_numeric_value .
-_:c14n556 a owl:Restriction ;
-	rdfs:subClassOf biolink:VariantToPhenotypicFeatureAssociation ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:VariantToPhenotypicFeatureAssociation .
-_:c14n557 a owl:Restriction ;
-	owl:allValuesFrom biolink:ResearchPhaseEnum ;
-	owl:onProperty biolink:max_research_phase .
+_:c14n557 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#sulfation ;
+	rdf:rest _:c14n1346 .
 _:c14n558 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n559 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:resource_role .
-_:c14n56 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n560 a owl:Restriction ;
-	owl:allValuesFrom linkml:Uriorcurie ;
-	owl:onProperty biolink:resource_id .
-_:c14n561 a owl:Restriction ;
+	owl:onProperty biolink:onset_qualifier .
+_:c14n56 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n562 a owl:Restriction ;
+	owl:onProperty biolink:subject .
+_:c14n560 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:trade_name .
+	owl:onProperty biolink:has_numeric_value .
+_:c14n561 a owl:Restriction ;
+	rdfs:subClassOf biolink:VariantToPhenotypicFeatureAssociation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:VariantToPhenotypicFeatureAssociation .
+_:c14n562 a owl:Restriction ;
+	owl:allValuesFrom biolink:ResearchPhaseEnum ;
+	owl:onProperty biolink:max_research_phase .
 _:c14n563 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n564 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:quantifier_qualifier .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:resource_role .
 _:c14n565 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:p_value .
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty biolink:resource_id .
 _:c14n566 a owl:Restriction ;
-	owl:allValuesFrom biolink:label_type ;
-	owl:onProperty biolink:name .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n567 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_aspect_qualifier .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:trade_name .
 _:c14n568 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:source_web_page .
+	owl:onProperty biolink:object .
 _:c14n569 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:quantifier_qualifier .
 _:c14n57 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:causal_mechanism_qualifier .
-_:c14n570 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
+	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
+_:c14n570 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:p_value .
 _:c14n571 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_aspect_qualifier .
+_:c14n572 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:source_web_page .
+_:c14n573 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n574 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:id .
-_:c14n572 a owl:Restriction ;
+_:c14n575 a owl:Restriction ;
 	rdfs:subClassOf biolink:SocioeconomicExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:SocioeconomicExposure .
-_:c14n573 a owl:Restriction ;
+_:c14n576 a owl:Restriction ;
 	rdfs:subClassOf biolink:Article ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Article .
-_:c14n574 owl:unionOf _:c14n493 .
-_:c14n575 a owl:Restriction ;
+_:c14n577 owl:unionOf _:c14n499 .
+_:c14n578 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:aggregator_knowledge_source .
-_:c14n576 a owl:Restriction ;
+_:c14n579 a owl:Restriction ;
 	rdfs:subClassOf biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:NamedThingAssociatedWithLikelihoodOfNamedThingAssociation .
-_:c14n577 rdf:first biolink:ReagentTargetedGene ;
-	rdf:rest _:c14n862 .
-_:c14n578 a owl:Restriction ;
+_:c14n58 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#molecular_interaction ;
+	rdf:rest _:c14n60 .
+_:c14n580 rdf:first biolink:ReagentTargetedGene ;
+	rdf:rest _:c14n865 .
+_:c14n581 a owl:Restriction ;
 	rdfs:subClassOf biolink:Haplotype ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Haplotype .
-_:c14n579 a owl:Restriction ;
+_:c14n582 a owl:Restriction ;
 	owl:allValuesFrom biolink:SequenceVariant ;
 	owl:onProperty biolink:subject .
-_:c14n58 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n580 a owl:Restriction ;
+_:c14n583 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:knowledge_source .
-_:c14n581 a owl:Restriction ;
+_:c14n584 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n582 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n583 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:species_context_qualifier .
-_:c14n584 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:qualified_predicate .
 _:c14n585 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:subject .
 _:c14n586 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n587 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:species_context_qualifier .
+_:c14n587 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:qualified_predicate .
 _:c14n588 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:highest_FDA_approval_status .
+	owl:onProperty biolink:predicate .
 _:c14n589 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n59 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:object .
+_:c14n590 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n591 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:highest_FDA_approval_status .
+_:c14n592 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:iri .
-_:c14n59 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n590 a owl:Restriction ;
+_:c14n593 a owl:Restriction ;
 	rdfs:subClassOf biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:AnatomicalEntityToAnatomicalEntityOntogenicAssociation .
-_:c14n591 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:anatomical_context_qualifier .
-_:c14n592 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n593 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n594 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:anatomical_context_qualifier .
 _:c14n595 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:predicate .
 _:c14n596 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n597 a owl:Restriction ;
-	owl:allValuesFrom biolink:MacromolecularMachineMixin ;
-	owl:onProperty biolink:subject .
-_:c14n598 rdf:first biolink:CausalMechanismQualifierEnum\#inverse_agonism ;
-	rdf:rest _:c14n848 .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n598 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n599 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:subject .
 _:c14n6 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n60 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#molecular_interaction ;
-	rdf:rest _:c14n62 .
+	owl:onProperty biolink:id .
+_:c14n60 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#molecular_modification ;
+	rdf:rest _:c14n960 .
 _:c14n600 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n601 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:primary_knowledge_source .
+	owl:allValuesFrom biolink:MacromolecularMachineMixin ;
+	owl:onProperty biolink:subject .
+_:c14n601 rdf:first biolink:CausalMechanismQualifierEnum\#inverse_agonism ;
+	rdf:rest _:c14n852 .
 _:c14n602 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:object .
 _:c14n603 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n604 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:primary_knowledge_source .
+_:c14n605 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n605 a owl:Restriction ;
+_:c14n606 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:object .
+_:c14n607 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n608 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_biological_sequence .
-_:c14n606 a owl:Restriction ;
+_:c14n609 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:id .
-_:c14n607 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:subject .
-_:c14n608 a owl:Restriction ;
-	owl:allValuesFrom biolink:MolecularEntity ;
-	owl:onProperty biolink:has_input .
-_:c14n609 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n61 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n610 a owl:Restriction ;
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:subject .
+_:c14n611 a owl:Restriction ;
+	owl:allValuesFrom biolink:MolecularEntity ;
+	owl:onProperty biolink:has_input .
+_:c14n612 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n613 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:is_metabolite .
-_:c14n611 a owl:Restriction ;
+_:c14n614 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:subject_context_qualifier .
-_:c14n612 a owl:Restriction ;
+_:c14n615 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n613 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#genetic_variant_form ;
-	rdf:rest _:c14n1500 .
-_:c14n614 a owl:Restriction ;
+_:c14n616 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#genetic_variant_form ;
+	rdf:rest _:c14n1505 .
+_:c14n617 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:exact_match .
-_:c14n615 owl:unionOf _:c14n772 .
-_:c14n616 a owl:Restriction ;
+_:c14n618 owl:unionOf _:c14n773 .
+_:c14n619 a owl:Restriction ;
 	owl:allValuesFrom biolink:DiseaseOrPhenotypicFeature ;
 	owl:onProperty biolink:object .
-_:c14n617 a owl:Restriction ;
+_:c14n62 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
+	owl:onProperty biolink:object_part_qualifier .
+_:c14n620 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n618 a owl:Restriction ;
+_:c14n621 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_derivative_qualifier .
-_:c14n619 a owl:Restriction ;
+_:c14n622 a owl:Restriction ;
 	rdfs:subClassOf biolink:EntityToPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:EntityToPhenotypicFeatureAssociation .
-_:c14n62 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#molecular_modification ;
-	rdf:rest _:c14n956 .
-_:c14n620 a owl:Restriction ;
+_:c14n623 a owl:Restriction ;
 	owl:allValuesFrom biolink:BiologicalSex ;
 	owl:onProperty biolink:sex_qualifier .
-_:c14n621 a owl:Restriction ;
+_:c14n624 a owl:Restriction ;
 	rdfs:subClassOf biolink:CodingSequence ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:CodingSequence .
-_:c14n622 a owl:Restriction ;
+_:c14n625 a owl:Restriction ;
 	rdfs:subClassOf biolink:Dataset ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Dataset .
-_:c14n623 a owl:Restriction ;
+_:c14n626 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:clinical_approval_status .
-_:c14n624 a owl:Restriction ;
+_:c14n627 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_dataset .
-_:c14n625 a owl:Restriction ;
+_:c14n628 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_attribute_type .
-_:c14n626 rdf:first biolink:CausalMechanismQualifierEnum\#stimulation ;
-	rdf:rest _:c14n342 .
-_:c14n627 a owl:Restriction ;
+_:c14n629 rdf:first biolink:CausalMechanismQualifierEnum\#stimulation ;
+	rdf:rest _:c14n347 .
+_:c14n63 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ribosylation ;
+	rdf:rest _:c14n486 .
+_:c14n630 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n628 rdf:first biolink:Genome ;
-	rdf:rest _:c14n1022 .
-_:c14n629 a owl:Restriction ;
+_:c14n631 rdf:first biolink:Genome ;
+	rdf:rest _:c14n1028 .
+_:c14n632 a owl:Restriction ;
 	rdfs:subClassOf biolink:RetrievalSource ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:RetrievalSource .
-_:c14n63 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n630 a owl:Restriction ;
+_:c14n633 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n631 rdf:first biolink:ReactionDirectionEnum\#left_to_right ;
-	rdf:rest _:c14n135 .
-_:c14n632 a owl:Restriction ;
+_:c14n634 rdf:first biolink:ReactionDirectionEnum\#left_to_right ;
+	rdf:rest _:c14n137 .
+_:c14n635 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n633 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n634 a owl:Restriction ;
-	owl:allValuesFrom biolink:label_type ;
-	owl:onProperty biolink:full_name .
-_:c14n635 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
 _:c14n636 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n637 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n638 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:object_part_qualifier .
-_:c14n637 a owl:Restriction ;
+_:c14n639 a owl:Restriction ;
 	rdfs:subClassOf biolink:JournalArticle ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:JournalArticle .
-_:c14n638 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:publications .
-_:c14n639 a owl:Restriction ;
-	owl:allValuesFrom owl:Thing ;
-	owl:onProperty biolink:object .
 _:c14n64 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
-	owl:onProperty biolink:object_part_qualifier .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
 _:c14n640 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_derivative_qualifier .
+	owl:onProperty biolink:publications .
 _:c14n641 a owl:Restriction ;
-	owl:allValuesFrom biolink:unit ;
-	owl:onProperty biolink:has_unit .
+	owl:allValuesFrom owl:Thing ;
+	owl:onProperty biolink:object .
 _:c14n642 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_derivative_qualifier .
+_:c14n643 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n643 a owl:Restriction ;
+_:c14n644 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:distribution_download_url .
-_:c14n644 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
 _:c14n645 a owl:Restriction ;
-	owl:minCardinality 1 ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n646 a owl:Restriction ;
 	owl:minCardinality 1 ;
@@ -10494,984 +10493,985 @@ _:c14n647 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n648 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n649 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n649 a owl:Restriction ;
+_:c14n65 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:published_in .
+_:c14n650 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneHasVariantThatContributesToDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneHasVariantThatContributesToDiseaseAssociation .
-_:c14n65 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#ribosylation ;
-	rdf:rest _:c14n480 .
-_:c14n650 a owl:Restriction ;
+_:c14n651 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n651 a owl:Restriction ;
+_:c14n652 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_context_qualifier .
-_:c14n652 a owl:Restriction ;
+_:c14n653 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n653 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase_2 ;
-	rdf:rest _:c14n538 .
-_:c14n654 a owl:Restriction ;
+_:c14n654 rdf:first biolink:ResearchPhaseEnum\#clinical_trial_phase_2 ;
+	rdf:rest _:c14n543 .
+_:c14n655 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:object_context_qualifier .
-_:c14n655 a owl:Restriction ;
+_:c14n656 a owl:Restriction ;
 	rdfs:subClassOf biolink:PathologicalProcessExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PathologicalProcessExposure .
-_:c14n656 a owl:Restriction ;
+_:c14n657 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:resource_id .
-_:c14n657 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_gene_or_gene_product .
 _:c14n658 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_derivative_qualifier .
+	owl:onProperty biolink:has_gene_or_gene_product .
 _:c14n659 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom biolink:NarrativeText ;
+	owl:onProperty biolink:description .
 _:c14n66 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n660 a owl:Restriction ;
-	owl:allValuesFrom biolink:biological_sequence ;
-	owl:onProperty biolink:has_biological_sequence .
-_:c14n661 rdf:first biolink:StrandEnum\#\%3F ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_derivative_qualifier .
+_:c14n661 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n662 rdf:first biolink:StrandEnum\#\%3F ;
 	rdf:rest rdf:nil .
-_:c14n662 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#transport ;
-	rdf:rest _:c14n1328 .
-_:c14n663 a owl:Restriction ;
+_:c14n663 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#transport ;
+	rdf:rest _:c14n1332 .
+_:c14n664 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n664 a owl:Restriction ;
+_:c14n665 a owl:Restriction ;
 	rdfs:subClassOf biolink:CommonDataElement ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:CommonDataElement .
-_:c14n665 a owl:Restriction ;
+_:c14n666 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n666 a owl:Restriction ;
+_:c14n667 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:species_context_qualifier .
-_:c14n667 a owl:Restriction ;
+_:c14n668 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n668 a owl:Restriction ;
+_:c14n669 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n669 a owl:Restriction ;
-	owl:allValuesFrom biolink:OntologyClass ;
-	owl:onProperty biolink:subject_context_qualifier .
 _:c14n67 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:published_in .
+	owl:onProperty biolink:has_biological_sequence .
 _:c14n670 a owl:Restriction ;
+	owl:allValuesFrom biolink:OntologyClass ;
+	owl:onProperty biolink:subject_context_qualifier .
+_:c14n671 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_part_qualifier .
-_:c14n671 a owl:Restriction ;
+_:c14n672 a owl:Restriction ;
 	owl:allValuesFrom biolink:Onset ;
 	owl:onProperty biolink:onset_qualifier .
-_:c14n672 a owl:Restriction ;
+_:c14n673 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n673 a owl:Restriction ;
+_:c14n674 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:pages .
-_:c14n674 a owl:Restriction ;
+_:c14n675 a owl:Restriction ;
 	owl:allValuesFrom biolink:ChemicalRole ;
 	owl:onProperty biolink:has_chemical_role .
-_:c14n675 a owl:Restriction ;
+_:c14n676 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n676 a owl:Restriction ;
+_:c14n677 a owl:Restriction ;
 	owl:allValuesFrom biolink:Attribute ;
 	owl:onProperty biolink:has_attribute .
-_:c14n677 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:summary .
 _:c14n678 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:summary .
 _:c14n679 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n68 a owl:Restriction ;
+	owl:allValuesFrom biolink:SymbolType ;
+	owl:onProperty biolink:name .
+_:c14n680 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:quantifier_qualifier .
-_:c14n68 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n680 a owl:Restriction ;
+_:c14n681 a owl:Restriction ;
 	rdfs:subClassOf biolink:PopulationToPopulationAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PopulationToPopulationAssociation .
-_:c14n681 a owl:Restriction ;
+_:c14n682 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:iso_abbreviation .
-_:c14n682 a owl:Restriction ;
+_:c14n683 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n683 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:clinical_approval_status .
 _:c14n684 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:clinical_approval_status .
 _:c14n685 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n686 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n686 a owl:Restriction ;
+_:c14n687 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:clinical_approval_status .
-_:c14n687 a owl:Restriction ;
+_:c14n688 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalMixture ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalMixture .
-_:c14n688 rdf:first biolink:CausalMechanismQualifierEnum\#molecular_channel_blockage ;
-	rdf:rest _:c14n598 .
-_:c14n689 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
+_:c14n689 rdf:first biolink:CausalMechanismQualifierEnum\#molecular_channel_blockage ;
+	rdf:rest _:c14n601 .
 _:c14n69 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:has_biological_sequence .
-_:c14n690 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n691 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n692 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n693 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n694 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n695 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_context_qualifier .
-_:c14n696 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:reaction_direction .
-_:c14n697 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:has_input .
-_:c14n698 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n699 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:object .
-_:c14n7 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n70 a owl:Restriction ;
 	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:has_attribute_type .
-_:c14n700 a owl:Restriction ;
+_:c14n690 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n691 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
+_:c14n692 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n693 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n694 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n695 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n696 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_context_qualifier .
+_:c14n697 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:reaction_direction .
+_:c14n698 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:has_input .
+_:c14n699 a owl:Restriction ;
+	owl:allValuesFrom biolink:LabelType ;
+	owl:onProperty biolink:in_taxon_label .
+_:c14n7 rdf:first biolink:KnowledgeLevelEnum\#statistical_association ;
+	rdf:rest _:c14n133 .
+_:c14n70 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n700 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
 _:c14n701 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:object .
+_:c14n702 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n703 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n702 a owl:Restriction ;
+_:c14n704 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneToGoTermAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneToGoTermAssociation .
-_:c14n703 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:clinical_approval_status .
-_:c14n704 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:name .
 _:c14n705 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n706 rdf:first biolink:ApprovalStatusEnum\#fda_post_market_safety_review ;
-	rdf:rest _:c14n1369 .
+	owl:onProperty biolink:clinical_approval_status .
+_:c14n706 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:name .
 _:c14n707 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n708 rdf:first biolink:ApprovalStatusEnum\#fda_post_market_safety_review ;
+	rdf:rest _:c14n1373 .
+_:c14n709 a owl:Restriction ;
 	rdfs:subClassOf biolink:OrganismTaxonToOrganismTaxonSpecialization ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:OrganismTaxonToOrganismTaxonSpecialization .
-_:c14n708 a owl:Restriction ;
+_:c14n71 a owl:Restriction ;
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:object .
+_:c14n710 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n709 a owl:Restriction ;
+_:c14n711 a owl:Restriction ;
 	owl:allValuesFrom biolink:BehavioralFeature ;
 	owl:onProperty biolink:object .
-_:c14n71 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n710 a owl:Restriction ;
+_:c14n712 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n713 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalPartQualifierEnum ;
 	owl:onProperty biolink:object_part_qualifier .
-_:c14n711 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#metabolic_processing ;
-	rdf:rest _:c14n1384 .
-_:c14n712 a owl:Restriction ;
+_:c14n714 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#metabolic_processing ;
+	rdf:rest _:c14n1388 .
+_:c14n715 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_specialization_qualifier .
-_:c14n713 rdf:first biolink:CausalMechanismQualifierEnum\#binding ;
-	rdf:rest _:c14n363 .
-_:c14n714 a owl:Restriction ;
+_:c14n716 rdf:first biolink:CausalMechanismQualifierEnum\#binding ;
+	rdf:rest _:c14n368 .
+_:c14n717 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n715 rdf:first biolink:StudyResult ;
-	rdf:rest _:c14n345 .
-_:c14n716 a owl:Restriction ;
+_:c14n718 rdf:first biolink:StudyResult ;
+	rdf:rest _:c14n350 .
+_:c14n719 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation .
-_:c14n717 a owl:Restriction ;
-	owl:allValuesFrom biolink:time_type ;
-	owl:onProperty biolink:timepoint .
-_:c14n718 a owl:Restriction ;
+_:c14n72 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n720 a owl:Restriction ;
 	rdfs:subClassOf biolink:Genotype ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Genotype .
-_:c14n719 a owl:Restriction ;
+_:c14n721 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_part_qualifier .
-_:c14n72 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:object .
-_:c14n720 a owl:Restriction ;
+_:c14n722 a owl:Restriction ;
 	owl:allValuesFrom biolink:BiologicalProcess ;
 	owl:onProperty biolink:subject .
-_:c14n721 a owl:Restriction ;
+_:c14n723 a owl:Restriction ;
 	rdfs:subClassOf biolink:PopulationOfIndividualOrganisms ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PopulationOfIndividualOrganisms .
-_:c14n722 a owl:Restriction ;
+_:c14n724 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenotypeAsAModelOfDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenotypeAsAModelOfDiseaseAssociation .
-_:c14n723 a owl:Restriction ;
+_:c14n725 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
 	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n724 a owl:Restriction ;
+_:c14n726 a owl:Restriction ;
 	owl:allValuesFrom biolink:Gene ;
 	owl:onProperty biolink:subject .
-_:c14n725 a owl:Restriction ;
+_:c14n727 a owl:Restriction ;
 	owl:allValuesFrom biolink:PhenotypicFeature ;
 	owl:onProperty biolink:object .
-_:c14n726 a owl:Restriction ;
+_:c14n728 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n727 a owl:Restriction ;
-	owl:allValuesFrom biolink:label_type ;
-	owl:onProperty biolink:in_taxon_label .
-_:c14n728 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
 _:c14n729 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n73 a owl:Restriction ;
-	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n730 rdf:first biolink:AgentTypeEnum\#computational_model ;
-	rdf:rest _:c14n246 .
-_:c14n731 a owl:Restriction ;
+_:c14n73 a owl:Restriction ;
+	owl:allValuesFrom biolink:Study ;
+	owl:onProperty biolink:has_supporting_studies .
+_:c14n730 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n731 rdf:first biolink:AgentTypeEnum\#computational_model ;
+	rdf:rest _:c14n249 .
+_:c14n732 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:full_name .
-_:c14n732 a owl:Restriction ;
+_:c14n733 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:end_interbase_coordinate .
-_:c14n733 a owl:Restriction ;
+_:c14n734 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:xref .
-_:c14n734 a owl:Restriction ;
+_:c14n735 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:subject .
-_:c14n735 a owl:Restriction ;
+_:c14n736 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n736 a owl:Restriction ;
+_:c14n737 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n737 a owl:Restriction ;
+_:c14n738 a owl:Restriction ;
 	rdfs:subClassOf biolink:Procedure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Procedure .
-_:c14n738 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n739 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:format .
+	owl:onProperty biolink:subject .
 _:c14n74 a owl:Restriction ;
-	owl:allValuesFrom biolink:Study ;
-	owl:onProperty biolink:has_supporting_studies .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:predicate .
 _:c14n740 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:format .
 _:c14n741 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n742 a owl:Restriction ;
 	rdfs:subClassOf biolink:Protein ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Protein .
-_:c14n742 a owl:Restriction ;
+_:c14n743 a owl:Restriction ;
 	rdfs:subClassOf biolink:Attribute ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Attribute .
-_:c14n743 a owl:Restriction ;
+_:c14n744 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n744 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#nitrosation ;
-	rdf:rest _:c14n1777 .
-_:c14n745 a owl:Restriction ;
+_:c14n745 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#nitrosation ;
+	rdf:rest _:c14n1779 .
+_:c14n746 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n746 a owl:Restriction ;
+_:c14n747 a owl:Restriction ;
 	rdfs:subClassOf biolink:GrossAnatomicalStructure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GrossAnatomicalStructure .
-_:c14n747 a owl:Restriction ;
+_:c14n748 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:provided_by .
-_:c14n748 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n749 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:anatomical_context_qualifier .
+	owl:onProperty biolink:subject .
 _:c14n75 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
 _:c14n750 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:anatomical_context_qualifier .
+_:c14n751 a owl:Restriction ;
 	rdfs:subClassOf biolink:ProteinFamily ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ProteinFamily .
-_:c14n751 a owl:Restriction ;
+_:c14n752 a owl:Restriction ;
 	owl:allValuesFrom biolink:Disease ;
 	owl:onProperty biolink:object .
-_:c14n752 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:id .
 _:c14n753 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:iso_abbreviation .
+	owl:onProperty biolink:id .
 _:c14n754 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:iso_abbreviation .
+_:c14n755 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n755 a owl:Restriction ;
+_:c14n756 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
-_:c14n756 a owl:Restriction ;
+_:c14n757 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n757 a owl:Restriction ;
+_:c14n758 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:max_research_phase .
-_:c14n758 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:stoichiometry .
 _:c14n759 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:stoichiometry .
 _:c14n76 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
+	owl:onProperty biolink:object_specialization_qualifier .
 _:c14n760 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n761 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:subject .
+_:c14n762 a owl:Restriction ;
 	rdfs:subClassOf biolink:ClinicalModifier ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ClinicalModifier .
-_:c14n762 a owl:Restriction ;
+_:c14n763 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenomicSequenceLocalization ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenomicSequenceLocalization .
-_:c14n763 a owl:Restriction ;
+_:c14n764 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n764 a owl:Restriction ;
+_:c14n765 a owl:Restriction ;
 	rdfs:subClassOf biolink:EnvironmentalFoodContaminant ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:EnvironmentalFoodContaminant .
-_:c14n765 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
 _:c14n766 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:predicate .
 _:c14n767 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
+	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n768 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:subject .
+_:c14n769 a owl:Restriction ;
 	owl:allValuesFrom biolink:Pathway ;
 	owl:onProperty biolink:object .
-_:c14n769 a owl:Restriction ;
+_:c14n77 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object_aspect_qualifier .
+_:c14n770 a owl:Restriction ;
 	owl:allValuesFrom biolink:DatasetDistribution ;
 	owl:onProperty biolink:has_distribution .
-_:c14n77 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_specialization_qualifier .
-_:c14n770 a owl:Restriction ;
+_:c14n771 a owl:Restriction ;
 	rdfs:subClassOf biolink:PhysicalEntity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PhysicalEntity .
-_:c14n771 a owl:Restriction ;
+_:c14n772 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:object_form_or_variant_qualifier .
-_:c14n772 rdf:first biolink:Association ;
-	rdf:rest _:c14n1530 .
-_:c14n773 a owl:Restriction ;
+_:c14n773 rdf:first biolink:Association ;
+	rdf:rest _:c14n1533 .
+_:c14n774 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n774 a owl:Restriction ;
+_:c14n775 a owl:Restriction ;
 	owl:allValuesFrom biolink:PredicateMapping ;
 	owl:onProperty biolink:predicate_mappings .
-_:c14n775 rdf:first biolink:ApprovalStatusEnum\#discovery_and_development_phase ;
-	rdf:rest _:c14n1733 .
-_:c14n776 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:volume .
+_:c14n776 rdf:first biolink:ApprovalStatusEnum\#discovery_and_development_phase ;
+	rdf:rest _:c14n1736 .
 _:c14n777 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:volume .
 _:c14n778 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n779 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:longitude .
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:object .
 _:c14n78 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_aspect_qualifier .
-_:c14n780 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:is_toxic .
-_:c14n781 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:object_closure .
-_:c14n782 a owl:Restriction ;
-	owl:allValuesFrom biolink:Disease ;
-	owl:onProperty biolink:object .
-_:c14n783 a owl:Restriction ;
-	rdfs:subClassOf biolink:ClinicalIntervention ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ClinicalIntervention .
-_:c14n784 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n785 rdf:first biolink:BiologicalProcessOrActivity ;
-	rdf:rest _:c14n1893 .
-_:c14n786 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n787 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:subject .
-_:c14n788 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glycation ;
-	rdf:rest _:c14n1480 .
-_:c14n789 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n79 a owl:Restriction ;
 	rdfs:subClassOf biolink:TextMiningResult ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:TextMiningResult .
+_:c14n780 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:longitude .
+_:c14n781 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:is_toxic .
+_:c14n782 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:object_closure .
+_:c14n783 a owl:Restriction ;
+	owl:allValuesFrom biolink:Disease ;
+	owl:onProperty biolink:object .
+_:c14n784 a owl:Restriction ;
+	rdfs:subClassOf biolink:ClinicalIntervention ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ClinicalIntervention .
+_:c14n785 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n786 rdf:first biolink:BiologicalProcessOrActivity ;
+	rdf:rest _:c14n1893 .
+_:c14n787 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n788 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:subject .
+_:c14n789 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#glycation ;
+	rdf:rest _:c14n1485 .
+_:c14n79 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n790 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n791 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n792 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n792 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:original_object .
 _:c14n793 a owl:Restriction ;
-	owl:minCardinality 1 ;
+	owl:allValuesFrom biolink:PredicateType ;
 	owl:onProperty biolink:predicate .
 _:c14n794 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:original_object .
 _:c14n795 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:predicate .
 _:c14n796 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:onProperty biolink:subject .
 _:c14n797 a owl:Restriction ;
+	owl:allValuesFrom biolink:TimeType ;
+	owl:onProperty biolink:timepoint .
+_:c14n798 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n799 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n8 a owl:Restriction ;
+	owl:onDataRange biolink:ChemicalFormulaValue ;
+	owl:onProperty linkml:topValue ;
+	owl:qualifiedCardinality 1 .
+_:c14n80 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n800 a owl:Restriction ;
 	rdfs:subClassOf biolink:ComplexMolecularMixture ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ComplexMolecularMixture .
-_:c14n798 a owl:Restriction ;
+_:c14n801 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:name .
-_:c14n799 rdf:first biolink:Gene ;
-	rdf:rest _:c14n216 .
-_:c14n8 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:id .
-_:c14n80 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n800 a owl:Restriction ;
+_:c14n802 rdf:first biolink:Gene ;
+	rdf:rest _:c14n218 .
+_:c14n803 a owl:Restriction ;
 	owl:allValuesFrom linkml:Date ;
 	owl:onProperty biolink:creation_date .
-_:c14n801 a owl:Restriction ;
+_:c14n804 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:subject .
-_:c14n802 a owl:Restriction ;
+_:c14n805 a owl:Restriction ;
 	rdfs:subClassOf biolink:DrugToGeneAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DrugToGeneAssociation .
-_:c14n803 a owl:Restriction ;
+_:c14n806 a owl:Restriction ;
 	owl:allValuesFrom biolink:MolecularActivity ;
 	owl:onProperty biolink:object .
-_:c14n804 rdf:first biolink:CausalMechanismQualifierEnum\#antagonism ;
-	rdf:rest _:c14n688 .
-_:c14n805 a owl:Restriction ;
+_:c14n807 rdf:first biolink:CausalMechanismQualifierEnum\#antagonism ;
+	rdf:rest _:c14n689 .
+_:c14n808 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n806 a owl:Restriction ;
+_:c14n809 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:stage_qualifier .
-_:c14n807 a owl:Restriction ;
-	owl:allValuesFrom biolink:AnatomicalEntity ;
-	owl:onProperty biolink:object .
-_:c14n808 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
-	owl:onProperty biolink:subject_aspect_qualifier .
-_:c14n809 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
 _:c14n81 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:onProperty biolink:id .
 _:c14n810 a owl:Restriction ;
+	owl:allValuesFrom biolink:AnatomicalEntity ;
+	owl:onProperty biolink:object .
+_:c14n811 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProductOrChemicalEntityAspectEnum ;
+	owl:onProperty biolink:subject_aspect_qualifier .
+_:c14n812 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n813 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_evidence .
-_:c14n811 a owl:Restriction ;
+_:c14n814 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:timepoint .
-_:c14n812 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#palmitoylation ;
-	rdf:rest _:c14n1442 .
-_:c14n813 a owl:Restriction ;
+_:c14n815 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#palmitoylation ;
+	rdf:rest _:c14n1447 .
+_:c14n816 a owl:Restriction ;
 	rdfs:subClassOf biolink:DatasetVersion ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DatasetVersion .
-_:c14n814 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object_namespace .
-_:c14n815 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_part_qualifier .
-_:c14n816 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:symbol .
 _:c14n817 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:population_context_qualifier .
-_:c14n818 owl:unionOf _:c14n1648 .
-_:c14n819 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
-	owl:onProperty biolink:subject .
-_:c14n82 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:id .
-_:c14n820 a owl:Restriction ;
-	owl:allValuesFrom biolink:OntologyClass ;
-	owl:onProperty biolink:object_category .
-_:c14n821 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#activity_or_abundance ;
-	rdf:rest _:c14n199 .
-_:c14n822 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n823 a owl:Restriction ;
-	owl:allValuesFrom linkml:Uriorcurie ;
-	owl:onProperty biolink:xref .
-_:c14n824 a owl:Restriction ;
+	owl:onProperty biolink:object_namespace .
+_:c14n818 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_biological_sequence .
-_:c14n825 a owl:Restriction ;
+	owl:onProperty biolink:object_part_qualifier .
+_:c14n819 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n826 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:drug_regulatory_status_world_wide .
-_:c14n827 a owl:Restriction ;
-	owl:allValuesFrom linkml:Uriorcurie ;
-	owl:onProperty biolink:xref .
-_:c14n828 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n829 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase_4 ;
-	rdf:rest _:c14n1138 .
-_:c14n83 a owl:Restriction ;
+	owl:onProperty biolink:symbol .
+_:c14n82 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_drug .
+_:c14n820 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:population_context_qualifier .
+_:c14n821 owl:unionOf _:c14n1652 .
+_:c14n822 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalEntityOrGeneOrGeneProduct ;
+	owl:onProperty biolink:subject .
+_:c14n823 a owl:Restriction ;
+	owl:allValuesFrom biolink:OntologyClass ;
+	owl:onProperty biolink:object_category .
+_:c14n824 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#activity_or_abundance ;
+	rdf:rest _:c14n201 .
+_:c14n825 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n826 a owl:Restriction ;
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty biolink:xref .
+_:c14n827 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_biological_sequence .
+_:c14n828 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n829 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:drug_regulatory_status_world_wide .
+_:c14n83 a owl:Restriction ;
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:species_context_qualifier .
 _:c14n830 a owl:Restriction ;
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty biolink:xref .
+_:c14n831 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n832 rdf:first biolink:ApprovalStatusEnum\#fda_clinical_research_phase_4 ;
+	rdf:rest _:c14n1143 .
+_:c14n833 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n834 a owl:Restriction ;
 	rdfs:subClassOf biolink:DiseaseOrPhenotypicFeature ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:DiseaseOrPhenotypicFeature .
-_:c14n831 a owl:Restriction ;
+_:c14n835 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n832 a owl:Restriction ;
+_:c14n836 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:in_taxon_label .
-_:c14n833 a owl:Restriction ;
+_:c14n837 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_namespace .
-_:c14n834 a owl:Restriction ;
+_:c14n838 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n835 rdf:first biolink:DirectionQualifierEnum\#increased ;
-	rdf:rest _:c14n908 .
-_:c14n836 a owl:Restriction ;
+_:c14n839 rdf:first biolink:DirectionQualifierEnum\#increased ;
+	rdf:rest _:c14n912 .
+_:c14n84 a owl:Restriction ;
+	owl:allValuesFrom biolink:StrandEnum ;
+	owl:onProperty biolink:genome_build .
+_:c14n840 a owl:Restriction ;
 	owl:allValuesFrom biolink:Disease ;
 	owl:onProperty biolink:subject .
-_:c14n837 a owl:Restriction ;
+_:c14n841 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_input .
-_:c14n838 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n839 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:qualified_predicate .
-_:c14n84 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:species_context_qualifier .
-_:c14n840 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:object .
-_:c14n841 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#polymorphic_form ;
-	rdf:rest _:c14n1294 .
 _:c14n842 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:predicate .
 _:c14n843 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:object .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:qualified_predicate .
 _:c14n844 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:subject .
-_:c14n845 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:object .
+_:c14n845 rdf:first biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum\#polymorphic_form ;
+	rdf:rest _:c14n1299 .
 _:c14n846 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:is_supplement .
+	owl:onProperty biolink:predicate .
 _:c14n847 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:object .
+_:c14n848 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:subject .
+_:c14n849 a owl:Restriction ;
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:subject .
+_:c14n85 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n848 rdf:first biolink:CausalMechanismQualifierEnum\#negative_allosteric_modulation ;
-	rdf:rest _:c14n442 .
-_:c14n849 a owl:Restriction ;
-	owl:allValuesFrom biolink:time_type ;
-	owl:onProperty biolink:timepoint .
-_:c14n85 a owl:Restriction ;
-	owl:allValuesFrom biolink:StrandEnum ;
-	owl:onProperty biolink:genome_build .
-_:c14n850 rdf:first biolink:OrganismTaxonToOrganismTaxonSpecialization ;
-	rdf:rest rdf:nil .
+_:c14n850 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:is_supplement .
 _:c14n851 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n852 rdf:first biolink:CausalMechanismQualifierEnum\#negative_allosteric_modulation ;
+	rdf:rest _:c14n449 .
+_:c14n853 rdf:first biolink:OrganismTaxonToOrganismTaxonSpecialization ;
+	rdf:rest rdf:nil .
+_:c14n854 a owl:Restriction ;
 	owl:allValuesFrom biolink:PhenotypicFeature ;
 	owl:onProperty biolink:object .
-_:c14n852 a owl:Restriction ;
+_:c14n855 a owl:Restriction ;
 	rdfs:subClassOf biolink:ComplexChemicalExposure ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ComplexChemicalExposure .
-_:c14n853 a owl:Restriction ;
+_:c14n856 a owl:Restriction ;
 	owl:allValuesFrom biolink:NamedThing ;
 	owl:onProperty biolink:object .
-_:c14n854 a owl:Restriction ;
+_:c14n857 a owl:Restriction ;
 	rdfs:subClassOf biolink:PhenotypicFeatureToPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:PhenotypicFeatureToPhenotypicFeatureAssociation .
-_:c14n855 a owl:Restriction ;
+_:c14n858 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:reaction_side .
-_:c14n856 a owl:Restriction ;
+_:c14n859 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n857 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject_namespace .
-_:c14n858 rdf:first biolink:AgentTypeEnum\#not_provided ;
-	rdf:rest rdf:nil .
-_:c14n859 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:published_in .
 _:c14n86 a owl:Restriction ;
-	owl:maxCardinality 1 ;
+	owl:allValuesFrom biolink:ChemicalEntity ;
 	owl:onProperty biolink:subject .
 _:c14n860 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject_namespace .
+_:c14n861 rdf:first biolink:AgentTypeEnum\#not_provided ;
+	rdf:rest rdf:nil .
+_:c14n862 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:published_in .
+_:c14n863 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty biolink:is_metabolite .
-_:c14n861 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:genome_build .
-_:c14n862 rdf:first biolink:RegulatoryRegion ;
-	rdf:rest _:c14n1037 .
-_:c14n863 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:synonym .
 _:c14n864 a owl:Restriction ;
 	owl:maxCardinality 1 ;
+	owl:onProperty biolink:genome_build .
+_:c14n865 rdf:first biolink:RegulatoryRegion ;
+	rdf:rest _:c14n1043 .
+_:c14n866 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:synonym .
+_:c14n867 a owl:Restriction ;
+	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n865 a owl:Restriction ;
+_:c14n868 a owl:Restriction ;
 	owl:allValuesFrom biolink:CausalMechanismQualifierEnum ;
 	owl:onProperty biolink:causal_mechanism_qualifier .
-_:c14n866 a owl:Restriction ;
+_:c14n869 a owl:Restriction ;
 	rdfs:subClassOf biolink:ExonToTranscriptRelationship ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ExonToTranscriptRelationship .
-_:c14n867 a owl:Restriction ;
+_:c14n87 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:predicate_mappings .
+_:c14n870 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n871 a owl:Restriction ;
 	owl:allValuesFrom owl:Thing ;
 	owl:onProperty biolink:subject .
-_:c14n868 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n869 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_biological_sequence .
-_:c14n87 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntity ;
-	owl:onProperty biolink:subject .
-_:c14n870 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:name .
-_:c14n871 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
 _:c14n872 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
 _:c14n873 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_biological_sequence .
+_:c14n874 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:name .
+_:c14n875 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n876 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n877 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:FDA_adverse_event_level .
-_:c14n874 a owl:Restriction ;
+_:c14n878 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n875 rdf:first biolink:ApprovalStatusEnum\#fda_review_phase_4 ;
-	rdf:rest _:c14n706 .
-_:c14n876 a owl:Restriction ;
+_:c14n879 rdf:first biolink:ApprovalStatusEnum\#fda_review_phase_4 ;
+	rdf:rest _:c14n708 .
+_:c14n88 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n880 a owl:Restriction ;
 	rdfs:subClassOf biolink:ClinicalAttribute ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ClinicalAttribute .
-_:c14n877 a owl:Restriction ;
+_:c14n881 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:iso_abbreviation .
-_:c14n878 a owl:Restriction ;
-	owl:allValuesFrom biolink:iri_type ;
-	owl:onProperty biolink:iri .
-_:c14n879 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n88 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:predicate_mappings .
-_:c14n880 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n881 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#myristoylation ;
-	rdf:rest _:c14n812 .
 _:c14n882 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n883 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n884 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#myristoylation ;
+	rdf:rest _:c14n815 .
+_:c14n885 a owl:Restriction ;
 	rdfs:subClassOf biolink:StudyResult ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:StudyResult .
-_:c14n883 a owl:Restriction ;
+_:c14n886 a owl:Restriction ;
 	rdfs:subClassOf biolink:Cell ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Cell .
-_:c14n884 a owl:Restriction ;
+_:c14n887 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
-_:c14n885 a owl:Restriction ;
+_:c14n888 a owl:Restriction ;
 	rdfs:subClassOf biolink:InformationContentEntityToNamedThingAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:InformationContentEntityToNamedThingAssociation .
-_:c14n886 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-	owl:onProperty biolink:object_form_or_variant_qualifier .
-_:c14n887 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
-_:c14n888 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:id .
 _:c14n889 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
 _:c14n89 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:keywords .
 _:c14n890 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+	owl:onProperty biolink:object_form_or_variant_qualifier .
+_:c14n891 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n892 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:predicate .
+_:c14n893 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:id .
+_:c14n894 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n895 a owl:Restriction ;
 	owl:allValuesFrom biolink:AnatomicalEntity ;
 	owl:onProperty biolink:object .
-_:c14n891 a owl:Restriction ;
+_:c14n896 a owl:Restriction ;
 	rdfs:subClassOf biolink:ChemicalGeneInteractionAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:ChemicalGeneInteractionAssociation .
-_:c14n892 a owl:Restriction ;
+_:c14n897 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_total .
-_:c14n893 a owl:Restriction ;
+_:c14n898 a owl:Restriction ;
 	rdfs:subClassOf biolink:GenotypeToDiseaseAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GenotypeToDiseaseAssociation .
-_:c14n894 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n895 a owl:Restriction ;
+_:c14n899 a owl:Restriction ;
 	owl:allValuesFrom biolink:Disease ;
 	owl:onProperty biolink:object .
-_:c14n896 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:object .
-_:c14n897 a owl:Restriction ;
-	rdfs:subClassOf biolink:GeographicLocation ;
+_:c14n9 a owl:Restriction ;
+	rdfs:subClassOf biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation ;
 	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:GeographicLocation .
-_:c14n898 a owl:Restriction ;
-	owl:allValuesFrom biolink:Publication ;
-	owl:onProperty biolink:publications .
-_:c14n899 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
-	owl:onProperty biolink:subject_form_or_variant_qualifier .
-_:c14n9 rdf:first biolink:KnowledgeLevelEnum\#statistical_association ;
-	rdf:rest _:c14n131 .
+	owl:someValuesFrom biolink:ChemicalOrDrugOrTreatmentSideEffectDiseaseOrPhenotypicFeatureAssociation .
 _:c14n90 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:has_attribute_type .
 _:c14n900 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:associated_environmental_context .
-_:c14n901 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_evidence .
-_:c14n902 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n903 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
+_:c14n901 a owl:Restriction ;
+	rdfs:subClassOf biolink:GeographicLocation ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:GeographicLocation .
+_:c14n902 a owl:Restriction ;
+	owl:allValuesFrom biolink:Publication ;
+	owl:onProperty biolink:publications .
+_:c14n903 a owl:Restriction ;
+	owl:allValuesFrom biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum ;
+	owl:onProperty biolink:subject_form_or_variant_qualifier .
 _:c14n904 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:associated_environmental_context .
+_:c14n905 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_evidence .
+_:c14n906 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n907 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n908 a owl:Restriction ;
 	rdfs:subClassOf biolink:Entity ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Entity .
-_:c14n905 a owl:Restriction ;
+_:c14n909 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:source_logo .
-_:c14n906 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_specialization_qualifier .
-_:c14n907 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:type .
-_:c14n908 rdf:first biolink:DirectionQualifierEnum\#upregulated ;
-	rdf:rest _:c14n1882 .
-_:c14n909 a owl:Restriction ;
-	rdfs:subClassOf biolink:LifeStage ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:LifeStage .
 _:c14n91 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n910 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:predicate .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:subject_specialization_qualifier .
 _:c14n911 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:reaction_direction .
-_:c14n912 a owl:Restriction ;
-	owl:allValuesFrom biolink:Zygosity ;
-	owl:onProperty biolink:has_zygosity .
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:type .
+_:c14n912 rdf:first biolink:DirectionQualifierEnum\#upregulated ;
+	rdf:rest _:c14n1884 .
 _:c14n913 a owl:Restriction ;
-	owl:allValuesFrom biolink:DirectionQualifierEnum ;
-	owl:onProperty biolink:subject_direction_qualifier .
+	rdfs:subClassOf biolink:LifeStage ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:LifeStage .
 _:c14n914 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
 _:c14n915 a owl:Restriction ;
-	rdfs:subClassOf biolink:ProteinIsoform ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ProteinIsoform .
-_:c14n916 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:species_context_qualifier .
+	owl:onProperty biolink:reaction_direction .
+_:c14n916 a owl:Restriction ;
+	owl:allValuesFrom biolink:Zygosity ;
+	owl:onProperty biolink:has_zygosity .
 _:c14n917 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_device .
+	owl:allValuesFrom biolink:DirectionQualifierEnum ;
+	owl:onProperty biolink:subject_direction_qualifier .
 _:c14n918 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
 _:c14n919 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:subject_closure .
+	rdfs:subClassOf biolink:ProteinIsoform ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ProteinIsoform .
 _:c14n92 a owl:Restriction ;
 	rdfs:subClassOf biolink:GeneAffectsChemicalAssociation ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:GeneAffectsChemicalAssociation .
-_:c14n920 rdf:first biolink:FDAIDAAdverseEventEnum\#life_threatening_adverse_event ;
-	rdf:rest _:c14n933 .
+_:c14n920 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:species_context_qualifier .
 _:c14n921 a owl:Restriction ;
-	owl:allValuesFrom linkml:Float ;
-	owl:onProperty biolink:adjusted_p_value .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_device .
 _:c14n922 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:subject .
-_:c14n923 a owl:Restriction ;
-	owl:allValuesFrom biolink:OntologyClass ;
-	owl:onProperty biolink:subject_category_closure .
-_:c14n924 a owl:Restriction ;
-	owl:allValuesFrom biolink:OrganismTaxon ;
-	owl:onProperty biolink:subject .
-_:c14n925 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n926 a owl:Restriction ;
-	owl:allValuesFrom linkml:Integer ;
-	owl:onProperty biolink:stoichiometry .
-_:c14n927 a owl:Restriction ;
+_:c14n923 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:name .
+	owl:onProperty biolink:subject_closure .
+_:c14n924 rdf:first biolink:FDAIDAAdverseEventEnum\#life_threatening_adverse_event ;
+	rdf:rest _:c14n938 .
+_:c14n925 a owl:Restriction ;
+	owl:allValuesFrom linkml:Float ;
+	owl:onProperty biolink:adjusted_p_value .
+_:c14n926 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:subject .
+_:c14n927 a owl:Restriction ;
+	owl:allValuesFrom biolink:OntologyClass ;
+	owl:onProperty biolink:subject_category_closure .
 _:c14n928 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:allValuesFrom biolink:OrganismTaxon ;
+	owl:onProperty biolink:subject .
 _:c14n929 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
+	owl:onProperty biolink:predicate .
 _:c14n93 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_chemical_role .
 _:c14n930 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_form_or_variant_qualifier .
+	owl:allValuesFrom linkml:Integer ;
+	owl:onProperty biolink:stoichiometry .
 _:c14n931 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:license .
-_:c14n932 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:category .
-_:c14n933 rdf:first biolink:FDAIDAAdverseEventEnum\#serious_adverse_event ;
-	rdf:rest _:c14n1628 .
-_:c14n934 rdf:first os:AllSomeInterpretation ;
-	rdf:rest _:c14n1915 .
-_:c14n935 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n936 a owl:Restriction ;
-	owl:onDataRange biolink:chemical_formula_value ;
-	owl:onProperty linkml:topValue ;
-	owl:qualifiedCardinality 1 .
-_:c14n937 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:source_web_page .
-_:c14n938 a owl:Restriction ;
+	owl:onProperty biolink:name .
+_:c14n932 a owl:Restriction ;
+	owl:allValuesFrom biolink:LabelType ;
+	owl:onProperty biolink:full_name .
+_:c14n933 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n939 a owl:Restriction ;
-	rdfs:subClassOf biolink:ChemicalExposure ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:ChemicalExposure .
+_:c14n934 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n935 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_form_or_variant_qualifier .
+_:c14n936 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:license .
+_:c14n937 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:category .
+_:c14n938 rdf:first biolink:FDAIDAAdverseEventEnum\#serious_adverse_event ;
+	rdf:rest _:c14n1632 .
+_:c14n939 rdf:first os:AllSomeInterpretation ;
+	rdf:rest _:c14n1915 .
 _:c14n94 a owl:Restriction ;
 	owl:allValuesFrom biolink:DirectionQualifierEnum ;
 	owl:onProperty biolink:subject_direction_qualifier .
@@ -11479,195 +11479,195 @@ _:c14n940 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n941 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:subject .
-_:c14n942 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:id .
-_:c14n943 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_supporting_studies .
+	owl:onProperty biolink:source_web_page .
+_:c14n942 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
+_:c14n943 a owl:Restriction ;
+	rdfs:subClassOf biolink:ChemicalExposure ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:ChemicalExposure .
 _:c14n944 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:subject .
 _:c14n945 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:has_taxonomic_rank .
-_:c14n946 rdf:first biolink:EvidenceType ;
-	rdf:rest _:c14n1678 .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:subject .
+_:c14n946 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:id .
 _:c14n947 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:stage_qualifier .
+	owl:onProperty biolink:has_supporting_studies .
 _:c14n948 a owl:Restriction ;
-	rdfs:subClassOf biolink:PhenotypicSex ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:PhenotypicSex .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:subject .
 _:c14n949 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:object .
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:has_taxonomic_rank .
 _:c14n95 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:affiliation .
-_:c14n950 a owl:Restriction ;
-	owl:minCardinality 1 ;
-	owl:onProperty biolink:predicate .
+_:c14n950 rdf:first biolink:EvidenceType ;
+	rdf:rest _:c14n1682 .
 _:c14n951 a owl:Restriction ;
-	owl:allValuesFrom biolink:GeneOrGeneProduct ;
-	owl:onProperty biolink:object .
-_:c14n952 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty biolink:type .
+	owl:onProperty biolink:stage_qualifier .
+_:c14n952 a owl:Restriction ;
+	rdfs:subClassOf biolink:PhenotypicSex ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:PhenotypicSex .
 _:c14n953 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:has_output .
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:object .
 _:c14n954 a owl:Restriction ;
 	owl:minCardinality 1 ;
-	owl:onProperty biolink:knowledge_level .
+	owl:onProperty biolink:predicate .
 _:c14n955 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty biolink:causal_mechanism_qualifier .
-_:c14n956 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#acetylation ;
-	rdf:rest _:c14n1771 .
+	owl:allValuesFrom biolink:GeneOrGeneProduct ;
+	owl:onProperty biolink:object .
+_:c14n956 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:type .
 _:c14n957 a owl:Restriction ;
-	owl:allValuesFrom biolink:ApprovalStatusEnum ;
-	owl:onProperty biolink:highest_FDA_approval_status .
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:has_output .
 _:c14n958 a owl:Restriction ;
-	owl:allValuesFrom biolink:Disease ;
-	owl:onProperty biolink:disease_context_qualifier .
+	owl:minCardinality 1 ;
+	owl:onProperty biolink:knowledge_level .
 _:c14n959 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty biolink:id .
+	owl:onProperty biolink:causal_mechanism_qualifier .
 _:c14n96 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n960 a owl:Restriction ;
+_:c14n960 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#acetylation ;
+	rdf:rest _:c14n1773 .
+_:c14n961 a owl:Restriction ;
+	owl:allValuesFrom biolink:ApprovalStatusEnum ;
+	owl:onProperty biolink:highest_FDA_approval_status .
+_:c14n962 a owl:Restriction ;
+	owl:allValuesFrom biolink:Disease ;
+	owl:onProperty biolink:disease_context_qualifier .
+_:c14n963 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty biolink:id .
+_:c14n964 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n961 a owl:Restriction ;
+_:c14n965 a owl:Restriction ;
 	owl:allValuesFrom linkml:Uriorcurie ;
 	owl:onProperty biolink:category .
-_:c14n962 a owl:Restriction ;
+_:c14n966 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n963 a owl:Restriction ;
+_:c14n967 a owl:Restriction ;
 	owl:allValuesFrom biolink:DirectionQualifierEnum ;
 	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n964 a owl:Restriction ;
+_:c14n968 a owl:Restriction ;
 	rdfs:subClassOf biolink:EvidenceType ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:EvidenceType .
-_:c14n965 a owl:Restriction ;
+_:c14n969 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n966 a owl:Restriction ;
-	owl:allValuesFrom biolink:StrandEnum ;
-	owl:onProperty biolink:strand .
-_:c14n967 rdf:first biolink:CausalMechanismQualifierEnum\#transcriptional_regulation ;
-	rdf:rest _:c14n1564 .
-_:c14n968 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty biolink:predicate .
-_:c14n969 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:object_direction_qualifier .
 _:c14n97 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_percentage .
-_:c14n970 rdf:first biolink:CausalMechanismQualifierEnum\#inducer ;
-	rdf:rest _:c14n967 .
-_:c14n971 a owl:Restriction ;
+_:c14n970 a owl:Restriction ;
+	owl:allValuesFrom biolink:StrandEnum ;
+	owl:onProperty biolink:strand .
+_:c14n971 rdf:first biolink:CausalMechanismQualifierEnum\#transcriptional_regulation ;
+	rdf:rest _:c14n1567 .
+_:c14n972 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty biolink:predicate .
+_:c14n973 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty biolink:object_direction_qualifier .
+_:c14n974 rdf:first biolink:CausalMechanismQualifierEnum\#inducer ;
+	rdf:rest _:c14n971 .
+_:c14n975 a owl:Restriction ;
 	rdfs:subClassOf biolink:Bacterium ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Bacterium .
-_:c14n972 a owl:Restriction ;
+_:c14n976 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n973 a owl:Restriction ;
-	owl:allValuesFrom biolink:predicate_type ;
-	owl:onProperty biolink:predicate .
-_:c14n974 a owl:Restriction ;
+_:c14n977 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:adjusted_p_value .
-_:c14n975 a owl:Restriction ;
+_:c14n978 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:object_category .
-_:c14n976 a owl:Restriction ;
+_:c14n979 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n977 a owl:Restriction ;
+_:c14n98 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#release ;
+	rdf:rest _:c14n1199 .
+_:c14n980 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty biolink:qualified_predicate .
-_:c14n978 a owl:Restriction ;
+_:c14n981 a owl:Restriction ;
 	rdfs:subClassOf biolink:Invertebrate ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:Invertebrate .
-_:c14n979 a owl:Restriction ;
+_:c14n982 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object_direction_qualifier .
-_:c14n98 rdf:first biolink:GeneOrGeneProductOrChemicalEntityAspectEnum\#release ;
-	rdf:rest _:c14n1194 .
-_:c14n980 a owl:Restriction ;
+_:c14n983 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:object .
-_:c14n981 a owl:Restriction ;
+_:c14n984 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:has_input .
-_:c14n982 a owl:Restriction ;
+_:c14n985 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:original_subject .
-_:c14n983 a owl:Restriction ;
+_:c14n986 a owl:Restriction ;
+	owl:allValuesFrom biolink:PredicateType ;
+	owl:onProperty biolink:predicate .
+_:c14n987 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n984 a owl:Restriction ;
+_:c14n988 a owl:Restriction ;
 	owl:allValuesFrom biolink:GeneOrGeneProduct ;
 	owl:onProperty biolink:subject .
-_:c14n985 a owl:Restriction ;
+_:c14n989 a owl:Restriction ;
 	rdfs:subClassOf biolink:RelativeFrequencyAnalysisResult ;
 	owl:onProperty biolink:category ;
 	owl:someValuesFrom biolink:RelativeFrequencyAnalysisResult .
-_:c14n986 a owl:Restriction ;
-	owl:allValuesFrom biolink:NamedThing ;
-	owl:onProperty biolink:subject .
-_:c14n987 a owl:Restriction ;
-	rdfs:subClassOf biolink:RegulatoryRegion ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:RegulatoryRegion .
-_:c14n988 rdf:first biolink:ApprovalStatusEnum\#post_approval_withdrawal ;
-	rdf:rest rdf:nil .
-_:c14n989 a owl:Restriction ;
-	owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
-	owl:onProperty biolink:population_context_qualifier .
 _:c14n99 a owl:Restriction ;
 	owl:allValuesFrom biolink:DirectionQualifierEnum ;
 	owl:onProperty biolink:object_direction_qualifier .
 _:c14n990 a owl:Restriction ;
+	owl:allValuesFrom biolink:NamedThing ;
+	owl:onProperty biolink:subject .
+_:c14n991 a owl:Restriction ;
+	rdfs:subClassOf biolink:RegulatoryRegion ;
+	owl:onProperty biolink:category ;
+	owl:someValuesFrom biolink:RegulatoryRegion .
+_:c14n992 rdf:first biolink:ApprovalStatusEnum\#post_approval_withdrawal ;
+	rdf:rest rdf:nil .
+_:c14n993 a owl:Restriction ;
+	owl:allValuesFrom biolink:PopulationOfIndividualOrganisms ;
+	owl:onProperty biolink:population_context_qualifier .
+_:c14n994 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:subject_context_qualifier .
-_:c14n991 a owl:Restriction ;
+_:c14n995 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:has_percentage .
-_:c14n992 a owl:Restriction ;
+_:c14n996 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty biolink:subject_direction_qualifier .
-_:c14n993 a owl:Restriction ;
+_:c14n997 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n994 a owl:Restriction ;
+_:c14n998 a owl:Restriction ;
 	owl:allValuesFrom biolink:ClinicalApprovalStatusEnum ;
 	owl:onProperty biolink:clinical_approval_status .
-_:c14n995 a owl:Restriction ;
+_:c14n999 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty biolink:predicate .
-_:c14n996 a owl:Restriction ;
-	rdfs:subClassOf biolink:RNAProductIsoform ;
-	owl:onProperty biolink:category ;
-	owl:someValuesFrom biolink:RNAProductIsoform .
-_:c14n997 a owl:Restriction ;
-	owl:allValuesFrom biolink:NucleicAcidEntity ;
-	owl:onProperty biolink:object .
-_:c14n998 a owl:Restriction ;
-	owl:allValuesFrom biolink:ChemicalEntity ;
-	owl:onProperty biolink:subject .
-_:c14n999 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty biolink:latitude .

--- a/tests/linkml/test_generators/test_javagen.py
+++ b/tests/linkml/test_generators/test_javagen.py
@@ -104,7 +104,7 @@ def test_generate_enum_objects(kitchen_sink_path):
     # Same, but with an enum with names that must be transformed
     expected_enum = OOEnum(
         name="OtherCodes",
-        enum_uri="https://w3id.org/linkml/tests/kitchen_sink/other codes",
+        enum_uri="https://w3id.org/linkml/tests/kitchen_sink/OtherCodes",
     )
     expected_enum.values = [OOEnumValue(label="a_b", text="a b")]
     assert expected_enum == enum_objects["other codes"]

--- a/tests/linkml/test_issues/__snapshots__/issue_163.owl
+++ b/tests/linkml/test_issues/__snapshots__/issue_163.owl
@@ -1,159 +1,131 @@
-@prefix ex: <http://example.org/> .
-@prefix linkml: <https://w3id.org/linkml/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-ex:D2 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "d2" ;
-    rdfs:subClassOf ex:C ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:E a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "e" ;
-    rdfs:subClassOf ex:D1 ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:D1 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "d1" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:has_c ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ex:C ;
-            owl:onProperty ex:has_c ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:has_c ],
-        ex:C ;
-    skos:inScheme <http://example.org/sample/example1> .
-
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix linkml: <https://w3id.org/linkml/> .
+@prefix ex: <http://example.org/> .
+ex:A a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "a" ;
+	rdfs:subClassOf _:c14n1 , _:c14n10 , _:c14n14 , _:c14n17 , _:c14n18 , _:c14n19 , _:c14n2 , _:c14n21 , _:c14n5 , _:c14n6 , _:c14n7 , _:c14n9 ;
+	skos:inScheme ex:sample\/example1 .
+ex:B a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "b" ;
+	rdfs:subClassOf ex:A , _:c14n0 , _:c14n11 , _:c14n4 ;
+	skos:inScheme ex:sample\/example1 .
+ex:C a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "c" ;
+	rdfs:subClassOf ex:B , _:c14n13 , _:c14n15 , _:c14n16 ;
+	skos:inScheme ex:sample\/example1 .
+ex:D1 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "d1" ;
+	rdfs:subClassOf ex:C , _:c14n12 , _:c14n3 , _:c14n8 ;
+	skos:inScheme ex:sample\/example1 .
+ex:D2 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "d2" ;
+	rdfs:subClassOf ex:C ;
+	skos:inScheme ex:sample\/example1 .
+ex:E a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "e" ;
+	rdfs:subClassOf ex:D1 ;
+	skos:inScheme ex:sample\/example1 .
+ex:Unitcode a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf _:c14n20 .
+ex:has_a a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "has a" ;
+	rdfs:range ex:A ;
+	skos:inScheme ex:sample\/example1 .
+ex:has_b a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "has b" ;
+	rdfs:range ex:B ;
+	skos:inScheme ex:sample\/example1 .
+ex:has_c a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "has c" ;
+	rdfs:range ex:C ;
+	skos:inScheme ex:sample\/example1 .
+ex:id a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "id" ;
+	skos:inScheme ex:sample\/example1 .
+ex:len a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "len" ;
+	rdfs:range linkml:Integer ;
+	skos:inScheme ex:sample\/example1 .
+ex:name a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "name" ;
+	rdfs:range linkml:String ;
+	skos:inScheme ex:sample\/example1 .
+ex:sample\/example1 a owl:Ontology ;
+	rdfs:label "example1" .
+ex:unit a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "unit" ;
+	rdfs:range ex:Unitcode ;
+	skos:inScheme ex:sample\/example1 .
 linkml:topValue a owl:DatatypeProperty ;
-    rdfs:label "value" .
-
-ex:A a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "a" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:len ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty ex:len ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty ex:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ex:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:unit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:len ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ex:unitcode ;
-            owl:onProperty ex:unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty ex:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:unit ] ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:B a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "b" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:has_a ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ex:A ;
-            owl:onProperty ex:has_a ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:has_a ],
-        ex:A ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:has_a a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "has a" ;
-    rdfs:range ex:A ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:has_b a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "has b" ;
-    rdfs:range ex:B ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:has_c a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "has c" ;
-    rdfs:range ex:C ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:id a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "id" ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:len a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "len" ;
-    rdfs:range linkml:Integer ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:name a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "name" ;
-    rdfs:range linkml:String ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:unit a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "unit" ;
-    rdfs:range ex:unitcode ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:unitcode a owl:Class,
-        linkml:TypeDefinition ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onDataRange ex:unitcode ;
-            owl:onProperty linkml:topValue ;
-            owl:qualifiedCardinality 1 ] .
-
-ex:C a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "c" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:has_b ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:has_b ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ex:B ;
-            owl:onProperty ex:has_b ],
-        ex:B ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-<http://example.org/sample/example1> a owl:Ontology ;
-    rdfs:label "example1" .
-
+	rdfs:label "value" .
+_:c14n0 a owl:Restriction ;
+	owl:allValuesFrom ex:A ;
+	owl:onProperty ex:has_a .
+_:c14n1 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:name .
+_:c14n10 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:unit .
+_:c14n11 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:has_a .
+_:c14n12 a owl:Restriction ;
+	owl:allValuesFrom ex:C ;
+	owl:onProperty ex:has_c .
+_:c14n13 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:has_b .
+_:c14n14 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:len .
+_:c14n15 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:has_b .
+_:c14n16 a owl:Restriction ;
+	owl:allValuesFrom ex:B ;
+	owl:onProperty ex:has_b .
+_:c14n17 a owl:Restriction ;
+	owl:allValuesFrom ex:Unitcode ;
+	owl:onProperty ex:unit .
+_:c14n18 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:len .
+_:c14n19 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:unit .
+_:c14n2 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty ex:name .
+_:c14n20 a owl:Restriction ;
+	owl:onDataRange ex:Unitcode ;
+	owl:onProperty linkml:topValue ;
+	owl:qualifiedCardinality 1 .
+_:c14n21 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:id .
+_:c14n3 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:has_c .
+_:c14n4 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:has_a .
+_:c14n5 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:name .
+_:c14n6 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty ex:id .
+_:c14n7 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty ex:id .
+_:c14n8 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:has_c .
+_:c14n9 a owl:Restriction ;
+	owl:allValuesFrom linkml:Integer ;
+	owl:onProperty ex:len .

--- a/tests/linkml/test_issues/__snapshots__/issue_163b.owl
+++ b/tests/linkml/test_issues/__snapshots__/issue_163b.owl
@@ -1,159 +1,131 @@
-@prefix ex: <http://example.org/sample/example1/> .
-@prefix linkml: <https://w3id.org/linkml/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex: <http://example.org/sample/example1/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-ex:D2 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "d2" ;
-    rdfs:subClassOf ex:C ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:E a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "e" ;
-    rdfs:subClassOf ex:D1 ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:D1 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "d1" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:has_c ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ex:C ;
-            owl:onProperty ex:has_c ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:has_c ],
-        ex:C ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-linkml:topValue a owl:DatatypeProperty ;
-    rdfs:label "value" .
-
-ex:A a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "a" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:len ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:len ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ex:unitcode ;
-            owl:onProperty ex:unit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty ex:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty ex:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty ex:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:unit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty ex:len ] ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:B a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "b" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom ex:A ;
-            owl:onProperty ex:has_a ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:has_a ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:has_a ],
-        ex:A ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:has_a a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "has a" ;
-    rdfs:range ex:A ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:has_b a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "has b" ;
-    rdfs:range ex:B ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:has_c a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "has c" ;
-    rdfs:range ex:C ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:id a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "id" ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:len a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "len" ;
-    rdfs:range linkml:Integer ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:name a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "name" ;
-    rdfs:range linkml:String ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:unit a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "unit" ;
-    rdfs:range ex:unitcode ;
-    skos:inScheme <http://example.org/sample/example1> .
-
-ex:unitcode a owl:Class,
-        linkml:TypeDefinition ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onDataRange ex:unitcode ;
-            owl:onProperty linkml:topValue ;
-            owl:qualifiedCardinality 1 ] .
-
-ex:C a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "c" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:has_b ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:has_b ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom ex:B ;
-            owl:onProperty ex:has_b ],
-        ex:B ;
-    skos:inScheme <http://example.org/sample/example1> .
-
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix linkml: <https://w3id.org/linkml/> .
+ex:A a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "a" ;
+	rdfs:subClassOf _:c14n0 , _:c14n11 , _:c14n12 , _:c14n13 , _:c14n15 , _:c14n18 , _:c14n2 , _:c14n3 , _:c14n4 , _:c14n6 , _:c14n8 , _:c14n9 ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:B a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "b" ;
+	rdfs:subClassOf ex:A , _:c14n20 , _:c14n5 , _:c14n7 ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:C a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "c" ;
+	rdfs:subClassOf ex:B , _:c14n14 , _:c14n16 , _:c14n21 ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:D1 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "d1" ;
+	rdfs:subClassOf ex:C , _:c14n1 , _:c14n17 , _:c14n19 ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:D2 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "d2" ;
+	rdfs:subClassOf ex:C ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:E a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "e" ;
+	rdfs:subClassOf ex:D1 ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:Unitcode a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf _:c14n10 .
+ex:has_a a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "has a" ;
+	rdfs:range ex:A ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:has_b a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "has b" ;
+	rdfs:range ex:B ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:has_c a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "has c" ;
+	rdfs:range ex:C ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:id a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "id" ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:len a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "len" ;
+	rdfs:range linkml:Integer ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:name a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "name" ;
+	rdfs:range linkml:String ;
+	skos:inScheme <http://example.org/sample/example1> .
+ex:unit a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "unit" ;
+	rdfs:range ex:Unitcode ;
+	skos:inScheme <http://example.org/sample/example1> .
 <http://example.org/sample/example1> a owl:Ontology ;
-    rdfs:label "example1" .
-
+	rdfs:label "example1" .
+linkml:topValue a owl:DatatypeProperty ;
+	rdfs:label "value" .
+_:c14n0 a owl:Restriction ;
+	owl:allValuesFrom linkml:Integer ;
+	owl:onProperty ex:len .
+_:c14n1 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:has_c .
+_:c14n10 a owl:Restriction ;
+	owl:onDataRange ex:Unitcode ;
+	owl:onProperty linkml:topValue ;
+	owl:qualifiedCardinality 1 .
+_:c14n11 a owl:Restriction ;
+	owl:allValuesFrom ex:Unitcode ;
+	owl:onProperty ex:unit .
+_:c14n12 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:name .
+_:c14n13 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:len .
+_:c14n14 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:has_b .
+_:c14n15 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty ex:name .
+_:c14n16 a owl:Restriction ;
+	owl:allValuesFrom ex:B ;
+	owl:onProperty ex:has_b .
+_:c14n17 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:has_c .
+_:c14n18 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:name .
+_:c14n19 a owl:Restriction ;
+	owl:allValuesFrom ex:C ;
+	owl:onProperty ex:has_c .
+_:c14n2 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty ex:id .
+_:c14n20 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:has_a .
+_:c14n21 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:has_b .
+_:c14n3 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty ex:id .
+_:c14n4 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:len .
+_:c14n5 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:has_a .
+_:c14n6 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:unit .
+_:c14n7 a owl:Restriction ;
+	owl:allValuesFrom ex:A ;
+	owl:onProperty ex:has_a .
+_:c14n8 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:id .
+_:c14n9 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:unit .

--- a/tests/linkml/test_issues/__snapshots__/issue_163c.owl
+++ b/tests/linkml/test_issues/__snapshots__/issue_163c.owl
@@ -1,54 +1,47 @@
-@prefix ex: <http://example.org/> .
-@prefix linkml: <https://w3id.org/linkml/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-ex:C1 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "c1" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:s1 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty ex:s1 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:s1 ] ;
-    skos:inScheme <http://example.org/sample/example163c> .
-
-ex:C2 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "c2" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty ex:s2 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty ex:s2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty ex:s2 ] ;
-    skos:inScheme <http://example.org/sample/example163c> .
-
-ex:s1 a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "s1" ;
-    rdfs:range linkml:String ;
-    skos:definition "This is a slot used in one context whose range is a description" ;
-    skos:inScheme <http://example.org/sample/example163c> ;
-    skos:prefLabel "source" .
-
-ex:s2 a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "s2" ;
-    rdfs:range linkml:Uriorcurie ;
-    skos:definition "A second slot which wishes to be called \"source\", but is a URI" ;
-    skos:inScheme <http://example.org/sample/example163c> ;
-    skos:prefLabel "source" .
-
-<http://example.org/sample/example163c> a owl:Ontology ;
-    rdfs:label "example163c" .
-
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix linkml: <https://w3id.org/linkml/> .
+@prefix ex: <http://example.org/> .
+ex:C1 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "c1" ;
+	rdfs:subClassOf _:c14n0 , _:c14n3 , _:c14n5 ;
+	skos:inScheme ex:sample\/example163c .
+ex:C2 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "c2" ;
+	rdfs:subClassOf _:c14n1 , _:c14n2 , _:c14n4 ;
+	skos:inScheme ex:sample\/example163c .
+ex:s1 a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "s1" ;
+	rdfs:range linkml:String ;
+	skos:definition "This is a slot used in one context whose range is a description" ;
+	skos:inScheme ex:sample\/example163c ;
+	skos:prefLabel "source" .
+ex:s2 a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "s2" ;
+	rdfs:range linkml:Uriorcurie ;
+	skos:definition "A second slot which wishes to be called \"source\", but is a URI" ;
+	skos:inScheme ex:sample\/example163c ;
+	skos:prefLabel "source" .
+ex:sample\/example163c a owl:Ontology ;
+	rdfs:label "example163c" .
+_:c14n0 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:s1 .
+_:c14n1 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty ex:s2 .
+_:c14n2 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:s2 .
+_:c14n3 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty ex:s1 .
+_:c14n4 a owl:Restriction ;
+	owl:allValuesFrom linkml:Uriorcurie ;
+	owl:onProperty ex:s2 .
+_:c14n5 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty ex:s1 .

--- a/tests/linkml/test_utils/__snapshots__/owl1.owl
+++ b/tests/linkml/test_utils/__snapshots__/owl1.owl
@@ -1,88 +1,74 @@
-@prefix linkml: <https://w3id.org/linkml/> .
-@prefix meta: <http://example.org/owl1/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-meta:string a owl:Class,
-        linkml:TypeDefinition ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onDataRange meta:string ;
-            owl:onProperty linkml:topValue ;
-            owl:qualifiedCardinality 1 ] .
-
-linkml:topValue a owl:DatatypeProperty ;
-    rdfs:label "value" .
-
-meta:slotonemany a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "slotonemany" ;
-    rdfs:domain meta:C1 ;
-    rdfs:range meta:C2 ;
-    skos:inScheme <http://example.org/owl1> .
-
-meta:slotzeromany a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "slotzeromany" ;
-    rdfs:domain meta:C1 ;
-    rdfs:range meta:C2 ;
-    skos:inScheme <http://example.org/owl1> .
-
-meta:slotopt a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "slotopt" ;
-    rdfs:domain meta:C1 ;
-    rdfs:range meta:C2 ;
-    skos:inScheme <http://example.org/owl1> .
-
-meta:slotreq a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "slotreq" ;
-    rdfs:domain meta:C1 ;
-    rdfs:range meta:C2 ;
-    skos:inScheme <http://example.org/owl1> .
-
-meta:C1 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "c1" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty meta:slotreq ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom meta:C2 ;
-            owl:onProperty meta:slotopt ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty meta:slotonemany ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom meta:C2 ;
-            owl:onProperty meta:slotreq ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty meta:slotopt ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty meta:slotzeromany ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom meta:C2 ;
-            owl:onProperty meta:slotzeromany ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty meta:slotreq ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty meta:slotopt ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom meta:C2 ;
-            owl:onProperty meta:slotonemany ] ;
-    skos:inScheme <http://example.org/owl1> .
-
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix linkml: <https://w3id.org/linkml/> .
+@prefix meta: <http://example.org/owl1/> .
+meta:C1 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "c1" ;
+	rdfs:subClassOf _:c14n0 , _:c14n1 , _:c14n10 , _:c14n3 , _:c14n4 , _:c14n5 , _:c14n6 , _:c14n7 , _:c14n8 , _:c14n9 ;
+	skos:inScheme <http://example.org/owl1> .
+meta:C2 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "c2" ;
+	skos:inScheme <http://example.org/owl1> .
+meta:String a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf _:c14n2 .
+meta:slotonemany a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:domain meta:C1 ;
+	rdfs:label "slotonemany" ;
+	rdfs:range meta:C2 ;
+	skos:inScheme <http://example.org/owl1> .
+meta:slotopt a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:domain meta:C1 ;
+	rdfs:label "slotopt" ;
+	rdfs:range meta:C2 ;
+	skos:inScheme <http://example.org/owl1> .
+meta:slotreq a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:domain meta:C1 ;
+	rdfs:label "slotreq" ;
+	rdfs:range meta:C2 ;
+	skos:inScheme <http://example.org/owl1> .
+meta:slotzeromany a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:domain meta:C1 ;
+	rdfs:label "slotzeromany" ;
+	rdfs:range meta:C2 ;
+	skos:inScheme <http://example.org/owl1> .
 <http://example.org/owl1> a owl:Ontology ;
-    rdfs:label "owl1" .
-
-meta:C2 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "c2" ;
-    skos:inScheme <http://example.org/owl1> .
-
+	rdfs:label "owl1" .
+linkml:topValue a owl:DatatypeProperty ;
+	rdfs:label "value" .
+_:c14n0 a owl:Restriction ;
+	owl:allValuesFrom meta:C2 ;
+	owl:onProperty meta:slotzeromany .
+_:c14n1 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty meta:slotopt .
+_:c14n10 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty meta:slotreq .
+_:c14n2 a owl:Restriction ;
+	owl:onDataRange meta:String ;
+	owl:onProperty linkml:topValue ;
+	owl:qualifiedCardinality 1 .
+_:c14n3 a owl:Restriction ;
+	owl:allValuesFrom meta:C2 ;
+	owl:onProperty meta:slotreq .
+_:c14n4 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty meta:slotzeromany .
+_:c14n5 a owl:Restriction ;
+	owl:allValuesFrom meta:C2 ;
+	owl:onProperty meta:slotonemany .
+_:c14n6 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty meta:slotreq .
+_:c14n7 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty meta:slotopt .
+_:c14n8 a owl:Restriction ;
+	owl:allValuesFrom meta:C2 ;
+	owl:onProperty meta:slotopt .
+_:c14n9 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty meta:slotonemany .

--- a/tests/linkml/test_utils/__snapshots__/owl2.owl
+++ b/tests/linkml/test_utils/__snapshots__/owl2.owl
@@ -1,94 +1,80 @@
-@prefix linkml: <https://w3id.org/linkml/> .
-@prefix meta: <http://example.org/owl2/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-linkml:topValue a owl:DatatypeProperty ;
-    rdfs:label "value" .
-
-meta:annotslot a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "annotslot" ;
-    rdfs:domain meta:C1 ;
-    rdfs:range meta:C2 ;
-    skos:inScheme <http://example.org/owl2> .
-
-meta:annotslot2 a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "annotslot2" ;
-    rdfs:domain meta:C1 ;
-    rdfs:range meta:string ;
-    skos:inScheme <http://example.org/owl2> .
-
-meta:dataslot a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "dataslot" ;
-    rdfs:domain meta:C1 ;
-    rdfs:range meta:string ;
-    skos:inScheme <http://example.org/owl2> .
-
-meta:objslot a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "objslot" ;
-    rdfs:domain meta:C1 ;
-    rdfs:range meta:C2 ;
-    skos:inScheme <http://example.org/owl2> .
-
-meta:C1 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "c1" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty meta:dataslot ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom meta:string ;
-            owl:onProperty meta:annotslot2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty meta:annotslot ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty meta:annotslot ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom meta:C2 ;
-            owl:onProperty meta:objslot ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty meta:objslot ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom meta:string ;
-            owl:onProperty meta:dataslot ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty meta:dataslot ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty meta:objslot ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty meta:annotslot2 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty meta:annotslot2 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom meta:C2 ;
-            owl:onProperty meta:annotslot ] ;
-    skos:inScheme <http://example.org/owl2> .
-
-meta:C2 a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "c2" ;
-    skos:inScheme <http://example.org/owl2> .
-
-meta:string a owl:Class,
-        linkml:TypeDefinition ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onDataRange meta:string ;
-            owl:onProperty linkml:topValue ;
-            owl:qualifiedCardinality 1 ] .
-
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix linkml: <https://w3id.org/linkml/> .
+@prefix meta: <http://example.org/owl2/> .
+meta:C1 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "c1" ;
+	rdfs:subClassOf _:c14n0 , _:c14n1 , _:c14n11 , _:c14n12 , _:c14n2 , _:c14n3 , _:c14n4 , _:c14n5 , _:c14n6 , _:c14n7 , _:c14n8 , _:c14n9 ;
+	skos:inScheme <http://example.org/owl2> .
+meta:C2 a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "c2" ;
+	skos:inScheme <http://example.org/owl2> .
+meta:String a owl:Class , linkml:TypeDefinition ;
+	rdfs:subClassOf _:c14n10 .
+meta:annotslot2 a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:domain meta:C1 ;
+	rdfs:label "annotslot2" ;
+	rdfs:range meta:String ;
+	skos:inScheme <http://example.org/owl2> .
+meta:annotslot a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:domain meta:C1 ;
+	rdfs:label "annotslot" ;
+	rdfs:range meta:C2 ;
+	skos:inScheme <http://example.org/owl2> .
+meta:dataslot a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:domain meta:C1 ;
+	rdfs:label "dataslot" ;
+	rdfs:range meta:String ;
+	skos:inScheme <http://example.org/owl2> .
+meta:objslot a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:domain meta:C1 ;
+	rdfs:label "objslot" ;
+	rdfs:range meta:C2 ;
+	skos:inScheme <http://example.org/owl2> .
 <http://example.org/owl2> a owl:Ontology ;
-    rdfs:label "owl2" .
-
+	rdfs:label "owl2" .
+linkml:topValue a owl:DatatypeProperty ;
+	rdfs:label "value" .
+_:c14n0 a owl:Restriction ;
+	owl:allValuesFrom meta:String ;
+	owl:onProperty meta:annotslot2 .
+_:c14n1 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty meta:dataslot .
+_:c14n10 a owl:Restriction ;
+	owl:onDataRange meta:String ;
+	owl:onProperty linkml:topValue ;
+	owl:qualifiedCardinality 1 .
+_:c14n11 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty meta:objslot .
+_:c14n12 a owl:Restriction ;
+	owl:allValuesFrom meta:C2 ;
+	owl:onProperty meta:annotslot .
+_:c14n2 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty meta:objslot .
+_:c14n3 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty meta:annotslot .
+_:c14n4 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty meta:annotslot2 .
+_:c14n5 a owl:Restriction ;
+	owl:allValuesFrom meta:String ;
+	owl:onProperty meta:dataslot .
+_:c14n6 a owl:Restriction ;
+	owl:allValuesFrom meta:C2 ;
+	owl:onProperty meta:objslot .
+_:c14n7 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty meta:annotslot .
+_:c14n8 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty meta:dataslot .
+_:c14n9 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty meta:annotslot2 .

--- a/tests/linkml_runtime/test_utils/test_schemaview.py
+++ b/tests/linkml_runtime/test_utils/test_schemaview.py
@@ -1656,6 +1656,20 @@ def test_get_uri(schema_view_with_imports: SchemaView) -> None:
 
     assert view.get_uri("string") == "xsd:string"
 
+    # SubsetDefinition: multi-word names are camelcased when building the native URI.
+    # "subset A" -> "SubsetA"; the transformation is directly observable.
+    assert view.get_uri("subset A") == "ks:SubsetA"
+    assert view.get_uri("subset A", expand=True) == "https://w3id.org/linkml/tests/kitchen_sink/SubsetA"
+    assert view.get_uri("subset B") == "ks:SubsetB"
+
+    # TypeDefinition and EnumDefinition: add multi-word names to the kitchen_sink schema
+    # so the camelcase transformation is directly observable (the fixture is function-scoped).
+    view.add_type(TypeDefinition(name="my custom type"))
+    assert view.get_uri("my custom type") == "ks:MyCustomType"
+
+    view.add_enum(EnumDefinition(name="relationship type"))
+    assert view.get_uri("relationship type") == "ks:RelationshipType"
+
 
 def test_uris_without_default_prefix() -> None:
     """Test if uri is correct if no default_prefix is defined for the schema.


### PR DESCRIPTION
## Summary

Fixes #3690

SchemaView's `get_uri` should return normalized names (CamelCase) for Types and Enums for `native`, `expand`ed URIs, but wasn't. Therefore the OWL generator had an [ugly hack](https://github.com/linkml/linkml/blob/b8fe8b7da89cf1332aece90bdccaa0a4243932dc/packages/linkml/src/linkml/generators/owlgen.py#L1573). This PR fixes it.

The [mentioned ugly hack](https://github.com/linkml/linkml/blob/b8fe8b7da89cf1332aece90bdccaa0a4243932dc/packages/linkml/src/linkml/generators/owlgen.py#L1573) was also buggy, because it was only normalizing Types for the `linkml` namespace. Therefore some changes are also needed on the tests. Unfortunately the snapshots get reordered on serialization and therefore the changes look bigger than they are.

This is a preparation fix to replace SchemaLoader (to be phased-out) with SchemaView in JSON-LD generator: #3689 

## How was this tested?

Using available tests. Some changes have been needed in the snapshots (see comment above).

## Areas of uncertainty

Correction on expectations (and therefore snapshot updates) is right. Why was the OWL ugly hack only fixing Types in the `linkml` namespace? [`schema_fixer.py` looks very clear on this](https://github.com/linkml/linkml/blob/de7fae4c5f56bd398569bc9f8545074b03bbc7ad/packages/linkml/src/linkml/utils/schema_fixer.py#L340): `TypeDefinition.__name__: camelcase` for Type and `EnumDefinition.__name__: camelcase` for Enum.

> [!Warning]
> It's changing snapshots from the BioLink model, testing downstream might be needed.
> I'm not deep into OWL, therefore I've used AI to assess the correctness of the snapshot changes and this is what I get: "_The UGLY HACK in owlgen.py only camelcased linkml: prefix types. BiologicalSequence (a biolink-prefix type extending string) was being suppressed or incorrectly handled. With the hack removed and get_uri correctly returning camelcase for ALL types, BiologicalSequence now correctly appears as a TypeDefinition OWL class._"

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
