### PR TITLE
fix(openapigen): replace raw schema with schemaview provided one

### DIFF
--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -250,7 +250,9 @@ class OpenApiGenerator(Generator):
             if referenced_resource_name != class_name:
                 self._renaming[class_name] = referenced_resource_name
             referenced_class_names.add(class_name)
-            json_schema = JsonSchemaGenerator(self.schema, include_null=False, top_class=class_name).generate()
+            json_schema = JsonSchemaGenerator(
+                self.schemaview.schema, include_null=False, top_class=class_name
+            ).generate()
             json_schema_classes = json.loads(json_schema.to_json())["$defs"]
             class_schemas = class_schemas | json_schema_classes
         class_schemas = self._sanitize_schemas(class_schemas, referenced_class_names)
@@ -267,7 +269,8 @@ class OpenApiGenerator(Generator):
 
     def printout_template(self) -> str:
         """Return a generic OpenAPI template pre-filled with the first class of the schema."""
-        first_class = next(iter(self.schema.classes.keys()))
+        class_names = self.schemaview.all_classes().keys()
+        first_class = next(iter(class_names))
         if re.search(r"[ :\d]", first_class):
             first_class = f'"{first_class}"'
         return openapi_generic_template.format(schema_id=self.schema.id, schema_class=first_class)

--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -31,27 +31,27 @@ paths:
     get:
       responses:
         '200':
-          description: Endpoint example involving random schema class
+          description: Endpoint example involving random data schema
           content:
             application/json:
               schema:
                 # any broken reference will cause template instantiation to fail
                 # OpenAPI editors typically also report them
-                $ref: '#/components/schemas/{schema_class}'
+                $ref: '#/components/schemas/{data_schema}'
 components:
-  # any class schema provided here that is not used by at least
+  # any data schema provided here that is not used by at least
   # one endpoint will be eliminated from the template instantiation
   # OpenAPI editors typically also report them
   schemas:
     # this resource name can differ from the name in the LinkML schema
     # it must only match the corresponding endpoint `$ref` references
-    {schema_class}:
+    {data_schema}:
       type: object
       description: Resource schema to be generated from the LinkML data model.
       # schema ID mismatching with provided schema will cause template
       # instantiation to fail
-      x-linkml-schema: {schema_id}
-      x-linkml-source: {schema_class}
+      x-linkml-schema: {linkml_schema_id}
+      x-linkml-source: {data_schema}
 """
 
 
@@ -62,9 +62,9 @@ class OpenApiGenerator(Generator):
 
     The generator composes a user-provided OpenAPI template (containing the API header,
     paths/endpoints, and security schemes) with JSON Schema components generated from
-    the LinkML schema via :class:`.JsonSchemaGenerator`. Only classes referenced by the
-    template's endpoints (and their transitive dependencies) are included in the
-    ``components/schemas`` section.
+    the LinkML schema via :class:`.JsonSchemaGenerator`. Only data schemas referenced
+    by the template's endpoints (and their transitive dependencies) are included in
+    the ``components/schemas`` section.
     """
 
     generatorname = os.path.basename(__file__)
@@ -90,7 +90,7 @@ class OpenApiGenerator(Generator):
         repr=False,
     )
 
-    def _find_referenced_resources(self) -> set[str]:
+    def _find_referenced_schemas(self) -> set[str]:
         """Return the set of resource names referenced by the template's endpoints."""
         result = set()
         for endp_spec in self._template["paths"].values():
@@ -105,8 +105,8 @@ class OpenApiGenerator(Generator):
                         if "content" in response:
                             for content_spec in response["content"].values():
                                 if "$ref" in content_spec["schema"]:
-                                    class_name = content_spec["schema"]["$ref"].removeprefix("#/components/schemas/")
-                                    result.add(class_name)
+                                    resource_name = content_spec["schema"]["$ref"].removeprefix("#/components/schemas/")
+                                    result.add(resource_name)
         return result
 
     def _fix_openapi_spec(self, element: dict | list) -> dict | list | None:
@@ -143,7 +143,7 @@ class OpenApiGenerator(Generator):
 
     def _rename(self, element: dict | list) -> dict | list | None:
         """
-        If the resource names do not correspond the schema class names,
+        If the resource names do not correspond the data schema names,
         then some renaming is needed so that OpenAPI resource names
         are properly referenced throughout the whole OpenAPI file.
         """
@@ -156,9 +156,9 @@ class OpenApiGenerator(Generator):
                 if isinstance(value, dict | list):
                     value = self._rename(value)
                 elif isinstance(value, str) and value.startswith("#/components/schemas/"):
-                    class_name = value[len("#/components/schemas/") :]
-                    if class_name in self._renaming:
-                        value = value.replace(class_name, self._renaming[class_name])
+                    data_schema_name = value[len("#/components/schemas/") :]
+                    if data_schema_name in self._renaming:
+                        value = value.replace(data_schema_name, self._renaming[data_schema_name])
                 renamed_element[key] = value
         elif isinstance(element, list):
             renamed_element = []
@@ -166,37 +166,37 @@ class OpenApiGenerator(Generator):
                 if isinstance(item, dict | list):
                     item = self._rename(item)
                 elif isinstance(item, str) and item.startswith("#/components/schemas/"):
-                    class_name = item[len("#/components/schemas/") :]
-                    if class_name in self._renaming:
-                        item = item.replace(class_name, self._renaming[class_name])
+                    data_schema_name = item[len("#/components/schemas/") :]
+                    if data_schema_name in self._renaming:
+                        item = item.replace(data_schema_name, self._renaming[data_schema_name])
                 renamed_element.append(item)
         return renamed_element
 
-    def _find_references(self, element: dict | list, referenced_classes: set[str]) -> None:
-        """Recursively collect all ``$ref`` target names from ``element`` into ``referenced_classes``."""
+    def _find_references(self, element: dict | list, referenced_data_schemas: set[str]) -> None:
+        """Recursively collect all ``$ref`` target names from ``element`` into ``referenced_data_schemas``."""
         if isinstance(element, dict):
             if "$ref" in element:
-                referenced_classes.add(element["$ref"].replace("#/$defs/", ""))
+                referenced_data_schemas.add(element["$ref"].replace("#/$defs/", ""))
             for value in element.values():
-                self._find_references(value, referenced_classes)
+                self._find_references(value, referenced_data_schemas)
         elif isinstance(element, list):
             for item in element:
-                self._find_references(item, referenced_classes)
+                self._find_references(item, referenced_data_schemas)
 
-    def _sanitize_schemas(self, class_schemas: dict, endpoint_referenced_classes: set[str]) -> dict:
-        """Remove schemas not transitively reachable from any endpoint-referenced class."""
-        referenced_classes = endpoint_referenced_classes.copy()
-        for class_schema in class_schemas.values():
-            self._find_references(class_schema, referenced_classes)
-        while set(class_schemas.keys()).difference(referenced_classes):
-            class_schema_names = list(class_schemas.keys())
-            for class_name in class_schema_names:
-                if class_name not in referenced_classes:
-                    del class_schemas[class_name]
-            referenced_classes = endpoint_referenced_classes.copy()
-            for class_schema in class_schemas.values():
-                self._find_references(class_schema, referenced_classes)
-        return class_schemas
+    def _sanitize_schemas(self, data_schemas: dict, endpoint_referenced_schemas: set[str]) -> dict:
+        """Remove schemas not transitively reachable from any endpoint-referenced data schema."""
+        referenced_schemas = endpoint_referenced_schemas.copy()
+        for data_schema in data_schemas.values():
+            self._find_references(data_schema, referenced_schemas)
+        while set(data_schemas.keys()).difference(referenced_schemas):
+            data_schema_names = list(data_schemas.keys())
+            for data_schema_name in data_schema_names:
+                if data_schema_name not in referenced_schemas:
+                    del data_schemas[data_schema_name]
+            referenced_schemas = endpoint_referenced_schemas.copy()
+            for data_schema in data_schemas.values():
+                self._find_references(data_schema, referenced_schemas)
+        return data_schemas
 
     def serialize(self, template_file: str = "", **kwargs) -> str:
         """Generate an OpenAPI v3.0.3 spec from ``template_file`` and the loaded LinkML schema."""
@@ -225,55 +225,62 @@ class OpenApiGenerator(Generator):
             raise ValueError("OpenAPI template is missing required 'paths' section")
         if not isinstance(self._template.get("components"), dict):
             raise ValueError("OpenAPI template is missing required 'components' section")
-        referenced_resource_names = self._find_referenced_resources()
-        resource_schemas = self._template["components"]["schemas"]
-        class_schemas = {}
-        self._renaming = {}
-        referenced_class_names = set()
-        # get only the resource schemas that are really referenced from an endpoint
-        for referenced_resource_name in referenced_resource_names:
-            if referenced_resource_name not in resource_schemas:
+        endpoint_ref_schema_names = self._find_referenced_schemas()  # schemas referenced by OpenAPI endpoint(s)
+        openapi_schemas = self._template["components"]["schemas"]  # data schemas provided by the template
+        all_req_data_schemas = {}  # data schemas directly or transitively required by the API
+        self._renaming = {}  # openapi <-> linkml renaming map
+        directly_required_linkml_elements: set[str] = set()  # LinkML class/type names of directly-referenced schemas
+        # get only the data schemas that are really referenced from an endpoint
+        for endpoint_reference_name in endpoint_ref_schema_names:
+            if endpoint_reference_name not in openapi_schemas:
                 raise KeyError(
-                    f"resource '{referenced_resource_name}' referenced in one of the endpoints "
+                    f"data schema '{endpoint_reference_name}' referenced in one of the endpoints "
                     "does not have a schema declaration"
                 )
-            resource_schema = resource_schemas[referenced_resource_name]
+            data_schema = openapi_schemas[endpoint_reference_name]
             # validate that linkml schema id is correct
-            if resource_schema["x-linkml-schema"] != self.schema.id:
+            if data_schema["x-linkml-schema"] != self.schema.id:
                 raise ValueError(
-                    f"Template resource '{referenced_resource_name}' declares "
-                    f"x-linkml-schema '{resource_schema['x-linkml-schema']}' "
+                    f"Template data schema '{endpoint_reference_name}' declares "
+                    f"x-linkml-schema '{data_schema['x-linkml-schema']}' "
                     f"but the loaded schema has id '{self.schema.id}'"
                 )
-            # if resource name differs from schema class name, keep mapping
-            class_name = resource_schema["x-linkml-source"]
-            if referenced_resource_name != class_name:
-                self._renaming[class_name] = referenced_resource_name
-            referenced_class_names.add(class_name)
+            # if openapi schema name differs from linkml element name, add mapping
+            linkml_element_name = data_schema["x-linkml-source"]
+            if endpoint_reference_name != linkml_element_name:
+                self._renaming[linkml_element_name] = endpoint_reference_name
+            directly_required_linkml_elements.add(linkml_element_name)
             json_schema = JsonSchemaGenerator(
-                self.schemaview.schema, include_null=False, top_class=class_name
+                self.schemaview.schema, include_null=False, top_class=linkml_element_name
             ).generate()
             json_schema_classes = json.loads(json_schema.to_json())["$defs"]
-            class_schemas = class_schemas | json_schema_classes
-        class_schemas = self._sanitize_schemas(class_schemas, referenced_class_names)
+            all_req_data_schemas = all_req_data_schemas | json_schema_classes
+        sanitized_data_schemas = self._sanitize_schemas(all_req_data_schemas, directly_required_linkml_elements)
         # title always duplicates the schema dict key, so it is redundant in components/schemas
-        for class_schema in class_schemas.values():
-            class_schema.pop("title", None)
-        class_schemas = self._fix_openapi_spec(class_schemas)
+        for data_schema in sanitized_data_schemas.values():
+            data_schema.pop("title", None)
+        sanitized_data_schemas = self._fix_openapi_spec(sanitized_data_schemas)
         if self._renaming:
-            class_schemas = self._rename(class_schemas)
-        self._template["components"]["schemas"] = class_schemas
+            sanitized_data_schemas = self._rename(sanitized_data_schemas)
+        self._template["components"]["schemas"] = sanitized_data_schemas
         # Validate the generated output against the OpenAPI specification
         validate(self._template, cls=validator_class)
         return yaml.dump(self._template, sort_keys=False)
 
     def printout_template(self) -> str:
-        """Return a generic OpenAPI template pre-filled with the first class of the schema."""
-        class_names = self.schemaview.all_classes().keys()
-        first_class = next(iter(class_names))
-        if re.search(r"[ :\d]", first_class):
-            first_class = f'"{first_class}"'
-        return openapi_generic_template.format(schema_id=self.schema.id, schema_class=first_class)
+        """Return a generic OpenAPI template pre-filled with the first class/type of the LinkML schema."""
+        element_names = self.schemaview.all_classes().keys()
+        if not element_names:
+            element_names = self.schemaview.all_types().keys()
+        if not element_names:
+            # if no realistic schema and data can be used, put some placeholders
+            return openapi_generic_template.format(
+                linkml_schema_id="<LinkML Schema ID>", data_schema="<data schema name>"
+            )
+        first_element = next(iter(element_names))
+        if re.search(r"[ :\d]", first_element):
+            first_element = f'"{first_element}"'
+        return openapi_generic_template.format(linkml_schema_id=self.schema.id, data_schema=first_element)
 
 
 @shared_arguments(OpenApiGenerator)
@@ -287,12 +294,15 @@ class OpenApiGenerator(Generator):
 def cli(yamlfile, template, **args):
     """Generate an OpenAPI v3.0.3 spec with resources modelled with LinkML.
     If no OpenAPI template is provided,
-    a generic one with placeholders for all the classes in the schema is printed out."""
-    # if no template provided, print out a generic one with all the classes of the schema
+    a generic one with one exemplary class/type schema is printed out."""
+    # if no template provided, print out a generic one
     if not template:
         print(OpenApiGenerator(yamlfile, **args).printout_template())
         return
-    print(OpenApiGenerator(yamlfile, **args).serialize(template_file=template, **args), end="")
+    print(
+        OpenApiGenerator(yamlfile, **args).serialize(template_file=template, **args),
+        end="",
+    )
 
 
 if __name__ == "__main__":

--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -10,12 +10,12 @@ import yaml
 from openapi_spec_validator import OpenAPIV30SpecValidator, validate
 
 from linkml._version import __version__
-from linkml.generators.jsonschemagen import JsonSchemaGenerator
+from linkml.generators.jsonschemagen import JsonSchemaGenerator, json_schema_types
 from linkml.utils.generator import Generator, shared_arguments
 
 openapi_generic_template = """openapi: 3.0.3
 # This is a valid OpenAPI template to be used by the LinkML OpenAPI generator.
-# It adds one (random) class of the schema as an example.
+# It adds one (random) class or type of the LinkML schema as an example.
 # Please adapt it to your needs.
 # See more information in the online documentation:
 #   https://linkml.io/linkml/generators/openapi.html
@@ -98,8 +98,13 @@ class OpenApiGenerator(Generator):
                 if "requestBody" in req_spec and "content" in req_spec["requestBody"]:
                     for content_spec in req_spec["requestBody"]["content"].values():
                         if "$ref" in content_spec["schema"]:
-                            class_name = content_spec["schema"]["$ref"].removeprefix("#/components/schemas/")
-                            result.add(class_name)
+                            resource_name = content_spec["schema"]["$ref"].removeprefix("#/components/schemas/")
+                            result.add(resource_name)
+                if "parameters" in req_spec:
+                    for param_spec in req_spec["parameters"]:
+                        if "$ref" in param_spec["schema"]:
+                            resource_name = param_spec["schema"]["$ref"].removeprefix("#/components/schemas/")
+                            result.add(resource_name)
                 if "responses" in req_spec:
                     for response in req_spec["responses"].values():
                         if "content" in response:
@@ -198,6 +203,29 @@ class OpenApiGenerator(Generator):
                 self._find_references(data_schema, referenced_schemas)
         return data_schemas
 
+    def _generate_type_schema(self, type_name: str) -> dict:
+        """Build an OpenAPI-compatible JSON Schema for a LinkML TypeDefinition."""
+        type_def = self.schemaview.get_type(type_name)
+        typ, fmt = json_schema_types.get(type_def.base.lower(), ("string", None))
+        schema: dict = {}
+        if typ:
+            schema["type"] = str(typ)
+        if fmt:
+            schema["format"] = str(fmt)
+        if type_def.pattern:
+            schema["pattern"] = str(type_def.pattern)
+        if type_def.minimum_value is not None:
+            schema["minimum"] = str(type_def.minimum_value)
+        if type_def.maximum_value is not None:
+            schema["maximum"] = str(type_def.maximum_value)
+        if type_def.equals_string is not None:
+            schema["const"] = str(type_def.equals_string)
+        if type_def.equals_number is not None:
+            schema["const"] = str(type_def.equals_number)
+        if type_def.description:
+            schema["description"] = str(type_def.description)
+        return schema
+
     def serialize(self, template_file: str = "", **kwargs) -> str:
         """Generate an OpenAPI v3.0.3 spec from ``template_file`` and the loaded LinkML schema."""
         if not template_file:
@@ -250,6 +278,9 @@ class OpenApiGenerator(Generator):
             if endpoint_reference_name != linkml_element_name:
                 self._renaming[linkml_element_name] = endpoint_reference_name
             directly_required_linkml_elements.add(linkml_element_name)
+            if linkml_element_name in self.schemaview.all_types().keys():
+                all_req_data_schemas[linkml_element_name] = self._generate_type_schema(linkml_element_name)
+                continue
             json_schema = JsonSchemaGenerator(
                 self.schemaview.schema, include_null=False, top_class=linkml_element_name
             ).generate()

--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -3,11 +3,13 @@
 import json
 import os
 import re
+import textwrap
 from dataclasses import dataclass, field
 
 import click
 import yaml
 from openapi_spec_validator import OpenAPIV30SpecValidator, validate
+from yaml import MappingNode, ScalarNode
 
 from linkml._version import __version__
 from linkml.generators.jsonschemagen import JsonSchemaGenerator, json_schema_types
@@ -226,12 +228,30 @@ class OpenApiGenerator(Generator):
             schema["description"] = str(type_def.description)
         return schema
 
+    def _find_schemas_line(self, template_text: str) -> int:
+        """Return the 0-indexed line number of the ``schemas`` key under ``components``."""
+        doc = yaml.compose(template_text)
+        if not isinstance(doc, MappingNode):
+            raise ValueError("OpenAPI template is not a YAML mapping")
+        components_node = None
+        for key, value in doc.value:
+            if isinstance(key, ScalarNode) and key.value == "components":
+                components_node = value
+                break
+        if not isinstance(components_node, MappingNode):
+            raise ValueError("OpenAPI template is missing a valid 'components' section")
+        for key, _ in components_node.value:
+            if isinstance(key, ScalarNode) and key.value == "schemas":
+                return key.start_mark.line
+        raise ValueError("OpenAPI template is missing 'schemas' section under 'components'")
+
     def serialize(self, template_file: str = "", **kwargs) -> str:
         """Generate an OpenAPI v3.0.3 spec from ``template_file`` and the loaded LinkML schema."""
         if not template_file:
             raise ValueError("An OpenAPI template file is required")
         with open(template_file) as tf:
-            self._template = yaml.safe_load(tf)
+            template_text = tf.read()
+            self._template = yaml.safe_load(template_text)
         # Determine the expected OpenAPI version from the active output format
         format_name = getattr(self, "format", self.valid_formats[0]) or self.valid_formats[0]
         expected_version = self._openapi_versions.get(format_name)
@@ -293,10 +313,16 @@ class OpenApiGenerator(Generator):
         sanitized_data_schemas = self._fix_openapi_spec(sanitized_data_schemas)
         if self._renaming:
             sanitized_data_schemas = self._rename(sanitized_data_schemas)
-        self._template["components"]["schemas"] = sanitized_data_schemas
+        # Replace the existing schemas section in the text template with the generated schemas
+        lines = template_text.splitlines(keepends=True)
+        schemas_line_idx = self._find_schemas_line(template_text)
+        text_before_schemas = "".join(lines[:schemas_line_idx])
+        schemas_yaml = yaml.dump(sanitized_data_schemas, sort_keys=False)
+        indented_schemas = textwrap.indent(schemas_yaml, "    ")
+        result = text_before_schemas + "  schemas:\n" + indented_schemas
         # Validate the generated output against the OpenAPI specification
-        validate(self._template, cls=validator_class)
-        return yaml.dump(self._template, sort_keys=False)
+        validate(yaml.safe_load(result), cls=validator_class)
+        return result
 
     def printout_template(self) -> str:
         """Return a generic OpenAPI template pre-filled with the first class/type of the LinkML schema."""

--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -287,11 +287,11 @@ class OpenApiGenerator(Generator):
                 )
             data_schema = openapi_schemas[endpoint_reference_name]
             # validate that linkml schema id is correct
-            if data_schema["x-linkml-schema"] != self.schema.id:
+            if data_schema["x-linkml-schema"] != self.schemaview.schema.id:
                 raise ValueError(
                     f"Template data schema '{endpoint_reference_name}' declares "
                     f"x-linkml-schema '{data_schema['x-linkml-schema']}' "
-                    f"but the loaded schema has id '{self.schema.id}'"
+                    f"but the loaded schema has id '{self.schemaview.schema.id}'"
                 )
             # if openapi schema name differs from linkml element name, add mapping
             linkml_element_name = data_schema["x-linkml-source"]
@@ -337,7 +337,7 @@ class OpenApiGenerator(Generator):
         first_element = next(iter(element_names))
         if re.search(r"[ :\d]", first_element):
             first_element = f'"{first_element}"'
-        return openapi_generic_template.format(linkml_schema_id=self.schema.id, data_schema=first_element)
+        return openapi_generic_template.format(linkml_schema_id=self.schemaview.schema.id, data_schema=first_element)
 
 
 @shared_arguments(OpenApiGenerator)

--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -95,7 +95,9 @@ class OpenApiGenerator(Generator):
         repr=False,
     )
 
-    def _validate_oa_template(self, oa_validator_class: type[OaSpecValidator], expected_version: str, format_name: str):
+    def _validate_oad_template(
+        self, oad_validator_class: type[OaSpecValidator], expected_version: str, format_name: str
+    ):
         """Validate the OpenAPI template"""
         # Validate that the template declares the expected OpenAPI version
         declared_version = self._template.get("openapi")
@@ -106,10 +108,12 @@ class OpenApiGenerator(Generator):
             )
         # Validate the input template against the OpenAPI specification.
         # This also catches dangling $ref targets in endpoints.
-        openapi_validate(self._template, cls=oa_validator_class)
+        openapi_validate(self._template, cls=oad_validator_class)
         # Validation: every template schema must declare this LinkML schema.
         if "components" in self._template and "schemas" in self._template["components"]:
             for name, schema in self._template["components"]["schemas"].items():
+                if "x-linkml-schema" not in schema:
+                    raise KeyError(f"Template data schema '{name}' is missing required 'x-linkml-schema'")
                 if schema["x-linkml-schema"] != self.schemaview.schema.id:
                     raise ValueError(
                         f"Template data schema '{name}' declares "
@@ -297,11 +301,11 @@ class OpenApiGenerator(Generator):
             raise ValueError(f"Unsupported output format '{format_name}'")
 
         # get the corresponding OpenAPI validator
-        oa_validator_class = self._openapi_validators.get(expected_version)
-        if oa_validator_class is None:
+        oad_validator_class = self._openapi_validators.get(expected_version)
+        if oad_validator_class is None:
             raise ValueError(f"No validator available for OpenAPI version {expected_version}")
         # validate the OpenAPI template before further processing
-        self._validate_oa_template(oa_validator_class, expected_version, format_name)
+        self._validate_oad_template(oad_validator_class, expected_version, format_name)
         # if no schemas to instantiate, return the template itself
         if (
             "components" not in self._template
@@ -350,7 +354,7 @@ class OpenApiGenerator(Generator):
         result = text_before_schemas + "  schemas:\n" + indented_schemas
 
         # validate the generated output against the OpenAPI specification before returning
-        openapi_validate(yaml.safe_load(result), cls=oa_validator_class)
+        openapi_validate(yaml.safe_load(result), cls=oad_validator_class)
         return result
 
     def printout_template(self) -> str:

--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -5,10 +5,13 @@ import os
 import re
 import textwrap
 from dataclasses import dataclass, field
+from typing import cast
 
 import click
 import yaml
-from openapi_spec_validator import OpenAPIV30SpecValidator, validate
+from openapi_spec_validator import OpenAPIV30SpecValidator
+from openapi_spec_validator import validate as openapi_validate
+from openapi_spec_validator.validation.validators import SpecValidator as OaSpecValidator
 from yaml import MappingNode, ScalarNode
 
 from linkml._version import __version__
@@ -47,6 +50,7 @@ components:
   schemas:
     # this resource name can differ from the name in the LinkML schema
     # it must only match the corresponding endpoint `$ref` references
+    # it creates a mapping between names in OpenAPI and LinkML
     {data_schema}:
       type: object
       description: Resource schema to be generated from the LinkML data model.
@@ -76,7 +80,6 @@ class OpenApiGenerator(Generator):
     uses_schemaloader = False
 
     _template: dict = field(default_factory=dict, init=False, repr=False)
-    _renaming: dict[str, str] = field(default_factory=dict, init=False, repr=False)
     # Mapping of valid_formats entries to OpenAPI version strings.
     # Extend this dict when adding support for additional OpenAPI versions.
     _openapi_versions: dict[str, str] = field(
@@ -86,11 +89,33 @@ class OpenApiGenerator(Generator):
     )
     # Mapping of OpenAPI version strings to validators from openapi-spec-validator.
     # Extend this dict when adding support for additional OpenAPI versions.
-    _openapi_validators: dict[str, type] = field(
+    _openapi_validators: dict[str, type[OaSpecValidator]] = field(
         default_factory=lambda: {"3.0.3": OpenAPIV30SpecValidator},
         init=False,
         repr=False,
     )
+
+    def _validate_oa_template(self, oa_validator_class: type[OaSpecValidator], expected_version: str, format_name: str):
+        """Validate the OpenAPI template"""
+        # Validate that the template declares the expected OpenAPI version
+        declared_version = self._template.get("openapi")
+        if declared_version != expected_version:
+            raise ValueError(
+                f"Template OpenAPI version is '{declared_version}', "
+                f"but format '{format_name}' requires version '{expected_version}'"
+            )
+        # Validate the input template against the OpenAPI specification.
+        # This also catches dangling $ref targets in endpoints.
+        openapi_validate(self._template, cls=oa_validator_class)
+        # Validation: every template schema must declare this LinkML schema.
+        if "components" in self._template and "schemas" in self._template["components"]:
+            for name, schema in self._template["components"]["schemas"].items():
+                if schema["x-linkml-schema"] != self.schemaview.schema.id:
+                    raise ValueError(
+                        f"Template data schema '{name}' declares "
+                        f"x-linkml-schema '{schema['x-linkml-schema']}' "
+                        f"but the loaded schema has id '{self.schemaview.schema.id}'"
+                    )
 
     def _find_referenced_schemas(self) -> set[str]:
         """Return the set of resource names referenced by the template's endpoints."""
@@ -116,7 +141,41 @@ class OpenApiGenerator(Generator):
                                     result.add(resource_name)
         return result
 
-    def _fix_openapi_spec(self, element: dict | list) -> dict | list | None:
+    def _generate_type_schema(self, type_name: str) -> dict:
+        """Build an OpenAPI-compatible JSON Schema for a LinkML TypeDefinition."""
+        type_def = self.schemaview.get_type(type_name)
+        typ, fmt = json_schema_types.get(type_def.base.lower(), ("string", None))
+        schema: dict = {}
+        if typ:
+            schema["type"] = str(typ)
+        if fmt:
+            schema["format"] = str(fmt)
+        if type_def.pattern:
+            schema["pattern"] = str(type_def.pattern)
+        if type_def.minimum_value is not None:
+            schema["minimum"] = str(type_def.minimum_value)
+        if type_def.maximum_value is not None:
+            schema["maximum"] = str(type_def.maximum_value)
+        if type_def.equals_string is not None:
+            schema["const"] = str(type_def.equals_string)
+        if type_def.equals_number is not None:
+            schema["const"] = str(type_def.equals_number)
+        if type_def.description:
+            schema["description"] = str(type_def.description)
+        return schema
+
+    def _find_references(self, element: dict | list, referenced_data_schemas: set[str]) -> None:
+        """Recursively collect all ``$ref`` target names from ``element`` into ``referenced_data_schemas``."""
+        if isinstance(element, dict):
+            if "$ref" in element:
+                referenced_data_schemas.add(element["$ref"].replace("#/$defs/", ""))
+            for value in element.values():
+                self._find_references(value, referenced_data_schemas)
+        elif isinstance(element, list):
+            for item in element:
+                self._find_references(item, referenced_data_schemas)
+
+    def _fix_openapi_spec(self, element: dict | list) -> dict | list:
         """
         Transform JSON Schema constructs into OpenAPI v3.0.3 compatible forms:
 
@@ -148,85 +207,63 @@ class OpenApiGenerator(Generator):
                 fixed_element.append(item)
         return fixed_element
 
-    def _rename(self, element: dict | list) -> dict | list | None:
+    def _rename(self, name_map: dict[str, str], element: dict | list) -> dict | list:
         """
         If the resource names do not correspond the data schema names,
         then some renaming is needed so that OpenAPI resource names
         are properly referenced throughout the whole OpenAPI file.
         """
-        renamed_element = None
         if isinstance(element, dict):
-            renamed_element = {}
+            renamed_element: dict | list = {}
             for key, value in element.items():
-                if key in self._renaming:
-                    key = self._renaming[key]
+                if key in name_map:
+                    key = name_map[key]
                 if isinstance(value, dict | list):
-                    value = self._rename(value)
+                    value = self._rename(name_map, value)
                 elif isinstance(value, str) and value.startswith("#/components/schemas/"):
                     data_schema_name = value[len("#/components/schemas/") :]
-                    if data_schema_name in self._renaming:
-                        value = value.replace(data_schema_name, self._renaming[data_schema_name])
+                    if data_schema_name in name_map:
+                        value = value.replace(data_schema_name, name_map[data_schema_name])
                 renamed_element[key] = value
         elif isinstance(element, list):
-            renamed_element = []
+            renamed_element: dict | list = []
             for item in element:
                 if isinstance(item, dict | list):
-                    item = self._rename(item)
+                    item = self._rename(name_map, item)
                 elif isinstance(item, str) and item.startswith("#/components/schemas/"):
                     data_schema_name = item[len("#/components/schemas/") :]
-                    if data_schema_name in self._renaming:
-                        item = item.replace(data_schema_name, self._renaming[data_schema_name])
+                    if data_schema_name in name_map:
+                        item = item.replace(data_schema_name, name_map[data_schema_name])
                 renamed_element.append(item)
+        else:
+            raise TypeError(f"Unexpected type '{type(element)}', only 'dict' and 'list' supported.")
         return renamed_element
 
-    def _find_references(self, element: dict | list, referenced_data_schemas: set[str]) -> None:
-        """Recursively collect all ``$ref`` target names from ``element`` into ``referenced_data_schemas``."""
-        if isinstance(element, dict):
-            if "$ref" in element:
-                referenced_data_schemas.add(element["$ref"].replace("#/$defs/", ""))
-            for value in element.values():
-                self._find_references(value, referenced_data_schemas)
-        elif isinstance(element, list):
-            for item in element:
-                self._find_references(item, referenced_data_schemas)
-
-    def _sanitize_schemas(self, data_schemas: dict, endpoint_referenced_schemas: set[str]) -> dict:
-        """Remove schemas not transitively reachable from any endpoint-referenced data schema."""
-        referenced_schemas = endpoint_referenced_schemas.copy()
-        for data_schema in data_schemas.values():
-            self._find_references(data_schema, referenced_schemas)
-        while set(data_schemas.keys()).difference(referenced_schemas):
-            data_schema_names = list(data_schemas.keys())
-            for data_schema_name in data_schema_names:
-                if data_schema_name not in referenced_schemas:
-                    del data_schemas[data_schema_name]
-            referenced_schemas = endpoint_referenced_schemas.copy()
-            for data_schema in data_schemas.values():
-                self._find_references(data_schema, referenced_schemas)
-        return data_schemas
-
-    def _generate_type_schema(self, type_name: str) -> dict:
-        """Build an OpenAPI-compatible JSON Schema for a LinkML TypeDefinition."""
-        type_def = self.schemaview.get_type(type_name)
-        typ, fmt = json_schema_types.get(type_def.base.lower(), ("string", None))
-        schema: dict = {}
-        if typ:
-            schema["type"] = str(typ)
-        if fmt:
-            schema["format"] = str(fmt)
-        if type_def.pattern:
-            schema["pattern"] = str(type_def.pattern)
-        if type_def.minimum_value is not None:
-            schema["minimum"] = str(type_def.minimum_value)
-        if type_def.maximum_value is not None:
-            schema["maximum"] = str(type_def.maximum_value)
-        if type_def.equals_string is not None:
-            schema["const"] = str(type_def.equals_string)
-        if type_def.equals_number is not None:
-            schema["const"] = str(type_def.equals_number)
-        if type_def.description:
-            schema["description"] = str(type_def.description)
-        return schema
+    def _sanitize_schemas(
+        self, name_map: dict[str, str], openapi_schemas: dict, endpoint_ref_linkml_names: set[str]
+    ) -> dict:
+        """
+        Prune unreachable schemas, remove redundant metadata, convert JSON Schema constructs
+        to OpenAPI 3.0.3 compat, and apply any OpenAPI↔LinkML name renames.
+        """
+        referenced_schemas = endpoint_ref_linkml_names.copy()
+        for openapi_schema in openapi_schemas.values():
+            self._find_references(openapi_schema, referenced_schemas)
+        while set(openapi_schemas.keys()).difference(referenced_schemas):
+            openapi_schema_names = list(openapi_schemas.keys())
+            for openapi_schema_name in openapi_schema_names:
+                if openapi_schema_name not in referenced_schemas:
+                    del openapi_schemas[openapi_schema_name]
+            referenced_schemas = endpoint_ref_linkml_names.copy()
+            for openapi_schema in openapi_schemas.values():
+                self._find_references(openapi_schema, referenced_schemas)
+        # title always duplicates the schema dict key, so it is redundant in components/schemas
+        for openapi_schema in openapi_schemas.values():
+            openapi_schema.pop("title", None)
+        openapi_schemas = cast(dict, self._fix_openapi_spec(openapi_schemas))
+        if name_map:
+            openapi_schemas = cast(dict, self._rename(name_map, openapi_schemas))
+        return openapi_schemas
 
     def _find_schemas_line(self, template_text: str) -> int:
         """Return the 0-indexed line number of the ``schemas`` key under ``components``."""
@@ -247,81 +284,73 @@ class OpenApiGenerator(Generator):
 
     def serialize(self, template_file: str = "", **kwargs) -> str:
         """Generate an OpenAPI v3.0.3 spec from ``template_file`` and the loaded LinkML schema."""
+        # load the template
         if not template_file:
             raise ValueError("An OpenAPI template file is required")
         with open(template_file) as tf:
             template_text = tf.read()
             self._template = yaml.safe_load(template_text)
-        # Determine the expected OpenAPI version from the active output format
+        # determine the expected OpenAPI version from the active output format
         format_name = getattr(self, "format", self.valid_formats[0]) or self.valid_formats[0]
         expected_version = self._openapi_versions.get(format_name)
         if expected_version is None:
             raise ValueError(f"Unsupported output format '{format_name}'")
-        validator_class = self._openapi_validators.get(expected_version)
-        if validator_class is None:
+
+        # get the corresponding OpenAPI validator
+        oa_validator_class = self._openapi_validators.get(expected_version)
+        if oa_validator_class is None:
             raise ValueError(f"No validator available for OpenAPI version {expected_version}")
-        # Validate that the template declares the expected OpenAPI version
-        declared_version = self._template.get("openapi")
-        if declared_version != expected_version:
-            raise ValueError(
-                f"Template OpenAPI version is '{declared_version}', "
-                f"but format '{format_name}' requires version '{expected_version}'"
-            )
-        # Validate the input template against the OpenAPI specification
-        validate(self._template, cls=validator_class)
-        if not isinstance(self._template.get("paths"), dict):
-            raise ValueError("OpenAPI template is missing required 'paths' section")
-        if not isinstance(self._template.get("components"), dict):
-            raise ValueError("OpenAPI template is missing required 'components' section")
-        endpoint_ref_schema_names = self._find_referenced_schemas()  # schemas referenced by OpenAPI endpoint(s)
-        openapi_schemas = self._template["components"]["schemas"]  # data schemas provided by the template
-        all_req_data_schemas = {}  # data schemas directly or transitively required by the API
-        self._renaming = {}  # openapi <-> linkml renaming map
-        directly_required_linkml_elements: set[str] = set()  # LinkML class/type names of directly-referenced schemas
-        # get only the data schemas that are really referenced from an endpoint
-        for endpoint_reference_name in endpoint_ref_schema_names:
-            if endpoint_reference_name not in openapi_schemas:
-                raise KeyError(
-                    f"data schema '{endpoint_reference_name}' referenced in one of the endpoints "
-                    "does not have a schema declaration"
-                )
-            data_schema = openapi_schemas[endpoint_reference_name]
-            # validate that linkml schema id is correct
-            if data_schema["x-linkml-schema"] != self.schemaview.schema.id:
-                raise ValueError(
-                    f"Template data schema '{endpoint_reference_name}' declares "
-                    f"x-linkml-schema '{data_schema['x-linkml-schema']}' "
-                    f"but the loaded schema has id '{self.schemaview.schema.id}'"
-                )
-            # if openapi schema name differs from linkml element name, add mapping
-            linkml_element_name = data_schema["x-linkml-source"]
-            if endpoint_reference_name != linkml_element_name:
-                self._renaming[linkml_element_name] = endpoint_reference_name
-            directly_required_linkml_elements.add(linkml_element_name)
-            if linkml_element_name in self.schemaview.all_types().keys():
-                all_req_data_schemas[linkml_element_name] = self._generate_type_schema(linkml_element_name)
-                continue
-            json_schema = JsonSchemaGenerator(
-                self.schemaview.schema, include_null=False, top_class=linkml_element_name
-            ).generate()
-            json_schema_classes = json.loads(json_schema.to_json())["$defs"]
-            all_req_data_schemas = all_req_data_schemas | json_schema_classes
-        sanitized_data_schemas = self._sanitize_schemas(all_req_data_schemas, directly_required_linkml_elements)
-        # title always duplicates the schema dict key, so it is redundant in components/schemas
-        for data_schema in sanitized_data_schemas.values():
-            data_schema.pop("title", None)
-        sanitized_data_schemas = self._fix_openapi_spec(sanitized_data_schemas)
-        if self._renaming:
-            sanitized_data_schemas = self._rename(sanitized_data_schemas)
-        # Replace the existing schemas section in the text template with the generated schemas
+        # validate the OpenAPI template before further processing
+        self._validate_oa_template(oa_validator_class, expected_version, format_name)
+        # if no schemas to instantiate, return the template itself
+        if (
+            "components" not in self._template
+            or "schemas" not in self._template["components"]
+            or not self._template["components"]["schemas"]
+        ):
+            return template_text
+
+        # Two namespaces exist: OpenAPI schema names (from the template's
+        # components/schemas keys) and LinkML element names (from the LinkML schema).
+        # Every schema has a name in both namespaces and the template declares the
+        # mapping between them in the x-linkml-schema values; they may be identical or differ.
+        # When they differ, name_map records the synonym (LinkML element name -> OpenAPI schema name).
+        endpoint_ref_openapi_names = self._find_referenced_schemas()  # OpenAPI names referenced by endpoints
+        openapi_schemas = self._template["components"]["schemas"]  # schemas provided by the OpenAPI template
+        # collect the LinkML names referenced by endpoints (seed for sanitizing below)
+        endpoint_ref_linkml_names: set[str] = {
+            openapi_schemas[n]["x-linkml-source"] for n in endpoint_ref_openapi_names
+        }
+        # when OpenAPI and LinkML names differ, record the synonym for later renaming
+        name_map: dict[str, str] = {
+            openapi_schemas[n]["x-linkml-source"]: n
+            for n in endpoint_ref_openapi_names
+            if n != openapi_schemas[n]["x-linkml-source"]
+        }
+
+        # JsonSchemaGenerator.generate() emits every class/enum of the LinkML schema into
+        # $defs. LinkML types are not part of $defs and are generated separately.
+        # all_req_schemas contains all directly or transitively required schemas from
+        # LinkML classes and types
+        json_schema = JsonSchemaGenerator(self.schemaview.schema, include_null=False).generate()
+        all_req_schemas: dict[str, dict] = json.loads(json_schema.to_json())["$defs"]
+        for linkml_name in endpoint_ref_linkml_names:
+            if linkml_name in self.schemaview.all_types():
+                all_req_schemas[linkml_name] = self._generate_type_schema(linkml_name)
+
+        # sanitize schemas not transitively reachable from any endpoint-referenced schema
+        sanitized_data_schemas = self._sanitize_schemas(name_map, all_req_schemas, endpoint_ref_linkml_names)
+
+        # instantiate the real OpenAPI YAML replacing the schema placeholders
         lines = template_text.splitlines(keepends=True)
         schemas_line_idx = self._find_schemas_line(template_text)
         text_before_schemas = "".join(lines[:schemas_line_idx])
         schemas_yaml = yaml.dump(sanitized_data_schemas, sort_keys=False)
         indented_schemas = textwrap.indent(schemas_yaml, "    ")
         result = text_before_schemas + "  schemas:\n" + indented_schemas
-        # Validate the generated output against the OpenAPI specification
-        validate(yaml.safe_load(result), cls=validator_class)
+
+        # validate the generated output against the OpenAPI specification before returning
+        openapi_validate(yaml.safe_load(result), cls=oa_validator_class)
         return result
 
     def printout_template(self) -> str:

--- a/tests/linkml/test_generators/input/openapi/schema_type_constraints.yaml
+++ b/tests/linkml/test_generators/input/openapi/schema_type_constraints.yaml
@@ -1,3 +1,4 @@
+# LinkML schema providing constrained types
 id: https://w3id.org/linkml/tests/type_constraints
 name: type_constraints
 default_prefix: type_constraints

--- a/tests/linkml/test_generators/input/openapi/spec-fixed.openapi.yaml
+++ b/tests/linkml/test_generators/input/openapi/spec-fixed.openapi.yaml
@@ -1,3 +1,5 @@
+# OpenAPI template provided as template that is fully fixed
+# because there are no fields to be replaced
 openapi: 3.0.3
 info:
   title: LinkML tests

--- a/tests/linkml/test_generators/input/openapi/spec-fixed.openapi.yaml
+++ b/tests/linkml/test_generators/input/openapi/spec-fixed.openapi.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: LinkML tests
+  version: 1.0.0
+servers:
+  - url: https://example.org/
+security:
+  - PayloadSignature: []
+paths:
+  /api/endpoint1:
+    post:
+      security:
+        - PayloadSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Success

--- a/tests/linkml/test_generators/input/openapi/spec-types.openapi.yaml
+++ b/tests/linkml/test_generators/input/openapi/spec-types.openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: LinkML type constraints test
+  version: 1.0.0
+servers:
+  - url: https://example.org/
+paths:
+  /api/code:
+    get:
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeStringRef'
+
+components:
+  schemas:
+    CodeStringRef:
+      type: object
+      x-linkml-schema: https://w3id.org/linkml/tests/type_constraints
+      x-linkml-source: CodeString

--- a/tests/linkml/test_generators/input/openapi/spec-types.openapi.yaml
+++ b/tests/linkml/test_generators/input/openapi/spec-types.openapi.yaml
@@ -1,3 +1,4 @@
+# OpenAPI template referring a Type defined in the LinkML schema
 openapi: 3.0.3
 info:
   title: LinkML type constraints test

--- a/tests/linkml/test_generators/input/openapi/test_schema_type_constraints.yaml
+++ b/tests/linkml/test_generators/input/openapi/test_schema_type_constraints.yaml
@@ -1,0 +1,25 @@
+id: https://w3id.org/linkml/tests/type_constraints
+name: type_constraints
+default_prefix: type_constraints
+imports:
+  - linkml:types
+
+types:
+  CodeString:
+    base: str
+    pattern: "^[A-Z]{2,10}$"
+    description: A 2-10 character uppercase code
+
+  PositiveInt:
+    base: int
+    minimum_value: 1
+    maximum_value: 9999
+    description: A positive integer between 1 and 9999
+
+classes:
+  WithCode:
+    description: A thing with a code
+    attributes:
+      code:
+        range: CodeString
+        required: true

--- a/tests/linkml/test_generators/test_openapigen.py
+++ b/tests/linkml/test_generators/test_openapigen.py
@@ -114,6 +114,22 @@ def test_missing_schema_declaration_raises(tmp_path, kitchen_sink_path):
         OpenApiGenerator(kitchen_sink_path).serialize(str(template))
 
 
+def test_openapi_type_constraints(input_path):
+    """Test that LinkML types with constraints (e.g., pattern) are properly generated in the spec."""
+    schema_path = str(input_path("openapi/test_schema_type_constraints.yaml"))
+    head_path = str(input_path("openapi/spec-types.openapi.yaml"))
+    spec = yaml.safe_load(OpenApiGenerator(schema_path).serialize(head_path))
+    schemas = spec["components"]["schemas"]
+    # the type schema is exposed under the template's resource name
+    code_str = schemas["CodeStringRef"]
+    assert code_str["type"] == "string"
+    assert code_str["pattern"] == "^[A-Z]{2,10}$"
+    assert code_str["description"] == "A 2-10 character uppercase code"
+    assert validate(spec, cls=OpenAPIV30SpecValidator) is None
+    for schema in schemas.values():
+        assert "#/$defs/" not in str(schema)
+
+
 def test_renaming(input_path, kitchen_sink_path):
     """Test that resource names differing from LinkML class names are renamed throughout the spec."""
     head_path = str(input_path("openapi/spec-renaming.openapi.yaml"))

--- a/tests/linkml/test_generators/test_openapigen.py
+++ b/tests/linkml/test_generators/test_openapigen.py
@@ -123,7 +123,7 @@ def test_missing_schema_declaration_raises(tmp_path, kitchen_sink_path):
 
 def test_openapi_type_constraints(input_path):
     """Test that LinkML types with constraints (e.g., pattern) are properly generated in the spec."""
-    schema_path = str(input_path("openapi/test_schema_type_constraints.yaml"))
+    schema_path = str(input_path("openapi/schema_type_constraints.yaml"))
     head_path = str(input_path("openapi/spec-types.openapi.yaml"))
     spec = yaml.safe_load(OpenApiGenerator(schema_path).serialize(head_path))
     schemas = spec["components"]["schemas"]

--- a/tests/linkml/test_generators/test_openapigen.py
+++ b/tests/linkml/test_generators/test_openapigen.py
@@ -34,6 +34,13 @@ def test_openapi_missing_template(kitchen_sink_path):
         OpenApiGenerator(kitchen_sink_path).serialize()
 
 
+def test_openapi_fixed_template(input_path, kitchen_sink_path):
+    """Test that serialize raises ValueError when no template file is provided."""
+    head_path = str(input_path("openapi/spec-fixed.openapi.yaml"))
+    oa_spec = OpenApiGenerator(kitchen_sink_path).serialize(head_path)
+    assert open(head_path).read() == oa_spec
+
+
 def test_openapi_spec_no_defs_references(openapi_spec):
     """Test that all $defs references are converted to components/schemas."""
     for schema in openapi_spec["components"]["schemas"].values():


### PR DESCRIPTION
## Summary

Fixes #3764
Fixes #3768 

`self.schema` returns the raw parsed schema without any imports resolution. This patch replaces it with the schema provided by the SchemaView which provides lazy resolution.

Replacing the wording `schema class` with `data schema` in the OpenAPI context. That specification uses the workding *data* (whereas *class*  is not used with that meaning at all) and provides the section `components/schema` to provide those *data's schemas*. Therefore the new naming.

## How was this tested?

<!-- Describe how you verified your changes (e.g. new tests, existing test suite, manual testing). -->

## Areas of uncertainty

<!-- Are there parts of this change you'd like reviewers to look at more closely? -->

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
