### PR TITLE
fix(oogen): update abstract signature

### DIFF
--- a/packages/linkml/src/linkml/generators/oocodegen.py
+++ b/packages/linkml/src/linkml/generators/oocodegen.py
@@ -128,7 +128,13 @@ class OOCodeGenerator(Generator):
         super().__post_init__()
 
     @abc.abstractmethod
-    def serialize(self, directory: str) -> None:
+    def serialize(self, directory: str | None = None, **kwargs) -> str | None:
+        """Serialize the schema to generated code.
+
+        Single-file generators return the generated code as a ``str``;
+        multi-file generators (e.g. javagen) write one file per class
+        into ``directory`` and return ``None``.
+        """
         raise NotImplementedError("Not implemented.")
 
     @abc.abstractmethod


### PR DESCRIPTION
## Summary

Fixes #3776 

- The `serialize` abstract method declared -> None, but all concrete subclasses (except javagen) actually return str.
- Python's  @abstractmethod does not enforce method signature matching with overrides apparently

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [ ] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes