### PR TITLE
ci: scope CVE audit to PRs that change dependencies

### DIFF
--- a/.github/scripts/uv_lock_deps_changed.py
+++ b/.github/scripts/uv_lock_deps_changed.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Decide whether the resolved ``uv.lock`` dependency set changed between refs.
+
+``uv.lock`` is regenerated non-deterministically: reordering, hashes, and
+metadata can differ between two lockfiles that resolve to exactly the same
+packages. ``uv audit`` only cares about the multiset of ``(name, version)``
+pairs, so this script compares that set between a base ref and ``HEAD`` and
+prints ``true`` only when it actually differs.
+
+Usage:
+    uv_lock_deps_changed.py <base_ref>
+
+Prints ``true`` when the resolved ``(name, version)`` set at ``HEAD`` differs
+from the one at ``<base_ref>`` (or when the lockfile is absent at either ref),
+otherwise ``false``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+
+
+def package_set(ref: str) -> set[tuple[str, str | None]] | None:
+    """Return the ``{(name, version)}`` set from ``uv.lock`` at ``ref``.
+
+    Args:
+        ref: A git ref (SHA, branch, ``HEAD``) to read ``uv.lock`` from.
+
+    Returns:
+        The set of ``(name, version)`` tuples for every locked package, or
+        ``None`` if ``uv.lock`` does not exist at ``ref``.
+    """
+    result = subprocess.run(
+        ["git", "show", f"{ref}:uv.lock"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    data = tomllib.loads(result.stdout)
+    return {(pkg["name"], pkg.get("version")) for pkg in data.get("package", [])}
+
+
+def resolved_set_changed(base_ref: str) -> bool:
+    """Return whether the resolved dependency set differs between refs.
+
+    Args:
+        base_ref: The ref to compare ``HEAD`` against.
+
+    Returns:
+        ``True`` if the ``(name, version)`` set differs, or if ``uv.lock`` is
+        missing at either ref; ``False`` when the sets are identical.
+    """
+    base = package_set(base_ref)
+    head = package_set("HEAD")
+    return base is None or head is None or base != head
+
+
+def main() -> None:
+    """Print ``true``/``false`` for the base ref given as the sole argument."""
+    print("true" if resolved_set_changed(sys.argv[1]) else "false")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/uv_lock_deps_changed.py
+++ b/.github/scripts/uv_lock_deps_changed.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+
 import tomllib
 
 

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -16,19 +16,11 @@ on:
   pull_request:
   merge_group:
   workflow_dispatch:
-  schedule:
-    # Weekly, Monday 09:00 UTC. Catches advisories newly published against
-    # already-pinned dependencies — the case the per-change gate deliberately
-    # ignores — and reports them in a tracking issue rather than blocking CI.
-    - cron: "0 9 * * 1"
 
 jobs:
   security-check:
     name: Validate Dependencies
     runs-on: ubuntu-latest
-    # The blocking gate is about the *change under test*; on the schedule there is
-    # no change to gate, so the scheduled run only files the tracking issue below.
-    if: github.event_name != 'schedule'
 
     steps:
       - name: Check out repository
@@ -128,94 +120,3 @@ jobs:
       #
       - name: Verify Environment Sync (Anti-Malware Gate)
         run: uv sync --frozen --all-groups
-
-  # Non-blocking detection of CVEs on the current main lockfile — including
-  # advisories published against dependencies that no PR has touched. Instead of
-  # failing CI, it keeps a single rolling tracking issue in sync with the audit:
-  # opened when vulnerabilities appear, refreshed while they persist, and closed
-  # automatically once the lockfile is clean again. It never assigns or mentions
-  # anyone, so it stays quiet (an entry in the issue list, no email drip) and is
-  # fully under the project's control — unlike Dependabot alert emails.
-  audit-issue:
-    name: Report CVEs via tracking issue
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    permissions:
-      contents: read
-      issues: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      AUDIT_LABEL: dependency-audit
-      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Install uv and setup uv caching
-        uses: astral-sh/setup-uv@v8.2.0
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: 3.13
-
-      - name: Audit and sync tracking issue
-        shell: bash
-        run: |
-          set -uo pipefail
-
-          # Capture findings without letting a non-zero audit fail the job:
-          # a scheduled failure would notify, which is exactly what we avoid.
-          findings="$(uv audit --ignore GHSA-6w46-j5rx-g56g 2>&1)"; rc=$?
-
-          # Ensure the tracking label exists (idempotent).
-          gh label create "$AUDIT_LABEL" --color B60205 \
-            --description "Open CVE(s) in uv.lock found by the scheduled dependency audit" \
-            2>/dev/null || true
-
-          open_issue="$(gh issue list --label "$AUDIT_LABEL" --state open \
-            --json number --jq '.[0].number // empty')"
-
-          if [ "$rc" -eq 0 ]; then
-            if [ -n "$open_issue" ]; then
-              gh issue close "$open_issue" \
-                --comment "\`uv audit\` no longer reports vulnerabilities as of ${RUN_URL} — closing automatically."
-              echo "Closed tracking issue #$open_issue (lockfile clean)."
-            else
-              echo "No vulnerabilities and no open tracking issue; nothing to do."
-            fi
-            exit 0
-          fi
-
-          # Vulnerabilities present: build the issue body from the raw audit output.
-          {
-            echo "\`uv audit\` reports known vulnerabilities in the committed \`uv.lock\`."
-            echo "These are not tied to any single change, so they are tracked here rather than blocking CI."
-            echo
-            echo '```'
-            printf '%s\n' "$findings"
-            echo '```'
-            echo
-            echo "_Maintained automatically by the scheduled dependency audit; it refreshes"
-            echo "while vulnerabilities remain and closes when \`uv audit\` is clean._"
-            echo
-            echo "[Latest run]($RUN_URL)"
-          } > "$RUNNER_TEMP/audit-body.md"
-
-          if [ -n "$open_issue" ]; then
-            # Only edit when the content actually changed, to avoid churn.
-            current="$(gh issue view "$open_issue" --json body --jq .body)"
-            if [ "$current" != "$(cat "$RUNNER_TEMP/audit-body.md")" ]; then
-              gh issue edit "$open_issue" --body-file "$RUNNER_TEMP/audit-body.md"
-              echo "Refreshed tracking issue #$open_issue."
-            else
-              echo "Tracking issue #$open_issue already current."
-            fi
-          else
-            gh issue create --title "Dependency vulnerabilities detected by uv audit" \
-              --label "$AUDIT_LABEL" --body-file "$RUNNER_TEMP/audit-body.md"
-          fi

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -25,6 +25,31 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          # Full history so we can diff a PR against its base to see whether
+          # dependency files changed (see "Detect dependency changes" below).
+          fetch-depth: 0
+
+      # The CVE audit reflects the state of the *upstream advisory database*, not
+      # the PR's diff: a newly-published advisory against an already-pinned
+      # package turns every open PR red, even one that never touches dependencies.
+      # Scope the audit to PRs that actually change dependency files so unrelated
+      # PRs aren't held hostage. Non-PR events (push to main, merge_group,
+      # workflow_dispatch) always audit, keeping trunk's signal intact.
+      - name: Detect dependency changes
+        id: deps
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD" \
+                | grep -qE '(^|/)(uv\.lock|pyproject\.toml)$'; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              echo "No dependency files changed in this PR; skipping the CVE audit."
+            fi
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       # Pin uv to a known-good, recent release.
       - name: Install uv and setup uv caching
@@ -47,6 +72,7 @@ jobs:
       # (see packages/linkml/pyproject.toml) and ignore this single test-only,
       # low-risk advisory until conftest is migrated to stdlib difflib.
       - name: Audit lockfile for CVEs
+        if: steps.deps.outputs.changed == 'true'
         run: uv audit --ignore GHSA-6w46-j5rx-g56g
 
       # Step 2: Run a sync. If a package contains known malware,

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -26,30 +26,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
-          # Full history so we can diff a PR against its base to see whether
-          # dependency files changed (see "Detect dependency changes" below).
+          # Full history so we can diff against a base ref to see whether the
+          # resolved dependency set changed (see "Detect dependency changes").
           fetch-depth: 0
-
-      # The CVE audit reflects the state of the *upstream advisory database*, not
-      # the PR's diff: a newly-published advisory against an already-pinned
-      # package turns every open PR red, even one that never touches dependencies.
-      # Scope the audit to PRs that actually change dependency files so unrelated
-      # PRs aren't held hostage. Non-PR events (push to main, merge_group,
-      # workflow_dispatch) always audit, keeping trunk's signal intact.
-      - name: Detect dependency changes
-        id: deps
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            if git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD" \
-                | grep -qE '(^|/)(uv\.lock|pyproject\.toml)$'; then
-              echo "changed=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "changed=false" >> "$GITHUB_OUTPUT"
-              echo "No dependency files changed in this PR; skipping the CVE audit."
-            fi
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
 
       # Pin uv to a known-good, recent release.
       - name: Install uv and setup uv caching
@@ -63,6 +42,58 @@ jobs:
         id: setup-python
         with:
           python-version: 3.13
+
+      # The CVE audit reflects the state of the *upstream advisory database*,
+      # not the change under test: a newly-published advisory against an
+      # already-pinned package would otherwise turn every open PR — and the next
+      # innocent merge to main — red, regardless of whether it touched deps.
+      #
+      # So gate the audit on whether the change actually altered dependencies,
+      # relative to each event's natural base:
+      #   * pull_request -> the PR base
+      #   * push (main)  -> the commit before the push (github.event.before)
+      #   * merge_group  -> the queue base
+      #   * otherwise (workflow_dispatch, first/force push) -> audit
+      #
+      # A pyproject.toml change is always a real dependency change. uv.lock is
+      # regenerated non-deterministically, so a textual change there is only
+      # treated as real if the resolved (name, version) set actually differs.
+      - name: Detect dependency changes
+        id: deps
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ github.event_name }}" in
+            pull_request) base="${{ github.event.pull_request.base.sha }}" ;;
+            merge_group)  base="${{ github.event.merge_group.base_sha }}" ;;
+            push)         base="${{ github.event.before }}" ;;
+            *)            base="" ;;
+          esac
+
+          zero="0000000000000000000000000000000000000000"
+          if [ -z "$base" ] || [ "$base" = "$zero" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            echo "No comparable base ref for '${{ github.event_name }}'; auditing."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$base...HEAD")"
+
+          if grep -qE '(^|/)pyproject\.toml$' <<<"$changed_files"; then
+            echo "pyproject.toml changed; auditing."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif grep -qE '(^|/)uv\.lock$' <<<"$changed_files"; then
+            changed="$(python3 .github/scripts/uv_lock_deps_changed.py "$base")"
+            if [ "$changed" = "true" ]; then
+              echo "uv.lock resolved dependency set changed; auditing."
+            else
+              echo "uv.lock changed but the resolved dependency set is identical; skipping audit."
+            fi
+            echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          else
+            echo "No dependency files changed; skipping audit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # Step 1: Run uv audit to check for vulnerabilities (CVEs)
       #

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -16,11 +16,19 @@ on:
   pull_request:
   merge_group:
   workflow_dispatch:
+  schedule:
+    # Weekly, Monday 09:00 UTC. Catches advisories newly published against
+    # already-pinned dependencies — the case the per-change gate deliberately
+    # ignores — and reports them in a tracking issue rather than blocking CI.
+    - cron: "0 9 * * 1"
 
 jobs:
   security-check:
     name: Validate Dependencies
     runs-on: ubuntu-latest
+    # The blocking gate is about the *change under test*; on the schedule there is
+    # no change to gate, so the scheduled run only files the tracking issue below.
+    if: github.event_name != 'schedule'
 
     steps:
       - name: Check out repository
@@ -120,3 +128,94 @@ jobs:
       #
       - name: Verify Environment Sync (Anti-Malware Gate)
         run: uv sync --frozen --all-groups
+
+  # Non-blocking detection of CVEs on the current main lockfile — including
+  # advisories published against dependencies that no PR has touched. Instead of
+  # failing CI, it keeps a single rolling tracking issue in sync with the audit:
+  # opened when vulnerabilities appear, refreshed while they persist, and closed
+  # automatically once the lockfile is clean again. It never assigns or mentions
+  # anyone, so it stays quiet (an entry in the issue list, no email drip) and is
+  # fully under the project's control — unlike Dependabot alert emails.
+  audit-issue:
+    name: Report CVEs via tracking issue
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      AUDIT_LABEL: dependency-audit
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install uv and setup uv caching
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: 3.13
+
+      - name: Audit and sync tracking issue
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Capture findings without letting a non-zero audit fail the job:
+          # a scheduled failure would notify, which is exactly what we avoid.
+          findings="$(uv audit --ignore GHSA-6w46-j5rx-g56g 2>&1)"; rc=$?
+
+          # Ensure the tracking label exists (idempotent).
+          gh label create "$AUDIT_LABEL" --color B60205 \
+            --description "Open CVE(s) in uv.lock found by the scheduled dependency audit" \
+            2>/dev/null || true
+
+          open_issue="$(gh issue list --label "$AUDIT_LABEL" --state open \
+            --json number --jq '.[0].number // empty')"
+
+          if [ "$rc" -eq 0 ]; then
+            if [ -n "$open_issue" ]; then
+              gh issue close "$open_issue" \
+                --comment "\`uv audit\` no longer reports vulnerabilities as of ${RUN_URL} — closing automatically."
+              echo "Closed tracking issue #$open_issue (lockfile clean)."
+            else
+              echo "No vulnerabilities and no open tracking issue; nothing to do."
+            fi
+            exit 0
+          fi
+
+          # Vulnerabilities present: build the issue body from the raw audit output.
+          {
+            echo "\`uv audit\` reports known vulnerabilities in the committed \`uv.lock\`."
+            echo "These are not tied to any single change, so they are tracked here rather than blocking CI."
+            echo
+            echo '```'
+            printf '%s\n' "$findings"
+            echo '```'
+            echo
+            echo "_Maintained automatically by the scheduled dependency audit; it refreshes"
+            echo "while vulnerabilities remain and closes when \`uv audit\` is clean._"
+            echo
+            echo "[Latest run]($RUN_URL)"
+          } > "$RUNNER_TEMP/audit-body.md"
+
+          if [ -n "$open_issue" ]; then
+            # Only edit when the content actually changed, to avoid churn.
+            current="$(gh issue view "$open_issue" --json body --jq .body)"
+            if [ "$current" != "$(cat "$RUNNER_TEMP/audit-body.md")" ]; then
+              gh issue edit "$open_issue" --body-file "$RUNNER_TEMP/audit-body.md"
+              echo "Refreshed tracking issue #$open_issue."
+            else
+              echo "Tracking issue #$open_issue already current."
+            fi
+          else
+            gh issue create --title "Dependency vulnerabilities detected by uv audit" \
+              --label "$AUDIT_LABEL" --body-file "$RUNNER_TEMP/audit-body.md"
+          fi


### PR DESCRIPTION
## Problem

The `Audit lockfile for CVEs` step in `dependency-audit.yaml` reflects the state of the *upstream advisory database*, not the change under test. When a new advisory is published against an already-pinned package, **every open PR goes red at once** — and so does the next innocent merge to `main` — even when nothing touched dependencies. Right now 6 newly-published CVEs in `click` and `pillow` are failing unrelated PRs (e.g. #2602, #3766).

## Change

Gate the CVE audit on whether the change **actually altered dependencies**, diffed against each event's natural base:

- `pull_request` → the PR base
- `push` (main) → the commit before the push (`github.event.before`)
- `merge_group` → the queue base
- otherwise (`workflow_dispatch`, first/force push) → audit

A `pyproject.toml` change always counts as a real dependency change. `uv.lock` is regenerated non-deterministically (reordering, hashes, metadata), so a textual change there is only treated as real when the resolved `(name, version)` set actually differs — computed by a small stdlib-`tomllib` helper (`.github/scripts/uv_lock_deps_changed.py`). No third-party action added to the supply-chain workflow.

Implemented at the **step** level, not as an `on.pull_request.paths` filter: a path-filtered required workflow reports nothing on non-matching PRs and leaves the required check stuck *pending*. Here the job always runs and reports green; only the audit step is skipped.

Net effect: `main` can only go red from a merge that genuinely introduced a vulnerable dependency (which is a broken merge), never from an unrelated advisory. The malware `uv sync` anti-malware gate is unchanged and still hard-blocking on every event.

Closes #3767