### PR TITLE
Require core team approval for LinkML PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,13 @@
 # LinkML CODEOWNERS — DRAFT (see linkml/linkml#3140)
 #
-# Opt-in model: no default (`*`) rule. Paths not listed here have no required
-# CODEOWNER and are reviewed normally. Rules only appear where someone has
-# explicitly volunteered to steward an area.
+# Default model: all paths require core-team approval unless a more specific
+# CODEOWNER rule applies. Later rules override earlier ones (last match wins),
+# so per-subsystem rules below take precedence over the default for their paths.
 #
 # Process for adding rules: docs/maintainers/codeowners.md
-# Later rules override earlier ones for matched paths.
+
+# --- Default: require core-team approval everywhere ---
+*  @linkml/core-team
 
 # --- CODEOWNERS and governance docs ---
 /.github/CODEOWNERS                         @linkml/core-team
@@ -13,7 +15,7 @@
 /docs/maintainers/codeowners.md             @linkml/core-team
 /docs/maintainers/generator-governance.md   @linkml/core-team
 
-# --- Per-subsystem ownership (opt-in) ---
+# --- Per-subsystem ownership (overrides the default for these paths) ---
 
 # javagen
 /docs/generators/java.rst                            @gouttegd

--- a/docs/maintainers/codeowners.md
+++ b/docs/maintainers/codeowners.md
@@ -9,23 +9,33 @@ For the underlying GitHub mechanics, see the upstream
 [CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
 This page only covers how LinkML uses it.
 
-## The LinkML model: opt-in stewardship
+## The LinkML model: core-team default with per-area stewardship
 
-LinkML uses an **opt-in** model. The `CODEOWNERS` file contains:
+LinkML uses a **default-rule** model. The `CODEOWNERS` file contains:
 
-- **No default (`*`) rule.** Paths that no one has claimed are reviewed
-  normally, exactly as they were before CODEOWNERS existed. CODEOWNERS does
-  not create a new approval gate for the rest of the codebase.
+- **A default (`*`) rule** requiring `@linkml/core-team` approval on any path
+  not covered by a more specific rule. This closes the gap where a
+  write-access holder could merge a PR touching an unclaimed area without any
+  core-team sign-off. Because GitHub applies the *last* matching rule, the
+  per-subsystem rules below still take precedence over the default for their
+  own paths.
 - **Per-generator / per-subsystem rules** for specific directories (e.g.
   `packages/linkml/src/linkml/generators/pydanticgen/`,
   `packages/linkml/src/linkml/generators/yarrrmlgen.py`) where a contributor
-  has explicitly volunteered to steward the code. The baseline for
-  identifying candidate stewards per generator is
-  [Generator and Validator Governance](generator-governance.md), which
-  records contributor history from `git blame`.
+  has explicitly volunteered to steward the code. These override the default
+  for their paths. The baseline for identifying candidate stewards per
+  generator is [Generator and Validator Governance](generator-governance.md),
+  which records contributor history from `git blame`.
 - **Governance rules** — `CODEOWNERS` itself and the governance documents in
   `docs/maintainers/` are owned by `@linkml/core-team` to prevent accidental
   self-appointments.
+
+```{note}
+The default rule only has teeth if the branch protection rule **"Require
+review from Code Owners"** is enabled on `main`. Without it, GitHub records
+the code-owner requirement but does not block merges. Enabling that setting
+requires [admin](contributor-hierarchy.md) access.
+```
 
 Implications:
 

--- a/docs/maintainers/contributor-hierarchy.md
+++ b/docs/maintainers/contributor-hierarchy.md
@@ -67,9 +67,9 @@ Team: [`core-team`](https://github.com/orgs/linkml/teams/core-team)
 Capabilities:
 
 - All collaborator capabilities
-- Can review and approve PRs anywhere in the monorepo (team write access is
-  sufficient; CODEOWNER approval is only required for paths explicitly listed
-  in the [CODEOWNERS](codeowners.md) file)
+- Can review and approve PRs anywhere in the monorepo. By default, core-team
+  approval is what the [CODEOWNERS](codeowners.md) file requires everywhere;
+  paths with a per-subsystem rule additionally require that area's CODEOWNER
 - May invoke the [1-month CODEOWNER fallback](codeowners.md#avoiding-review-bottlenecks-the-1-month-fallback)
   to approve stalled PRs in areas with unresponsive CODEOWNERS
 - Still subject to branch protection rules (cannot force-push, etc.)


### PR DESCRIPTION
## Summary

Fixes #3777.

This PR updates codeowners contract to require core team approval for PRs _unless_ approved by a codeowner. Right now anyone with write access can merge _anything_. That was not the intention.

## How was this tested?

Mostly documentation changes, but need to remember to activate branch 

## Areas of uncertainty

<!-- Are there parts of this change you'd like reviewers to look at more closely? -->

## Checklist

- [X] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [ ] ~~I have added tests that prove my fix/feature works~~
- [X] Existing tests pass locally with my changes
- [x] AFTER MERGING ENSURE THAT BRANCH PROTECTION RULES ARE UPDATED

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
