### PR TITLE
minor: fix excelgen serialize bug and projectgen duplicate call

### DIFF
--- a/packages/linkml/src/linkml/generators/excelgen.py
+++ b/packages/linkml/src/linkml/generators/excelgen.py
@@ -171,7 +171,7 @@ class ExcelGenerator(Generator):
 
         dv.add(f"{column_letter}2:{column_letter}1048576")
 
-    def serialize(self, **kwargs) -> str:
+    def serialize(self, **kwargs) -> None:
         sv = self.schemaview
         all_classes = sv.all_classes(imports=self.mergeimports)
 

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -139,16 +139,14 @@ class ProjectGenerator:
                 logger.info(f" {gen_name} ARGS: {serialize_args}")
                 gen_dump = gen.serialize(**serialize_args)
 
-                if gen_name != "excel":
-                    if gen_path_full.suffix != "":
-                        logger.info(f"  WRITING TO: {gen_path_full}")
-                        with open(gen_path_full, "w", encoding="UTF-8") as stream:
-                            stream.write(gen_dump)
-                else:
-                    # special handling for excel generator
-                    # we do not need to route the output
-                    # into a file like the other generators
-                    gen.serialize(**serialize_args)
+                if gen_dump is None:
+                    # Generator wrote its own files during serialize() (e.g. excelgen,
+                    # which produces binary xlsx via openpyxl). Nothing to route to disk.
+                    continue
+                if gen_path_full.suffix != "":
+                    logger.info(f"  WRITING TO: {gen_path_full}")
+                    with open(gen_path_full, "w", encoding="UTF-8") as stream:
+                        stream.write(gen_dump)
 
 
 @click.command(name="project")

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -20,3 +20,7 @@ def test_projectgen(kitchen_sink_path, tmp_path):
     check_contains("CREATE TABLE", "sqlschema", "kitchen_sink.sql")
     check_contains("ks:age_in_years a owl:DatatypeProperty", "owl", "kitchen_sink.owl.ttl")
     check_contains('"additionalProperties": false', "jsonschema", "kitchen_sink.schema.json")
+    # Excel writes its own binary file via serialize(); guard against regressions
+    # in the generic "generator returned None -> skip disk-routing" branch.
+    excel_out = tmp_path / "excel" / "kitchen_sink.xlsx"
+    assert excel_out.is_file() and excel_out.stat().st_size > 0


### PR DESCRIPTION
## Summary

Fixes #3759

- ExcelGenerator.serialize was annotated '-> str' but has no return statement, so implicitly returns None. Fix.

- projectgen called gen.serialize() twice for excel (once at  generic call site,  again in 'excel' branch). The second call was redundant since the first already wrote the .xlsx file. Fix with generic 'if gen_dump is None: continue' - any generator whose serialize writes its own files and returns None is now auto-supported without special-casing.

- Harden `test_projectgen` to assert excel/kitchen_sink.xlsx is actually produced, guarding the is-None skip

## How was this tested?

Full suite
adjusted one test to guard against regression


## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance
LLM assist, human review