### PR TITLE
fix(projectgen): excel generation related bug fixes

### DIFF
--- a/examples/tutorial/tutorial08/project-listing.txt
+++ b/examples/tutorial/tutorial08/project-listing.txt
@@ -1,5 +1,6 @@
 excel
 graphql
+java
 jsonld
 jsonschema
 owl

--- a/packages/linkml/src/linkml/generators/excelgen.py
+++ b/packages/linkml/src/linkml/generators/excelgen.py
@@ -171,7 +171,7 @@ class ExcelGenerator(Generator):
 
         dv.add(f"{column_letter}2:{column_letter}1048576")
 
-    def serialize(self, **kwargs) -> str:
+    def serialize(self, **kwargs) -> None:
         sv = self.schemaview
         all_classes = sv.all_classes(imports=self.mergeimports)
 

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -52,14 +52,10 @@ GEN_MAP = {
     "sqltable": (SQLTableGenerator, "sqlschema/{name}.sql", {}),
     # JavaGenerator writes one file per class into a `directory` (passed to
     # serialize(), not the constructor) and returns None; see
-    # SELF_ROUTING_GENERATORS / SERIALIZE_ONLY_ARGS below.
+    # SERIALIZE_ONLY_ARGS below.
     "java": (JavaGenerator, "java/{name}.java", {"directory": "{parent}"}),
     "excel": (ExcelGenerator, "excel/{name}.xlsx", {"output": "{parent}/{name}.xlsx"}),
 }
-
-# Generators whose serialize() writes its own output files and returns None,
-# so ProjectGenerator must not route a returned string into a file.
-SELF_ROUTING_GENERATORS = {"excel", "java"}
 
 # Argument keys consumed by serialize() only, not by the generator constructor.
 SERIALIZE_ONLY_ARGS = {"directory"}
@@ -151,16 +147,17 @@ class ProjectGenerator:
                     serialize_args[k] = v
                 logger.info(f" {gen_name} ARGS: {serialize_args}")
 
-                if gen_name in SELF_ROUTING_GENERATORS:
-                    # Generator writes its own file(s) (excel workbook; one java
-                    # file per class into `directory`) and returns None.
-                    gen.serialize(**serialize_args)
-                else:
-                    gen_dump = gen.serialize(**serialize_args)
-                    if gen_path_full.suffix != "":
-                        logger.info(f"  WRITING TO: {gen_path_full}")
-                        with open(gen_path_full, "w", encoding="UTF-8") as stream:
-                            stream.write(gen_dump)
+                gen_dump = gen.serialize(**serialize_args)
+
+                if gen_dump is None:
+                    # Generator wrote its own file(s) during serialize() (e.g. excelgen's binary
+                    # xlsx workbook, or javagen's one-file-per-class output) and returns None.
+                    # Nothing to route to disk.
+                    continue
+                if gen_path_full.suffix != "":
+                    logger.info(f"  WRITING TO: {gen_path_full}")
+                    with open(gen_path_full, "w", encoding="UTF-8") as stream:
+                        stream.write(gen_dump)
 
 
 @click.command(name="project")

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -12,6 +12,7 @@ from linkml._version import __version__
 from linkml.cli.logging import log_level_option
 from linkml.generators.excelgen import ExcelGenerator
 from linkml.generators.graphqlgen import GraphqlGenerator
+from linkml.generators.javagen import JavaGenerator
 from linkml.generators.jsonldcontextgen import ContextGenerator
 from linkml.generators.jsonldgen import JSONLDGenerator
 from linkml.generators.jsonschemagen import JsonSchemaGenerator
@@ -49,11 +50,19 @@ GEN_MAP = {
     "shex": (ShExGenerator, "shex/{name}.shex", {}),
     "shacl": (ShaclGenerator, "shacl/{name}.shacl.ttl", {}),
     "sqltable": (SQLTableGenerator, "sqlschema/{name}.sql", {}),
-    # # linkml/generators/javagen.py uses different architecture from most of the other generators
-    # # also linkml/generators/excelgen.py, which has a different mechanism for determining the output path
-    # 'java': (JavaGenerator, 'java/{name}.java', {'directory': '{parent}'}),
+    # JavaGenerator writes one file per class into a `directory` (passed to
+    # serialize(), not the constructor) and returns None; see
+    # SELF_ROUTING_GENERATORS / SERIALIZE_ONLY_ARGS below.
+    "java": (JavaGenerator, "java/{name}.java", {"directory": "{parent}"}),
     "excel": (ExcelGenerator, "excel/{name}.xlsx", {"output": "{parent}/{name}.xlsx"}),
 }
+
+# Generators whose serialize() writes its own output files and returns None,
+# so ProjectGenerator must not route a returned string into a file.
+SELF_ROUTING_GENERATORS = {"excel", "java"}
+
+# Argument keys consumed by serialize() only, not by the generator constructor.
+SERIALIZE_ONLY_ARGS = {"directory"}
 
 
 @lru_cache
@@ -128,7 +137,11 @@ class ProjectGenerator:
                 if "output" in all_gen_args:
                     all_gen_args["output"] = all_gen_args["output"].format(name=name, parent=parent_dir)
 
-                gen = gen_cls(local_path, **all_gen_args)
+                # Some generators (e.g. JavaGenerator) accept `directory`
+                # only in serialize(), not in their constructor; so keep
+                # serialize-only keys out of the constructor call.
+                constructor_args = {k: v for k, v in all_gen_args.items() if k not in SERIALIZE_ONLY_ARGS}
+                gen = gen_cls(local_path, **constructor_args)
 
                 serialize_args = {"mergeimports": config.mergeimports}
                 for k, v in all_gen_args.items():
@@ -137,18 +150,17 @@ class ProjectGenerator:
                         v = v.format(name=name, parent=parent_dir)
                     serialize_args[k] = v
                 logger.info(f" {gen_name} ARGS: {serialize_args}")
-                gen_dump = gen.serialize(**serialize_args)
 
-                if gen_name != "excel":
+                if gen_name in SELF_ROUTING_GENERATORS:
+                    # Generator writes its own file(s) (excel workbook; one java
+                    # file per class into `directory`) and returns None.
+                    gen.serialize(**serialize_args)
+                else:
+                    gen_dump = gen.serialize(**serialize_args)
                     if gen_path_full.suffix != "":
                         logger.info(f"  WRITING TO: {gen_path_full}")
                         with open(gen_path_full, "w", encoding="UTF-8") as stream:
                             stream.write(gen_dump)
-                else:
-                    # special handling for excel generator
-                    # we do not need to route the output
-                    # into a file like the other generators
-                    gen.serialize(**serialize_args)
 
 
 @click.command(name="project")

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -20,6 +20,10 @@ def test_projectgen(kitchen_sink_path, tmp_path):
     check_contains("CREATE TABLE", "sqlschema", "kitchen_sink.sql")
     check_contains("ks:age_in_years a owl:DatatypeProperty", "owl", "kitchen_sink.owl.ttl")
     check_contains('"additionalProperties": false', "jsonschema", "kitchen_sink.schema.json")
+    # Excel writes its own binary file via serialize(); guard against regressions
+    # in the generic "generator returned None -> skip disk-routing" branch.
+    excel_out = tmp_path / "excel" / "kitchen_sink.xlsx"
+    assert excel_out.is_file() and excel_out.stat().st_size > 0
 
 
 def test_projectgen_java_package_from_config(kitchen_sink_path, tmp_path):

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -20,3 +20,24 @@ def test_projectgen(kitchen_sink_path, tmp_path):
     check_contains("CREATE TABLE", "sqlschema", "kitchen_sink.sql")
     check_contains("ks:age_in_years a owl:DatatypeProperty", "owl", "kitchen_sink.owl.ttl")
     check_contains('"additionalProperties": false', "jsonschema", "kitchen_sink.schema.json")
+
+
+def test_projectgen_java_package_from_config(kitchen_sink_path, tmp_path):
+    """gen-project forwards generator_args to gen-java, including the Java package.
+
+    Regression test for the gen-java / gen-project integration (issue #2537):
+    JavaGenerator takes ``directory`` in serialize() (not the constructor) and
+    writes one file per class, so ProjectGenerator must split those args and not
+    route a returned string.
+    """
+    config = ProjectConfiguration()
+    config.directory = tmp_path
+    config.includes = ["java"]
+    config.generator_args["java"] = {"package": "com.example.generated"}
+
+    ProjectGenerator().generate(kitchen_sink_path, config)
+
+    java_files = list((tmp_path / "java").glob("*.java"))
+    assert java_files, "expected gen-java to write .java files under java/"
+    for java_file in java_files:
+        assert java_file.read_text(encoding="UTF-8").startswith("package com.example.generated;")


### PR DESCRIPTION
## Summary

Wait for #3781 

Fixes #3759

- ExcelGenerator.serialize was annotated '-> str' but has no return statement, so implicitly returns None. Fix.

- projectgen called gen.serialize() twice for excel (once at generic call site, again in 'excel' branch). The second call was redundant since the first already wrote the .xlsx file. Fix with generic 'if gen_dump is None: continue' - any generator whose serialize writes its own files and returns None is now auto-supported without special-casing.

- Harden test_projectgen to assert excel/kitchen_sink.xlsx is actually produced, guarding the is-None skip

## How was this tested?

local testing

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
