### PR TITLE
feat(javagen): configure java/golang package name via config.yaml / gen-project integration

### DIFF
--- a/docs/generators/golang.rst
+++ b/docs/generators/golang.rst
@@ -33,11 +33,19 @@ Package Configuration
 
 The generated Go ``package`` clause is driven by the following precedence:
 
-1. ``--package`` command-line option (``--package-name`` is a deprecated alias)
+1. ``--package`` command-line option, or ``package=...`` when using ``GolangGenerator``
+   programmatically (``--package-name``/``package_name=...`` is a deprecated alias)
 2. ``generator_args.golang.package`` set via ``--config-file``/``-C`` (see below)
 3. Fallback: derived from the schema name -- lowercased, truncated at the first
    underscore, with any character outside ``[a-z0-9_]`` stripped (e.g. a schema
    named ``kitchen_sink`` yields ``package kitchen``)
+
+The derived fallback is always a legal Go package name: a name that collides with a
+Go reserved word is suffixed with an underscore (similar to pythongen.py, ``type_test``
+produces ``package type_``), and one that strips down to nothing -- for example, a
+schema named ``_private``, -- falls back to ``example``. A ``--package`` or config-file
+value, by contrast, is never rewritten: an invalid one is reported as an error rather
+than silently corrected.
 
 Configuration File
 ------------------
@@ -65,3 +73,9 @@ Deprecation note
 The ``--package-name`` option still works but is deprecated in favour of
 ``--package``, which is the canonical option name across package-scoped generators
 (matching ``gen-java``). Using ``--package-name`` emits a deprecation warning.
+
+The same rename applies to the generator's constructor: ``GolangGenerator`` takes
+``package``, the same field ``JavaGenerator`` takes, so the two are configured
+identically in code. ``package_name=...`` remains accepted as a deprecated alias, and
+reading ``.package_name`` off an instance still returns the package; both emit the
+same deprecation warning.

--- a/docs/generators/golang.rst
+++ b/docs/generators/golang.rst
@@ -34,10 +34,8 @@ Package Configuration
 The generated Go ``package`` clause is driven by the following precedence:
 
 1. ``--package`` command-line option (``--package-name`` is a deprecated alias)
-2. ``generator_args.golang.package`` set via an explicit ``--config-file``/``-C`` (see below)
-3. ``generator_args.golang.package`` set via a ``config.yaml`` auto-detected in the
-   current working directory (only checked when ``--config-file`` is not given)
-4. Fallback: derived from the schema name -- lowercased, truncated at the first
+2. ``generator_args.golang.package`` set via ``--config-file``/``-C`` (see below)
+3. Fallback: derived from the schema name -- lowercased, truncated at the first
    underscore, with any character outside ``[a-z0-9_]`` stripped (e.g. a schema
    named ``kitchen_sink`` yields ``package kitchen``)
 
@@ -60,10 +58,6 @@ project-wide ``config.yaml`` can be shared between them. ``package`` lives under
 ``gen-golang`` only ever reads ``generator_args.golang.package`` out of this file --
 every other key is ignored, so a full multi-generator project ``config.yaml`` can be
 passed as-is without modification.
-
-If ``--config-file`` is not given, ``gen-golang`` looks for a ``config.yaml`` in the
-current working directory (the conventional top-level directory of a project) and
-uses its ``generator_args.golang.package`` value automatically, if present.
 
 Deprecation note
 ----------------

--- a/docs/generators/golang.rst
+++ b/docs/generators/golang.rst
@@ -1,0 +1,73 @@
+Go
+====
+
+Overview
+--------
+
+The Go Generator produces idiomatic Go code from a LinkML model: structs for
+classes, const blocks for enums, JSON tags for serialization, and struct
+embedding for inheritance. Custom Jinja2 templates can be supplied via
+``--template-dir`` to override any of the built-in templates.
+
+Docs
+----
+
+Command Line
+^^^^^^^^^^^^
+
+.. currentmodule:: linkml.generators.golanggen
+
+.. click:: linkml.generators.golanggen.golanggen:cli
+    :prog: gen-golang
+    :nested: short
+
+Code
+^^^^
+
+
+.. autoclass:: GolangGenerator
+    :members: serialize
+
+Package Configuration
+---------------------
+
+The generated Go ``package`` clause is driven by the following precedence:
+
+1. ``--package`` command-line option (``--package-name`` is a deprecated alias)
+2. ``generator_args.golang.package`` set via an explicit ``--config-file``/``-C`` (see below)
+3. ``generator_args.golang.package`` set via a ``config.yaml`` auto-detected in the
+   current working directory (only checked when ``--config-file`` is not given)
+4. Fallback: derived from the schema name -- lowercased, truncated at the first
+   underscore, with any character outside ``[a-z0-9_]`` stripped (e.g. a schema
+   named ``kitchen_sink`` yields ``package kitchen``)
+
+Configuration File
+------------------
+
+As an alternative to ``--package``, ``gen-golang`` accepts a ``--config-file``/``-C``
+YAML file -- the **same format** used by ``gen-project``'s own ``--config-file``
+(see :doc:`project-generator`) and by ``gen-java`` (see :doc:`java`), so a single
+project-wide ``config.yaml`` can be shared between them. ``package`` lives under
+``generator_args.golang``:
+
+.. code-block:: yaml
+
+    # config.yaml
+    generator_args:
+      golang:
+        package: mypackage
+
+``gen-golang`` only ever reads ``generator_args.golang.package`` out of this file --
+every other key is ignored, so a full multi-generator project ``config.yaml`` can be
+passed as-is without modification.
+
+If ``--config-file`` is not given, ``gen-golang`` looks for a ``config.yaml`` in the
+current working directory (the conventional top-level directory of a project) and
+uses its ``generator_args.golang.package`` value automatically, if present.
+
+Deprecation note
+----------------
+
+The ``--package-name`` option still works but is deprecated in favour of
+``--package``, which is the canonical option name across package-scoped generators
+(matching ``gen-java``). Using ``--package-name`` emits a deprecation warning.

--- a/docs/generators/index.rst
+++ b/docs/generators/index.rst
@@ -79,6 +79,7 @@ languages such as Python, Javascript, or Java.
    python
    pydantic
    java
+   golang
    typescript
    rust
 

--- a/docs/generators/java.rst
+++ b/docs/generators/java.rst
@@ -102,6 +102,9 @@ The generated Java ``package`` statement is driven by the following precedence:
 2. ``generator_args.java.package`` set via ``--config-file``/``-C`` (see :ref:`java-configuration-file` below)
 3. Fallback default: ``example``
 
+The package name is validated wherever it comes from. An invalid name (``1bad.pkg``,
+``org.class.model``) is reported as an error.
+
 NOTE:
     The package name is *not* configurable via schema-level annotations: LinkML
     classes, slots, and enums live in a single global namespace regardless of

--- a/docs/generators/java.rst
+++ b/docs/generators/java.rst
@@ -94,6 +94,56 @@ expected to be serialised in the JSON or YAML serialisations; the
 ``--use-aliases`` option only affects the symbol used to represent the
 slot in the Java code.
 
+Package Configuration
+---------------------
+The generated Java ``package`` statement is driven by the following precedence:
+
+1. ``--package`` command-line option (or ``package=...`` when using ``JavaGenerator`` programmatically)
+2. ``generator_args.java.package`` set via ``--config-file``/``-C`` (see :ref:`java-configuration-file` below)
+3. Fallback default: ``example``
+
+NOTE:
+    The package name is *not* configurable via schema-level annotations: LinkML
+    classes, slots, and enums live in a single global namespace regardless of
+    which (sub-)schema declares them - the package is a global configuration for
+    the generator, not a property of the model.
+
+
+The package applies to every generated class and enum: ``gen-java`` emits one file per
+class into a single flat output directory, and cross-class references rely on all
+generated types sharing one package.
+
+.. _java-configuration-file:
+
+Configuration File
+-------------------
+
+As an alternative to the ``--package`` argument, ``gen-java`` accepts a
+``--config-file``/``-C`` YAML file -- the **same format** used by
+``gen-project``'s own ``--config-file`` (see :doc:`project-generator`), so a single
+project-wide ``config.yaml`` can be shared between ``gen-project`` and a
+standalone ``gen-java`` run. ``package`` lives under ``generator_args.java``,
+since that file is structured to configure every generator at once:
+
+.. code-block:: yaml
+
+    # config.yaml
+    generator_args:
+      java:
+        package: org.example.model
+
+``gen-java`` only ever reads ``generator_args.java.package`` out of this file --
+every other key (``directory``, ``excludes``, other generators' ``generator_args``
+entries, etc.) is ignored, so a full multi-generator project ``config.yaml`` can be
+passed as-is without modification.
+
+An explicit ``--package`` command-line option always overrides a value set via
+``--config-file``.
+
+The same configuration-file mechanism is supported by ``gen-golang`` (see
+:doc:`golang`), which reads ``generator_args.golang.package`` from the same file.
+
+
 Generating Visitor Patterns
 ---------------------------
 

--- a/examples/tutorial/tutorial08/project-listing.txt
+++ b/examples/tutorial/tutorial08/project-listing.txt
@@ -1,5 +1,6 @@
 excel
 graphql
+java
 jsonld
 jsonschema
 owl

--- a/packages/linkml/src/linkml/generators/excelgen.py
+++ b/packages/linkml/src/linkml/generators/excelgen.py
@@ -171,7 +171,7 @@ class ExcelGenerator(Generator):
 
         dv.add(f"{column_letter}2:{column_letter}1048576")
 
-    def serialize(self, **kwargs) -> str:
+    def serialize(self, **kwargs) -> None:
         sv = self.schemaview
         all_classes = sv.all_classes(imports=self.mergeimports)
 

--- a/packages/linkml/src/linkml/generators/golanggen/README.md
+++ b/packages/linkml/src/linkml/generators/golanggen/README.md
@@ -29,7 +29,7 @@ Top-level template rendered once per schema.
 
 | Variable | Type | Description |
 |---|---|---|
-| `package_name` | `str` | Go package name (derived from schema name or `--package-name`) |
+| `package_name` | `str` | Go package name (from `--package`, else derived from schema name) |
 | `imports` | `str` | Rendered import block (from `imports.go.jinja`) |
 | `enums` | `dict[str, str]` | Rendered enum blocks keyed by enum name |
 | `structs` | `dict[str, str]` | Rendered struct blocks keyed by struct name |

--- a/packages/linkml/src/linkml/generators/golanggen/golanggen.py
+++ b/packages/linkml/src/linkml/generators/golanggen/golanggen.py
@@ -26,7 +26,7 @@ from linkml.generators.golanggen.template import (
 )
 from linkml.generators.oocodegen import OOCodeGenerator
 from linkml.utils.deprecation import deprecation_warning
-from linkml.utils.generator import read_generator_config_arg, shared_arguments
+from linkml.utils.generator import read_generator_config, shared_arguments
 from linkml_runtime.linkml_model.meta import ClassDefinition, EnumDefinition, SlotDefinition
 from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml_runtime.utils.schemaview import SchemaView
@@ -696,7 +696,7 @@ def cli(
         if package is None:
             package = package_name
     if package is None:
-        package = read_generator_config_arg(config_file, "golang", "package")
+        package = read_generator_config(config_file, "golang").get("package")
 
     if template_dir is not None:
         if not Path(template_dir).exists():

--- a/packages/linkml/src/linkml/generators/golanggen/golanggen.py
+++ b/packages/linkml/src/linkml/generators/golanggen/golanggen.py
@@ -25,7 +25,8 @@ from linkml.generators.golanggen.template import (
     Imports,
 )
 from linkml.generators.oocodegen import OOCodeGenerator
-from linkml.utils.generator import shared_arguments
+from linkml.utils.deprecation import deprecation_warning
+from linkml.utils.generator import read_generator_config_arg, shared_arguments
 from linkml_runtime.linkml_model.meta import ClassDefinition, EnumDefinition, SlotDefinition
 from linkml_runtime.utils.formatutils import camelcase, underscore
 from linkml_runtime.utils.schemaview import SchemaView
@@ -614,9 +615,25 @@ _TEMPLATE_NAMES = [
 
 @shared_arguments(GolangGenerator)
 @click.option(
-    "--package-name",
+    "--package",
+    "package",
     type=str,
     help="Override the Go package name (default: derived from schema name)",
+)
+@click.option(
+    "--package-name",
+    "package_name",
+    type=str,
+    help="DEPRECATED alias for --package",
+)
+@click.option(
+    "--config-file",
+    "-C",
+    type=click.File("rb"),
+    help="Path to a gen-project-style YAML config file setting "
+    "'generator_args: {golang: {package: ...}}'. An explicit --package always "
+    "takes precedence over the config file. If not given, a 'config.yaml' in the current "
+    "working directory is used automatically if present.",
 )
 @click.option(
     "--alphabetical-sort/--no-alphabetical-sort",
@@ -657,7 +674,9 @@ Available templates to override:
 @click.command(name="golang")
 def cli(
     yamlfile,
+    package: str | None = None,
     package_name: str | None = None,
+    config_file=None,
     alphabetical_sort: bool = False,
     nullable_primitives: bool = True,
     named_slot_types: bool = False,
@@ -673,13 +692,20 @@ def cli(
     - JSON tags for serialization
     - Struct embedding for inheritance
     """
+    if package_name is not None:
+        deprecation_warning("golanggen-package-name-option")
+        if package is None:
+            package = package_name
+    if package is None:
+        package = read_generator_config_arg(config_file, "golang", "package")
+
     if template_dir is not None:
         if not Path(template_dir).exists():
             raise FileNotFoundError(f"The template directory {template_dir} does not exist!")
 
     gen = GolangGenerator(
         yamlfile,
-        package_name=package_name,
+        package_name=package,
         alphabetical_sort=alphabetical_sort,
         nullable_primitives=nullable_primitives,
         named_slot_types=named_slot_types,

--- a/packages/linkml/src/linkml/generators/golanggen/golanggen.py
+++ b/packages/linkml/src/linkml/generators/golanggen/golanggen.py
@@ -7,8 +7,10 @@ Based on the PydanticGenerator architecture.
 import logging
 import os
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import click
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader
@@ -24,8 +26,8 @@ from linkml.generators.golanggen.template import (
     Import,
     Imports,
 )
-from linkml.generators.oocodegen import OOCodeGenerator
-from linkml.utils.deprecation import deprecation_warning
+from linkml.generators.oocodegen import PACKAGE, OOCodeGenerator
+from linkml.utils.deprecation import deprecated_fields, deprecation_warning
 from linkml.utils.generator import read_generator_config, shared_arguments
 from linkml_runtime.linkml_model.meta import ClassDefinition, EnumDefinition, SlotDefinition
 from linkml_runtime.utils.formatutils import camelcase, underscore
@@ -71,7 +73,81 @@ GO_PRIMITIVE_TYPES = frozenset(
     }
 )
 
+# Fallback package when a schema name yields no usable identifier,
+# mirroring JavaGenerator's "example" default.
+DEFAULT_GO_PACKAGE = "example"
 
+# The 25 reserved words that may not be used as identifiers.
+# https://go.dev/ref/spec#Keywords
+GO_KEYWORDS = frozenset(
+    {
+        "break",
+        "case",
+        "chan",
+        "const",
+        "continue",
+        "default",
+        "defer",
+        "else",
+        "fallthrough",
+        "for",
+        "func",
+        "go",
+        "goto",
+        "if",
+        "import",
+        "interface",
+        "map",
+        "package",
+        "range",
+        "return",
+        "select",
+        "struct",
+        "switch",
+        "type",
+        "var",
+    }
+)
+
+
+def _is_valid_go_package(package_name: str) -> bool:
+    """Return True if ``package_name`` is a legal Go package identifier.
+
+    Unlike Java, a Go package clause (``package foo``) names a single
+    identifier, not a dotted path. It must start with a letter or
+    underscore, contain only letters/digits/underscores, and must not be a
+    reserved keyword. See specs for grammar/identifier rules:
+    https://go.dev/ref/spec#Package_clause
+    https://go.dev/ref/spec#Identifiers
+    """
+    if not package_name or not (package_name[0].isalpha() or package_name[0] == "_"):
+        return False
+    if any(not (ch.isalnum() or ch == "_") for ch in package_name):
+        return False
+    if package_name in GO_KEYWORDS:
+        return False
+    return True
+
+
+def _derive_go_package(schema_name: str) -> str:
+    """Derive a legal Go package identifier from a schema name.
+
+    Mirrors ``JavaGenerator``'s guarantee that the fallback package is always
+    valid: a schema name that sanitises to nothing (e.g. ``_private``) falls
+    back to :data:`DEFAULT_GO_PACKAGE`, and one that collides with a reserved
+    word is suffixed with ``_``, the same escape ``map_name`` applies to
+    keyword-named fields.
+    """
+    # Take the leading segment (e.g. "kitchen_sink" -> "kitchen")
+    stem = schema_name.split("_", 1)[0]
+    # Keep only characters legal in a Go package name (lowercase, alphanumeric, underscore)
+    candidate = re.sub(r"[^a-z0-9_]", "", stem.lower())
+    if candidate in GO_KEYWORDS:
+        candidate += "_"
+    return candidate if _is_valid_go_package(candidate) else DEFAULT_GO_PACKAGE
+
+
+@deprecated_fields({"package_name": "package"}, "golanggen-package-name-option")
 @dataclass
 class GolangGenerator(OOCodeGenerator):
     """
@@ -94,8 +170,13 @@ class GolangGenerator(OOCodeGenerator):
     file_extension = "go"
 
     # ObjectVars
-    package_name: str | None = None
-    """Override the package name. If None, derived from schema name."""
+    package: PACKAGE | None = None
+    """Override the Go package name. If unset, derived from the schema name.
+
+    Overrides :class:`~linkml.generators.oocodegen.OOCodeGenerator`'s ``"example"``
+    default so that an unset package can be told apart from an explicit one and
+    derived from the schema name instead. ``package_name`` is a deprecated alias.
+    """
 
     gen_slots: bool = True
     """Generate struct fields"""
@@ -167,6 +248,19 @@ class GolangGenerator(OOCodeGenerator):
 
     def __post_init__(self):
         super().__post_init__()
+        if self.package in (None, ""):
+            self.package = _derive_go_package(self.schemaview.schema.name)
+        else:
+            # guards against a non-string value, e.g. an unquoted number in config.yaml
+            self.package = str(self.package)
+        if not _is_valid_go_package(self.package):
+            raise ValueError(f"{self.package!r} is not a valid Go package name")
+
+    @classmethod
+    def validate_generator_args(cls, args: Mapping[str, Any]) -> None:
+        package = args.get("package")
+        if package not in (None, "") and not _is_valid_go_package(str(package)):
+            raise click.UsageError(f"{package!r} is not a valid Go package name")
 
     def default_value_for_type(self, typ: str) -> str:
         """
@@ -515,18 +609,6 @@ class GolangGenerator(OOCodeGenerator):
                 if sv.slot_children(slot_name):
                     self._parent_slot_names.add(slot_name)
 
-        # Determine package name
-        package_name = self.package_name
-        if package_name is None:
-            schema_name = sv.schema.name
-            # Extract package name from schema name (e.g., "kitchen_sink" -> "kitchen")
-            if "_" in schema_name:
-                package_name = schema_name[: schema_name.find("_")]
-            else:
-                package_name = schema_name
-            # Make it valid Go package name (lowercase, alphanumeric + underscore)
-            package_name = re.sub(r"[^a-z0-9_]", "", package_name.lower())
-
         # Generate enums
         enums = {}
         for enum_def in sv.all_enums().values():
@@ -566,7 +648,7 @@ class GolangGenerator(OOCodeGenerator):
             imports.sort()
 
         module = GolangModule(
-            package_name=package_name,
+            package_name=self.package,
             imports=imports,
             enums=enums,
             structs=structs,
@@ -697,14 +779,19 @@ def cli(
             package = package_name
     if package is None:
         package = read_generator_config(config_file, "golang").get("package")
+    GolangGenerator.validate_generator_args({"package": package})
 
     if template_dir is not None:
         if not Path(template_dir).exists():
             raise FileNotFoundError(f"The template directory {template_dir} does not exist!")
 
+    # The package was already validated above; a ValueError raised while actually
+    # constructing the generator here is therefore a genuine failure (e.g. an
+    # unloadable schema), not a bad package name, and is left to propagate with
+    # its own traceback rather than being caught and mistaken for one.
     gen = GolangGenerator(
         yamlfile,
-        package_name=package,
+        package=package,
         alphabetical_sort=alphabetical_sort,
         nullable_primitives=nullable_primitives,
         named_slot_types=named_slot_types,

--- a/packages/linkml/src/linkml/generators/golanggen/golanggen.py
+++ b/packages/linkml/src/linkml/generators/golanggen/golanggen.py
@@ -632,8 +632,7 @@ _TEMPLATE_NAMES = [
     type=click.File("rb"),
     help="Path to a gen-project-style YAML config file setting "
     "'generator_args: {golang: {package: ...}}'. An explicit --package always "
-    "takes precedence over the config file. If not given, a 'config.yaml' in the current "
-    "working directory is used automatically if present.",
+    "takes precedence over the config file.",
 )
 @click.option(
     "--alphabetical-sort/--no-alphabetical-sort",

--- a/packages/linkml/src/linkml/generators/javagen.py
+++ b/packages/linkml/src/linkml/generators/javagen.py
@@ -534,8 +534,8 @@ def cli(
     """Generate java classes to represent a LinkML model"""
     if package is None:
         package = read_generator_config(config_file, "java").get("package")
-        if package is not None and not _is_valid_java_package(str(package)):
-            logging.warning("Config value %r is not a valid Java package name; using it as-is.", package)
+    if package is not None and not _is_valid_java_package(str(package)):
+        raise click.UsageError(f"{package!r} is not a valid Java package name")
     if generate_records:
         template_variant = "records"
     if template_file is not None:

--- a/packages/linkml/src/linkml/generators/javagen.py
+++ b/packages/linkml/src/linkml/generators/javagen.py
@@ -9,7 +9,7 @@ from jinja2 import Template
 from linkml._version import __version__
 from linkml.generators.oocodegen import OOCodeGenerator, OODocument
 from linkml.utils.deprecation import deprecated_fields, deprecation_warning
-from linkml.utils.generator import shared_arguments
+from linkml.utils.generator import read_generator_config_arg, shared_arguments
 from linkml_runtime.linkml_model.meta import ClassDefinition, SlotDefinition, TypeDefinition
 from linkml_runtime.utils.formatutils import camelcase
 
@@ -48,6 +48,7 @@ JAVA_KEYWORDS = [
     "else",
     "enum",
     "extends",
+    "false",
     "final",
     "finally",
     "float",
@@ -62,6 +63,7 @@ JAVA_KEYWORDS = [
     "long",
     "native",
     "new",
+    "null",
     "package",
     "private",
     "protected",
@@ -77,6 +79,7 @@ JAVA_KEYWORDS = [
     "throw",
     "throws",
     "transient",
+    "true",
     "try",
     "void",
     "volatile",
@@ -84,6 +87,23 @@ JAVA_KEYWORDS = [
 ]
 
 TYPE_DEFAULTS = {"boolean": "false", "int": "0", "float": "0f", "double": "0d", "String": '""'}
+
+
+def _is_valid_java_package(package_name: str) -> bool:
+    """Return True if ``package_name`` is a dot-separated list of legal Java identifiers.
+
+    Each name segment must be a valid Java identifier (letter/underscore/dollar start,
+    followed by letters/digits/underscore/dollar) and not a reserved keyword.
+    """
+    segments = package_name.split(".")
+    for segment in segments:
+        if not segment or not (segment[0].isalpha() or segment[0] in "_$"):
+            return False
+        if any(not (ch.isalnum() or ch in "_$") for ch in segment):
+            return False
+        if segment in JAVA_KEYWORDS:
+            return False
+    return True
 
 
 @dataclass
@@ -222,6 +242,8 @@ class JavaGenerator(OOCodeGenerator):
         if self.template_file is not None:
             self.template_cache.force_template(Path(self.template_file))
         super().__post_init__()
+        if self.package in (None, ""):
+            self.package = "example"
 
     def default_value_for_type(self, typ: str) -> str:
         return TYPE_DEFAULTS.get(typ, "null")
@@ -459,6 +481,15 @@ class JavaGenerator(OOCodeGenerator):
 )
 @click.option("--package", help="Package name where relevant for generated class files")
 @click.option(
+    "--config-file",
+    "-C",
+    type=click.File("rb"),
+    help="Path to a gen-project-style YAML config file setting "
+    "'generator_args: {java: {package: ...}}'. An explicit --package always takes "
+    "precedence over the config file. If not given, a 'config.yaml' in the current "
+    "working directory is used automatically if present.",
+)
+@click.option(
     "--template-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
     help="Directory containing the Jinja2 templates to use",
@@ -485,6 +516,7 @@ def cli(
     yamlfile,
     output_directory=None,
     package=None,
+    config_file=None,
     template_dir=None,
     template_variant=None,
     template_file=None,
@@ -501,6 +533,10 @@ def cli(
     **args,
 ):
     """Generate java classes to represent a LinkML model"""
+    if package is None:
+        package = read_generator_config_arg(config_file, "java", "package")
+        if package is not None and not _is_valid_java_package(str(package)):
+            logging.warning("Config value %r is not a valid Java package name; using it as-is.", package)
     if generate_records:
         template_variant = "records"
     if template_file is not None:

--- a/packages/linkml/src/linkml/generators/javagen.py
+++ b/packages/linkml/src/linkml/generators/javagen.py
@@ -486,8 +486,7 @@ class JavaGenerator(OOCodeGenerator):
     type=click.File("rb"),
     help="Path to a gen-project-style YAML config file setting "
     "'generator_args: {java: {package: ...}}'. An explicit --package always takes "
-    "precedence over the config file. If not given, a 'config.yaml' in the current "
-    "working directory is used automatically if present.",
+    "precedence over the config file.",
 )
 @click.option(
     "--template-dir",

--- a/packages/linkml/src/linkml/generators/javagen.py
+++ b/packages/linkml/src/linkml/generators/javagen.py
@@ -9,7 +9,7 @@ from jinja2 import Template
 from linkml._version import __version__
 from linkml.generators.oocodegen import OOCodeGenerator, OODocument
 from linkml.utils.deprecation import deprecated_fields, deprecation_warning
-from linkml.utils.generator import read_generator_config_arg, shared_arguments
+from linkml.utils.generator import read_generator_config, shared_arguments
 from linkml_runtime.linkml_model.meta import ClassDefinition, SlotDefinition, TypeDefinition
 from linkml_runtime.utils.formatutils import camelcase
 
@@ -533,7 +533,7 @@ def cli(
 ):
     """Generate java classes to represent a LinkML model"""
     if package is None:
-        package = read_generator_config_arg(config_file, "java", "package")
+        package = read_generator_config(config_file, "java").get("package")
         if package is not None and not _is_valid_java_package(str(package)):
             logging.warning("Config value %r is not a valid Java package name; using it as-is.", package)
     if generate_records:

--- a/packages/linkml/src/linkml/generators/javagen.py
+++ b/packages/linkml/src/linkml/generators/javagen.py
@@ -1,7 +1,9 @@
 import logging
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import click
 from jinja2 import Template
@@ -244,6 +246,15 @@ class JavaGenerator(OOCodeGenerator):
         super().__post_init__()
         if self.package in (None, ""):
             self.package = "example"
+        # str() guards against a non-string value, e.g. an unquoted number in config.yaml
+        if not _is_valid_java_package(str(self.package)):
+            raise ValueError(f"{self.package!r} is not a valid Java package name")
+
+    @classmethod
+    def validate_generator_args(cls, args: Mapping[str, Any]) -> None:
+        package = args.get("package")
+        if package not in (None, "") and not _is_valid_java_package(str(package)):
+            raise click.UsageError(f"{package!r} is not a valid Java package name")
 
     def default_value_for_type(self, typ: str) -> str:
         return TYPE_DEFAULTS.get(typ, "null")
@@ -534,8 +545,7 @@ def cli(
     """Generate java classes to represent a LinkML model"""
     if package is None:
         package = read_generator_config(config_file, "java").get("package")
-    if package is not None and not _is_valid_java_package(str(package)):
-        raise click.UsageError(f"{package!r} is not a valid Java package name")
+    JavaGenerator.validate_generator_args({"package": package})
     if generate_records:
         template_variant = "records"
     if template_file is not None:
@@ -552,7 +562,11 @@ def cli(
     if head is not None:
         deprecation_warning("metadata-flag")
         args["metadata"] = head
-    JavaGenerator(
+    # The package was already validated above; a ValueError raised while actually
+    # constructing the generator here is therefore a genuine failure (e.g. an
+    # unloadable schema), not a bad package name, and is left to propagate with
+    # its own traceback rather than being caught and mistaken for one.
+    generator = JavaGenerator(
         yamlfile,
         package=package,
         template_dir=template_dir,
@@ -563,7 +577,8 @@ def cli(
         true_enums=true_enums,
         use_aliases=use_aliases,
         **args,
-    ).serialize(
+    )
+    generator.serialize(
         output_directory, template_variant=template_variant, extra_templates=extra_template, visitors=visitor, **args
     )
 

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -155,7 +155,10 @@ class ProjectGenerator:
                 **gen_config.default_args,
                 **config.generator_args.get(gen_name, {}),
             }
-            gen_config.generator.validate_generator_args(all_gen_args)
+            try:
+                gen_config.generator.validate_generator_args(all_gen_args)
+            except click.UsageError as e:
+                raise click.UsageError(f"{gen_name}: {e.format_message()}") from e
             selected.append((gen_name, gen_config, all_gen_args))
 
         output_dir = Path(config.directory)

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import click
 import yaml
@@ -30,36 +30,70 @@ logger = logging.getLogger(__name__)
 PATH_FSTRING = str
 GENERATOR_NAME = str
 ARG_DICT = dict[str, Any]
-CONFIG_TUPLE = tuple[type[Generator], PATH_FSTRING, ARG_DICT]
-GEN_MAP: dict[GENERATOR_NAME, CONFIG_TUPLE]
+
+
+class GeneratorConfig(NamedTuple):
+    """How gen-project drives one generator.
+
+    A NamedTuple rather than a plain tuple so that ``serialize_only`` can be left
+    off the entries that don't need it, and so fields can be read by name; entries
+    still unpack positionally.
+    """
+
+    generator: type[Generator]
+    """The generator class to instantiate."""
+
+    path_fstring: PATH_FSTRING
+    """Output path template for the generated artefact, e.g. ``"owl/{name}.owl.ttl"``."""
+
+    default_args: ARG_DICT
+    """Arguments applied before any user-supplied ``generator_args``."""
+
+    serialize_only: frozenset[str] = frozenset()
+    """Keys to pass to ``serialize()`` but NOT to the constructor.
+
+    Scoped per generator so that a name which is serialize-only here (JavaGenerator's
+    ``directory``) is not dropped from a different generator's constructor call, where
+    the same name is a genuine constructor argument (dotgen, docgen and plantumlgen all
+    take ``directory`` that way).
+    """
+
+
+# Retained as the previous name for this entry type.
+CONFIG_TUPLE = GeneratorConfig
+
+GEN_MAP: dict[GENERATOR_NAME, GeneratorConfig]
 GEN_MAP = {
-    "graphql": (GraphqlGenerator, "graphql/{name}.graphql", {}),
-    "jsonldcontext": (ContextGenerator, "jsonld/{name}.context.jsonld", {}),
-    "jsonld": (
+    "graphql": GeneratorConfig(GraphqlGenerator, "graphql/{name}.graphql", {}),
+    "jsonldcontext": GeneratorConfig(ContextGenerator, "jsonld/{name}.context.jsonld", {}),
+    "jsonld": GeneratorConfig(
         JSONLDGenerator,
         "jsonld/{name}.jsonld",
         {"context": "{parent}/{name}.context.jsonld"},
     ),
-    "jsonschema": (JsonSchemaGenerator, "jsonschema/{name}.schema.json", {}),
-    "owl": (OwlSchemaGenerator, "owl/{name}.owl.ttl", {}),
-    "prefixmap": (PrefixGenerator, "prefixmap/{name}.yaml", {}),
-    "proto": (ProtoGenerator, "protobuf/{name}.proto", {}),
-    "python": (PythonGenerator, "{name}.py", {}),
-    #    'rdf': (RDFGenerator, 'rdf/{name}.ttl', {}),
-    #    'rdf': (RDFGenerator, 'rdf/{name}.ttl', {'context': '{parent}/../jsonld/{name}.context.jsonld'}),
-    "shex": (ShExGenerator, "shex/{name}.shex", {}),
-    "shacl": (ShaclGenerator, "shacl/{name}.shacl.ttl", {}),
-    "sqltable": (SQLTableGenerator, "sqlschema/{name}.sql", {}),
+    "jsonschema": GeneratorConfig(JsonSchemaGenerator, "jsonschema/{name}.schema.json", {}),
+    "owl": GeneratorConfig(OwlSchemaGenerator, "owl/{name}.owl.ttl", {}),
+    "prefixmap": GeneratorConfig(PrefixGenerator, "prefixmap/{name}.yaml", {}),
+    "proto": GeneratorConfig(ProtoGenerator, "protobuf/{name}.proto", {}),
+    "python": GeneratorConfig(PythonGenerator, "{name}.py", {}),
+    #    'rdf': GeneratorConfig(RDFGenerator, 'rdf/{name}.ttl', {}),
+    #    'rdf': GeneratorConfig(
+    #        RDFGenerator, 'rdf/{name}.ttl', {'context': '{parent}/../jsonld/{name}.context.jsonld'}
+    #    ),
+    "shex": GeneratorConfig(ShExGenerator, "shex/{name}.shex", {}),
+    "shacl": GeneratorConfig(ShaclGenerator, "shacl/{name}.shacl.ttl", {}),
+    "sqltable": GeneratorConfig(SQLTableGenerator, "sqlschema/{name}.sql", {}),
     # JavaGenerator writes one file per class directly into `directory`
     # (a serialize()-time argument, not a constructor argument) and its
-    # serialize() always returns None; see SERIALIZE_ONLY_ARGS below.
-    "java": (JavaGenerator, "java/{name}.java", {"directory": "{parent}"}),
-    "excel": (ExcelGenerator, "excel/{name}.xlsx", {"output": "{parent}/{name}.xlsx"}),
+    # serialize() always returns None.
+    "java": GeneratorConfig(
+        JavaGenerator,
+        "java/{name}.java",
+        {"directory": "{parent}"},
+        serialize_only=frozenset({"directory"}),
+    ),
+    "excel": GeneratorConfig(ExcelGenerator, "excel/{name}.xlsx", {"output": "{parent}/{name}.xlsx"}),
 }
-
-# Argument keys that must be passed to serialize() but NOT to the generator's
-# constructor (currently only JavaGenerator's `directory`).
-SERIALIZE_ONLY_ARGS = {"directory"}
 
 
 @lru_cache
@@ -100,6 +134,30 @@ class ProjectGenerator:
     def generate(schema_path: str, config: ProjectConfiguration = ProjectConfiguration()):
         if config.directory is None:
             raise Exception("Must pass directory")
+
+        # Resolve which generators run and with what merged arguments, rejecting
+        # any bad `generator_args` value before anything at all is generated or
+        # written -- a typo in the config for the last generator must not leave
+        # behind a half-built project. This is the only place a `generator_args`
+        # value gets checked; a ValueError raised later while actually
+        # constructing a generator is therefore a genuine failure (e.g. an
+        # unloadable schema) and is left to propagate with its own traceback,
+        # rather than being caught and mistaken for a bad config value.
+        selected: list[tuple[GENERATOR_NAME, GeneratorConfig, ARG_DICT]] = []
+        for gen_name, gen_config in GEN_MAP.items():
+            if config.includes is not None and config.includes != [] and gen_name not in config.includes:
+                logger.info(f"Skipping {gen_name} as not in inclusion list: {config.includes}")
+                continue
+            if config.excludes is not None and gen_name in config.excludes:
+                logger.info(f"Skipping {gen_name} as it is in exclusion list")
+                continue
+            all_gen_args = {
+                **gen_config.default_args,
+                **config.generator_args.get(gen_name, {}),
+            }
+            gen_config.generator.validate_generator_args(all_gen_args)
+            selected.append((gen_name, gen_config, all_gen_args))
+
         output_dir = Path(config.directory)
         output_dir.mkdir(parents=True, exist_ok=True)
         if config.mergeimports:
@@ -107,41 +165,36 @@ class ProjectGenerator:
         else:
             all_schemas = get_local_imports(schema_path, Path(schema_path).parent)
         logger.debug(f"ALL_SCHEMAS = {all_schemas}")
-        for gen_name, (gen_cls, gen_path_fmt, default_gen_args) in GEN_MAP.items():
-            if config.includes is not None and config.includes != [] and gen_name not in config.includes:
-                logger.info(f"Skipping {gen_name} as not in inclusion list: {config.includes}")
-                continue
-            if config.excludes is not None and gen_name in config.excludes:
-                logger.info(f"Skipping {gen_name} as it is in exclusion list")
-                continue
+        for gen_name, gen_config, all_gen_args in selected:
             logger.info(f"Generating: {gen_name}")
             for local_path in all_schemas:
                 logger.info(f" SCHEMA: {local_path}")
                 name = Path(local_path).stem
-                gen_path = gen_path_fmt.format(name=name)
+                gen_path = gen_config.path_fstring.format(name=name)
                 gen_path_full = output_dir / gen_path
                 parent_dir = gen_path_full.parent
                 logger.info(f" PARENT={parent_dir}")
                 parent_dir.mkdir(parents=True, exist_ok=True)
-                all_gen_args = {
-                    **default_gen_args,
-                    **config.generator_args.get(gen_name, {}),
-                }
                 gen: Generator
+
+                # Per-schema copy: the `output` value is interpolated per schema
+                # below and must not mutate `all_gen_args`, which is shared
+                # across schemas.
+                schema_gen_args = dict(all_gen_args)
 
                 # special check for output key because ExcelGenerator and
                 # SSSOMGenerator read in output file name during initialization
-                if "output" in all_gen_args:
-                    all_gen_args["output"] = all_gen_args["output"].format(name=name, parent=parent_dir)
+                if "output" in schema_gen_args:
+                    schema_gen_args["output"] = schema_gen_args["output"].format(name=name, parent=parent_dir)
 
-                # Some generators (e.g. JavaGenerator) accept `directory`
-                # only in serialize(), not in their constructor; so keep
+                # Some generators (e.g. JavaGenerator) accept an arg only in
+                # serialize(), not in their constructor; keep this generator's
                 # serialize-only keys out of the constructor call.
-                constructor_args = {k: v for k, v in all_gen_args.items() if k not in SERIALIZE_ONLY_ARGS}
-                gen = gen_cls(local_path, **constructor_args)
+                constructor_args = {k: v for k, v in schema_gen_args.items() if k not in gen_config.serialize_only}
+                gen = gen_config.generator(local_path, **constructor_args)
 
                 serialize_args = {"mergeimports": config.mergeimports}
-                for k, v in all_gen_args.items():
+                for k, v in schema_gen_args.items():
                     # all ARG_DICT values are interpolatable
                     if isinstance(v, str):
                         v = v.format(name=name, parent=parent_dir)
@@ -255,6 +308,8 @@ def cli(
         project_config.directory = dir
     project_config.mergeimports = mergeimports
     gen = ProjectGenerator()
+    # A bad `generator_args` value surfaces from Generator.validate_generator_args()
+    # as a click.UsageError, which click reports on its own; nothing to catch here.
     gen.generate(yamlfile, project_config)
 
 

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -12,6 +12,7 @@ from linkml._version import __version__
 from linkml.cli.logging import log_level_option
 from linkml.generators.excelgen import ExcelGenerator
 from linkml.generators.graphqlgen import GraphqlGenerator
+from linkml.generators.javagen import JavaGenerator
 from linkml.generators.jsonldcontextgen import ContextGenerator
 from linkml.generators.jsonldgen import JSONLDGenerator
 from linkml.generators.jsonschemagen import JsonSchemaGenerator
@@ -49,11 +50,16 @@ GEN_MAP = {
     "shex": (ShExGenerator, "shex/{name}.shex", {}),
     "shacl": (ShaclGenerator, "shacl/{name}.shacl.ttl", {}),
     "sqltable": (SQLTableGenerator, "sqlschema/{name}.sql", {}),
-    # # linkml/generators/javagen.py uses different architecture from most of the other generators
-    # # also linkml/generators/excelgen.py, which has a different mechanism for determining the output path
-    # 'java': (JavaGenerator, 'java/{name}.java', {'directory': '{parent}'}),
+    # JavaGenerator writes one file per class directly into `directory`
+    # (a serialize()-time argument, not a constructor argument) and its
+    # serialize() always returns None; see SERIALIZE_ONLY_ARGS below.
+    "java": (JavaGenerator, "java/{name}.java", {"directory": "{parent}"}),
     "excel": (ExcelGenerator, "excel/{name}.xlsx", {"output": "{parent}/{name}.xlsx"}),
 }
+
+# Argument keys that must be passed to serialize() but NOT to the generator's
+# constructor (currently only JavaGenerator's `directory`).
+SERIALIZE_ONLY_ARGS = {"directory"}
 
 
 @lru_cache
@@ -128,7 +134,11 @@ class ProjectGenerator:
                 if "output" in all_gen_args:
                     all_gen_args["output"] = all_gen_args["output"].format(name=name, parent=parent_dir)
 
-                gen = gen_cls(local_path, **all_gen_args)
+                # Some generators (e.g. JavaGenerator) accept `directory`
+                # only in serialize(), not in their constructor; so keep
+                # serialize-only keys out of the constructor call.
+                constructor_args = {k: v for k, v in all_gen_args.items() if k not in SERIALIZE_ONLY_ARGS}
+                gen = gen_cls(local_path, **constructor_args)
 
                 serialize_args = {"mergeimports": config.mergeimports}
                 for k, v in all_gen_args.items():
@@ -139,16 +149,15 @@ class ProjectGenerator:
                 logger.info(f" {gen_name} ARGS: {serialize_args}")
                 gen_dump = gen.serialize(**serialize_args)
 
-                if gen_name != "excel":
-                    if gen_path_full.suffix != "":
-                        logger.info(f"  WRITING TO: {gen_path_full}")
-                        with open(gen_path_full, "w", encoding="UTF-8") as stream:
-                            stream.write(gen_dump)
-                else:
-                    # special handling for excel generator
-                    # we do not need to route the output
-                    # into a file like the other generators
-                    gen.serialize(**serialize_args)
+                # Generators like ExcelGenerator and JavaGenerator write their
+                # own output file(s) internally and return None from
+                # serialize(); there is nothing left for us to write out.
+                if gen_dump is None:
+                    continue
+                if gen_path_full.suffix != "":
+                    logger.info(f"  WRITING TO: {gen_path_full}")
+                    with open(gen_path_full, "w", encoding="UTF-8") as stream:
+                        stream.write(gen_dump)
 
 
 @click.command(name="project")

--- a/packages/linkml/src/linkml/utils/deprecation.py
+++ b/packages/linkml/src/linkml/utils/deprecation.py
@@ -313,12 +313,13 @@ DEPRECATIONS = (
     ),
     Deprecation(
         name="golanggen-package-name-option",
-        deprecated_in=SemVer.from_str("1.11.0"),
+        deprecated_in=SemVer.from_str("1.12.0"),
         message=(
-            "The `--package-name` option of gen-golang has been renamed `--package` "
-            "for consistency with other package-scoped generators (e.g. gen-java)."
+            "The `package_name` parameter (`--package-name` on the command line) of "
+            "GolangGenerator has been renamed `package` (`--package`), for consistency "
+            "with other package-scoped generators (e.g. JavaGenerator's `package`)."
         ),
-        recommendation="Use `--package` instead.",
+        recommendation="Use `package` (`--package` on the command line) instead.",
         issue=3780,
     ),
 )  # type: tuple[Deprecation, ...]
@@ -359,11 +360,14 @@ MATERIALIZE_PATTERNS_GENERATOR_OPTION = "materialize-patterns-generator-option"
 T = TypeVar("T")
 
 
-def deprecated_fields(deprecated_map: dict[str, str]):
+def deprecated_fields(deprecated_map: dict[str, str], deprecation_name: str = METADATA_FLAG):
     """
     Decorator to handle deprecated fields in dataclasses.
 
     :param deprecated_map: Mapping from old field names to new field names
+    :param deprecation_name: Name of the :class:`.Deprecation` to report when an old
+        field name is used. Defaults to the metadata-flag rename, which is what most
+        callers are renaming.
     """
 
     def decorator(cls: type[T]) -> type[T]:
@@ -376,7 +380,7 @@ def deprecated_fields(deprecated_map: dict[str, str]):
             # Process kwargs to handle deprecated fields
             for old_field, new_field in deprecated_map.items():
                 if old_field in kwargs:
-                    deprecation_warning(METADATA_FLAG, stack_level=4)
+                    deprecation_warning(deprecation_name, stack_level=4)
                     if new_field not in kwargs:
                         kwargs[new_field] = kwargs[old_field]
                     # Remove the old field to prevent the "unexpected keyword argument" error
@@ -393,11 +397,11 @@ def deprecated_fields(deprecated_map: dict[str, str]):
             # Create a property for the deprecated field using a closure
             def make_property(new_name):
                 def getter(self):
-                    deprecation_warning(METADATA_FLAG, stack_level=4)
+                    deprecation_warning(deprecation_name, stack_level=4)
                     return getattr(self, new_name)
 
                 def setter(self, value):
-                    deprecation_warning(METADATA_FLAG, stack_level=4)
+                    deprecation_warning(deprecation_name, stack_level=4)
                     setattr(self, new_name, value)
 
                 return property(getter, setter)

--- a/packages/linkml/src/linkml/utils/deprecation.py
+++ b/packages/linkml/src/linkml/utils/deprecation.py
@@ -311,6 +311,16 @@ DEPRECATIONS = (
         recommendation="Remove the `materialize_patterns` option from generator calls and command lines.",
         issue=1557,
     ),
+    Deprecation(
+        name="golanggen-package-name-option",
+        deprecated_in=SemVer.from_str("1.11.0"),
+        message=(
+            "The `--package-name` option of gen-golang has been renamed `--package` "
+            "for consistency with other package-scoped generators (e.g. gen-java)."
+        ),
+        recommendation="Use `--package` instead.",
+        issue=3780,
+    ),
 )  # type: tuple[Deprecation, ...]
 
 EMITTED = set()  # type: set[str]

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -24,9 +24,10 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import ClassVar, TextIO, Union, cast
+from typing import IO, ClassVar, TextIO, Union, cast
 
 import click
+import yaml
 from click import Argument, Command, Option
 from jsonasobj2 import JsonObj
 
@@ -990,3 +991,41 @@ def shared_arguments(g: type[Generator]) -> Callable[[Command], Command]:
         return f
 
     return decorator
+
+
+DEFAULT_CONFIG_FILENAME = "config.yaml"
+
+
+def read_generator_config_arg(config_file: IO[bytes] | None, generator_name: str, arg: str):
+    """Read ``generator_args.<generator_name>.<arg>`` from a gen-project-style config file.
+
+    The file format matches the project-wide config.yaml consumed by
+    ``gen-project --config-file`` (see ``ProjectConfiguration.generator_args`` in
+    projectgen.py), so one config.yaml can be shared between generators.
+
+    :param config_file: Open binary stream from an explicit ``--config-file`` option
+        (``click.File("rb")``), or None to auto-detect ``config.yaml`` in the cwd.
+    :param generator_name: Key under ``generator_args`` (e.g. ``"java"``, ``"golang"``).
+    :param arg: Key under ``generator_args.<generator_name>`` (e.g. ``"package"``).
+    :return: The configured value, or None if no config file / key was found.
+    :raises click.UsageError: if the config file is not a YAML mapping.
+    """
+    if config_file is None:
+        default_config_path = Path.cwd() / DEFAULT_CONFIG_FILENAME
+        if not default_config_path.is_file():
+            return None
+        with default_config_path.open("rb") as stream:
+            config_data = yaml.safe_load(stream) or {}
+    else:
+        config_data = yaml.safe_load(config_file) or {}
+    if not isinstance(config_data, dict):
+        raise click.UsageError(
+            f"--config-file must contain a YAML mapping (e.g. 'generator_args: {{{generator_name}: {{{arg}: ...}}}}')"
+        )
+    generator_args = config_data.get("generator_args") or {}
+    if not isinstance(generator_args, dict):
+        return None
+    gen_args = generator_args.get(generator_name) or {}
+    if not isinstance(gen_args, dict):
+        return None
+    return gen_args.get(arg)

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -283,12 +283,13 @@ class Generator(metaclass=abc.ABCMeta):
                 for prefix in self.schema.prefixes.values():
                     self.namespaces[prefix.prefix_prefix] = prefix.prefix_reference
 
-    def serialize(self, **kwargs) -> str:
+    def serialize(self, **kwargs) -> str | None:
         """
         Generate output in the required format
 
         :param kwargs: Generator specific parameters
-        :return: Generated output
+        :return: Generated output, or None if the generator writes its output
+            directly to disk instead of returning it (e.g. ExcelGenerator, JavaGenerator)
         """
         out = ""
 

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -283,6 +283,24 @@ class Generator(metaclass=abc.ABCMeta):
                 for prefix in self.schema.prefixes.values():
                     self.namespaces[prefix.prefix_prefix] = prefix.prefix_reference
 
+    @classmethod
+    def validate_generator_args(cls, args: Mapping[str, Any]) -> None:
+        """Validate ``generator_args`` before any generator is built from them.
+
+        ``gen-project`` calls this once per selected generator, all before any
+        output is generated, and the generator CLIs (e.g. ``gen-java``) call it
+        on their resolved options before construction -- so a bad configuration
+        value is caught up front rather than surfacing later as a generic
+        exception raised somewhere during schema loading, which it would then be
+        indistinguishable from. The default implementation does nothing;
+        override to check specific keys eagerly.
+
+        :param args: The merged ``generator_args`` for this generator (defaults
+            plus any user-supplied ``generator_args`` section), before path
+            interpolation.
+        :raises click.UsageError: if a value is invalid.
+        """
+
     def serialize(self, **kwargs) -> str | None:
         """
         Generate output in the required format
@@ -1017,7 +1035,7 @@ def read_generator_config(config_file: IO[bytes] | None, generator_name: str) ->
     """Read one generator's settings out of a gen-project-style config file.
 
     This is the configuration file that ``gen-project --config-file`` reads so a
-    project can keep a singlefile and each generator can have its own section.
+    project can keep a single file and each generator can have its own section.
 
     Reading consumes ``config_file``, so call this once and lookup each setting
     on the returned dict. Calling it a second time with the same open file finds
@@ -1036,11 +1054,17 @@ def read_generator_config(config_file: IO[bytes] | None, generator_name: str) ->
     :param config_file: The open file from ``--config-file``, or None if absent.
     :param generator_name: Which section to read, e.g. ``"java"`` or ``"golang"``.
     :return: That generator's settings, empty if the file has none for it.
-    :raises click.UsageError: if the file, or the part of it this generator reads, isn't
-        a YAML mapping.
+    :raises click.UsageError: if the file is not parseable as YAML, or if the file, or
+        the part of it this generator reads, isn't a YAML mapping.
     """
     if config_file is None:
         return {}
-    config_data = _config_mapping(yaml.safe_load(config_file), "the top level")
+    try:
+        parsed = yaml.safe_load(config_file)
+    except yaml.YAMLError as e:
+        # unparsable YAML is a mistake in the file, so report it the same way a
+        # misshapen one is, rather than as a traceback
+        raise click.UsageError(f"--config-file: could not parse as YAML: {e}") from e
+    config_data = _config_mapping(parsed, "the top level")
     generator_args = _config_mapping(config_data.get("generator_args"), "'generator_args'")
     return _config_mapping(generator_args.get(generator_name), f"'generator_args.{generator_name}'")

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -993,9 +993,6 @@ def shared_arguments(g: type[Generator]) -> Callable[[Command], Command]:
     return decorator
 
 
-DEFAULT_CONFIG_FILENAME = "config.yaml"
-
-
 def read_generator_config_arg(config_file: IO[bytes] | None, generator_name: str, arg: str):
     """Read ``generator_args.<generator_name>.<arg>`` from a gen-project-style config file.
 
@@ -1004,20 +1001,15 @@ def read_generator_config_arg(config_file: IO[bytes] | None, generator_name: str
     projectgen.py), so one config.yaml can be shared between generators.
 
     :param config_file: Open binary stream from an explicit ``--config-file`` option
-        (``click.File("rb")``), or None to auto-detect ``config.yaml`` in the cwd.
+        (``click.File("rb")``), or None if no config file was given.
     :param generator_name: Key under ``generator_args`` (e.g. ``"java"``, ``"golang"``).
     :param arg: Key under ``generator_args.<generator_name>`` (e.g. ``"package"``).
     :return: The configured value, or None if no config file / key was found.
     :raises click.UsageError: if the config file is not a YAML mapping.
     """
     if config_file is None:
-        default_config_path = Path.cwd() / DEFAULT_CONFIG_FILENAME
-        if not default_config_path.is_file():
-            return None
-        with default_config_path.open("rb") as stream:
-            config_data = yaml.safe_load(stream) or {}
-    else:
-        config_data = yaml.safe_load(config_file) or {}
+        return None
+    config_data = yaml.safe_load(config_file) or {}
     if not isinstance(config_data, dict):
         raise click.UsageError(
             f"--config-file must contain a YAML mapping (e.g. 'generator_args: {{{generator_name}: {{{arg}: ...}}}}')"

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -24,7 +24,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import IO, ClassVar, TextIO, Union, cast
+from typing import IO, Any, ClassVar, TextIO, Union, cast
 
 import click
 import yaml
@@ -993,31 +993,53 @@ def shared_arguments(g: type[Generator]) -> Callable[[Command], Command]:
     return decorator
 
 
-def read_generator_config_arg(config_file: IO[bytes] | None, generator_name: str, arg: str):
-    """Read ``generator_args.<generator_name>.<arg>`` from a gen-project-style config file.
+def _config_mapping(value: Any, where: str) -> dict[str, Any]:
+    """Check that one level of a config file is a mapping, and hand it back.
 
-    The file format matches the project-wide config.yaml consumed by
-    ``gen-project --config-file`` (see ``ProjectConfiguration.generator_args`` in
-    projectgen.py), so one config.yaml can be shared between generators.
+    An empty value (``java:`` with nothing under it) reads as None saying "nothing
+    configured here", so it returns as empty mapping. Anything else that is not a
+    mapping is a mistake in the file, and says so rather than being skipped.
 
-    :param config_file: Open binary stream from an explicit ``--config-file`` option
-        (``click.File("rb")``), or None if no config file was given.
-    :param generator_name: Key under ``generator_args`` (e.g. ``"java"``, ``"golang"``).
-    :param arg: Key under ``generator_args.<generator_name>`` (e.g. ``"package"``).
-    :return: The configured value, or None if no config file / key was found.
-    :raises click.UsageError: if the config file is not a YAML mapping.
+    :param value: Whatever was found at this point in the file.
+    :param where: Where that was, for the error message, e.g. ``"'generator_args'"``.
+    :return: The mapping, empty if nothing was configured.
+    :raises click.UsageError: if the value is neither a mapping nor empty.
+    """
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise click.UsageError(f"--config-file: expected a YAML mapping at {where}, found {type(value).__name__}")
+    return value
+
+
+def read_generator_config(config_file: IO[bytes] | None, generator_name: str) -> dict[str, Any]:
+    """Read one generator's settings out of a gen-project-style config file.
+
+    This is the configuration file that ``gen-project --config-file`` reads so a
+    project can keep a singlefile and each generator can have its own section.
+
+    Reading consumes ``config_file``, so call this once and lookup each setting
+    on the returned dict. Calling it a second time with the same open file finds
+    nothing, because the file has already been read to the end.
+
+    >>> from io import BytesIO
+    >>> config_file = BytesIO(b"generator_args:\\n  java:\\n    package: org.example.model\\n")
+    >>> read_generator_config(config_file, "java").get("package")
+    'org.example.model'
+    >>> read_generator_config(None, "java")
+    {}
+
+    A malformed written section - a scalar where a mapping belongs - is a usage
+    error, so report it. Absent/empty sections are fine (empty dict).
+
+    :param config_file: The open file from ``--config-file``, or None if absent.
+    :param generator_name: Which section to read, e.g. ``"java"`` or ``"golang"``.
+    :return: That generator's settings, empty if the file has none for it.
+    :raises click.UsageError: if the file, or the part of it this generator reads, isn't
+        a YAML mapping.
     """
     if config_file is None:
-        return None
-    config_data = yaml.safe_load(config_file) or {}
-    if not isinstance(config_data, dict):
-        raise click.UsageError(
-            f"--config-file must contain a YAML mapping (e.g. 'generator_args: {{{generator_name}: {{{arg}: ...}}}}')"
-        )
-    generator_args = config_data.get("generator_args") or {}
-    if not isinstance(generator_args, dict):
-        return None
-    gen_args = generator_args.get(generator_name) or {}
-    if not isinstance(gen_args, dict):
-        return None
-    return gen_args.get(arg)
+        return {}
+    config_data = _config_mapping(yaml.safe_load(config_file), "the top level")
+    generator_args = _config_mapping(config_data.get("generator_args"), "'generator_args'")
+    return _config_mapping(generator_args.get(generator_name), f"'generator_args.{generator_name}'")

--- a/tests/linkml/test_generators/test_golanggen.py
+++ b/tests/linkml/test_generators/test_golanggen.py
@@ -437,10 +437,57 @@ def test_package_name_derived():
     assert module.package_name == "simple"
 
 
-def test_package_name_override():
-    """Test that --package-name overrides the derived value."""
-    module = GolangGenerator(schema=SIMPLE_SCHEMA, package_name="mypkg").render()
+def test_package_override():
+    """`package` overrides the derived value, spelled the same as JavaGenerator's."""
+    module = GolangGenerator(schema=SIMPLE_SCHEMA, package="mypkg").render()
     assert module.package_name == "mypkg"
+
+
+def test_deprecated_package_name_kwarg_still_sets_package():
+    """`package_name=` remains accepted as a deprecated alias for `package=`, and records
+    its own deprecation rather than the generic metadata-flag one."""
+    from linkml.utils import deprecation as dep_mod
+
+    dep_mod.EMITTED.discard("golanggen-package-name-option")
+    gen = GolangGenerator(schema=SIMPLE_SCHEMA, package_name="legacypkg")
+
+    assert gen.package == "legacypkg"
+    assert gen.render().package_name == "legacypkg"
+    assert "golanggen-package-name-option" in dep_mod.EMITTED
+
+
+@pytest.mark.parametrize("package", ["1bad", "bad-pkg", "bad pkg", "bad.pkg", "type", "package"])
+def test_constructor_invalid_package_errors(package):
+    """An invalid package passed directly to the generator is rejected."""
+    with pytest.raises(ValueError, match="is not a valid Go package name"):
+        GolangGenerator(schema=SIMPLE_SCHEMA, package=package)
+
+
+def test_constructor_non_string_package_errors():
+    """A non-string package (e.g. an unquoted number from a config file) is coerced and rejected
+    rather than crashing, mirroring JavaGenerator's ``str(package)`` handling."""
+    with pytest.raises(ValueError, match="is not a valid Go package name"):
+        GolangGenerator(schema=SIMPLE_SCHEMA, package=123)
+
+
+def test_derived_package_name_escapes_go_keyword():
+    """A schema name deriving to a Go reserved word is escaped rather than emitting
+    uncompilable Go (``package type``)."""
+    schema = SIMPLE_SCHEMA.replace("name: simple_test", "name: type_test")
+    assert GolangGenerator(schema=schema).render().package_name == "type_"
+
+
+def test_derived_package_name_falls_back_when_nothing_usable():
+    """A schema name that sanitises to nothing (leading underscore) falls back to the
+    default package instead of emitting a bare ``package`` clause."""
+    schema = SIMPLE_SCHEMA.replace("name: simple_test", "name: _private")
+    assert GolangGenerator(schema=schema).render().package_name == "example"
+
+
+def test_empty_package_uses_derived_default():
+    """An empty package is treated as unset and derived from the schema name, mirroring
+    JavaGenerator's ``in (None, "")`` handling."""
+    assert GolangGenerator(schema=SIMPLE_SCHEMA, package="").render().package_name == "simple"
 
 
 TIME_SCHEMA = """
@@ -1539,6 +1586,58 @@ def test_cli_package_option(tmp_path):
 
     assert result.exit_code == 0
     assert "package mypkg" in result.output
+
+
+def test_cli_invalid_package_errors(tmp_path):
+    """An invalid Go package name passed via --package is rejected rather than emitted verbatim."""
+    schema_file = _write_simple_schema(tmp_path)
+
+    result = _invoke_cli([str(schema_file), "--package", "1 bad-pkg"])
+
+    assert result.exit_code != 0
+    assert "not a valid Go package name" in result.output
+
+
+def test_cli_does_not_mistake_a_schema_error_for_a_bad_package(tmp_path):
+    """A broken schema (not a bad package) must surface as its own error, not get caught by
+    the package check and misreported as a package problem. The invocation was fine; the
+    schema is broken -- `--help` sends the user in the wrong direction."""
+    import click
+
+    schema_file = tmp_path / "bad.yaml"
+    schema_file.write_text("justastring\n", encoding="UTF-8")
+
+    result = _invoke_cli([str(schema_file)])
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, click.UsageError)
+    assert "not a valid Go package name" not in str(result.exception)
+    assert "Unexpected type" in str(result.exception)
+
+
+def test_cli_invalid_config_package_errors(tmp_path):
+    """An invalid Go package name from the config file is rejected."""
+    schema_file = _write_simple_schema(tmp_path)
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text(_golang_config_yaml("1bad.pkg"))
+
+    result = _invoke_cli([str(schema_file), "--config-file", str(config_path)])
+
+    assert result.exit_code != 0
+    assert "not a valid Go package name" in result.output
+
+
+def test_cli_unquoted_numeric_config_package_errors_cleanly(tmp_path):
+    """An unquoted numeric package (parsed by YAML as an int) is rejected with a usage
+    error instead of crashing with an unhandled TypeError."""
+    schema_file = _write_simple_schema(tmp_path)
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text(_golang_config_yaml("123"))
+
+    result = _invoke_cli([str(schema_file), "--config-file", str(config_path)])
+
+    assert result.exit_code != 0
+    assert "not a valid Go package name" in result.output
 
 
 def test_cli_package_name_deprecated_but_works(tmp_path):

--- a/tests/linkml/test_generators/test_golanggen.py
+++ b/tests/linkml/test_generators/test_golanggen.py
@@ -1505,3 +1505,119 @@ classes:
 
     code = GolangGenerator(schema, mergeimports=True).serialize()
     assert 'IntDict []KeyedIntId `json:"int_dict,omitempty"`' in code
+
+
+# ---------------------------------------------------------------------------
+# CLI package configuration (--package, deprecated --package-name, --config-file)
+# ---------------------------------------------------------------------------
+
+
+def _golang_config_yaml(package: str) -> str:
+    """The same `generator_args.golang.package` shape used by gen-project's config.yaml."""
+    return f"generator_args:\n  golang:\n    package: {package}\n"
+
+
+def _invoke_cli(args):
+    from click.testing import CliRunner
+
+    from linkml.generators.golanggen.golanggen import cli
+
+    return CliRunner().invoke(cli, args)
+
+
+def _write_simple_schema(tmp_path):
+    schema_file = tmp_path / "schema.yaml"
+    schema_file.write_text(SIMPLE_SCHEMA)
+    return schema_file
+
+
+def test_cli_package_option(tmp_path):
+    """The canonical --package option overrides the schema-derived package name."""
+    schema_file = _write_simple_schema(tmp_path)
+
+    result = _invoke_cli([str(schema_file), "--package", "mypkg"])
+
+    assert result.exit_code == 0
+    assert "package mypkg" in result.output
+
+
+def test_cli_package_name_deprecated_but_works(tmp_path):
+    """--package-name still works but registers its deprecation."""
+    from linkml.utils import deprecation as dep_mod
+
+    schema_file = _write_simple_schema(tmp_path)
+
+    result = _invoke_cli([str(schema_file), "--package-name", "mypkg"])
+
+    assert result.exit_code == 0
+    assert "package mypkg" in result.output
+    assert "golanggen-package-name-option" in dep_mod.EMITTED
+
+
+def test_cli_package_overrides_deprecated_package_name(tmp_path):
+    """When both spellings are given, the canonical --package wins."""
+    schema_file = _write_simple_schema(tmp_path)
+
+    result = _invoke_cli([str(schema_file), "--package", "canonical", "--package-name", "legacy"])
+
+    assert result.exit_code == 0
+    assert "package canonical" in result.output
+
+
+def test_cli_config_file_sets_package(tmp_path):
+    """--config-file's `generator_args.golang.package` sets the package when no flag is given."""
+    schema_file = _write_simple_schema(tmp_path)
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text(_golang_config_yaml("mypkgfromconfig"))
+
+    result = _invoke_cli([str(schema_file), "--config-file", str(config_path)])
+
+    assert result.exit_code == 0
+    assert "package mypkgfromconfig" in result.output
+
+
+def test_cli_package_overrides_config_file(tmp_path):
+    """An explicit --package always takes precedence over --config-file."""
+    schema_file = _write_simple_schema(tmp_path)
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text(_golang_config_yaml("mypkgfromconfig"))
+
+    result = _invoke_cli([str(schema_file), "--config-file", str(config_path), "--package", "explicit"])
+
+    assert result.exit_code == 0
+    assert "package explicit" in result.output
+
+
+def test_cli_config_file_without_golang_section_falls_back_to_derived(tmp_path):
+    """A config file with no `generator_args.golang.package` falls back to schema-name derivation."""
+    schema_file = _write_simple_schema(tmp_path)
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text("generator_args:\n  java:\n    package: org.example.java\n")
+
+    result = _invoke_cli([str(schema_file), "--config-file", str(config_path)])
+
+    assert result.exit_code == 0
+    assert "package simple" in result.output
+
+
+def test_cli_autodetects_config_yaml_in_cwd(tmp_path, monkeypatch):
+    """When --config-file is omitted, a `config.yaml` in the cwd is used automatically."""
+    schema_file = _write_simple_schema(tmp_path)
+    (tmp_path / "config.yaml").write_text(_golang_config_yaml("autocwdpkg"))
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke_cli([str(schema_file)])
+
+    assert result.exit_code == 0
+    assert "package autocwdpkg" in result.output
+
+
+def test_cli_no_config_yaml_in_cwd_falls_back_to_derived(tmp_path, monkeypatch):
+    """No config.yaml in cwd and no flags: package name is derived from the schema name."""
+    schema_file = _write_simple_schema(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke_cli([str(schema_file)])
+
+    assert result.exit_code == 0
+    assert "package simple" in result.output

--- a/tests/linkml/test_generators/test_golanggen.py
+++ b/tests/linkml/test_generators/test_golanggen.py
@@ -1600,20 +1600,21 @@ def test_cli_config_file_without_golang_section_falls_back_to_derived(tmp_path):
     assert "package simple" in result.output
 
 
-def test_cli_autodetects_config_yaml_in_cwd(tmp_path, monkeypatch):
-    """When --config-file is omitted, a `config.yaml` in the cwd is used automatically."""
+def test_cli_ignores_config_yaml_in_cwd(tmp_path, monkeypatch):
+    """A `config.yaml` in the cwd is never read implicitly: --config-file must be explicit."""
     schema_file = _write_simple_schema(tmp_path)
-    (tmp_path / "config.yaml").write_text(_golang_config_yaml("autocwdpkg"))
+    (tmp_path / "config.yaml").write_text(_golang_config_yaml("cwdpkg"))
     monkeypatch.chdir(tmp_path)
 
     result = _invoke_cli([str(schema_file)])
 
     assert result.exit_code == 0
-    assert "package autocwdpkg" in result.output
+    assert "package cwdpkg" not in result.output
+    assert "package simple" in result.output
 
 
-def test_cli_no_config_yaml_in_cwd_falls_back_to_derived(tmp_path, monkeypatch):
-    """No config.yaml in cwd and no flags: package name is derived from the schema name."""
+def test_cli_no_config_file_falls_back_to_derived(tmp_path, monkeypatch):
+    """No --config-file: package name is derived from the schema name."""
     schema_file = _write_simple_schema(tmp_path)
     monkeypatch.chdir(tmp_path)
 

--- a/tests/linkml/test_generators/test_javagen.py
+++ b/tests/linkml/test_generators/test_javagen.py
@@ -411,25 +411,30 @@ def test_cli_invalid_config_package_warns_but_is_used(tmp_path, caplog):
     assert any("not a valid Java package name" in record.message for record in caplog.records)
 
 
-def test_cli_config_file_missing_path_errors(tmp_path):
-    """A --config-file path that doesn't exist is a usage error (click.File's own behavior)."""
-    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
-
-    result = CliRunner().invoke(cli, ["--config-file", str(tmp_path / "nonexistent.yaml"), str(schema_path)])
-
-    assert result.exit_code != 0
-
-
-def test_cli_config_file_invalid_yaml_errors(tmp_path):
-    """A --config-file that isn't a YAML mapping is rejected with a clear error."""
+@pytest.mark.parametrize(
+    ("config_yaml", "where"),
+    [
+        pytest.param("- 1\n- 2\n", "the top level", id="top-level-list"),
+        pytest.param("generator_args: notamapping\n", "'generator_args'", id="scalar-generator-args"),
+        pytest.param(
+            "generator_args:\n  java: package=org.example.model\n",
+            "'generator_args.java'",
+            id="scalar-section",
+        ),
+    ],
+)
+def test_cli_config_file_malformed_section_errors(tmp_path, config_yaml, where):
+    """A malformed --config-file fails loudly. A malformed `generator_args.java` in
+    particular must not be skipped over, leaving the user with the `example` default
+    and no clue why their configured package was ignored."""
     schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
     config_path = tmp_path / "myconfig.yaml"
-    config_path.write_text("- 1\n- 2\n")
+    config_path.write_text(config_yaml)
 
     result = CliRunner().invoke(cli, ["--config-file", str(config_path), str(schema_path)])
 
     assert result.exit_code != 0
-    assert "must contain a YAML mapping" in str(result.output) + str(result.exception)
+    assert f"expected a YAML mapping at {where}" in str(result.output) + str(result.exception)
 
 
 def test_cli_config_file_real_project_config_shape(tmp_path):

--- a/tests/linkml/test_generators/test_javagen.py
+++ b/tests/linkml/test_generators/test_javagen.py
@@ -1,3 +1,6 @@
+import logging
+
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -421,6 +424,29 @@ def test_cli_invalid_explicit_package_errors(tmp_path):
     assert "not a valid Java package name" in result.output
 
 
+def test_cli_does_not_mistake_a_schema_error_for_a_bad_package(tmp_path):
+    """A broken schema (not a bad package) must surface as its own error, not get caught by
+    the package check and misreported as a package problem. The invocation was fine; the
+    schema is broken -- `--help` sends the user in the wrong direction."""
+    schema_path = tmp_path / "bad.yaml"
+    schema_path.write_text("justastring\n", encoding="UTF-8")
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(cli, ["--output-directory", str(out_dir), str(schema_path)])
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, click.UsageError)
+    assert "not a valid Java package name" not in str(result.exception)
+    assert "Unexpected type" in str(result.exception)
+
+
+@pytest.mark.parametrize("package", ["1bad.pkg", "org.class.model", "org..model", "org.my-model"])
+def test_constructor_invalid_package_errors(kitchen_sink_path, package):
+    """An invalid package passed directly to the generator (as gen-project does) is rejected."""
+    with pytest.raises(ValueError, match="is not a valid Java package name"):
+        JavaGenerator(kitchen_sink_path, package=package)
+
+
 @pytest.mark.parametrize(
     ("config_yaml", "where"),
     [
@@ -444,7 +470,7 @@ def test_cli_config_file_malformed_section_errors(tmp_path, config_yaml, where):
     result = CliRunner().invoke(cli, ["--config-file", str(config_path), str(schema_path)])
 
     assert result.exit_code != 0
-    assert f"expected a YAML mapping at {where}" in str(result.output) + str(result.exception)
+    assert f"expected a YAML mapping at {where}" in result.output
 
 
 def test_cli_config_file_real_project_config_shape(tmp_path):

--- a/tests/linkml/test_generators/test_javagen.py
+++ b/tests/linkml/test_generators/test_javagen.py
@@ -1,8 +1,9 @@
 import logging
 
 import pytest
+from click.testing import CliRunner
 
-from linkml.generators.javagen import JavaBundle, JavaGenerator
+from linkml.generators.javagen import JavaBundle, JavaGenerator, cli
 from linkml.generators.oocodegen import OOEnum, OOEnumValue
 from tests.linkml.utils.fileutils import assert_file_contains
 
@@ -314,3 +315,195 @@ def test_serialize_accepts_str_or_path_directory(kitchen_sink_path, tmp_path, as
     gen.serialize(directory=directory)
 
     assert_file_contains(tmp_path / "Address.java", "public class Address", after=f"package {PACKAGE}")
+
+
+def _write_minimal_schema(path):
+    path.write_text(
+        "id: https://example.org/pkg\n"
+        "name: pkg\n"
+        "imports:\n"
+        "  - linkml:types\n"
+        "classes:\n"
+        "  Thing:\n"
+        "    attributes:\n"
+        "      id:\n"
+        "        range: string\n"
+    )
+    return path
+
+
+def _java_config_yaml(package: str) -> str:
+    """The same `generator_args.java.package` shape used by gen-project's config.yaml."""
+    return f"generator_args:\n  java:\n    package: {package}\n"
+
+
+def test_cli_config_file_sets_package(tmp_path):
+    """--config-file's `generator_args.java.package` sets the Java package when --package is not given."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text(_java_config_yaml("org.example.fromconfig"))
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config-file", str(config_path), "--output-directory", str(out_dir), str(schema_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package org.example.fromconfig")
+
+
+def test_cli_explicit_package_overrides_config_file(tmp_path):
+    """An explicit --package always takes precedence over --config-file."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text(_java_config_yaml("org.example.fromconfig"))
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config-file",
+            str(config_path),
+            "--package",
+            "org.example.explicit",
+            "--output-directory",
+            str(out_dir),
+            str(schema_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package org.example.explicit")
+
+
+def test_cli_config_file_without_java_package_falls_back_to_default(tmp_path):
+    """A config file with no `generator_args.java.package` falls through to the `example` default."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text("generator_args:\n  owl:\n    mergeimports: true\n")
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config-file", str(config_path), "--output-directory", str(out_dir), str(schema_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package example")
+
+
+def test_cli_invalid_config_package_warns_but_is_used(tmp_path, caplog):
+    """An invalid Java package name from the config file warns but is still emitted verbatim."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text(_java_config_yaml("1bad.pkg"))
+    out_dir = tmp_path / "out"
+
+    with caplog.at_level(logging.WARNING):
+        result = CliRunner().invoke(
+            cli,
+            ["--config-file", str(config_path), "--output-directory", str(out_dir), str(schema_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package 1bad.pkg")
+    assert any("not a valid Java package name" in record.message for record in caplog.records)
+
+
+def test_cli_config_file_missing_path_errors(tmp_path):
+    """A --config-file path that doesn't exist is a usage error (click.File's own behavior)."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+
+    result = CliRunner().invoke(cli, ["--config-file", str(tmp_path / "nonexistent.yaml"), str(schema_path)])
+
+    assert result.exit_code != 0
+
+
+def test_cli_config_file_invalid_yaml_errors(tmp_path):
+    """A --config-file that isn't a YAML mapping is rejected with a clear error."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    config_path = tmp_path / "myconfig.yaml"
+    config_path.write_text("- 1\n- 2\n")
+
+    result = CliRunner().invoke(cli, ["--config-file", str(config_path), str(schema_path)])
+
+    assert result.exit_code != 0
+    assert "must contain a YAML mapping" in str(result.output) + str(result.exception)
+
+
+def test_cli_config_file_real_project_config_shape(tmp_path):
+    """gen-java's --config-file accepts a full, real-world gen-project config.yaml
+    (other generators' sections, excludes/includes, etc.) and only reads
+    generator_args.java.package out of it, ignoring the rest."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "excludes:\n"
+        "  - markdown\n"
+        "generator_args:\n"
+        "  excel:\n"
+        "    mergeimports: true\n"
+        "  owl:\n"
+        "    mergeimports: true\n"
+        "    metaclasses: false\n"
+        "  java:\n"
+        "    mergeimports: true\n"
+        "    package: org.example.fromrealproject\n"
+        "  python:\n"
+        "    mergeimports: true\n"
+    )
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config-file", str(config_path), "--output-directory", str(out_dir), str(schema_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package org.example.fromrealproject")
+
+
+def test_cli_autodetects_config_yaml_in_cwd(tmp_path, monkeypatch):
+    """When --config-file is omitted, a `config.yaml` in the cwd is used automatically."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    (tmp_path / "config.yaml").write_text(_java_config_yaml("org.example.autocwd"))
+    out_dir = tmp_path / "out"
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["--output-directory", str(out_dir), str(schema_path)])
+
+    assert result.exit_code == 0, result.output
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package org.example.autocwd")
+
+
+def test_cli_explicit_config_file_overrides_autodetected_cwd_config(tmp_path, monkeypatch):
+    """An explicit --config-file wins over an auto-detected config.yaml in the cwd."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    (tmp_path / "config.yaml").write_text(_java_config_yaml("org.example.autocwd"))
+    explicit_dir = tmp_path / "explicit"
+    explicit_dir.mkdir()
+    explicit_config_path = explicit_dir / "explicit_config.yaml"
+    explicit_config_path.write_text(_java_config_yaml("org.example.explicitfile"))
+    out_dir = tmp_path / "out"
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config-file", str(explicit_config_path), "--output-directory", str(out_dir), str(schema_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package org.example.explicitfile")
+
+
+def test_cli_no_config_yaml_in_cwd_falls_back_to_default(tmp_path, monkeypatch):
+    """No config.yaml in cwd and no --config-file: falls through to the `example` default."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    out_dir = tmp_path / "out"
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["--output-directory", str(out_dir), str(schema_path)])
+
+    assert result.exit_code == 0, result.output
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package example")

--- a/tests/linkml/test_generators/test_javagen.py
+++ b/tests/linkml/test_generators/test_javagen.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 from click.testing import CliRunner
 
@@ -393,22 +391,34 @@ def test_cli_config_file_without_java_package_falls_back_to_default(tmp_path):
     assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package example")
 
 
-def test_cli_invalid_config_package_warns_but_is_used(tmp_path, caplog):
-    """An invalid Java package name from the config file warns but is still emitted verbatim."""
+def test_cli_invalid_config_package_errors(tmp_path):
+    """An invalid Java package name from the config file is rejected rather than emitted verbatim."""
     schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
     config_path = tmp_path / "myconfig.yaml"
     config_path.write_text(_java_config_yaml("1bad.pkg"))
     out_dir = tmp_path / "out"
 
-    with caplog.at_level(logging.WARNING):
-        result = CliRunner().invoke(
-            cli,
-            ["--config-file", str(config_path), "--output-directory", str(out_dir), str(schema_path)],
-        )
+    result = CliRunner().invoke(
+        cli,
+        ["--config-file", str(config_path), "--output-directory", str(out_dir), str(schema_path)],
+    )
 
-    assert result.exit_code == 0, result.output
-    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package 1bad.pkg")
-    assert any("not a valid Java package name" in record.message for record in caplog.records)
+    assert result.exit_code != 0
+    assert "not a valid Java package name" in result.output
+
+
+def test_cli_invalid_explicit_package_errors(tmp_path):
+    """An invalid Java package name passed via --package is rejected, matching the config-file behavior."""
+    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--package", "1bad.pkg", "--output-directory", str(out_dir), str(schema_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "not a valid Java package name" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/linkml/test_generators/test_javagen.py
+++ b/tests/linkml/test_generators/test_javagen.py
@@ -464,41 +464,21 @@ def test_cli_config_file_real_project_config_shape(tmp_path):
     assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package org.example.fromrealproject")
 
 
-def test_cli_autodetects_config_yaml_in_cwd(tmp_path, monkeypatch):
-    """When --config-file is omitted, a `config.yaml` in the cwd is used automatically."""
+def test_cli_ignores_config_yaml_in_cwd(tmp_path, monkeypatch):
+    """A `config.yaml` in the cwd is never read implicitly: --config-file must be explicit."""
     schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
-    (tmp_path / "config.yaml").write_text(_java_config_yaml("org.example.autocwd"))
+    (tmp_path / "config.yaml").write_text(_java_config_yaml("org.example.cwd"))
     out_dir = tmp_path / "out"
     monkeypatch.chdir(tmp_path)
 
     result = CliRunner().invoke(cli, ["--output-directory", str(out_dir), str(schema_path)])
 
     assert result.exit_code == 0, result.output
-    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package org.example.autocwd")
+    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package example")
 
 
-def test_cli_explicit_config_file_overrides_autodetected_cwd_config(tmp_path, monkeypatch):
-    """An explicit --config-file wins over an auto-detected config.yaml in the cwd."""
-    schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
-    (tmp_path / "config.yaml").write_text(_java_config_yaml("org.example.autocwd"))
-    explicit_dir = tmp_path / "explicit"
-    explicit_dir.mkdir()
-    explicit_config_path = explicit_dir / "explicit_config.yaml"
-    explicit_config_path.write_text(_java_config_yaml("org.example.explicitfile"))
-    out_dir = tmp_path / "out"
-    monkeypatch.chdir(tmp_path)
-
-    result = CliRunner().invoke(
-        cli,
-        ["--config-file", str(explicit_config_path), "--output-directory", str(out_dir), str(schema_path)],
-    )
-
-    assert result.exit_code == 0, result.output
-    assert_file_contains(out_dir / "Thing.java", "public class Thing", after="package org.example.explicitfile")
-
-
-def test_cli_no_config_yaml_in_cwd_falls_back_to_default(tmp_path, monkeypatch):
-    """No config.yaml in cwd and no --config-file: falls through to the `example` default."""
+def test_cli_no_config_file_falls_back_to_default(tmp_path, monkeypatch):
+    """No --config-file: falls through to the `example` default."""
     schema_path = _write_minimal_schema(tmp_path / "pkg.yaml")
     out_dir = tmp_path / "out"
     monkeypatch.chdir(tmp_path)

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -20,6 +20,10 @@ def test_projectgen(kitchen_sink_path, tmp_path):
     check_contains("CREATE TABLE", "sqlschema", "kitchen_sink.sql")
     check_contains("ks:age_in_years a owl:DatatypeProperty", "owl", "kitchen_sink.owl.ttl")
     check_contains('"additionalProperties": false', "jsonschema", "kitchen_sink.schema.json")
+    # Excel writes its own binary file via serialize(); guard against regressions
+    # in the generic "generator returned None -> skip disk-routing" branch.
+    excel_out = tmp_path / "excel" / "kitchen_sink.xlsx"
+    assert excel_out.is_file() and excel_out.stat().st_size > 0
 
 
 def test_projectgen_java_package_from_config(kitchen_sink_path, tmp_path):

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -1,4 +1,13 @@
+from dataclasses import dataclass
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from linkml.generators import projectgen
 from linkml.generators.projectgen import ProjectConfiguration, ProjectGenerator
+from linkml.generators.projectgen import cli as projectgen_cli
+from linkml.utils.generator import Generator
 
 
 def test_projectgen(kitchen_sink_path, tmp_path):
@@ -40,9 +49,46 @@ def test_projectgen_java_package_from_config(kitchen_sink_path, tmp_path):
         assert "package com.example.generated;" in f.read_text(encoding="UTF-8")
 
 
+def test_directory_arg_scoped_per_generator_not_globally_stripped(kitchen_sink_path, tmp_path, monkeypatch):
+    """A `directory` value configured for a generator other than java must reach that
+    generator's constructor. Serialize-only args are scoped per GEN_MAP entry, not filtered
+    by a name shared globally across every generator (several real generators -- dotgen,
+    docgen, plantumlgen -- take `directory` as a constructor arg, not a serialize-only one)."""
+    captured = {}
+
+    @dataclass
+    class FakeDirGenerator(Generator):
+        uses_schemaloader = False
+        requires_metamodel = False
+        valid_formats = ["fake"]
+        directory: str | None = None
+
+        def serialize(self, **kwargs):
+            captured["directory"] = self.directory
+            return None
+
+    # `serialize_only` omitted: a generator that takes `directory` in its constructor
+    # needs no entry in it, which is the default.
+    monkeypatch.setitem(
+        projectgen.GEN_MAP,
+        "fakedir",
+        projectgen.GeneratorConfig(FakeDirGenerator, "fakedir/{name}.fake", {}),
+    )
+
+    config = ProjectConfiguration()
+    config.directory = tmp_path
+    config.includes = ["fakedir"]
+    config.generator_args["fakedir"] = {"directory": "passthrough-value"}
+
+    ProjectGenerator().generate(kitchen_sink_path, config)
+
+    assert captured["directory"] == "passthrough-value"
+
+
 def test_projectgen_java_default_package_without_config(kitchen_sink_path, tmp_path):
     """Without generator_args for java, the normal package precedence (schema annotation, then
-    the `example` default) still applies via gen-project, unaffected by SERIALIZE_ONLY_ARGS filtering."""
+    the `example` default) still applies via gen-project, unaffected by the constructor/serialize
+    arg-filtering in GEN_MAP."""
     config = ProjectConfiguration()
     config.directory = tmp_path
     config.includes = ["java"]
@@ -52,3 +98,71 @@ def test_projectgen_java_default_package_without_config(kitchen_sink_path, tmp_p
     assert java_files, "expected at least one generated .java file"
     for f in java_files:
         assert "package example;" in f.read_text(encoding="UTF-8")
+
+
+def test_generate_validates_generator_args_before_constructing_anything(kitchen_sink_path, tmp_path):
+    """A bad `generator_args` value is rejected by JavaGenerator.validate_generator_args()
+    before any generator is built for any schema -- so this, and not construction itself, is
+    the only place in `generate()` a bad config value can come from. The message is already
+    generator-specific ("valid Java package name") so needs no extra prefixing."""
+    config = ProjectConfiguration()
+    config.directory = tmp_path
+    config.includes = ["java"]
+    config.generator_args["java"] = {"package": "1bad.pkg"}
+
+    with pytest.raises(click.UsageError, match="is not a valid Java package name"):
+        ProjectGenerator().generate(kitchen_sink_path, config)
+
+
+def test_generate_rejects_bad_config_before_generating_anything(kitchen_sink_path, tmp_path):
+    """A bad `generator_args` value for one generator is rejected before ANY generator
+    runs -- generators earlier in GEN_MAP (graphql here) must not have written output,
+    nor the project directory been created, only for the run to die halfway through."""
+    out_dir = tmp_path / "out"
+    config = ProjectConfiguration()
+    config.directory = out_dir
+    config.includes = ["graphql", "java"]  # graphql iterates first in GEN_MAP
+    config.generator_args["java"] = {"package": "1bad.pkg"}
+
+    with pytest.raises(click.UsageError, match="is not a valid Java package name"):
+        ProjectGenerator().generate(kitchen_sink_path, config)
+
+    assert not out_dir.exists()
+
+
+def test_generate_does_not_mistake_a_schema_error_for_a_bad_config_value(tmp_path):
+    """A ValueError raised while actually constructing a generator (e.g. an unloadable
+    schema) is a genuine failure, not a `generator_args` problem, and must propagate with
+    its own traceback rather than being caught and relabelled -- reproduces
+    https://github.com/linkml/linkml/pull/3781#discussion_r3862911491 (too broadl)."""
+    bad_schema = tmp_path / "bad.yaml"
+    bad_schema.write_text("justastring\n", encoding="UTF-8")
+    config = ProjectConfiguration()
+    config.directory = tmp_path / "out"
+    config.mergeimports = True  # matches gen-project's own CLI default
+
+    with pytest.raises(ValueError) as exc_info:
+        ProjectGenerator().generate(str(bad_schema), config)
+
+    # a plain ValueError with its own message intact -- not the click.UsageError
+    # validate_generator_args() raises, and not relabelled with a generator name
+    assert type(exc_info.value) is ValueError
+    assert not str(exc_info.value).startswith(tuple(f"{name}:" for name in projectgen.GEN_MAP))
+
+
+def test_cli_bad_generator_args_is_a_usage_error_not_a_traceback(kitchen_sink_path, tmp_path):
+    """gen-project reports a bad `generator_args` value the way the individual generator
+    CLIs do, rather than letting a ValueError escape as a traceback."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        f"directory: {tmp_path / 'out'}\ngenerator_args:\n  java:\n    package: 1bad.pkg\n",
+        encoding="UTF-8",
+    )
+
+    result = CliRunner().invoke(
+        projectgen_cli, ["--config-file", str(config_path), "-I", "java", str(kitchen_sink_path)]
+    )
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, ValueError)
+    assert "is not a valid Java package name" in result.output

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -20,3 +20,31 @@ def test_projectgen(kitchen_sink_path, tmp_path):
     check_contains("CREATE TABLE", "sqlschema", "kitchen_sink.sql")
     check_contains("ks:age_in_years a owl:DatatypeProperty", "owl", "kitchen_sink.owl.ttl")
     check_contains('"additionalProperties": false', "jsonschema", "kitchen_sink.schema.json")
+
+
+def test_projectgen_java_package_from_config(kitchen_sink_path, tmp_path):
+    """java GEN_MAP wiring: package flows from generator_args through to JavaGenerator."""
+    config = ProjectConfiguration()
+    config.directory = tmp_path
+    config.includes = ["java"]
+    config.generator_args["java"] = {"package": "com.example.generated"}
+    gen = ProjectGenerator()
+    gen.generate(kitchen_sink_path, config)
+    java_files = list((tmp_path / "java").glob("*.java"))
+    assert java_files, "expected at least one generated .java file"
+    for f in java_files:
+        assert "package com.example.generated;" in f.read_text(encoding="UTF-8")
+
+
+def test_projectgen_java_default_package_without_config(kitchen_sink_path, tmp_path):
+    """Without generator_args for java, the normal package precedence (schema annotation, then
+    the `example` default) still applies via gen-project, unaffected by SERIALIZE_ONLY_ARGS filtering."""
+    config = ProjectConfiguration()
+    config.directory = tmp_path
+    config.includes = ["java"]
+    gen = ProjectGenerator()
+    gen.generate(kitchen_sink_path, config)
+    java_files = list((tmp_path / "java").glob("*.java"))
+    assert java_files, "expected at least one generated .java file"
+    for f in java_files:
+        assert "package example;" in f.read_text(encoding="UTF-8")

--- a/tests/linkml/test_utils/test_generator.py
+++ b/tests/linkml/test_utils/test_generator.py
@@ -7,7 +7,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from io import BytesIO, StringIO
-from typing import TextIO, cast
+from typing import cast
 
 import click
 import pytest

--- a/tests/linkml/test_utils/test_generator.py
+++ b/tests/linkml/test_utils/test_generator.py
@@ -4,14 +4,16 @@ Tests the generic generator framework
 
 import logging
 import os
+import re
 from dataclasses import dataclass, field
-from io import StringIO
-from typing import cast
+from io import BytesIO, StringIO
+from typing import TextIO, cast
 
+import click
 import pytest
 
 from linkml import LOCAL_METAMODEL_YAML_FILE
-from linkml.utils.generator import Generator
+from linkml.utils.generator import Generator, read_generator_config
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
     ClassDefinitionName,
@@ -691,3 +693,60 @@ def test_meta_neighborhood():
     #                            slotrefs={'is_a', 'apply_to', 'mixins', 'owner'},
     #                            typerefs={'boolean', 'datetime', 'uri', 'string', 'uriorcurie', 'ncname'},
     #                            subsetrefs=set()), neighbor_refs)
+
+
+CONFIG_YAML = b"""
+generator_args:
+  java:
+    package: org.example.model
+    mergeimports: true
+  golang:
+    package: mypackage
+"""
+
+
+@pytest.mark.parametrize(
+    ("generator_name", "expected"),
+    [
+        ("java", {"package": "org.example.model", "mergeimports": True}),
+        ("golang", {"package": "mypackage"}),
+    ],
+)
+def test_read_generator_config_returns_whole_section(generator_name, expected):
+    """Each generator gets its own section out of one shared config file, and gets all of
+    it in a single read - the file is a stream, so a second read would find nothing."""
+    assert read_generator_config(BytesIO(CONFIG_YAML), generator_name) == expected
+
+
+@pytest.mark.parametrize(
+    ("config_yaml", "generator_name"),
+    [
+        pytest.param(None, "java", id="no-config-file"),
+        pytest.param(b"", "java", id="empty-file"),
+        pytest.param(CONFIG_YAML, "rust", id="generator-absent"),
+        pytest.param(b"generator_args:\n  java:\n", "java", id="empty-section"),
+        pytest.param(b"generator_args:\n", "java", id="empty-generator-args"),
+        pytest.param(b"excludes:\n  - markdown\n", "java", id="no-generator-args"),
+    ],
+)
+def test_read_generator_config_absent_section_is_empty(config_yaml, generator_name):
+    """A section that is absent, or written but left empty, gives an empty dict."""
+    config_file = None if config_yaml is None else BytesIO(config_yaml)
+
+    assert read_generator_config(config_file, generator_name) == {}
+
+
+@pytest.mark.parametrize(
+    ("config_yaml", "where"),
+    [
+        pytest.param(b"- 1\n- 2\n", "the top level", id="top-level-list"),
+        pytest.param(b"justastring\n", "the top level", id="top-level-scalar"),
+        pytest.param(b"generator_args: notamapping\n", "'generator_args'", id="scalar-generator-args"),
+        pytest.param(b"generator_args:\n  java: notamapping\n", "'generator_args.java'", id="scalar-section"),
+    ],
+)
+def test_read_generator_config_rejects_malformed_section(config_yaml, where):
+    """A scalar where a mapping belongs is a usage error naming the offending key -
+    never silently ignored, which would leave the generator on its default."""
+    with pytest.raises(click.UsageError, match=f"expected a YAML mapping at {re.escape(where)}"):
+        read_generator_config(BytesIO(config_yaml), "java")

--- a/tests/linkml/test_utils/test_generator.py
+++ b/tests/linkml/test_utils/test_generator.py
@@ -750,3 +750,24 @@ def test_read_generator_config_rejects_malformed_section(config_yaml, where):
     never silently ignored, which would leave the generator on its default."""
     with pytest.raises(click.UsageError, match=f"expected a YAML mapping at {re.escape(where)}"):
         read_generator_config(BytesIO(config_yaml), "java")
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        pytest.param(b"generator_args:\n  java:\n   package: [unclosed\n", id="unclosed-bracket"),
+        pytest.param(b"generator_args:\n\tjava:\n\t\tpackage: x\n", id="tab-indent"),
+    ],
+)
+def test_read_generator_config_rejects_unparsable_yaml(config_yaml):
+    """A file that isn't valid YAML at all is reported as a usage error, like a misshapen
+    one, rather than escaping as a raw parser traceback."""
+    with pytest.raises(click.UsageError, match="could not parse as YAML"):
+        read_generator_config(BytesIO(config_yaml), "java")
+
+
+def test_validate_generator_args_default_is_a_noop():
+    """The base implementation accepts anything -- generators that have no config value
+    worth checking up front (which is most of them) need not override it."""
+    Generator.validate_generator_args({})
+    Generator.validate_generator_args({"anything": "goes", "even": None})


### PR DESCRIPTION
## Summary

JAVA - #3780
- Option to set Java `package` value from `config.yaml`
- Adds javagen support to `projectgen` per #2537
- Adds three missing Java keywords from https://docs.oracle.com/cd/E19316-01/819-3669/bnbuk/index.html 

GOLANG
- Add missing doc
- Generalize the solution (per https://github.com/linkml/linkml/pull/3781#pullrequestreview-4737743023)

Excel #3759
- `excelgen.py` - fix `serialize` return signature.
- `projectgen.py` - remove redundant excel serialization

## Full list of changes following PR review

Added

- --config-file/-C on gen-java and gen-golang, reading package from generator_args.{java,golang} - the same configuraion file style gen-project takes.
- gen-project now emits Java.
- Invalid package names are rejected instead of emitted into uncompilable output.
- Docs - created golang.rst, updated javagen.rst

Changed

- gen-golang uses --package / package= to match gen-java. --package-name / package_name= still work, deprecated.

Fixed
- gen-project ran the Excel generator twice.
- A directory set for one generator could be silently dropped from another's config.
- JAVA_KEYWORDS was missing true/false/null.
- Bad config files and generator_args values now give usage errors, not tracebacks.
- Go's derived fallback package is always a legal identifier.

## How was this tested?

Locally (slow, network)
added new  tests

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance
LLM assisted