### PR TITLE
Global Config v2

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -1,0 +1,26 @@
+{#linkml-config-cli}
+# `linkml config`
+
+```{eval-rst}
+.. click:: linkml.cli.config:config
+    :prog: linkml config
+    :nested: short
+```
+
+{#linkml-config-get-cli}
+## `linkml config get`
+
+```{eval-rst}
+.. click:: linkml.cli.config:get
+    :prog: linkml config get
+    :nested: short
+```
+
+{#linkml-config-set-cli}
+## `linkml config set`
+
+```{eval-rst}
+.. click:: linkml.cli.config:set
+    :prog: linkml config set
+    :nested: short
+```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,6 +2,7 @@
 
 The CLI interface to LinkML is currently divided into two styles:
 - One combined cli underneath [`linkml`](./linkml.md)
+  - [`linkml config`](./config.md)
   - [`linkml generate`](./generate.md)
   - [`linkml lint`](./lint.md)
   - [`linkml validate`](./validate.md)
@@ -12,6 +13,7 @@ The CLI interface to LinkML is currently divided into two styles:
 maxdepth: 1
 ---
 linkml
+config
 generate
 lint
 validate

--- a/docs/cli/linkml.md
+++ b/docs/cli/linkml.md
@@ -11,6 +11,7 @@
 
 See subpages for further details on commands:
 
+- [`linkml config`](./config.md)
 - [`linkml generate`](./generate.md)
 - [`linkml lint`](./lint.md)
 - [`linkml validate`](./validate.md)

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1,0 +1,149 @@
+# Configuration
+
+Global configuration in linkml uses [`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)
+
+
+## Sources
+
+Config values can be set (in order of priority from high to low, where higher
+priorities override lower priorities)
+
+* in the arguments passed to the class constructor (not user configurable)
+* in environment variables like `export LINKML_LOG_DIR=~/`
+* in a `.env` file in the working directory
+* in a `linkml_config.yaml` file in the working directory
+* in the `tool.linkml.config` table in a `pyproject.toml` file in the working directory
+* in the global `linkml_config.yaml` file in the platform-specific data directory
+  (use `linkml config get config_file` to find its location)
+* the default values in the {class}`~linkml.utils.config.GlobalConfig` model
+
+Parent directories are _not_ checked.
+
+## Keys
+
+### Prefix
+
+Keys for environment variables (i.e. set in a shell with e.g. `export` or in a `.env` file)
+are prefixed with `LINKML_` to not shadow other environment variables.
+Keys in `toml` or `yaml` files are not prefixed with `LINKML_` .
+
+### Nesting
+
+Keys for nested models are separated by a `__` double underscore in `.env`
+files or environment variables (eg. `LINKML_LOG__DIR`)
+
+Keys in `toml` or `yaml` files do not have a dunder separator because
+they can represent the nesting directly (see examples below)
+
+When setting values from the cli, keys for nested models are separated with a `.`.
+
+### Case
+
+Keys are case-insensitive, i.e. these are equivalent::
+
+    export LINKML_LOG__DIR=~/
+    export linkml_log__dir=~/
+
+## CLI
+
+Global settings can be gotten and set via the CLI, for example:
+
+### Getting values
+
+```{command-output} linkml config get
+---
+ellipsis: 5
+---
+```
+
+Index nested config models with `.`
+
+```{command-output} linkml config get log.level
+```
+
+### Setting values
+
+Values are set in the global `linkml_config.yaml` file with a similar syntax
+
+```{note}
+Values set via the CLI are set in the global `linkml_config.yaml`
+file, which is the lowest priority source of settings, and will thus be
+overridden by any local configs in `.env` files or otherwise.
+```
+
+```{command-output} linkml config set log.level WARNING
+```
+
+```{command-output} linkml config get log.level
+```
+
+
+## Examples
+
+
+`````{tab-set}
+````{tab-item} linkml_config.yaml
+```{code-block} yaml
+user_dir: ~/.config/linkml
+config_file: linkml_config.yaml
+log:
+  dir: /var/log/linkml
+  level_file: INFO
+  level_stream: WARNING
+  file_n: 5
+```
+````
+````{tab-item} env vars
+```{code-block} bash
+export LINKML_USER_DIR='~/.config/linkml'
+export LINKML_CONFIG_FILE='linkml_config.yaml'
+export LINKML_LOG__DIR='/var/log/linkml'
+export LINKML_LOG__LEVEL_FILE='INFO'
+export LINKML_LOG__LEVEL_STREAM='WARNING'
+export LINKML_LOG__FILE_N=5
+```
+````
+````{tab-item} .env file
+```{code-block} python
+LINKML_USER_DIR='~/.config/linkml'
+LINKML_CONFIG_FILE='linkml_config.yaml'
+LINKML_LOG__DIR='/var/log/linkml'
+LINKML_LOG__LEVEL_FILE='INFO'
+LINKML_LOG__LEVEL_STREAM='WARNING'
+LINKML_LOG__FILE_N=5
+```
+````
+````{tab-item} pyproject.toml
+```{code-block} toml
+[tool.linkml.config]
+user_dir = "~/.config/linkml"
+config_file = "linkml_config.yaml"
+
+[tool.linkml.config.log]
+dir = "/var/log/linkml"
+level_file = "INFO"
+level_stream = "WARNING"
+file_n = 5
+
+```
+````
+````{tab-item} cli
+```{code-block} bash
+linkml config set user_dir '~/.config/linkml'
+linkml config set config_file 'linkml_config.yaml'
+linkml config set log.dir '/var/log/linkml'
+linkml config set log.level_file 'info'
+linkml config set log.level_stream 'warning'
+linkml config set log.file_n 5
+```
+````
+`````
+
+
+## API
+
+```{eval-rst}
+.. automodule:: linkml.utils.config
+    :members:
+
+```

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -13,11 +13,18 @@ priorities override lower priorities)
 * in a `.env` file in the working directory
 * in a `linkml_config.yaml` file in the working directory
 * in the `tool.linkml.config` table in a `pyproject.toml` file in the working directory
-* in the global `linkml_config.yaml` file in the platform-specific data directory
+* in the global `linkml_config.yaml` file in the platform-specific data directory[^platformdirs]
   (use `linkml config get config_file` to find its location)
 * the default values in the {class}`~linkml.utils.config.GlobalConfig` model
 
 Parent directories are _not_ checked.
+
+[^platformdirs]: These directories come from [platformdirs](https://platformdirs.readthedocs.io/en/latest/index.html),
+  see [their documentation](https://platformdirs.readthedocs.io/en/latest/platforms.html) for more info.
+  The default configuration directories for linkml are:
+    - Linux: `~/.config/linkml/`
+    - Mac: `~/Library/Application Support/linkml/`
+    - Windows: `~\AppData\Local\linkml\linkml\`
 
 ## Keys
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,6 +67,7 @@ work with data, or integrate LinkML into your applications, this section is for 
    cli/index
    developers/index
    code/index
+   config/index
 
 Maintainers
 -----------

--- a/packages/linkml/pyproject.toml
+++ b/packages/linkml/pyproject.toml
@@ -64,6 +64,8 @@ dependencies = [ # Specifier syntax: https://peps.python.org/pep-0631/
     "typing-extensions >= 4.6.0; python_version < '3.12'",
     "sphinx-click (>=6.0.0)",
     "openapi-spec-validator >= 0.8.4",
+    "pydantic-settings>=2.14.2",
+    "platformdirs>=4.5.0",
 ]
 
 [dependency-groups]
@@ -82,6 +84,7 @@ tests = [
   { include-group = "shacl" },
   "duckdb>=1.5.2",
   "sqlalchemy-bigquery >= 1.9.0",
+  "tomli-w>=1.2.0",
 ]
 dev = [
   {include-group = "tests" },
@@ -144,6 +147,7 @@ docs = [
   "matplotlib >= 3.7",
   "sphinx-jinja >= 2.0.2",
   "sphinxcontrib-programoutput >= 0.17",
+  "sphinx-design>=0.6.1",
 ]
 
 [tool.uv.sources]

--- a/packages/linkml/pyproject.toml
+++ b/packages/linkml/pyproject.toml
@@ -64,6 +64,8 @@ dependencies = [ # Specifier syntax: https://peps.python.org/pep-0631/
     "typing-extensions >= 4.6.0; python_version < '3.12'",
     "sphinx-click (>=6.0.0)",
     "openapi-spec-validator >= 0.8.4",
+    "pydantic-settings>=2.14.2",
+    "platformdirs>=4.5.0",
 ]
 
 [dependency-groups]
@@ -82,6 +84,7 @@ tests = [
   { include-group = "shacl" },
   "duckdb>=1.5.5",
   "sqlalchemy-bigquery>=1.17.2",
+  "tomli-w>=1.2.0",
 ]
 dev = [
   {include-group = "tests" },
@@ -140,6 +143,7 @@ docs = [
   "matplotlib >= 3.7",
   "sphinx-jinja >= 2.0.2",
   "sphinxcontrib-programoutput>=0.20",
+  "sphinx-design>=0.6.1",
 ]
 
 [tool.uv.sources]

--- a/packages/linkml/src/linkml/cli/config.py
+++ b/packages/linkml/src/linkml/cli/config.py
@@ -1,0 +1,125 @@
+"""
+CLI for global config
+
+See docs/config/index.md for documentation
+"""
+
+import json
+
+import click
+import yaml
+from pydantic import BaseModel
+
+from linkml.utils.config import GlobalConfig, get_config
+
+
+@click.group("config")
+def config():
+    """
+    LinkML Global Configuration
+    """
+
+
+@config.command(name="get")
+@click.argument("key", required=False)
+def get(key=None):
+    """
+    Get a configuration value. If no setting name is passed, show entire config
+
+    Examples:
+    ---------
+
+    .. code-block:: shell
+
+        $ linkml config get
+
+    .. code-block:: yaml
+
+        \b
+        user_dir: /Users/jonny/Library/Application Support/linkml
+        config_file: /Users/jonny/Library/Application Support/linkml/linkml_config.yaml
+        log:
+          dir: /Users/jonny/Library/Logs/linkml
+          file_name: linkml.log
+          level: WARNING
+          # ...
+
+    .. code-block:: shell
+
+        $ linkml config get log
+
+    .. code-block:: yaml
+
+        \b
+        dir: /Users/jonny/Library/Logs/linkml
+        file_name: linkml.log
+        level: WARNING
+        # ...
+
+    .. code-block:: shell
+
+        $ linkml config get log.level
+
+    .. code-block::
+
+        WARNING
+
+
+    """
+    config = get_config()
+    if key is not None:
+        subkeys = key.split(".")
+        for subkey in subkeys:
+            config = getattr(config, subkey)
+
+    if isinstance(config, BaseModel):
+        config = config.model_dump_json()
+        config = json.loads(config)
+        print(yaml.safe_dump(config, sort_keys=False))
+    else:
+        print(config)
+
+
+@config.command(name="set")
+@click.argument("key")
+@click.argument("value", required=False)
+def set(key, value=None):
+    """
+    Set a configuration value in the global `linkml_config.yaml` file.
+
+    If a ``value`` is absent, the key is deleted from the global yaml config.
+    """
+    config = get_config()
+    global_config_file = config.config_file
+    if global_config_file.exists():
+        with open(global_config_file) as f:
+            global_config = yaml.safe_load(f)
+    else:
+        global_config = {}
+
+    subkeys = key.split(".")
+    if len(subkeys) == 1:
+        if value is None and subkeys[0] in global_config:
+            del global_config[subkeys[0]]
+        elif value is not None:
+            global_config[subkeys[0]] = value
+
+    else:
+        config = global_config
+        for subkey in subkeys[:-1]:
+            config = config.setdefault(subkey, {})
+        if value is None and subkeys[-1] in config:
+            del config[subkeys[-1]]
+        elif value is not None:
+            config[subkeys[-1]] = value
+
+    # validate model
+    _ = GlobalConfig.model_validate(global_config)
+
+    with open(global_config_file, "w") as f:
+        yaml.safe_dump(global_config, f)
+
+    # shouldn't need to force reset the in-memory config here,
+    # since this cli command only runs in an ephemeral CLI session
+
+    print(f"Updated linkml config:\nkey: {key}\nvalue: {value}\nconfig file: {str(global_config_file)}")

--- a/packages/linkml/src/linkml/cli/main.py
+++ b/packages/linkml/src/linkml/cli/main.py
@@ -7,6 +7,7 @@ Gathers all the other linkml click entrypoints and puts them under ``linkml`` :)
 import click
 
 from linkml._version import __version__
+from linkml.cli.config import config
 from linkml.converter.cli import cli as linkml_convert
 from linkml.generators.csvgen import cli as gen_csv
 from linkml.generators.dbmlgen import cli as gen_dbml
@@ -93,6 +94,7 @@ linkml.add_command(linkml_sqldb, name="sqldb")
 linkml.add_command(linkml_schema_fixer, name="fix")
 linkml.add_command(linkml_run_examples, name="examples")
 linkml.add_command(linkml_validate, name="validate")
+linkml.add_command(config, name="config")
 
 # Generators
 generate.add_command(gen_jsonld_context, name="jsonld-context")

--- a/packages/linkml/src/linkml/utils/config.py
+++ b/packages/linkml/src/linkml/utils/config.py
@@ -1,0 +1,191 @@
+"""
+Session-global configuration (see docs/config/index.md for documentation)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from platformdirs import PlatformDirs
+from pydantic import BaseModel, Field, TypeAdapter, field_validator, model_validator
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    PyprojectTomlConfigSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
+
+LOG_LEVELS = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
+_dirs = PlatformDirs("linkml", "linkml")
+_config: GlobalConfig | None = None
+
+
+def get_config(reload: bool = False) -> GlobalConfig:
+    """
+    Get the global linkml configuration
+
+    Args:
+        reload (bool): If ``True``, force reloading the config from disk,
+            clearing the in-memory cached version
+    """
+    global _config
+    if _config is None or reload:
+        _config = GlobalConfig()
+    return _config
+
+
+class _GlobalYamlConfigSource(YamlConfigSettingsSource):
+    """Yaml config source that gets the location of the global settings file from the prior sources"""
+
+    def __init__(self, *args, **kwargs):
+        self._global_config = None
+        super().__init__(*args, **kwargs)
+
+    @property
+    def global_config_path(self) -> Path:
+        """
+        Location of the global ``linkml_config.yaml`` file,
+        given the current state of prior config sources
+        """
+        current_state = self.current_state
+        config_file = Path(current_state.get("config_file", "linkml_config.yaml"))
+        user_dir = Path(current_state.get("user_dir", _dirs.user_config_dir))
+        if not config_file.is_absolute():
+            config_file = (user_dir / config_file).resolve()
+        return config_file
+
+    @property
+    def global_config(self) -> dict[str, Any]:
+        """
+        Contents of the global config file
+        """
+        if self._global_config is None:
+            if self.global_config_path.exists():
+                self._global_config = self._read_files(self.global_config_path)
+            else:
+                self._global_config = {}
+        return self._global_config
+
+    def __call__(self) -> dict[str, Any]:
+        return (
+            TypeAdapter(dict[str, Any]).dump_python(self.global_config)
+            if self.nested_model_default_partial_update
+            else self.global_config
+        )
+
+
+class LogConfig(BaseModel):
+    """
+    Config params for logging
+    """
+
+    dir: Path = Field(default=_dirs.user_log_dir, description="Directory where logs are stored")
+    file_name: str = Field("linkml.log", description="Base name to use for rotating file logs")
+    level: LOG_LEVELS = Field(
+        "INFO",
+        description="Base level to use for loggers. "
+        "If more specific settings are not present (ie. level_file), use this as a default.",
+    )
+    level_file: LOG_LEVELS | None = Field(None, description="Log level for file logging")
+    level_stream: LOG_LEVELS | None = Field(None, description="Log level for stdout/stderr stream logging")
+    file_n: int = Field(5, description="Number of log files to rotate through")
+    file_size: int = Field(2**22, description="Maximum size of log files (bytes)")
+
+    @field_validator("level", "level_file", "level_stream", mode="before")
+    @classmethod
+    def uppercase_levels(cls, value: str | None = None) -> str | None:
+        """
+        Ensure log level strings are uppercased
+        """
+        if value is not None:
+            value = value.upper()
+        return value
+
+    @model_validator(mode="after")
+    def inherit_base_level(self) -> LogConfig:
+        """
+        If loglevels for specific output streams are unset, set from base :attr:`.level`
+        """
+        levels = ("level_file", "level_stream")
+        for level_name in levels:
+            if getattr(self, level_name) is None:
+                setattr(self, level_name, self.level)
+        return self
+
+
+class GlobalConfig(BaseSettings):
+    """
+    Global LinkML configuration that determines the behavior of linkml in a given shell session.
+
+    Distinct from generator and project configs,
+    which control the behavior of specific generators and projects, respectively.
+    """
+
+    user_dir: Path = Field(_dirs.user_config_dir, description="Directory containing linkml config files")
+    config_file: Path = Field(
+        Path("linkml_config.yaml"),
+        description="Location of global linkml config file. "
+        "If a relative path, interpreted as a relative to ``user_dir``",
+    )
+    log: LogConfig = LogConfig()
+
+    model_config = SettingsConfigDict(
+        env_prefix="linkml_",
+        env_file=".env",
+        env_nested_delimiter="__",
+        extra="ignore",
+        nested_model_default_partial_update=True,
+        yaml_file="linkml_config.yaml",
+        pyproject_toml_table_header=("tool", "linkml", "config"),
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """
+        Read config settings from, in order of priority from high to low, where
+        high priorities override lower priorities:
+
+        * in the arguments passed to the class constructor (not user configurable)
+        * in environment variables like ``export LINKML_LOG_DIR=~/``
+        * in a ``.env`` file in the working directory
+        * in a ``linkml_config.yaml`` file in the working directory
+        * in the ``tool.linkml.config`` table in a ``pyproject.toml`` file in the working directory
+        * in the global ``linkml_config.yaml`` file in the platform-specific data directory
+          (use ``linkml config get config_file`` to find its location)
+        * the default values in the :class:`.GlobalConfig` model
+        """
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlConfigSettingsSource(settings_cls),
+            PyprojectTomlConfigSettingsSource(settings_cls),
+            _GlobalYamlConfigSource(settings_cls),
+        )
+
+    @field_validator("user_dir", mode="after")
+    @classmethod
+    def user_dir_exists(cls, v: Path) -> Path:
+        """Ensure user_dir exists, make it otherwise"""
+        v = Path(v)
+        v.mkdir(exist_ok=True, parents=True)
+        assert v.exists(), f"{v} does not exist!"
+        return v
+
+    @model_validator(mode="after")
+    def config_file_is_absolute(self) -> GlobalConfig:
+        """
+        If ``config_file`` is relative, make it absolute underneath user_dir
+        """
+        if not self.config_file.is_absolute():
+            self.config_file = self.user_dir / self.config_file
+        return self

--- a/tests/linkml/test_utils/test_config.py
+++ b/tests/linkml/test_utils/test_config.py
@@ -1,0 +1,262 @@
+""" "
+Test configuration settings
+"""
+
+from collections.abc import Callable, MutableMapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+import tomli_w
+import yaml
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from linkml.cli.config import get as cli_get
+from linkml.cli.config import set as cli_set
+from linkml.utils.config import GlobalConfig, LogConfig, _dirs
+
+
+def _flatten(d, parent_key="", separator="__") -> dict:
+    """https://stackoverflow.com/a/6027615/13113166"""
+    items = []
+    for key, value in d.items():
+        new_key = parent_key + separator + key if parent_key else key
+        if isinstance(value, MutableMapping):
+            items.extend(_flatten(value, new_key, separator=separator).items())
+        else:
+            items.append((new_key, value))
+    return dict(items)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def dodge_existing_global_config(tmp_path_factory):
+    """
+    Suspend any existing global config file during config tests
+    """
+    tmp_path = tmp_path_factory.mktemp("config_backup")
+    default_global_config_path = Path(_dirs.user_config_dir) / "linkml_config.yaml"
+    backup_global_config_path = tmp_path / "linkml_config.yaml.bak"
+
+    configured_global_config_path = GlobalConfig().config_file
+    backup_configured_global_path = tmp_path / "linkml_config_custom.yaml.bak"
+
+    if default_global_config_path.exists():
+        default_global_config_path.rename(backup_global_config_path)
+    if configured_global_config_path.exists():
+        default_global_config_path.rename(backup_configured_global_path)
+
+    yield
+
+    if backup_global_config_path.exists():
+        default_global_config_path.unlink(missing_ok=True)
+        backup_global_config_path.rename(default_global_config_path)
+    if backup_configured_global_path.exists():
+        configured_global_config_path.unlink(missing_ok=True)
+        backup_configured_global_path.rename(configured_global_config_path)
+
+
+@pytest.fixture()
+def tmp_cwd(tmp_path, monkeypatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture()
+def set_env(monkeypatch) -> Callable[[dict[str, Any]], None]:
+    """
+    Function fixture to set environment variables using a nested dict
+    matching a GlobalConfig.model_dump()
+    """
+
+    def _set_env(config: dict[str, Any]) -> None:
+        for key, value in _flatten(config).items():
+            key = "LINKML_" + key.upper()
+            monkeypatch.setenv(key, str(value))
+
+    return _set_env
+
+
+@pytest.fixture()
+def set_dotenv(tmp_cwd) -> Callable[[dict[str, Any]], Path]:
+    """
+    Function fixture to set config variables in a .env file
+    """
+    dotenv_path = tmp_cwd / ".env"
+
+    def _set_dotenv(config: dict[str, Any]) -> Path:
+        with open(dotenv_path, "w") as dfile:
+            for key, value in _flatten(config).items():
+                key = "LINKML_" + key.upper()
+                dfile.write(f"{key}={value}\n")
+        return dotenv_path
+
+    return _set_dotenv
+
+
+@pytest.fixture()
+def set_pyproject(tmp_cwd) -> Callable[[dict[str, Any]], Path]:
+    """
+    Function fixture to set config variables in a pyproject.toml file
+    """
+    toml_path = tmp_cwd / "pyproject.toml"
+
+    def _set_pyproject(config: dict[str, Any]) -> Path:
+        config = {"tool": {"linkml": {"config": config}}}
+
+        with open(toml_path, "wb") as tfile:
+            tomli_w.dump(config, tfile)
+
+        return toml_path
+
+    return _set_pyproject
+
+
+@pytest.fixture()
+def set_local_yaml(tmp_cwd) -> Callable[[dict[str, Any]], Path]:
+    """
+    Function fixture to set config variables in a local linkml_config.yaml file
+    """
+    yaml_path = tmp_cwd / "linkml_config.yaml"
+
+    def _set_local_yaml(config: dict[str, Any]) -> Path:
+        with open(yaml_path, "w") as yfile:
+            yaml.safe_dump(config, yfile)
+        return yaml_path
+
+    return _set_local_yaml
+
+
+@pytest.fixture()
+def set_global_yaml() -> Callable[[dict[str, Any]], Path]:
+    """
+    Function fixture to reversibly set config variables in a global linkml_config.yaml file
+    """
+    global_config_path = Path(_dirs.user_config_dir) / "linkml_config.yaml"
+    backup_path = Path(_dirs.user_config_dir) / "linkml_config.yaml.bak"
+    restore_backup = global_config_path.exists()
+
+    try:
+        if restore_backup:
+            global_config_path.rename(backup_path)
+
+        def _set_global_yaml(config: dict[str, Any]) -> Path:
+            with open(global_config_path, "w") as gfile:
+                yaml.safe_dump(config, gfile)
+            return global_config_path
+
+        yield _set_global_yaml
+
+    finally:
+        global_config_path.unlink(missing_ok=True)
+        if restore_backup:
+            backup_path.rename(global_config_path)
+
+
+def test_log_level_propagates():
+    """
+    the level field should propagate to the individual `level_file` etc settings
+    when they aren't set
+    """
+    log_config = LogConfig(level="WARNING", level_file=None, level_stream=None)
+    assert log_config.level == "WARNING"
+    assert log_config.level_file == "WARNING"
+    assert log_config.level_stream == "WARNING"
+
+
+@pytest.mark.parametrize(
+    "setter",
+    ["set_env", "set_dotenv", "set_pyproject", "set_local_yaml", "set_global_yaml"],
+)
+def test_config_sources(setter, request):
+    """
+    Base test that each of the settings sources in isolation can set values
+    """
+    assert GlobalConfig().log.level != "WARNING"
+
+    setting = {"log": {"level": "WARNING"}}
+    fixture_fn = request.getfixturevalue(setter)
+    fixture_fn(setting)
+    config = GlobalConfig()
+    assert config.log.level == "WARNING"
+
+
+def test_config_sources_overrides(set_env, set_dotenv, set_pyproject, set_local_yaml, set_global_yaml):
+    """Test that the different config sources are overridden in the correct order"""
+    set_global_yaml({"log": {"file_n": 0}})
+    assert GlobalConfig().log.file_n == 0
+    set_pyproject({"log": {"file_n": 1}})
+    assert GlobalConfig().log.file_n == 1
+    set_local_yaml({"log": {"file_n": 2}})
+    assert GlobalConfig().log.file_n == 2
+    set_dotenv({"log": {"file_n": 3}})
+    assert GlobalConfig().log.file_n == 3
+    set_env({"log": {"file_n": 5}})
+    assert GlobalConfig().log.file_n == 5
+    assert GlobalConfig(**{"log": {"file_n": 6}}).log.file_n == 6
+
+
+def test_cli_get_config():
+    """
+    linkml config get <key> can get config values
+    """
+
+    config = GlobalConfig()
+
+    # get all values in yaml-serializable form
+    runner = CliRunner()
+    result = runner.invoke(cli_get)
+    printed_value = yaml.safe_load(result.stdout)
+    assert GlobalConfig(**printed_value) == config
+
+    # get single value in base model
+    runner = CliRunner()
+    result = runner.invoke(cli_get, ["user_dir"])
+    assert result.stdout.strip() == str(config.user_dir)
+
+    # and a single value in a nested model
+    runner = CliRunner()
+    result = runner.invoke(cli_get, ["log.level"])
+    assert result.stdout.strip() == str(config.log.level)
+
+
+def test_cli_set_config(set_global_yaml, set_dotenv):
+    """
+    linkml config set <key> <value> can set config values
+    """
+
+    set_global_yaml({"log": {"level": "INFO"}})
+
+    config = GlobalConfig()
+    global_config_file = config.config_file
+
+    with open(global_config_file) as gfile:
+        assert yaml.safe_load(gfile)["log"]["level"] == "INFO"
+
+    # Setting a value in a nested model
+    runner = CliRunner()
+    result = runner.invoke(cli_set, ["log.level", "WARNING"])
+    assert result.exit_code == 0
+    with open(global_config_file) as gfile:
+        assert yaml.safe_load(gfile)["log"]["level"] == "WARNING"
+
+    # Ensure we validate models
+
+    runner = CliRunner()
+    result = runner.invoke(cli_set, ["log.level", "INVALID_VALUE"])
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValidationError)
+
+    # Key with no value sets to null, even if `NULL` is not an allowable value
+    runner = CliRunner()
+    result = runner.invoke(cli_set, ["log.level"])
+    assert result.exit_code == 0
+    with open(global_config_file) as gfile:
+        assert "level" not in yaml.safe_load(gfile)["log"]
+
+    # Can delete multiple times without choking
+    runner = CliRunner()
+    result = runner.invoke(cli_set, ["log.level"])
+    assert result.exit_code == 0
+    with open(global_config_file) as gfile:
+        assert "level" not in yaml.safe_load(gfile)["log"]

--- a/uv.lock
+++ b/uv.lock
@@ -2250,9 +2250,11 @@ dependencies = [
     { name = "openapi-spec-validator" },
     { name = "openpyxl" },
     { name = "parse" },
+    { name = "platformdirs" },
     { name = "prefixcommons" },
     { name = "prefixmaps" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pyjsg" },
     { name = "pyshex" },
     { name = "pyshexc" },
@@ -2301,6 +2303,7 @@ dev = [
     { name = "sphinx-design" },
     { name = "sqlalchemy-bigquery" },
     { name = "testcontainers" },
+    { name = "tomli-w" },
     { name = "tox" },
     { name = "tox-uv" },
 ]
@@ -2311,6 +2314,7 @@ docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-click" },
+    { name = "sphinx-design" },
     { name = "sphinx-jinja" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinxcontrib-mermaid" },
@@ -2333,6 +2337,7 @@ tests = [
     { name = "numpydantic" },
     { name = "pyshacl" },
     { name = "sqlalchemy-bigquery" },
+    { name = "tomli-w" },
 ]
 tests-extra = [
     { name = "jsonpatch" },
@@ -2371,9 +2376,11 @@ requires-dist = [
     { name = "openapi-spec-validator", specifier = ">=0.8.4" },
     { name = "openpyxl" },
     { name = "parse" },
+    { name = "platformdirs", specifier = ">=4.5.0" },
     { name = "prefixcommons", specifier = ">=0.1.7" },
     { name = "prefixmaps", specifier = ">=0.2.2" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjsg", specifier = ">=0.12.3" },
     { name = "pyshex", specifier = ">=0.9.0" },
     { name = "pyshexc", specifier = ">=0.10.3" },
@@ -2420,6 +2427,7 @@ dev = [
     { name = "sphinx-design", specifier = ">=0.5.0" },
     { name = "sqlalchemy-bigquery", specifier = ">=1.9.0" },
     { name = "testcontainers", specifier = "==3.7.1" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "tox", specifier = ">=4" },
     { name = "tox-uv" },
 ]
@@ -2429,6 +2437,7 @@ docs = [
     { name = "myst-parser" },
     { name = "sphinx" },
     { name = "sphinx-click" },
+    { name = "sphinx-design", specifier = ">=0.6.1" },
     { name = "sphinx-jinja", specifier = ">=2.0.2" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinxcontrib-mermaid", specifier = ">=0.7.1" },
@@ -2447,6 +2456,7 @@ tests = [
     { name = "numpydantic", specifier = ">=1.6.1" },
     { name = "pyshacl", specifier = ">=0.25.0" },
     { name = "sqlalchemy-bigquery", specifier = ">=1.9.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
 ]
 tests-extra = [
     { name = "jsonpatch", specifier = ">=1.33" },
@@ -5193,6 +5203,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -662,7 +662,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -735,7 +735,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1173,7 +1173,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1715,17 +1715,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -1743,17 +1743,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/34/29b18c62e39ee2f7a6a3bba7efd952729d8aadd45ca17efc34453b717665/ipython-9.6.0.tar.gz", hash = "sha256:5603d6d5d356378be5043e69441a072b50a5b33b4503428c77b04cb8ce7bc731", size = 4396932, upload-time = "2025-09-29T10:55:53.948Z" }
 wheels = [
@@ -1774,7 +1774,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -2386,9 +2386,11 @@ dependencies = [
     { name = "openapi-spec-validator" },
     { name = "openpyxl" },
     { name = "parse" },
+    { name = "platformdirs" },
     { name = "prefixcommons" },
     { name = "prefixmaps" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pyjsg" },
     { name = "pyshex" },
     { name = "pyshexc" },
@@ -2437,6 +2439,7 @@ dev = [
     { name = "sphinx-design" },
     { name = "sqlalchemy-bigquery" },
     { name = "testcontainers" },
+    { name = "tomli-w" },
     { name = "tox" },
     { name = "tox-uv" },
 ]
@@ -2447,6 +2450,7 @@ docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-click" },
+    { name = "sphinx-design" },
     { name = "sphinx-jinja" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinxcontrib-mermaid" },
@@ -2469,6 +2473,7 @@ tests = [
     { name = "numpydantic" },
     { name = "pyshacl" },
     { name = "sqlalchemy-bigquery" },
+    { name = "tomli-w" },
 ]
 tests-extra = [
     { name = "jsonpatch" },
@@ -2507,9 +2512,11 @@ requires-dist = [
     { name = "openapi-spec-validator", specifier = ">=0.8.4" },
     { name = "openpyxl" },
     { name = "parse" },
+    { name = "platformdirs", specifier = ">=4.5.0" },
     { name = "prefixcommons", specifier = ">=0.1.7" },
     { name = "prefixmaps", specifier = ">=0.2.2" },
     { name = "pydantic", specifier = ">=2.13.4,<3.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjsg", specifier = ">=0.12.3" },
     { name = "pyshex", specifier = ">=0.9.0" },
     { name = "pyshexc", specifier = ">=0.10.3" },
@@ -2556,6 +2563,7 @@ dev = [
     { name = "sphinx-design", specifier = ">=0.5.0" },
     { name = "sqlalchemy-bigquery", specifier = ">=1.17.2" },
     { name = "testcontainers", specifier = "==4.15.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "tox", specifier = ">=4.60.1" },
     { name = "tox-uv" },
 ]
@@ -2565,6 +2573,7 @@ docs = [
     { name = "myst-parser" },
     { name = "sphinx" },
     { name = "sphinx-click" },
+    { name = "sphinx-design", specifier = ">=0.6.1" },
     { name = "sphinx-jinja", specifier = ">=2.0.2" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinxcontrib-mermaid", specifier = ">=2.1.0" },
@@ -2583,6 +2592,7 @@ tests = [
     { name = "numpydantic", specifier = ">=1.10.0" },
     { name = "pyshacl", specifier = ">=0.40.1" },
     { name = "sqlalchemy-bigquery", specifier = ">=1.17.2" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
 ]
 tests-extra = [
     { name = "jsonpatch", specifier = ">=1.33" },
@@ -4965,23 +4975,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -4999,23 +5009,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals-py" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "imagesize", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [


### PR DESCRIPTION
## Summary

#2335 except redone over the monorepo structure. easier to just redo it than it was to rebase.

the description is the same as over there, just copy/pasting that here with one change - instead of the pattern being to instantiate `GlobalConfig` every time, which is expensive, or having some permanent module-level global, we instead have a `get_config()` function with a `reload` param so that we can get and store a globally cached version and have a predictable way to reload that if needed.

begin copy paste

---

Fix: https://github.com/linkml/linkml/issues/2331

alright here's a global config.

At the moement it's not hooked up into anything, but if we like this then i can continue the lovely work in https://github.com/linkml/linkml/pull/2323 and make it control log levels and whatnot as the config object suggests should be possible.

It should be all spelled out in the docs, but just for the good of the order here's the impl:

## Motivation

We want to be able to configure logging at first, but generally have a tidy way to specify behavior that might need to be customized in a per-system, per-session, and per-project way.

This is probably extremely overengineered, but i'm also laying groundwork for [`linkml build`](https://github.com/linkml/linkml/pull/2263) with a project-level config that can get sourced from one of potentially several places in several formats, so that's why. In the future i would anticipate additional global config stuff including whether we should try to resolve schema via url, location of cache directories, etc. so this sets us up for any of that.

## Implementation

Use `pydantic-settings`. 

Specifically, create a `GlobalConfig` class that sources from the following locations, in order of priority from high to low, where higher priority sources override lower priority

* in the arguments passed to the class constructor (not user configurable)
* in environment variables like ``export LINKML_LOG_DIR=~/``
* in a ``.env`` file in the working directory
* in a ``linkml_config.yaml`` file in the working directory
* in the ``tool.linkml.config`` table in a ``pyproject.toml`` file in the working directory
* in the global ``linkml_config.yaml`` file in the platform-specific data directory
  (use ``linkml config get config_file`` to find its location)
* the default values in the `GlobalConfig` model

There is an example of each kind of configuration in the docs in a tab group.

We can use nested models here, and imo we should do that to keep config reasonable instead of turning into a junk drawer, so I added an initial set of config options for handling stream and file logging to demo that. Descriptions of how to handle nested models are also in the docs.

I also added some cli commands to get and set global config values. values are printed as yaml so they can be re-parsed if needed (i did when writing tests)

```shell
$ linkml config get

user_dir: /Users/jonny/Library/Application Support/linkml
config_file: /Users/jonny/Library/Application Support/linkml/linkml_config.yaml
log:
  dir: /Users/jonny/Library/Logs/linkml
  file_name: linkml.log
  level: WARNING
  # ...
```

```shell
$ linkml config get log.level
WARNING
```

Setting values handles `None` to delete keys, nested models, and does model validation as well. We shouldn't be trying to set nonscalar/anything that doesn't have an unambiguous representation in a shell in the config, so hopefully that's as complex as we need it to be.

```shell
$ linkml config set log.level WARNING
Updated linkml config:
key: log.level
value: WARNING
config file: /Users/jonny/Library/Application Support/linkml/linkml_config.yaml
```

## Caveats

There's bound to be a bit of stickiness where people want to specify where the global config file lives. There's a sort of chicken and egg problem here, where we want the global config to be the lowest priority source of config, but then we should have read it and applied it before we reach the shell/cwd-based config options that might want to override it. That might need more consideration in the future, but for now i'm assuming that people will just use the local config options rather than trying to reposition the global config

There's also probably going to be some confusion like "what the heck i called `linkml config set <key> <value>`" and it didn't set my config! when people have some conflicting config file in the cwd. I didn't want to rig up a whole `linkml config set global <key> <value>` like eg. `pyenv` does at the moment, but that might be what we need to do if that starts happening. Tried to flag that clearly in the docs but we'll see.

## Re: Deps

I added two required deps:
- `pydantic-settings`
- `platformdirs`

`pydantic-settings` has one additional non-pydantic dep, `python-dotenv`, which is pretty light, and `platformdirs` has no additional deps and is extremely common (it's probably already in our dep tree somewhere).

imo it's worth it - since we're already installing pydantic, `pydantic-settings` doesn't add a lot more.

I also moved some docs deps that were hanging out in the `dev` group down into the `docs` group and added a package to show pydantic models cleanly (because the config models looked like total garbage without it)

## Tests

Added the basic tests that i thought we might want, but lmk if i missed something.

what ya think?

---

## AI Assistance

you can pry my keyboard from my cold dead hands
