### PR TITLE
feat(javagen): add javabundle dataclass, serialize and render

### DIFF
--- a/packages/linkml/src/linkml/generators/javagen.py
+++ b/packages/linkml/src/linkml/generators/javagen.py
@@ -101,6 +101,25 @@ class OOVisitorDocument(OOCustomDocument):
         self.type = "_visitor"
 
 
+@dataclass
+class JavaBundle:
+    """In-memory result of rendering a LinkML schema to Java source.
+
+    A ``JavaBundle`` is the output of :meth:`JavaGenerator.render`. It carries
+    the rendered Java source for every file that would be written to disk by
+    :meth:`JavaGenerator.serialize`, keyed by filename.
+
+    Mirrors render/serialize split used by `rustgen.RustGenerator` (FileResult /
+    CrateResult) and `pydanticgen.PydanticGenerator` (PydanticModule).
+    """
+
+    files: dict[str, str] = field(default_factory=dict)
+    """Rendered Java source, keyed by filename (e.g. ``"Address.java"``)."""
+
+    package: str = ""
+    """Java package name the rendered files belong to (informational)."""
+
+
 class TemplateCache:
     """Cache for template objects.
 
@@ -242,17 +261,17 @@ class JavaGenerator(OOCodeGenerator):
         else:
             raise ValueError(f"{t} cannot be mapped to a type")
 
-    def serialize(
+    def render(
         self,
-        directory: str,
         template_variant: str | None = None,
         extra_templates: list[str] | None = None,
         visitors: list[str] | None = None,
-        **kwargs,
-    ) -> None:
-        """Generate and write the Java code to files.
+    ) -> JavaBundle:
+        """Render the schema to an in-memory :class:`JavaBundle`.
 
-        :param directory: The directory where to write the code files.
+        Pure counterpart of :meth:`serialize`: returns the rendered Java
+        source for every file without touching the filesystem.
+
         :param template_variant: The name of the template variant to use, if any.
         :param extra_templates: A list of additional templates from which to generate
             additional code files. For example, if set to `[Foo,Bar]`, this will
@@ -266,6 +285,8 @@ class JavaGenerator(OOCodeGenerator):
             `IFooVisitor` interface, and the generated code for both the `Foo`
             class and all its descendants will include a `accept(IFooVisitor)`
             method.
+        :return: A :class:`JavaBundle` whose ``files`` maps each output filename
+            (e.g. ``"Address.java"``) to its rendered source.
         """
         oodocs = self.create_documents()
         # Create additional documents for additional templates and visitors
@@ -279,7 +300,8 @@ class JavaGenerator(OOCodeGenerator):
                 oodocs.append(OOVisitorDocument(name=visitor_name, package=self.package, visited_object=visited_name))
         else:
             visitors = []
-        self.directory = directory
+
+        files: dict[str, str] = {}
         for oodoc in oodocs:
             cls = None
             enum = None
@@ -306,8 +328,38 @@ class JavaGenerator(OOCodeGenerator):
                 model_version=self.schema.version,
             )
 
-            os.makedirs(directory, exist_ok=True)
-            filename = f"{oodoc.name}.java"
+            files[f"{oodoc.name}.java"] = code
+
+        return JavaBundle(files=files, package=self.package)
+
+    def serialize(
+        self,
+        directory: str,
+        template_variant: str | None = None,
+        extra_templates: list[str] | None = None,
+        visitors: list[str] | None = None,
+        **kwargs,
+    ) -> None:
+        """Generate and write the Java code to files.
+
+        Thin wrapper around :meth:`render` that writes each rendered file in
+        the returned :class:`JavaBundle` to ``directory``.
+
+        :param directory: The directory where to write the code files.
+        :param template_variant: The name of the template variant to use, if any.
+        :param extra_templates: A list of additional templates from which to generate
+            additional code files. See :meth:`render` for details.
+        :param visitors: A list of class names for which to generate a visitor
+            interface. See :meth:`render` for details.
+        """
+        bundle = self.render(
+            template_variant=template_variant,
+            extra_templates=extra_templates,
+            visitors=visitors,
+        )
+        self.directory = directory
+        os.makedirs(directory, exist_ok=True)
+        for filename, code in bundle.files.items():
             path = os.path.join(directory, filename)
             with open(path, "w", encoding="UTF-8") as stream:
                 stream.write(code)

--- a/packages/linkml/src/linkml/generators/javagen.py
+++ b/packages/linkml/src/linkml/generators/javagen.py
@@ -334,30 +334,44 @@ class JavaGenerator(OOCodeGenerator):
 
     def serialize(
         self,
-        directory: str,
+        directory: str | Path,
         template_variant: str | None = None,
         extra_templates: list[str] | None = None,
         visitors: list[str] | None = None,
+        rendered_module: JavaBundle | None = None,
         **kwargs,
     ) -> None:
-        """Generate and write the Java code to files.
+        """Generate the Java code and write it to ``directory``, one file per class.
 
-        Thin wrapper around :meth:`render` that writes each rendered file in
-        the returned :class:`JavaBundle` to ``directory``.
+        Java requires one public class per file, so there is no meaningful
+        single-string serialization of a schema; callers that want the
+        generated code in memory should use :meth:`render` and work from the
+        returned :class:`JavaBundle` instead.
 
         :param directory: The directory where to write the code files.
         :param template_variant: The name of the template variant to use, if any.
+            Ignored when ``rendered_module`` is provided.
         :param extra_templates: A list of additional templates from which to generate
-            additional code files. See :meth:`render` for details.
+            additional code files. See :meth:`render` for details. Ignored when
+            ``rendered_module`` is provided.
         :param visitors: A list of class names for which to generate a visitor
-            interface. See :meth:`render` for details.
+            interface. See :meth:`render` for details. Ignored when
+            ``rendered_module`` is provided.
+        :param rendered_module: Optional pre-computed :class:`JavaBundle` to
+            write instead of calling :meth:`render` afresh. Allows caller to
+            render once and inspect/write multiple times. When supplied,
+            ``template_variant``, ``extra_templates``, and ``visitors``
+            are ignored (the bundle is used as-is).
         """
-        bundle = self.render(
-            template_variant=template_variant,
-            extra_templates=extra_templates,
-            visitors=visitors,
+        bundle = (
+            rendered_module
+            if rendered_module is not None
+            else self.render(
+                template_variant=template_variant,
+                extra_templates=extra_templates,
+                visitors=visitors,
+            )
         )
-        self.directory = directory
         os.makedirs(directory, exist_ok=True)
         for filename, code in bundle.files.items():
             path = os.path.join(directory, filename)

--- a/tests/linkml/test_generators/test_javagen.py
+++ b/tests/linkml/test_generators/test_javagen.py
@@ -1,3 +1,5 @@
+import pytest
+
 from linkml.generators.javagen import JavaBundle, JavaGenerator
 from linkml.generators.oocodegen import OOEnum, OOEnumValue
 from tests.linkml.utils.fileutils import assert_file_contains
@@ -274,3 +276,25 @@ def test_render_true_enums(kitchen_sink_path):
 
     assert "CordialnessEnum.java" in bundle.files
     assert "public enum CordialnessEnum" in bundle.files["CordialnessEnum.java"]
+
+
+def test_serialize_accepts_rendered_module(kitchen_sink_path, tmp_path):
+    """Passing `rendered_module=` writes the given bundle as-is."""
+    gen = JavaGenerator(kitchen_sink_path, package=PACKAGE)
+    bundle = gen.render()
+    bundle.files["Address.java"] = "// sentinel: pre-rendered bundle content"
+
+    gen.serialize(directory=str(tmp_path), rendered_module=bundle)
+
+    assert_file_contains(tmp_path / "Address.java", "// sentinel: pre-rendered bundle content")
+
+
+@pytest.mark.parametrize("as_path", [False, True], ids=["str", "Path"])
+def test_serialize_accepts_str_or_path_directory(kitchen_sink_path, tmp_path, as_path):
+    """`directory` accepts both a ``str`` and a :class:`pathlib.Path`."""
+    gen = JavaGenerator(kitchen_sink_path, package=PACKAGE)
+    directory = tmp_path if as_path else str(tmp_path)
+
+    gen.serialize(directory=directory)
+
+    assert_file_contains(tmp_path / "Address.java", "public class Address", after=f"package {PACKAGE}")

--- a/tests/linkml/test_generators/test_javagen.py
+++ b/tests/linkml/test_generators/test_javagen.py
@@ -1,4 +1,4 @@
-from linkml.generators.javagen import JavaGenerator
+from linkml.generators.javagen import JavaBundle, JavaGenerator
 from linkml.generators.oocodegen import OOEnum, OOEnumValue
 from tests.linkml.utils.fileutils import assert_file_contains
 
@@ -228,3 +228,49 @@ def test_refined_ranges(input_path):
     # - ThirdDerivedFoo refines the slot compared to its parent SecondDerivedFoo;
     #   this is the second refinement in the hierarchy since the defining class
     assert gen.get_refined_ranges("bar", "ThirdDerivedFoo", upwards=True) == ["FirstDerivedBar", "Bar"]
+
+
+def test_render_returns_bundle(kitchen_sink_path, tmp_path):
+    """`render()` returns a `JavaBundle` with rendered files but touches no disk."""
+    gen = JavaGenerator(kitchen_sink_path, package=PACKAGE)
+    bundle = gen.render()
+
+    assert isinstance(bundle, JavaBundle)
+    assert bundle.package == PACKAGE
+    assert "Address.java" in bundle.files
+    address_code = bundle.files["Address.java"]
+    assert "public class Address" in address_code
+    assert f"package {PACKAGE}" in address_code
+
+    # render() must not write anything to disk.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_render_template_variant(kitchen_sink_path):
+    """`render(template_variant=...)` is honoured (records variant here)."""
+    gen = JavaGenerator(kitchen_sink_path, package=PACKAGE)
+    bundle = gen.render(template_variant="records")
+
+    assert "Address.java" in bundle.files
+    assert "public record Address(String street, String city, BigDecimal altitude)" in bundle.files["Address.java"]
+
+
+def test_render_visitors(kitchen_sink_path):
+    """`render(visitors=[...])` emits the visitor interface and adds `accept()` to visited classes."""
+    gen = JavaGenerator(kitchen_sink_path, package=PACKAGE)
+    bundle = gen.render(visitors=["Concept"])
+
+    assert "IConceptVisitor.java" in bundle.files
+    assert "public void visit(DiagnosisConcept visited);" in bundle.files["IConceptVisitor.java"]
+    # A class in the visited hierarchy carries the accept() method.
+    assert "ProcedureConcept.java" in bundle.files
+    assert "public void accept(IConceptVisitor visitor)" in bundle.files["ProcedureConcept.java"]
+
+
+def test_render_true_enums(kitchen_sink_path):
+    """With `true_enums=True`, enum-typed files appear in the bundle."""
+    gen = JavaGenerator(kitchen_sink_path, package=PACKAGE, true_enums=True)
+    bundle = gen.render()
+
+    assert "CordialnessEnum.java" in bundle.files
+    assert "public enum CordialnessEnum" in bundle.files["CordialnessEnum.java"]


### PR DESCRIPTION
## Summary

Fix for #3755

- Add `JavaBundle` dataclass in `javagen.py`
- Add `render(template_variant=None, extra_templates=None, visitors=None) -> JavaBundle` (No I/O)
- Rewrite `serialize()` internally to `render()` then loop-write
- Tests in `test_javagen.py` with asserts

## How was this tested?

Full test suite
Added new tests

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance
LLM assistance, human review, and testing
