### PR TITLE
fix(rdflib_dumper): emit rdf:List for ordered inlined-as-dict slots

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/dumpers/rdflib_dumper.py
+++ b/packages/linkml_runtime/src/linkml_runtime/dumpers/rdflib_dumper.py
@@ -159,9 +159,11 @@ class RDFLibDumper(Dumper):
             if slot.identifier:
                 continue
             slot_uri = URIRef(schemaview.get_uri(slot, expand=True))
-            if slot.multivalued and slot.list_elements_ordered and isinstance(v_or_list, list):
+            if slot.multivalued and slot.list_elements_ordered:
                 # emit an ordered rdf:List (rdf:first/rdf:rest) so element order is part
-                # of the RDF semantics and survives canonicalization. See issue #3531.
+                # of the RDF semantics and survives canonicalization. This applies to
+                # both list- and dict-backed collections: ``vs`` is already in the
+                # correct (insertion) order for either form. See issue #3531.
                 nodes = [self.inject_triples(v, schemaview, graph, slot.range) for v in vs]
                 list_head = BNode()
                 Collection(graph, list_head, nodes)

--- a/tests/linkml_runtime/test_loaders_dumpers/models/ordered_list.py
+++ b/tests/linkml_runtime/test_loaders_dumpers/models/ordered_list.py
@@ -1,5 +1,5 @@
 # Auto generated from ordered_list.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-06-29T11:43:02
+# Generation date: 2026-07-02T16:20:46
 # Schema: ordered_list
 #
 # id: http://example.org/ordered_list
@@ -77,6 +77,9 @@ class ColumnDesc(YAMLRoot):
     atom: Union[str, ColumnDescAtom] = None
     scope: Optional[Union[str, list[str]]] = empty_list()
     items: Optional[Union[list[Union[str, ItemName]], dict[Union[str, ItemName], Union[dict, Item]]]] = empty_dict()
+    items_by_id: Optional[Union[list[Union[str, ItemName]], dict[Union[str, ItemName], Union[dict, Item]]]] = (
+        empty_dict()
+    )
     tags: Optional[Union[str, list[str]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -90,6 +93,8 @@ class ColumnDesc(YAMLRoot):
         self.scope = [v if isinstance(v, str) else str(v) for v in self.scope]
 
         self._normalize_inlined_as_list(slot_name="items", slot_type=Item, key_name="name", keyed=True)
+
+        self._normalize_inlined_as_dict(slot_name="items_by_id", slot_type=Item, key_name="name", keyed=True)
 
         if not isinstance(self.tags, list):
             self.tags = [self.tags] if self.tags is not None else []
@@ -133,6 +138,15 @@ slots.columnDesc__items = Slot(
     name="columnDesc__items",
     curie=EX.curie("items"),
     model_uri=EX.columnDesc__items,
+    domain=None,
+    range=Optional[Union[list[Union[str, ItemName]], dict[Union[str, ItemName], Union[dict, Item]]]],
+)
+
+slots.columnDesc__items_by_id = Slot(
+    uri=EX.items_by_id,
+    name="columnDesc__items_by_id",
+    curie=EX.curie("items_by_id"),
+    model_uri=EX.columnDesc__items_by_id,
     domain=None,
     range=Optional[Union[list[Union[str, ItemName]], dict[Union[str, ItemName], Union[dict, Item]]]],
 )

--- a/tests/linkml_runtime/test_loaders_dumpers/models/ordered_list.yaml
+++ b/tests/linkml_runtime/test_loaders_dumpers/models/ordered_list.yaml
@@ -35,6 +35,13 @@ classes:
         inlined_as_list: true
         range: Item
         slot_uri: ex:items
+      items_by_id:
+        description: ordered list of inlined objects held as a dict (inlined-as-dict)
+        multivalued: true
+        list_elements_ordered: true
+        inlined: true
+        range: Item
+        slot_uri: ex:items_by_id
       tags:
         description: unordered control slot (flat triples)
         multivalued: true

--- a/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_ordered_list.py
+++ b/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_ordered_list.py
@@ -133,3 +133,24 @@ def test_unordered_slot_stays_flat(schemaview, dumper):
     assert list(g.triples((None, RDF.first, None))) == []
     tag_values = {str(o) for o in g.objects() if str(o) in {"a", "b", "c"}}
     assert tag_values == {"a", "b", "c"}
+
+
+def test_ordered_inlined_as_dict_round_trip_preserves_order(schemaview, dumper, loader):
+    """Ordered inlined-as-dict slots also serialize as an ``rdf:List`` and preserve order.
+
+    Regression for the dict form of #3531: the dumper previously gated the ``rdf:List``
+    branch on ``isinstance(v_or_list, list)``, so a dict-backed collection fell through to
+    flat, order-losing triples -- even though the loader and ``gen-shacl`` already treat
+    the same slot as ordered.
+    """
+    obj = model.ColumnDesc(
+        atom="ex:sampled_data",
+        items_by_id=[model.Item(name) for name in ITEM_NAMES],
+    )
+    g = _graph(dumper.dumps(obj, schemaview=schemaview))
+    # emitted as an rdf:List (one rdf:first per element), not flat triples
+    assert len(list(g.triples((None, RDF.first, None)))) == len(ITEM_NAMES)
+    loaded = loader.loads(
+        dumper.dumps(obj, schemaview=schemaview), target_class=model.ColumnDesc, schemaview=schemaview
+    )
+    assert [item.name for item in loaded.items_by_id.values()] == ITEM_NAMES


### PR DESCRIPTION
## Summary

Follow-up to #3693 (targets its branch). While reviewing #3693 I found that ordered
multivalued slots that are **inlined-as-dict** silently lose their order: the dumper's
`rdf:List` branch is gated on `isinstance(v_or_list, list)`, but such slots are held in
Python as a **dict**, so they fall through to flat triples. The loader and `gen-shacl`
already treat the dict form as ordered (loader reads an `rdf:List` back in order;
gen-shacl emits the sequence path), so the three components disagree — and a
`required`/min-count dict-form slot's own dump fails the SHACL this PR generates.

## Change

- `rdflib_dumper.py`: drop the `isinstance(v_or_list, list)` condition on the `rdf:List`
  branch. `vs` is already in insertion order for both list- and dict-backed collections,
  so the `rdf:List` is built correctly for either form (and for a single scalar value).
- Add `items_by_id` (ordered, inlined-as-dict) to the `ordered_list` fixture and a
  round-trip regression test asserting the dict form emits an `rdf:List` and preserves
  order.

## Reproduction / verification

The new test **fails on the current #3693 branch** and passes with this change:

```
# WITHOUT the fix
FAILED test_ordered_inlined_as_dict_round_trip_preserves_order
# WITH the fix
11 passed
```

All existing ordered-list tests stay green, and the broader `rdflib` dumper/loader suite
(32 tests) is unaffected.

## Notes

This addresses only the dumper dict-form order loss. The separate SHACL cardinality point
from the review (`sh:minCount`/`sh:maxCount` count distinct values, not list members, on
the sequence path) is left for you to decide on — happy to follow up.
