### PR TITLE
fix owl canonicalization hang: add timeout (rdf graph with high symmetric blank-node structure)

### DIFF
--- a/packages/linkml_runtime/src/linkml_runtime/utils/rdf_canonicalize.py
+++ b/packages/linkml_runtime/src/linkml_runtime/utils/rdf_canonicalize.py
@@ -34,15 +34,80 @@ with stable blank node labels and sorted triples.
    is valid Turtle (PN_LOCAL_ESC), but rdflib's notation3 parser rejects
    it because it conflicts with the statement-terminator dot.  We
    post-process the output to expand such CURIEs to full ``<IRI>`` form.
+
+6. **Pathological blank-node structure**: ``rdflib.compare.to_canonical_graph``
+   (used for the fallback in limitation 2) has no complexity bound and can
+   take an unbounded amount of time on graphs with highly symmetric blank-node
+   structure (e.g. many structurally-similar ``owl:Restriction``/``rdf:List``
+   nodes). To guarantee ``canonicalize_rdf_graph`` always returns, this
+   canonicalization step runs in a subprocess with a timeout
+   (``fallback_timeout``, default :data:`DEFAULT_FALLBACK_TIMEOUT_SECONDS`).
+   If it does not finish in time, the subprocess is killed and the graph is
+   serialized directly (no blank-node canonicalization at all), with a
+   warning. Output is still valid RDF, just not guaranteed deterministic
+   across runs.
 """
 
 import io
+import multiprocessing
 import re
 import warnings
 
 import pyoxigraph as ox
 import rdflib
 from rdflib.compare import to_canonical_graph
+
+#: Default time budget, in seconds, for the rdflib fallback canonicalization
+#: (see limitation 6 above) before giving up and serializing non-canonically.
+DEFAULT_FALLBACK_TIMEOUT_SECONDS = 30.0
+
+
+def _canonicalize_worker(graph: rdflib.Graph, result_queue: "multiprocessing.Queue") -> None:
+    """Run ``to_canonical_graph`` and post the result back to the parent process.
+
+    Runs in a spawned subprocess so it can be forcibly terminated if it
+    doesn't finish in time -- ``to_canonical_graph`` is pure-Python and
+    CPU-bound with no cooperative-cancellation hook, so there is no way to
+    safely interrupt it in-process.
+    """
+    canonical = rdflib.Graph()
+    canonical += to_canonical_graph(graph)
+    result_queue.put(canonical)
+
+
+def _canonicalize_with_timeout(graph: rdflib.Graph, timeout: float) -> rdflib.Graph | None:
+    """Run ``to_canonical_graph`` on ``graph`` with a wall-clock timeout.
+
+    :param graph: The rdflib Graph to canonicalize.
+    :param timeout: Maximum time to wait, in seconds.
+    :return: The canonicalized graph, or ``None`` if it did not finish in time,
+        or if the subprocess could not be created/communicated with at all
+        (e.g. the host is out of file descriptors or processes). The whole
+        point of this function is that ``canonicalize_rdf_graph`` always
+        returns rather than hanging or crashing, so any failure mode here
+        degrades the same way a timeout does.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    try:
+        result_queue: multiprocessing.Queue = ctx.Queue()
+        process = ctx.Process(target=_canonicalize_worker, args=(graph, result_queue))
+        process.start()
+    except OSError:
+        return None
+    try:
+        process.join(timeout)
+        if process.is_alive():
+            process.terminate()
+            process.join()
+            return None
+        return result_queue.get_nowait()
+    except Exception:
+        # Worker exited without posting a result, or process management
+        # itself failed (e.g. OSError from resource exhaustion).
+        return None
+    finally:
+        result_queue.close()
+        result_queue.cancel_join_thread()
 
 
 class RDFCanonicalizationWarning(UserWarning):
@@ -80,7 +145,7 @@ _PREFIX_FORMATS = frozenset({ox.RdfFormat.TURTLE, ox.RdfFormat.TRIG, ox.RdfForma
 _LINE_ORIENTED_FORMATS = frozenset({"nt", "ntriples", "n-triples", "nt11", "nquads", "n-quads"})
 
 
-def _deterministic_fallback_serialize(graph: rdflib.Graph, output_format: str) -> str:
+def _deterministic_fallback_serialize(graph: rdflib.Graph, output_format: str, fallback_timeout: float) -> str:
     """Serialize a graph that pyoxigraph cannot canonicalize, deterministically.
 
     pyoxigraph rejects some graphs that rdflib accepts -- notably graphs
@@ -98,22 +163,43 @@ def _deterministic_fallback_serialize(graph: rdflib.Graph, output_format: str) -
     line-oriented formats we additionally sort the serialized lines, since
     rdflib does not emit N-Triples/N-Quads in a stable order.
 
+    ``to_canonical_graph`` has no complexity bound and can take an unbounded
+    amount of time on graphs with highly symmetric blank-node structure, so
+    it runs in a subprocess with a ``fallback_timeout`` budget (see module
+    docstring, limitation 6). If it doesn't finish in time, we give up on
+    canonicalization entirely and serialize the graph directly, with a
+    warning -- valid RDF, just not guaranteed deterministic across runs.
+
     Relative IRIs are preserved verbatim (not resolved against the base): the
     goal is deterministic output, and silently rewriting ``<testing>`` into an
     absolute IRI would mask what is really a data problem in the source graph.
 
     :param graph: The rdflib Graph that pyoxigraph could not parse.
     :param output_format: Target serialization format (e.g. ``"turtle"``, ``"nt"``).
-    :return: Deterministic string serialization of the graph.
+    :param fallback_timeout: Maximum time, in seconds, to spend on blank-node
+        canonicalization before giving up and serializing non-canonically.
+    :return: String serialization of the graph, canonicalized if it finished
+        within the timeout.
     """
-    canonical = to_canonical_graph(graph)
-    # to_canonical_graph builds a fresh graph without the source's namespace
-    # bindings; rebind them so the output does not fall back to rdflib's
-    # non-deterministic auto-generated ``ns1:``/``ns2:`` prefixes.
-    for prefix, namespace in graph.namespace_manager.namespaces():
-        canonical.namespace_manager.bind(prefix, namespace, replace=True)
-    canonical.base = graph.base
-    serialized = canonical.serialize(format=output_format)
+    canonical = _canonicalize_with_timeout(graph, fallback_timeout)
+    if canonical is None:
+        warnings.warn(
+            f"rdflib fallback canonicalization did not complete within {fallback_timeout}s "
+            "(graph has too much symmetric blank-node structure); falling back to "
+            "non-canonical serialization. Output is valid RDF but blank-node labels "
+            "and triple ordering are not guaranteed stable across runs.",
+            RDFCanonicalizationWarning,
+            stacklevel=3,
+        )
+        serialized = graph.serialize(format=output_format)
+    else:
+        # to_canonical_graph builds a fresh graph without the source's namespace
+        # bindings; rebind them so the output does not fall back to rdflib's
+        # non-deterministic auto-generated ``ns1:``/``ns2:`` prefixes.
+        for prefix, namespace in graph.namespace_manager.namespaces():
+            canonical.namespace_manager.bind(prefix, namespace, replace=True)
+        canonical.base = graph.base
+        serialized = canonical.serialize(format=output_format)
     if output_format.lower() in _LINE_ORIENTED_FORMATS:
         lines = [line for line in serialized.splitlines() if line.strip()]
         return "\n".join(sorted(lines)) + "\n"
@@ -287,6 +373,7 @@ def _is_safe_prefix_iri(iri: str) -> bool:
 def canonicalize_rdf_graph(
     graph: rdflib.Graph,
     output_format: str = "turtle",
+    fallback_timeout: float = DEFAULT_FALLBACK_TIMEOUT_SECONDS,
 ) -> str:
     """Serialize an rdflib Graph deterministically using RDFC-1.0 canonicalization.
 
@@ -296,11 +383,19 @@ def canonicalize_rdf_graph(
     for formats that support them (Turtle, TriG, N3, RDF/XML).
 
     Falls back to plain rdflib serialization for unsupported formats or
-    graphs containing non-standard RDF (e.g. literal predicates).
+    graphs containing non-standard RDF (e.g. literal predicates). That
+    fallback's own blank-node canonicalization step is bounded by
+    ``fallback_timeout`` (see module docstring, limitation 6) so this
+    function always returns rather than hanging.
 
     :param graph: The rdflib Graph to serialize.
     :param output_format: Target serialization format (e.g. ``"turtle"``, ``"nt"``).
-    :return: Deterministic string serialization of the graph.
+    :param fallback_timeout: Maximum time, in seconds, the rdflib fallback path
+        may spend on blank-node canonicalization before giving up and
+        serializing non-canonically.
+    :return: Deterministic string serialization of the graph (or, if the
+        fallback's canonicalization step timed out, a valid but
+        non-deterministic serialization).
     """
     ox_format = _FORMAT_MAP.get(output_format.lower())
     if ox_format is None:
@@ -330,7 +425,7 @@ def canonicalize_rdf_graph(
             RDFCanonicalizationWarning,
             stacklevel=2,
         )
-        return _deterministic_fallback_serialize(graph, output_format)
+        return _deterministic_fallback_serialize(graph, output_format, fallback_timeout)
 
     dataset = ox.Dataset()
     for triple in triples:

--- a/tests/linkml/test_utils/test_compare_rdf.py
+++ b/tests/linkml/test_utils/test_compare_rdf.py
@@ -1,0 +1,51 @@
+from rdflib import BNode, Graph, URIRef
+
+from tests.linkml.utils.compare_rdf import compare_rdf
+
+
+def _pathological_ttl(n_pairs: int) -> str:
+    """Turtle text with ``n_pairs`` disjoint symmetric blank-node pairs.
+
+    Same structural pattern used in
+    ``tests/linkml_runtime/test_utils/test_rdf_canonicalize.py`` to
+    reproduce the OWL metamodel hang: this shape is what makes
+    ``rdflib.compare.to_canonical_graph``/``graph_diff`` blow up.
+    """
+    g = Graph()
+    g.bind("ex", "http://example.com/")
+    p = URIRef("http://example.com/p")
+    for _ in range(n_pairs):
+        b1, b2 = BNode(), BNode()
+        g.add((b1, p, b2))
+        g.add((b2, p, b1))
+    return g.serialize(format="turtle")
+
+
+def test_compare_rdf_matches_identical_graphs():
+    ttl = "@prefix ex: <http://example.com/> .\nex:a ex:p ex:b .\n"
+    assert compare_rdf(ttl, ttl) is None
+
+
+def test_compare_rdf_reports_differences():
+    expected = "@prefix ex: <http://example.com/> .\nex:a ex:p ex:b, ex:c .\n"
+    actual = "@prefix ex: <http://example.com/> .\nex:a ex:p ex:b, ex:d .\n"
+    result = compare_rdf(expected, actual)
+    assert result is not None
+    assert "Missing Triples" in result
+    assert "Added Triples" in result
+    assert "ex:c" in result
+    assert "ex:d" in result
+
+
+def test_compare_rdf_on_pathological_graph_completes_quickly():
+    """Regression test: comparing two graphs with symmetric blank-node
+    structure must not hang.
+
+    This is the exact shape (minus the literal-predicate trigger, which is
+    irrelevant here since ``compare_rdf`` no longer routes through
+    pyoxigraph at all) that made ``rdflib.compare.graph_diff``/
+    ``to_isomorphic`` -- previously called directly by ``compare_rdf`` --
+    take an unbounded amount of time on the real OWL metamodel graph.
+    """
+    ttl = _pathological_ttl(8)
+    assert compare_rdf(ttl, ttl) is None

--- a/tests/linkml/utils/compare_rdf.py
+++ b/tests/linkml/utils/compare_rdf.py
@@ -3,7 +3,6 @@ from contextlib import redirect_stdout
 from io import StringIO
 
 from rdflib import RDF, Graph
-from rdflib.compare import IsomorphicGraph, graph_diff, to_isomorphic
 
 from linkml_runtime.linkml_model.meta import LINKML
 from linkml_runtime.utils.rdf_canonicalize import canonicalize_rdf_graph
@@ -56,7 +55,7 @@ def compare_rdf(
     :return: None if they match else summary of difference
     """
 
-    def rem_metadata(g: Graph) -> IsomorphicGraph:
+    def rem_metadata(g: Graph) -> Graph:
         # Remove list declarations from target
         for s in g.subjects(RDF.type, RDF.List):
             g.remove((s, RDF.type, RDF.List))
@@ -70,33 +69,52 @@ def compare_rdf(
                 TYPE.source_file_size,
             ):
                 g.remove(t)
-        g_iso = to_isomorphic(g)
-        return g_iso
+        return g
+
+    def to_subgraph(lines: set[str], source_graph: Graph) -> Graph:
+        # Rebuild a Graph from a subset of canonical N-Triples lines,
+        # keeping the source graph's prefixes so print_triples() output
+        # stays readable.
+        sub = Graph()
+        for prefix, namespace in source_graph.namespace_manager.namespaces():
+            sub.bind(prefix, namespace)
+        if lines:
+            sub.parse(data="\n".join(lines), format="nt")
+        return sub
 
     # Bypass compare if settings have turned it off
     if SKIP_RDF_COMPARE:
         print(f"tests/utils/compare_rdf.py: {SKIP_RDF_COMPARE_REASON}")
         return None
 
-    expected_graph = to_graph(expected, fmt)
-    expected_isomorphic = rem_metadata(expected_graph)
-    actual_graph = to_graph(actual, fmt)
-    actual_isomorphic = rem_metadata(actual_graph)
+    expected_graph = rem_metadata(to_graph(expected, fmt))
+    actual_graph = rem_metadata(to_graph(actual, fmt))
 
-    # Graph compare takes a Looong time
-    in_both, in_old, in_new = graph_diff(expected_isomorphic, actual_isomorphic)
-    # if old_iso != new_iso:
-    #     in_both, in_old, in_new = graph_diff(old_iso, new_iso)
-    old_len = len(list(in_old))
-    new_len = len(list(in_new))
-    if old_len or new_len:
-        txt = StringIO()
-        with redirect_stdout(txt):
-            print("----- Missing Triples -----")
-            if old_len:
-                print_triples(in_old)
-            print("----- Added Triples -----")
-            if new_len:
-                print_triples(in_new)
-        return txt.getvalue()
-    return None
+    # Isomorphism check via canonical N-Triples: same canonicalizer the
+    # generators use (fast pyoxigraph RDFC-1.0 path in the common case,
+    # timeout-bounded rdflib fallback otherwise -- see rdf_canonicalize.py),
+    # instead of rdflib.compare.graph_diff/to_isomorphic, which has no
+    # complexity bound and can hang on graphs with symmetric blank-node
+    # structure.
+    expected_nt = canonicalize_rdf_graph(expected_graph, output_format="nt")
+    actual_nt = canonicalize_rdf_graph(actual_graph, output_format="nt")
+    if expected_nt == actual_nt:
+        return None
+
+    expected_lines = set(expected_nt.splitlines())
+    actual_lines = set(actual_nt.splitlines())
+    missing_lines = expected_lines - actual_lines
+    added_lines = actual_lines - expected_lines
+
+    in_old = to_subgraph(missing_lines, expected_graph)
+    in_new = to_subgraph(added_lines, actual_graph)
+
+    txt = StringIO()
+    with redirect_stdout(txt):
+        print("----- Missing Triples -----")
+        if missing_lines:
+            print_triples(in_old)
+        print("----- Added Triples -----")
+        if added_lines:
+            print_triples(in_new)
+    return txt.getvalue()

--- a/tests/linkml_runtime/support/compare_rdf.py
+++ b/tests/linkml_runtime/support/compare_rdf.py
@@ -4,7 +4,6 @@ from io import StringIO
 from typing import Optional, Union
 
 from rdflib import RDF, Graph
-from rdflib.compare import IsomorphicGraph, graph_diff, to_isomorphic
 
 from linkml_runtime import LINKML
 from linkml_runtime.utils.rdf_canonicalize import canonicalize_rdf_graph
@@ -53,7 +52,7 @@ def compare_rdf(expected: Union[Graph, str], actual: Union[Graph, str], fmt: Opt
     :return: None if they match else summary of difference
     """
 
-    def rem_metadata(g: Graph) -> IsomorphicGraph:
+    def rem_metadata(g: Graph) -> Graph:
         # Remove list declarations from target
         for s in g.subjects(RDF.type, RDF.List):
             g.remove((s, RDF.type, RDF.List))
@@ -67,33 +66,52 @@ def compare_rdf(expected: Union[Graph, str], actual: Union[Graph, str], fmt: Opt
                 TYPE.source_file_size,
             ):
                 g.remove(t)
-        g_iso = to_isomorphic(g)
-        return g_iso
+        return g
+
+    def to_subgraph(lines: set, source_graph: Graph) -> Graph:
+        # Rebuild a Graph from a subset of canonical N-Triples lines,
+        # keeping the source graph's prefixes so print_triples() output
+        # stays readable.
+        sub = Graph()
+        for prefix, namespace in source_graph.namespace_manager.namespaces():
+            sub.bind(prefix, namespace)
+        if lines:
+            sub.parse(data="\n".join(lines), format="nt")
+        return sub
 
     # Bypass compare if settings have turned it off
     if SKIP_RDF_COMPARE:
         print(f"tests/utils/compare_rdf.py: {SKIP_RDF_COMPARE_REASON}")
         return None
 
-    expected_graph = to_graph(expected, fmt)
-    expected_isomorphic = rem_metadata(expected_graph)
-    actual_graph = to_graph(actual, fmt)
-    actual_isomorphic = rem_metadata(actual_graph)
+    expected_graph = rem_metadata(to_graph(expected, fmt))
+    actual_graph = rem_metadata(to_graph(actual, fmt))
 
-    # Graph compare takes a Looong time
-    in_both, in_old, in_new = graph_diff(expected_isomorphic, actual_isomorphic)
-    # if old_iso != new_iso:
-    #     in_both, in_old, in_new = graph_diff(old_iso, new_iso)
-    old_len = len(list(in_old))
-    new_len = len(list(in_new))
-    if old_len or new_len:
-        txt = StringIO()
-        with redirect_stdout(txt):
-            print("----- Missing Triples -----")
-            if old_len:
-                print_triples(in_old)
-            print("----- Added Triples -----")
-            if new_len:
-                print_triples(in_new)
-        return txt.getvalue()
-    return None
+    # Isomorphism check via canonical N-Triples: same canonicalizer the
+    # generators use (fast pyoxigraph RDFC-1.0 path in the common case,
+    # timeout-bounded rdflib fallback otherwise -- see rdf_canonicalize.py),
+    # instead of rdflib.compare.graph_diff/to_isomorphic, which has no
+    # complexity bound and can hang on graphs with symmetric blank-node
+    # structure.
+    expected_nt = canonicalize_rdf_graph(expected_graph, output_format="nt")
+    actual_nt = canonicalize_rdf_graph(actual_graph, output_format="nt")
+    if expected_nt == actual_nt:
+        return None
+
+    expected_lines = set(expected_nt.splitlines())
+    actual_lines = set(actual_nt.splitlines())
+    missing_lines = expected_lines - actual_lines
+    added_lines = actual_lines - expected_lines
+
+    in_old = to_subgraph(missing_lines, expected_graph)
+    in_new = to_subgraph(added_lines, actual_graph)
+
+    txt = StringIO()
+    with redirect_stdout(txt):
+        print("----- Missing Triples -----")
+        if missing_lines:
+            print_triples(in_old)
+        print("----- Added Triples -----")
+        if added_lines:
+            print_triples(in_new)
+    return txt.getvalue()

--- a/tests/linkml_runtime/test_utils/test_rdf_canonicalize.py
+++ b/tests/linkml_runtime/test_utils/test_rdf_canonicalize.py
@@ -502,3 +502,65 @@ def test_fallback_is_deterministic_across_processes(output_format):
     assert out_a == out_b, (
         "Fallback output differs across PYTHONHASHSEED values; blank-node canonicalization may be missing"
     )
+
+
+def _make_pathological_graph(n_pairs: int) -> Graph:
+    """Build a graph with ``n_pairs`` disjoint symmetric blank-node pairs.
+
+    Each pair ``(b1, p, b2), (b2, p, b1)`` is indistinguishable from every
+    other pair under local hashing, which is the structural pattern that
+    makes ``rdflib.compare.to_canonical_graph`` blow up (verified
+    empirically: 6 pairs already take several seconds; the real LinkML
+    metamodel's OWL graph, which has hundreds of similarly ambiguous
+    ``owl:Restriction``/``rdf:List`` blank nodes, does not finish in 20+
+    minutes). Also adds one literal-predicate triple so pyoxigraph rejects
+    the graph and it is routed into the rdflib fallback at all.
+    """
+    g = Graph()
+    g.bind("ex", "http://example.com/")
+    p = URIRef("http://example.com/p")
+    for _ in range(n_pairs):
+        b1, b2 = BNode(), BNode()
+        g.add((b1, p, b2))
+        g.add((b2, p, b1))
+    # Literal predicate -> pyoxigraph SyntaxError -> rdflib fallback.
+    g.add((URIRef("http://example.com/s"), Literal("not_a_predicate"), Literal("value")))
+    return g
+
+
+def test_fallback_timeout_prevents_hang_on_pathological_graph():
+    """A pathologically symmetric blank-node graph must not hang ``canonicalize_rdf_graph``.
+
+    Regression test for the OWL metamodel hang: 8 disjoint symmetric
+    blank-node pairs reliably exceed a short ``fallback_timeout``, forcing
+    the bounded subprocess canonicalization to be killed and the function to
+    degrade to non-canonical serialization instead of hanging.
+    """
+    g = _make_pathological_graph(8)
+
+    with pytest.warns(RDFCanonicalizationWarning, match="did not complete within"):
+        result = canonicalize_rdf_graph(g, output_format="turtle", fallback_timeout=1.0)
+
+    # Still valid, parseable RDF -- just not canonicalized.
+    parsed = Graph()
+    parsed.parse(data=result, format="turtle")
+    assert len(parsed) == len(g)
+
+
+def test_fallback_timeout_does_not_affect_small_graphs():
+    """Small non-pathological graphs still canonicalize fully within the default timeout.
+
+    Guards against the timeout being so aggressive that ordinary fallback
+    graphs (e.g. the existing ``test_fallback_on_invalid_rdf`` shape) start
+    degrading to non-canonical output.
+    """
+    g = _make_pathological_graph(2)
+
+    with pytest.warns(RDFCanonicalizationWarning, match="non-standard RDF"):
+        result = canonicalize_rdf_graph(g, output_format="turtle")
+
+    # No second (timeout) warning should have fired; result is fully
+    # canonical and thus deterministic across repeated calls.
+    with pytest.warns(RDFCanonicalizationWarning, match="non-standard RDF"):
+        result_again = canonicalize_rdf_graph(g, output_format="turtle")
+    assert result == result_again


### PR DESCRIPTION
## Summary

Fixes #3803

- `rdf_canonicalize.py` timeout hardening

- `compare_rdf.py` ×2 refactor - the target test no longer hangs and passes reliably (5/5 runs, ~34s each - it hits the 30s timeout and falls back to non-canonical output every time, but `compare_rdf`'s comparison still succeeds)

## How was this tested?

- new tests in `test_rdf_canonicalize.py`

## Areas of uncertainty

This PR treats `meta.yaml has malformed status value` as out of scope. The trade-off is the OWL/RDF/TTL metamodel generators stay ~30s slower for this one schema until #3760 is resolved upstream.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance
LLM assisted
