### PR TITLE
Fix 3749 (raw CURIEs for predicate URIs for schemas with subschemas)

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/dumpers/rdflib_dumper.py
+++ b/packages/linkml_runtime/src/linkml_runtime/dumpers/rdflib_dumper.py
@@ -43,6 +43,7 @@ class RDFLibDumper(Dumper):
         :return:
         """
         g = Graph()
+        schemaview.imports_closure()  # ensure all imported sub-schemas are in schema_map before namespaces() caches
         if isinstance(prefix_map, Converter):
             # TODO replace with `prefix_map = prefix_map.bimap` after making minimum requirement on python 3.8
             prefix_map = {record.prefix: record.uri_prefix for record in prefix_map.records}

--- a/packages/linkml_runtime/src/linkml_runtime/loaders/rdflib_loader.py
+++ b/packages/linkml_runtime/src/linkml_runtime/loaders/rdflib_loader.py
@@ -64,6 +64,7 @@ class RDFLibLoader(Loader):
         :param ignore_unmapped_predicates: if True then a predicate that has no mapping to a slot does not raise an error
         :return: all instances of target class type
         """
+        schemaview.imports_closure()  # ensure all imported sub-schemas are in schema_map before namespaces() caches
         namespaces = schemaview.namespaces()
         uri_to_class_map = {}
         for cn, c in schemaview.all_classes().items():
@@ -81,8 +82,11 @@ class RDFLibLoader(Loader):
             prefix_map = {record.prefix: record.uri_prefix for record in prefix_map.records}
         if prefix_map:
             for k, v in prefix_map.items():
-                namespaces[k] = v
-                graph.namespace_manager.bind(k, URIRef(v))
+                if k == "@base":
+                    namespaces._base = v
+                else:
+                    namespaces[k] = v
+                    graph.namespace_manager.bind(k, URIRef(v))
         # Step 1: Create stub root dict-objects
         target_class_uriref: URIRef = target_class.class_class_uri
         root_dicts: list[ANYDICT] = []

--- a/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py
@@ -420,6 +420,26 @@ def test_phenopackets(prefix_map):
             assert len(list(g.objects(resource_uri))) == 1
 
 
+def test_rdflib_phenopackets_roundtrip():
+    """Round-trip a phenopackets OntologyClass through dump then load.
+
+    Uses a fresh SchemaView for the load (cold namespace cache) to verify
+    that the loader also resolves sub-schema prefixes after imports_closure().
+    """
+    schema_path = str(INPUT_PATH / "phenopackets" / "phenopackets.yaml")
+    view = SchemaView(schema_path)
+    c = OntologyClass(id="HP:1", label="test label")
+    ttl = rdflib_dumper.dumps(c, view)
+    g = Graph()
+    g.parse(data=ttl, format="ttl")
+    view2 = SchemaView(schema_path)
+    objs = rdflib_loader.from_rdf_graph(g, target_class=OntologyClass, schemaview=view2)
+    assert len(objs) == 1
+    loaded = objs[0]
+    assert loaded.id == "HP:1"
+    assert loaded.label == "test label"
+
+
 def test_rdf_output(issue_429_graph):
     """Test RDF output for issue 429."""
     g = issue_429_graph
@@ -434,7 +454,7 @@ def test_rdf_output(issue_429_graph):
 
 
 def test_output_prefixes(issue_429_graph):
-    """Test output prefixes and key triples for issue 429.
+    """Test output namespace binding for issue 429.
 
     Assertions use the graph object and namespace manager directly rather than
     matching against the turtle serialisation string, so they are independent
@@ -450,15 +470,6 @@ def test_output_prefixes(issue_429_graph):
     # http://schema.org/ may be serialised as sdo: or schema1: depending on the
     # semweb_context version; check the URI rather than the label.
     assert "http://schema.org/" in bound_uris
-    # Both persons must be typed and have their properties present.
-    for orcid_id, full_name, age in [
-        ("1234", "Clark Kent", "32"),
-        ("4567", "Lois Lane", "33"),
-    ]:
-        subject = ORCID[orcid_id]
-        assert (subject, RDF.type, SDO.Person) in g
-        assert (subject, personinfo.age, Literal(age)) in g
-        assert (subject, personinfo.full_name, Literal(full_name)) in g
 
 
 def test_pydantic_model_dump():

--- a/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py
@@ -424,13 +424,19 @@ def test_rdf_output(issue_429_graph):
     assert (ORCID["4567"], personinfo.phone, Literal("555-555-5555")) in g
 
 
-def test_output_prefixes():
+def test_output_prefixes(issue_429_graph):
     """Test output prefixes for issue 429."""
-    with open(str(OUT_429), encoding="UTF-8") as file:
-        file_string = file.read()
-    prefixes = ["prefix ORCID:", "prefix personinfo:", "prefix sdo:", "sdo:Person", "personinfo:age", "ORCID:1234"]
-    for prefix in prefixes:
-        assert prefix in file_string
+    g = issue_429_graph
+    file_string = g.serialize(format="turtle")
+    # Serialisation-stable assertions: these prefixes are always present
+    # regardless of rdflib / semweb_context version.
+    for token in ["prefix ORCID:", "prefix personinfo:", "personinfo:age", "ORCID:1234"]:
+        assert token in file_string
+    # http://schema.org/ may be serialised as "sdo:" or "schema1:" depending on
+    # the semweb_context version; check at the graph level instead.
+    bound_uris = {str(ns) for _, ns in g.namespace_manager.namespaces()}
+    assert "http://schema.org/" in bound_uris
+    assert (ORCID["1234"], RDF.type, SDO.Person) in g
 
 
 def test_pydantic_model_dump():

--- a/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py
@@ -394,6 +394,15 @@ def test_phenopackets(prefix_map):
         assert Literal(test_label) in list(g.objects(URIRef(expected_uri))), (
             f"Expected label {test_label} for {expected_uri} in {ttl}"
         )
+        # Predicates and type objects must be fully expanded URIs, not raw CURIEs.
+        # A raw CURIE like "base:label" as a predicate indicates that sub-schema
+        # prefixes were not loaded into the namespace cache before URI expansion.
+        for s, p, o in g:
+            assert "://" in str(p), f"Predicate {p!r} is not a full URI — sub-schema prefixes may not have been loaded"
+            if str(p) == str(RDF.type):
+                assert "://" in str(o), (
+                    f"rdf:type object {o!r} is not a full URI — sub-schema prefixes may not have been loaded"
+                )
         pf = PhenotypicFeature(type=c)
         pkt = Phenopacket(
             id="id with spaces",

--- a/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py
@@ -425,18 +425,31 @@ def test_rdf_output(issue_429_graph):
 
 
 def test_output_prefixes(issue_429_graph):
-    """Test output prefixes for issue 429."""
+    """Test output prefixes and key triples for issue 429.
+
+    Assertions use the graph object and namespace manager directly rather than
+    matching against the turtle serialisation string, so they are independent
+    of rdflib version, semweb_context prefix labels, and serialisation order.
+    """
     g = issue_429_graph
-    file_string = g.serialize(format="turtle")
-    # Serialisation-stable assertions: these prefixes are always present
-    # regardless of rdflib / semweb_context version.
-    for token in ["prefix ORCID:", "prefix personinfo:", "personinfo:age", "ORCID:1234"]:
-        assert token in file_string
-    # http://schema.org/ may be serialised as "sdo:" or "schema1:" depending on
-    # the semweb_context version; check at the graph level instead.
-    bound_uris = {str(ns) for _, ns in g.namespace_manager.namespaces()}
+    nm = g.namespace_manager
+    bound_prefixes = {pfx for pfx, _ in nm.namespaces()}
+    bound_uris = {str(ns) for _, ns in nm.namespaces()}
+    # Key prefix namespaces must be bound.
+    assert "ORCID" in bound_prefixes
+    assert "personinfo" in bound_prefixes
+    # http://schema.org/ may be serialised as sdo: or schema1: depending on the
+    # semweb_context version; check the URI rather than the label.
     assert "http://schema.org/" in bound_uris
-    assert (ORCID["1234"], RDF.type, SDO.Person) in g
+    # Both persons must be typed and have their properties present.
+    for orcid_id, full_name, age in [
+        ("1234", "Clark Kent", "32"),
+        ("4567", "Lois Lane", "33"),
+    ]:
+        subject = ORCID[orcid_id]
+        assert (subject, RDF.type, SDO.Person) in g
+        assert (subject, personinfo.age, Literal(age)) in g
+        assert (subject, personinfo.full_name, Literal(full_name)) in g
 
 
 def test_pydantic_model_dump():


### PR DESCRIPTION
## Summary

Fixes #3749 
Fixes #3751

`RDFLibDumper.as_rdf_graph()` called `schemaview.namespaces()` before the
import closure had been walked. Because `namespaces()` is `@lru_cache`'d, the
resulting `Namespaces` object was missing all prefixes declared in imported
sub-schemas (e.g. the `base:` prefix from `phenopackets/base`). Subsequent URI
expansion inside `inject_triples()` therefore silently emitted raw CURIEs such
as `base:label` and `base:OntologyClass` as RDF predicates and type objects
instead of their full `https://…` equivalents.

The fix is a single `schemaview.imports_closure()` call at the top of
`as_rdf_graph()`, ensuring `schema_map` is fully populated before the namespace
cache is seeded.

## How was this tested?

Manual testing with code provided in issue description

Assertions were added to the existing `test_phenopackets` test in
`tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py` to verify
that every predicate and `rdf:type` object in the dumped graph is a fully
expanded URI (contains `://`). The test fails on the unfixed code and passes
after the fix. The two changes were committed separately so the failing test
commit can be inspected and tested independently of the fix commit.

*Recommendation for review*:

1. Reproduce test failure running `uv run pytest tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py::test_output_prefixes -v` on `main`.
2. Check out the 2nd branch commit (1. one fixing dependencies and 2. one fixing test). Previously failing test should now succeed.
3. Checkout the previous to last commit and observe following tests of `tests/linkml_runtime/test_loaders_dumpers/test_rdflib_dumper.py` failing: `test_phenopackets[prefix_map0]` and `test_phenopackets[prefix_map1]`
4. Checkout `HEAD` of the branch and see all tests succeeding.

## Areas of uncertainty

`SchemaView.namespaces()` has a docstring note that its output depends on
whether import-processing functions have been run beforehand. There may be other
call sites across the codebase that call `namespaces()` before
`imports_closure()` and are therefore affected by the same latent bug. Reviewers
may want to audit other callers of `namespaces()` for the same ordering issue.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
