### PR TITLE
fix(schemaview): resolve inlined through is_a and mixin chains

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
@@ -1948,13 +1948,33 @@ class SchemaView:
     def is_inlined(self, slot: SlotDefinition, imports: bool = True) -> bool:
         """Return true if slot is inferred or asserted inline.
 
+        A slot is inlined when:
+
+        * ``slot.inlined`` or ``slot.inlined_as_list`` is ``True`` (directly or
+          inherited through the slot's ``is_a`` chain), **or**
+        * the slot's range is a class with no identifier/key slot (which forces
+          inlining because there is no reference to use).
+
         :param slot:
         :param imports:
         :return:
         """
         slot_range = slot.range
         if slot_range in self.all_classes():
-            if slot.inlined or slot.inlined_as_list:
+            # Resolve inlined through the slot's is_a chain so that a slot that
+            # inherits inlined=True from a parent slot is correctly detected.
+            resolved_inlined = slot.inlined
+            resolved_inlined_as_list = slot.inlined_as_list
+            parent_name = getattr(slot, "is_a", None)
+            while (resolved_inlined is None and resolved_inlined_as_list is None) and parent_name:
+                parent = self.all_slots(imports=imports).get(parent_name)
+                if parent is None:
+                    break
+                resolved_inlined = parent.inlined
+                resolved_inlined_as_list = parent.inlined_as_list
+                parent_name = parent.is_a
+
+            if resolved_inlined or resolved_inlined_as_list:
                 return True
 
             id_slot = self.get_identifier_slot(slot_range, imports=imports)

--- a/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/schemaview.py
@@ -1951,7 +1951,7 @@ class SchemaView:
         A slot is inlined when:
 
         * ``slot.inlined`` or ``slot.inlined_as_list`` is ``True`` (directly or
-          inherited through the slot's ``is_a`` chain), **or**
+          inherited through the slot's ``is_a`` / ``mixins`` ancestry), **or**
         * the slot's range is a class with no identifier/key slot (which forces
           inlining because there is no reference to use).
 
@@ -1961,18 +1961,29 @@ class SchemaView:
         """
         slot_range = slot.range
         if slot_range in self.all_classes():
-            # Resolve inlined through the slot's is_a chain so that a slot that
-            # inherits inlined=True from a parent slot is correctly detected.
             resolved_inlined = slot.inlined
             resolved_inlined_as_list = slot.inlined_as_list
-            parent_name = getattr(slot, "is_a", None)
-            while (resolved_inlined is None and resolved_inlined_as_list is None) and parent_name:
-                parent = self.all_slots(imports=imports).get(parent_name)
-                if parent is None:
-                    break
-                resolved_inlined = parent.inlined
-                resolved_inlined_as_list = parent.inlined_as_list
-                parent_name = parent.is_a
+
+            slot_name = getattr(slot, "name", None)
+            if (resolved_inlined is None and resolved_inlined_as_list is None) and slot_name:
+                # walk all ancestors (reflexive=False to skip the slot itself,
+                # already checked above).
+                try:
+                    # slot_ancestors() is @lru_cache and handles both is_a and mixins;
+                    ancestors = self.slot_ancestors(slot_name, imports=imports, reflexive=False)
+                except ValueError:
+                    ancestors = []
+                if ancestors:
+                    # all_slots() is @lru_cache
+                    all_slots = self.all_slots(imports=imports)
+                    for anc_name in ancestors:
+                        anc = all_slots.get(anc_name)
+                        if anc is None:
+                            continue
+                        resolved_inlined = resolved_inlined or anc.inlined
+                        resolved_inlined_as_list = resolved_inlined_as_list or anc.inlined_as_list
+                        if resolved_inlined or resolved_inlined_as_list:
+                            break
 
             if resolved_inlined or resolved_inlined_as_list:
                 return True

--- a/tests/linkml_runtime/test_utils/input/schemaview_is_inlined.yaml
+++ b/tests/linkml_runtime/test_utils/input/schemaview_is_inlined.yaml
@@ -54,3 +54,14 @@ slots:
   inlined_as_list_integer:
     range: integer
     inlined_as_list: true
+
+  # is_a inheritance cases — inlined/inlined_as_list declared only on the parent slot.
+  # A child slot that does not re-declare inlined should still be considered inlined
+  # if its parent slot (via is_a) declares inlined: true.
+  child_of_inlined_thing_with_id:
+    is_a: inlined_thing_with_id       # parent has inlined: true
+    range: ThingWithId
+
+  child_of_inlined_as_list_thing_with_id:
+    is_a: inlined_as_list_thing_with_id  # parent has inlined_as_list: true
+    range: ThingWithId

--- a/tests/linkml_runtime/test_utils/input/schemaview_is_inlined.yaml
+++ b/tests/linkml_runtime/test_utils/input/schemaview_is_inlined.yaml
@@ -65,3 +65,24 @@ slots:
   child_of_inlined_as_list_thing_with_id:
     is_a: inlined_as_list_thing_with_id  # parent has inlined_as_list: true
     range: ThingWithId
+
+  # mixin inheritance cases — inlined/inlined_as_list declared only on a mixin slot.
+  # A slot that does not re-declare inlined should still be considered inlined
+  # if a mixin slot declares inlined: true.
+  inlined_mixin:
+    mixin: true
+    inlined: true
+
+  inlined_as_list_mixin:
+    mixin: true
+    inlined_as_list: true
+
+  child_via_inlined_mixin:
+    mixins:
+      - inlined_mixin       # inlined: true inherited via mixin
+    range: ThingWithId
+
+  child_via_inlined_as_list_mixin:
+    mixins:
+      - inlined_as_list_mixin   # inlined_as_list: true inherited via mixin
+    range: ThingWithId

--- a/tests/linkml_runtime/test_utils/test_schemaview.py
+++ b/tests/linkml_runtime/test_utils/test_schemaview.py
@@ -2999,6 +2999,10 @@ def test_materialize_patterns_attribute(sv_structured_patterns: SchemaView) -> N
         # is_inlined() must traverse the slot's is_a chain, not only check the slot itself.
         ("child_of_inlined_thing_with_id", True),
         ("child_of_inlined_as_list_thing_with_id", True),
+        # Slots that inherit inlined/inlined_as_list via mixins without redeclaring it.
+        # is_inlined() must also traverse mixin ancestry, not only is_a chains.
+        ("child_via_inlined_mixin", True),
+        ("child_via_inlined_as_list_mixin", True),
     ],
 )
 def test_is_inlined(sv_inlined: SchemaView, slot_name: str, expected_result: bool) -> None:

--- a/tests/linkml_runtime/test_utils/test_schemaview.py
+++ b/tests/linkml_runtime/test_utils/test_schemaview.py
@@ -2994,6 +2994,11 @@ def test_materialize_patterns_attribute(sv_structured_patterns: SchemaView) -> N
         ("an_integer", False),
         ("inlined_integer", False),
         ("inlined_as_list_integer", False),
+        # Slots that inherit inlined/inlined_as_list via is_a without redeclaring it.
+        # Regression test for https://github.com/linkml/linkml/issues/3695:
+        # is_inlined() must traverse the slot's is_a chain, not only check the slot itself.
+        ("child_of_inlined_thing_with_id", True),
+        ("child_of_inlined_as_list_thing_with_id", True),
     ],
 )
 def test_is_inlined(sv_inlined: SchemaView, slot_name: str, expected_result: bool) -> None:


### PR DESCRIPTION
## Summary

Fixes #3695

`SchemaView.is_inlined()` only checked `slot.inlined` and `slot.inlined_as_list` directly on the passed slot object, without traversing the slot's `is_a` chain. This meant a slot that inherited `inlined: true` from a parent slot via `is_a` was incorrectly reported as non-inlined.

The fix walks the slot's `is_a` chain through `all_slots()` to resolve the inherited value of `inlined` / `inlined_as_list` before making the determination, consistent with how `induced_slot()` already handles inherited slot properties. A `getattr` guard is also added so that `AnonymousSlotExpression` objects — which some callers pass despite the `SlotDefinition` type annotation — are handled safely.

This issue has appeared working on issue #3689: "Adapt JSON-LD generator to use SchemaView".

## How was this tested?

The fix is verified by the full existing test suite (`uv run pytest tests/`), which passes without regression. The bug had no existing test coverage because no test schema exercised the specific pattern of a slot inheriting `inlined` via `is_a` without redeclaring it. A dedicated test reproducing the issue has been added.

## Areas of uncertainty

- The `is_a` chain traversal uses `all_slots()`, which may be expensive for large schemas with deep slot hierarchies. An alternative would be to call `induced_slot()` directly, but that requires a class name which `is_inlined()` does not accept. Reviewers may want to assess whether the traversal cost is acceptable or whether `induced_slot()` should be used instead (requiring a signature change).
- The `getattr(slot, "is_a", None)` guard silently skips the chain traversal for `AnonymousSlotExpression` objects. Whether `is_inlined()` should instead reject non-`SlotDefinition` inputs with a `TypeError` is an open question.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
