### PR TITLE
feat(validator): support importmap for resolving schema imports

### DIFF
--- a/packages/linkml/src/linkml/validator/__init__.py
+++ b/packages/linkml/src/linkml/validator/__init__.py
@@ -3,6 +3,7 @@ The ``linkml.validator`` package contains the LinkML validation framework.
 """
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,7 @@ def _get_default_validator(
     strict: bool = False,
     closed: bool = True,
     config: str | Path | dict | None = None,
+    importmap: Mapping[str, str | dict] | None = None,
 ) -> Validator:
     """Build the default :class:`Validator` for a schema.
 
@@ -34,6 +36,9 @@ def _get_default_validator(
         to a ``linkml-validate``-style YAML file or a pre-parsed mapping.
         When the mapping contains a ``plugins:`` key, those plugins are
         used in place of the default and ``closed`` is ignored.
+    :param importmap: A map used to resolve the schema's imports. Values may be
+        file-path/URL strings or in-memory schema dicts. Forwarded to the
+        :class:`Validator`. Defaults to ``None``.
     """
     try:
         if isinstance(schema, Path):
@@ -50,7 +55,7 @@ def _get_default_validator(
 
     validation_plugins = _resolve_default_plugins(closed=closed, config=config)
 
-    return Validator(schema, validation_plugins=validation_plugins, strict=strict)
+    return Validator(schema, validation_plugins=validation_plugins, strict=strict, importmap=importmap)
 
 
 def _resolve_default_plugins(
@@ -91,6 +96,7 @@ def validate(
     target_class: str | None = None,
     *,
     strict: bool = False,
+    importmap: Mapping[str, str | dict] | None = None,
 ) -> ValidationReport:
     """Validate a data instance against a schema
 
@@ -109,11 +115,13 @@ def validate(
     :param strict: If ``True``, validation will stop after the first validation
         error is found, Otherwise all validation problems will be reported.
         Defaults to ``False``.
+    :param importmap: A map used to resolve the schema's imports. Values may be
+        file-path/URL strings or in-memory schema dicts. Defaults to ``None``.
     :raises ValidationError: If requested to raise and validation errors are found.
     :return: A validation report
     :rtype: ValidationReport
     """
-    validator = _get_default_validator(schema, strict=strict)
+    validator = _get_default_validator(schema, strict=strict, importmap=importmap)
     return validator.validate(instance, target_class)
 
 
@@ -123,6 +131,7 @@ def validate_file(
     target_class: str | None = None,
     *,
     strict: bool = False,
+    importmap: Mapping[str, str | dict] | None = None,
 ) -> ValidationReport:
     """Validate instances loaded from a file against a schema
 
@@ -147,12 +156,14 @@ def validate_file(
     :param strict: If ``True``, validation will stop after the first validation
         error is found, Otherwise all validation problems will be reported.
         Defaults to ``False``.
+    :param importmap: A map used to resolve the schema's imports. Values may be
+        file-path/URL strings or in-memory schema dicts. Defaults to ``None``.
     :return: A validation report
     :rtype: ValidationReport
     """
     schema_path = schema if isinstance(schema, str | Path) else None
     loader = default_loader_for_file(file, schema_path=schema_path, target_class=target_class)
-    validator = _get_default_validator(schema, strict=strict)
+    validator = _get_default_validator(schema, strict=strict, importmap=importmap)
     return validator.validate_source(loader, target_class)
 
 

--- a/packages/linkml/src/linkml/validator/__init__.py
+++ b/packages/linkml/src/linkml/validator/__init__.py
@@ -3,6 +3,7 @@ The ``linkml.validator`` package contains the LinkML validation framework.
 """
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,7 @@ def _get_default_validator(
     strict: bool = False,
     closed: bool = True,
     config: str | Path | dict | None = None,
+    importmap: Mapping[str, str | dict] | None = None,
 ) -> Validator:
     """Build the default :class:`Validator` for a schema.
 
@@ -34,6 +36,9 @@ def _get_default_validator(
         to a ``linkml-validate``-style YAML file or a pre-parsed mapping.
         When the mapping contains a ``plugins:`` key, those plugins are
         used in place of the default and ``closed`` is ignored.
+    :param importmap: A map used to resolve the schema's imports. Values may be
+        file-path/URL strings or in-memory schema dicts. Forwarded to the
+        :class:`Validator`. Defaults to ``None``.
     """
     try:
         if isinstance(schema, dict):
@@ -50,7 +55,7 @@ def _get_default_validator(
 
     validation_plugins = _resolve_default_plugins(closed=closed, config=config)
 
-    return Validator(schema, validation_plugins=validation_plugins, strict=strict)
+    return Validator(schema, validation_plugins=validation_plugins, strict=strict, importmap=importmap)
 
 
 def _resolve_default_plugins(
@@ -91,6 +96,7 @@ def validate(
     target_class: str | None = None,
     *,
     strict: bool = False,
+    importmap: Mapping[str, str | dict] | None = None,
 ) -> ValidationReport:
     """Validate a data instance against a schema
 
@@ -109,11 +115,13 @@ def validate(
     :param strict: If ``True``, validation will stop after the first validation
         error is found, Otherwise all validation problems will be reported.
         Defaults to ``False``.
+    :param importmap: A map used to resolve the schema's imports. Values may be
+        file-path/URL strings or in-memory schema dicts. Defaults to ``None``.
     :raises ValidationError: If requested to raise and validation errors are found.
     :return: A validation report
     :rtype: ValidationReport
     """
-    validator = _get_default_validator(schema, strict=strict)
+    validator = _get_default_validator(schema, strict=strict, importmap=importmap)
     return validator.validate(instance, target_class)
 
 
@@ -123,6 +131,7 @@ def validate_file(
     target_class: str | None = None,
     *,
     strict: bool = False,
+    importmap: Mapping[str, str | dict] | None = None,
 ) -> ValidationReport:
     """Validate instances loaded from a file against a schema
 
@@ -147,12 +156,14 @@ def validate_file(
     :param strict: If ``True``, validation will stop after the first validation
         error is found, Otherwise all validation problems will be reported.
         Defaults to ``False``.
+    :param importmap: A map used to resolve the schema's imports. Values may be
+        file-path/URL strings or in-memory schema dicts. Defaults to ``None``.
     :return: A validation report
     :rtype: ValidationReport
     """
     schema_path = schema if isinstance(schema, str | Path) else None
     loader = default_loader_for_file(file, schema_path=schema_path, target_class=target_class)
-    validator = _get_default_validator(schema, strict=strict)
+    validator = _get_default_validator(schema, strict=strict, importmap=importmap)
     return validator.validate_source(loader, target_class)
 
 

--- a/packages/linkml/src/linkml/validator/cli.py
+++ b/packages/linkml/src/linkml/validator/cli.py
@@ -3,7 +3,7 @@ import sys
 from collections import Counter
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 import click
 import yaml
@@ -17,6 +17,7 @@ from linkml.validator.plugins import ValidationPlugin
 from linkml.validator.report import Severity
 from linkml_runtime.linkml_model import SchemaDefinition
 from linkml_runtime.loaders import yaml_loader
+from linkml_runtime.utils.context_utils import parse_import_map
 
 
 class Config(BaseModel):
@@ -94,6 +95,7 @@ def _normalize_and_validate(
     plugins: list[ValidationPlugin],
     exit_on_first_failure: bool,
     include_context: bool,
+    importmap: dict[str, str | dict] | None = None,
 ) -> Counter:
     """Run ReferenceValidator to normalize data, then validate the result
     using the standard Validator path.
@@ -112,7 +114,7 @@ def _normalize_and_validate(
             f"Use 'linkml validate -s schema.yaml {data_path}' without --fix for other formats."
         )
 
-    sv = SchemaView(schema)
+    sv = SchemaView(schema, importmap=importmap)
     normalizer = ReferenceValidator(sv)
 
     with open(data_path) as f:
@@ -139,7 +141,7 @@ def _normalize_and_validate(
     click.echo(yaml.dump(output_object, sort_keys=False))
 
     # Validate normalized output using the standard Validator path
-    validator = Validator(sv.schema, validation_plugins=plugins, strict=exit_on_first_failure)
+    validator = Validator(sv.schema, validation_plugins=plugins, strict=exit_on_first_failure, importmap=importmap)
     for result in validator.iter_results(output_object, target_class):
         severity_counter[result.severity] += 1
         click.echo(f"[{result.severity.value}] [{data_path}/{result.instance_index}] {result.message}", err=True)
@@ -207,6 +209,12 @@ def _normalize_and_validate(
     "Diagnostics go to stderr. The normalized output is then validated to "
     "report any remaining issues.",
 )
+@click.option(
+    "--importmap",
+    "-im",
+    type=click.File(),
+    help="Import mapping file (YAML or JSON) used to resolve the schema's imports.",
+)
 @click.argument("data_sources", nargs=-1, type=click.Path(exists=True))
 @click.version_option(__version__, "-V", "--version")
 def cli(
@@ -219,6 +227,7 @@ def cli(
     include_context: bool,
     allow_null_for_optional_enums: bool,
     fix: bool,
+    importmap: TextIO | None,
 ):
     """Validate data against a LinkML schema, or validate a schema against the metamodel.
 
@@ -285,6 +294,8 @@ def cli(
         except ValueError as e:
             raise click.ClickException(str(e)) from e
 
+    import_map = parse_import_map(importmap.read(), str(Path(importmap.name).parent)) if importmap is not None else None
+
     severity_counter = Counter()
 
     if fix:
@@ -297,10 +308,13 @@ def cli(
             plugins,
             exit_on_first_failure,
             include_context,
+            import_map,
         )
     else:
         loaders = _resolve_loaders(cfg.data_sources, schema_path=cfg.schema_path, target_class=cfg.target_class)
-        validator = Validator(schema_def, validation_plugins=plugins, strict=exit_on_first_failure)
+        validator = Validator(
+            schema_def, validation_plugins=plugins, strict=exit_on_first_failure, importmap=import_map
+        )
 
         for loader in loaders:
             for result in validator.iter_results_from_source(loader, cfg.target_class):

--- a/packages/linkml/src/linkml/validator/validation_context.py
+++ b/packages/linkml/src/linkml/validator/validation_context.py
@@ -1,6 +1,7 @@
 import json
 import os
 from collections import OrderedDict
+from collections.abc import Mapping
 from functools import lru_cache
 
 import jsonschema
@@ -33,6 +34,10 @@ from linkml_runtime.utils.formatutils import camelcase
 #
 # The root's additionalProperties is overridden at retrieval time, so cached
 # $defs are reusable regardless of closed.
+#
+# The key does not include the importmap, so contexts with an importmap bypass this
+# shared cache to avoid colliding when one schema object is reused with different
+# importmaps (see json_schema_validator).
 _JSON_SCHEMA_CACHE_MAXSIZE = 32
 _json_schema_cache: OrderedDict[tuple, JsonSchema] = OrderedDict()
 _schema_pins: dict[tuple, SchemaDefinition] = {}
@@ -55,11 +60,18 @@ _ROOT_METADATA_KEYS: tuple = ("$schema", "$id", "metamodel_version", "version", 
 class ValidationContext:
     """Provides state that may be shared between validation plugins"""
 
-    def __init__(self, schema: SchemaDefinition, target_class: str | None = None) -> None:
+    def __init__(
+        self,
+        schema: SchemaDefinition,
+        target_class: str | None = None,
+        importmap: Mapping[str, str | dict] | None = None,
+    ) -> None:
         # Since SchemaDefinition is not hashable, to make caching simpler we store the schema
         # in a "private" property and assume it never changes.
         self._schema = schema
-        self._schema_view = SchemaView(self._schema)
+        # json_schema_validator() and _pydantic_module() resolve imports through the importmap
+        self._importmap = importmap
+        self._schema_view = SchemaView(self._schema, importmap=importmap)
         self._target_class = self._get_target_class(target_class)
 
     @property
@@ -69,6 +81,16 @@ class ValidationContext:
     @property
     def target_class(self):
         return self._target_class
+
+    def _generate_json_schema(self, *, closed: bool, include_range_class_descendants: bool) -> JsonSchema:
+        return JsonSchemaGenerator(
+            schema=self._schema,
+            mergeimports=True,
+            top_class=self._target_class,
+            not_closed=not closed,
+            include_range_class_descendants=include_range_class_descendants,
+            importmap=self._importmap,
+        ).generate()
 
     @lru_cache
     def json_schema_validator(
@@ -81,20 +103,24 @@ class ValidationContext:
         if path_override:
             with open(path_override) as json_schema_file:
                 json_schema = json.load(json_schema_file)
+        elif self._importmap is not None:
+            # The shared _json_schema_cache is keyed on id(schema) and omits the
+            # importmap, so a schema object reused with different importmaps would
+            # collide. Generate without the shared cache when an importmap is set;
+            # the per-context lru_cache on this method still serves repeated calls
+            # within one Validator.
+            json_schema = self._generate_json_schema(
+                closed=closed, include_range_class_descendants=include_range_class_descendants
+            )
         else:
             not_closed = not closed
             cache_key = _make_cache_key(self._schema, include_range_class_descendants)
 
             if cache_key not in _json_schema_cache:
                 # First call: generate and cache entire schema (full generation cost)
-                jsonschema_gen = JsonSchemaGenerator(
-                    schema=self._schema,
-                    mergeimports=True,
-                    top_class=self._target_class,
-                    not_closed=not_closed,
-                    include_range_class_descendants=include_range_class_descendants,
+                json_schema = self._generate_json_schema(
+                    closed=closed, include_range_class_descendants=include_range_class_descendants
                 )
-                json_schema = jsonschema_gen.generate()
                 _json_schema_cache[cache_key] = json_schema
                 # Pin the schema so id() cannot be recycled while this entry exists.
                 _schema_pins[cache_key] = self._schema
@@ -145,6 +171,7 @@ class ValidationContext:
         return PydanticGenerator(
             self._schema,
             extra_fields="forbid" if closed else "ignore" if closed is None else "allow",
+            importmap=self._importmap,
         ).compile_module()
 
     def _get_target_class(self, target_class: str | None = None) -> str:

--- a/packages/linkml/src/linkml/validator/validator.py
+++ b/packages/linkml/src/linkml/validator/validator.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, TextIO
@@ -22,6 +22,11 @@ class Validator:
         :class:`linkml.validator.plugins.ValidationPlugin`. Defaults to ``None``.
     :param strict: If ``True``, stop validating after the first validation problem
         is found. Defaults to ``False``.
+    :param importmap: A map used to resolve the schema's imports. Values may be
+        file-path/URL strings or in-memory schema dicts. Imports on the schema are
+        left intact and resolved through this map when the JSON Schema is generated,
+        so schemas with custom import URIs (for example, stored in a database) can be
+        validated without pre-merging or clearing their imports. Defaults to ``None``.
     """
 
     def __init__(
@@ -30,6 +35,7 @@ class Validator:
         validation_plugins: list[ValidationPlugin] | None = None,
         *,
         strict: bool = False,
+        importmap: Mapping[str, str | dict] | None = None,
     ) -> None:
         if isinstance(schema, Path):
             schema = str(schema)
@@ -41,6 +47,7 @@ class Validator:
             self._schema.source_file = schema
         self._validation_plugins = validation_plugins
         self.strict = strict
+        self._importmap = importmap
 
     def validate(self, instance: Any, target_class: str | None = None) -> ValidationReport:
         """Validate the given instance
@@ -119,4 +126,4 @@ class Validator:
 
     @lru_cache
     def _context(self, target_class: str | None = None) -> ValidationContext:
-        return ValidationContext(self._schema, target_class)
+        return ValidationContext(self._schema, target_class, importmap=self._importmap)

--- a/tests/linkml/test_validator/test_cli.py
+++ b/tests/linkml/test_validator/test_cli.py
@@ -505,3 +505,53 @@ def test_allow_null_for_optional_enums_valid_value_unaffected(cli_runner, json_d
     assert result.exception is None
     assert "No issues found" in result.output
     assert result.exit_code == 0
+
+
+@pytest.fixture
+def importmap_schema_files(tmp_path):
+    """Write a base schema, a user schema that imports it by URI, and an importmap
+    file that maps the URI to the base schema path. Returns their paths."""
+    base = tmp_path / "base_schema.yaml"
+    base.write_text(
+        "id: https://example.org/base_schema/0.1.0\n"
+        "name: base_schema\n"
+        "prefixes: {linkml: https://w3id.org/linkml/}\n"
+        "imports: [linkml:types]\n"
+        "classes:\n"
+        "  Record:\n"
+        "    tree_root: true\n"
+        "    attributes:\n"
+        "      code: {equals_string: 'OK'}\n"
+    )
+    user = tmp_path / "user_schema.yaml"
+    user.write_text(
+        "id: https://example.org/user_schema\n"
+        "name: user_schema\n"
+        "prefixes: {linkml: https://w3id.org/linkml/}\n"
+        "imports: [linkml:types, https://example.org/base_schema/0.1.0]\n"
+    )
+    importmap = tmp_path / "importmap.yaml"
+    importmap.write_text(f"https://example.org/base_schema/0.1.0: {base.with_suffix('')}\n")
+    return str(user), str(importmap)
+
+
+def test_importmap_option_resolves_imports(cli_runner, json_data_file, importmap_schema_files):
+    """``-im/--importmap`` resolves a schema's custom import URI so validation
+    enforces the imported constraint."""
+    user_schema, importmap = importmap_schema_files
+    data_path = json_data_file([{"code": "nope"}])
+    result = cli_runner.invoke(
+        cli,
+        ["-s", user_schema, "-C", "Record", "-im", importmap, data_path],
+    )
+    assert "'OK' was expected" in result.output
+    assert result.exit_code == 1
+
+    good_path = json_data_file([{"code": "OK"}], filename="good.json")
+    result_ok = cli_runner.invoke(
+        cli,
+        ["-s", user_schema, "-C", "Record", "-im", importmap, good_path],
+    )
+    assert result_ok.exception is None, result_ok.output
+    assert "No issues found" in result_ok.output
+    assert result_ok.exit_code == 0

--- a/tests/linkml/test_validator/test_validate.py
+++ b/tests/linkml/test_validator/test_validate.py
@@ -80,3 +80,28 @@ def test_not_a_valid_schema():
         assert False, "Expected an exception due to invalid schema, but none was raised"
     except Exception:
         pass  # This is expected
+
+
+def test_importmap_forwarded_to_validator():
+    """The module-level ``validate`` forwards ``importmap`` so a schema with a
+    custom import URI resolves against an in-memory imported schema dict."""
+    base_schema = {
+        "id": "https://example.org/base_schema/0.1.0",
+        "name": "base_schema",
+        "prefixes": {"linkml": "https://w3id.org/linkml/"},
+        "imports": ["linkml:types"],
+        "classes": {"Record": {"tree_root": True, "attributes": {"code": {"equals_string": "OK"}}}},
+    }
+    user_schema = {
+        "id": "https://example.org/user_schema",
+        "name": "user_schema",
+        "prefixes": {"linkml": "https://w3id.org/linkml/"},
+        "imports": ["linkml:types", "https://example.org/base_schema/0.1.0"],
+    }
+    importmap = {"https://example.org/base_schema/0.1.0": base_schema}
+
+    bad = validate({"code": "nope"}, user_schema, "Record", importmap=importmap)
+    assert [r.message for r in bad.results] == ["'OK' was expected in /code"]
+
+    good = validate({"code": "OK"}, user_schema, "Record", importmap=importmap)
+    assert good.results == []

--- a/tests/linkml/test_validator/test_validator.py
+++ b/tests/linkml/test_validator/test_validator.py
@@ -1,11 +1,12 @@
 from collections.abc import Iterable
 
 import pytest
+import yaml
 
 from linkml.utils.exceptions import ValidationError
 from linkml.validator import Validator
 from linkml.validator.loaders import Loader
-from linkml.validator.plugins import ValidationPlugin
+from linkml.validator.plugins import JsonschemaValidationPlugin, ValidationPlugin
 from linkml.validator.report import Severity, ValidationResult
 from linkml.validator.validation_context import ValidationContext
 from linkml_runtime.linkml_model import ClassDefinition, SchemaDefinition
@@ -178,3 +179,138 @@ classes:
 
     report = validator.validate({"an_attribute": "something"})
     assert report.results == []
+
+
+# Schema with a custom import URI that resolves (via importmap) to a base schema
+# defining abstract MyClass/DataFile. Mirrors the issue #3349 reproduction: the
+# equals_string constraint on SpecificFile.label must be enforced, which requires
+# the imported definitions to be merged through the importmap rather than cleared.
+_BASE_SCHEMA_YAML = """\
+id: https://example.org/base_schema/0.1.0
+name: base_schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  MyClass:
+    abstract: true
+    attributes:
+      name: {range: string, required: true}
+  DataFile:
+    abstract: true
+    attributes:
+      file: {range: string, required: true}
+      label: {range: string, required: true}
+"""
+
+_USER_SCHEMA_YAML = """\
+id: https://example.org/user_schema
+name: user_schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+  - https://example.org/base_schema/0.1.0
+classes:
+  MyRoot:
+    is_a: MyClass
+    tree_root: true
+    attributes:
+      files:
+        range: DataFile
+        multivalued: true
+        required: true
+        minimum_cardinality: 1
+  SpecificFile:
+    is_a: DataFile
+    attributes:
+      label:
+        equals_string: specific
+"""
+
+_BAD_INSTANCE = {"name": "test", "files": [{"file": "/data/file.txt", "label": "wrong_label"}]}
+_GOOD_INSTANCE = {"name": "test", "files": [{"file": "/data/file.txt", "label": "specific"}]}
+
+
+@pytest.fixture
+def importmap_factory(tmp_file_factory):
+    """Return (user_schema_dict, importmap) for a given importmap style.
+
+    ``kind="path"`` writes the base schema to disk and maps the import URI to that
+    path (without the ``.yaml`` suffix). ``kind="dict"`` maps the URI to the base
+    schema as an in-memory dict (the pattern used by database-backed callers).
+    """
+
+    def factory(kind: str):
+        user_schema = yaml.safe_load(_USER_SCHEMA_YAML)
+        uri = "https://example.org/base_schema/0.1.0"
+        if kind == "path":
+            base_path = tmp_file_factory("base_schema.yaml", _BASE_SCHEMA_YAML)
+            importmap = {uri: base_path.removesuffix(".yaml")}
+        elif kind == "dict":
+            importmap = {uri: yaml.safe_load(_BASE_SCHEMA_YAML)}
+        else:
+            raise ValueError(kind)
+        return user_schema, importmap
+
+    return factory
+
+
+@pytest.mark.parametrize("kind", ["path", "dict"])
+def test_importmap_enforces_imported_constraints(importmap_factory, kind):
+    """A schema with a custom import URI validates correctly when an importmap is
+    supplied: imports are resolved and merged, so the imported equals_string
+    constraint is enforced. Regression guard for https://github.com/linkml/linkml/issues/3349.
+    """
+    user_schema, importmap = importmap_factory(kind)
+    validator = Validator(user_schema, [JsonschemaValidationPlugin(closed=True)], importmap=importmap)
+
+    bad_report = validator.validate(_BAD_INSTANCE)
+    assert [r.message for r in bad_report.results] == ["'specific' was expected in /files/0/label"]
+
+    good_report = validator.validate(_GOOD_INSTANCE)
+    assert good_report.results == []
+
+
+def test_importmap_stored_on_validator(importmap_factory):
+    user_schema, importmap = importmap_factory("dict")
+    validator = Validator(user_schema, [JsonschemaValidationPlugin(closed=True)], importmap=importmap)
+    assert validator._importmap is importmap
+
+
+def test_importmap_reused_schema_object_does_not_collide():
+    """One SchemaDefinition object validated under two importmaps that map the same
+    import URI to different content must produce independent results. The shared JSON
+    Schema cache is keyed on id(schema) and omits the importmap, so contexts with an
+    importmap bypass it to avoid serving a stale cross-importmap result."""
+    uri = "https://example.org/base/0.1.0"
+    user = SchemaDefinition(
+        id="https://example.org/user",
+        name="user",
+        prefixes=[{"prefix_prefix": "linkml", "prefix_reference": "https://w3id.org/linkml/"}],
+        imports=["linkml:types", uri],
+        classes=[ClassDefinition(name="Root", tree_root=True, is_a="Base")],
+    )
+
+    def base(expected: str) -> dict:
+        return {
+            "id": uri,
+            "name": "base",
+            "prefixes": {"linkml": "https://w3id.org/linkml/"},
+            "imports": ["linkml:types"],
+            "classes": {"Base": {"attributes": {"code": {"equals_string": expected}}}},
+        }
+
+    data = {"code": "AAA"}  # valid only when the imported constraint expects "AAA"
+
+    report_aaa = Validator(user, [JsonschemaValidationPlugin(closed=True)], importmap={uri: base("AAA")}).validate(data)
+    report_bbb = Validator(user, [JsonschemaValidationPlugin(closed=True)], importmap={uri: base("BBB")}).validate(data)
+
+    assert report_aaa.results == []
+    assert [r.message for r in report_bbb.results] == ["'BBB' was expected in /code"]
+
+
+def test_no_importmap_defaults_to_none():
+    validator = Validator(SCHEMA)
+    assert validator._importmap is None


### PR DESCRIPTION
## Summary

Fixes #3349. This PR was written with assistance from Claude.

The `Validator` now accepts an `importmap` and threads it through the `ValidationContext` into the `SchemaView` and the JSON Schema / Pydantic generators. Schema imports are left intact and resolved through the map when the JSON Schema is generated, so a schema with custom import URIs (for example, one stored in a database) can be validated without pre-merging or clearing its imports.

Before this change there was no way to pass an `importmap` to the `Validator`. Callers worked around it by resolving the schema with `SchemaLoader(schema, importmap=...).resolve()` and then clearing `resolved.imports` before constructing the `Validator`, so its internal `SchemaView` would not re-resolve the imports over the network. That workaround degrades validation: because the schema is merged by `SchemaLoader` rather than by the `SchemaView`/`JsonSchemaGenerator` path, some file-level union/`anyOf` constraints are no longer enforced and invalid data can pass silently. Supplying the `importmap` directly keeps imports intact and merges them through the same path used when loading a schema from a file, so validation matches the file-path result.

```python
importmap = {"https://example.org/base_schema/0.1.0": base_schema_dict}  # or a file path
validator = Validator(user_schema, [JsonschemaValidationPlugin(closed=True)], importmap=importmap)
report = validator.validate(data)
```

Changes:

- **`Validator.__init__`**: new keyword-only `importmap` parameter, forwarded to the `ValidationContext`.
- **`ValidationContext`**: accepts `importmap` and threads it into the `SchemaView` it builds and into the `JsonSchemaGenerator` and `PydanticGenerator` used to produce validators.
- **Module helpers**: `validate`, `validate_file`, and `_get_default_validator` accept and forward `importmap`.
- **CLI**: new `-im/--importmap` option on `linkml validate`, taking a YAML/JSON import-map file, threaded into both the standard and `--fix` validation paths.
- **JSON Schema cache**: the shared `_json_schema_cache` is keyed on `id(schema)` and does not include the importmap. Contexts with an importmap bypass that cache and generate directly, so one schema object reused with different importmaps cannot serve a stale cross-importmap result. The per-context `lru_cache` still serves repeated calls within one `Validator`, and the `importmap is None` path (all existing usage) is unchanged.

`importmap` values may be file-path/URL strings or in-memory schema dicts. The in-memory dict form relies on `SchemaView` dict-importmap support (#3706), which follows #3391 for `SchemaLoader`.

## How was this tested?

New tests:

- `tests/linkml/test_validator/test_validator.py`: `test_importmap_enforces_imported_constraints` (parametrized over file-path and in-memory-dict importmap styles) reproduces the #3349 scenario and asserts the imported `equals_string` constraint is enforced on bad data and satisfied on good data. `test_importmap_reused_schema_object_does_not_collide` pins the cache-bypass behavior: one schema object validated under two importmaps that map the same URI to different content yields independent results. Plus tests for `importmap` storage and the `None` default.
- `tests/linkml/test_validator/test_validate.py`: the module-level `validate` forwards `importmap`.
- `tests/linkml/test_validator/test_cli.py`: the `-im/--importmap` option resolves a schema's custom import URI (validation reports the imported constraint with the option, and the schema cannot be resolved without it).

The full `tests/linkml/test_validator/` suite passes. `ruff check` and `ruff format --check` are clean.

## Areas of uncertainty

- The CLI `-im/--importmap` option reads an import-map file, so it can only carry file-path/URL string values; in-memory dict values are a programmatic-only feature. Relative paths in the import-map file are resolved relative to the file's directory.
- The in-memory dict importmap path depends on #3706.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
