### PR TITLE
JSON-Schema: nullable, required slots

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -779,6 +779,19 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
 
         return constraints
 
+    @staticmethod
+    def _value_is_nullable(slot: SlotDefinition | AnonymousSlotExpression) -> bool:
+        """Whether a ``null`` value is acceptable for the slot's value.
+
+        A ``null`` value is acceptable when either the slot is not ``required`` (the
+        classic optional case) or when the slot declares ``value_presence: UNCOMMITTED``.
+        The latter allows a slot to be ``required`` (its key must be present) while still
+        permitting an explicit ``null`` value, yielding a nullable JSON Schema property.
+        """
+        if not slot.required:
+            return True
+        return slot.value_presence == PresenceEnum(PresenceEnum.UNCOMMITTED)
+
     def get_subschema_for_slot(
         self, slot: SlotDefinition | AnonymousSlotExpression, omit_type: bool = False, include_null: bool = True
     ) -> JsonSchema:
@@ -786,6 +799,11 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
         Args:
             include_null: Include ``type: null`` when generating ranges that are not required
         """
+        # ``non_null_value`` is True when a ``null`` value is NOT acceptable, i.e. the slot
+        # is required and does not declare ``value_presence: UNCOMMITTED``. It is used in
+        # place of ``slot.required`` for null-emission decisions so that a required slot
+        # with ``value_presence: UNCOMMITTED`` still gets a nullable value schema.
+        non_null_value = not self._value_is_nullable(slot)
         prop = JsonSchema()
         if isinstance(slot, SlotDefinition) and slot.array:
             # TODO: this is currently too lax, in that it will validate ANY array.
@@ -796,7 +814,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                     "additionalProperties": True,
                 }
             )
-            prop = JsonSchema.array_of(prop, include_null, required=slot.required)
+            prop = JsonSchema.array_of(prop, include_null, required=non_null_value)
             if slot.examples:
                 prop.add_keyword("examples", _slot_examples_for_json_schema(slot.examples, is_array_valued=True))
             return prop
@@ -839,16 +857,16 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                             additionalProps = additionalProps[0]
                         else:
                             additionalProps = JsonSchema({"anyOf": additionalProps})
-                        if slot.required or not include_null:
+                        if non_null_value or not include_null:
                             typ = "object"
                         else:
                             typ = ["object", "null"]
                         prop = JsonSchema({"type": typ, "additionalProperties": additionalProps})
                         self.top_level_schema.add_lax_def(reference, self.aliased_slot_name(range_id_slot))
                     else:
-                        prop = JsonSchema.array_of(JsonSchema.ref_for(reference), include_null, required=slot.required)
+                        prop = JsonSchema.array_of(JsonSchema.ref_for(reference), include_null, required=non_null_value)
                 else:
-                    prop = JsonSchema.ref_for(reference, required=slot.required or not include_null)
+                    prop = JsonSchema.ref_for(reference, required=non_null_value or not include_null)
 
             else:
                 if not slot_is_boolean or slot.range != self.schemaview.schema.default_range:
@@ -861,7 +879,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                         # for multivalued slots, nullability applies to the array (via array_of
                         # below), not to the individual elements
                         prop = JsonSchema.ref_for(
-                            reference, required=slot.required or slot_is_multivalued or not include_null
+                            reference, required=non_null_value or slot_is_multivalued or not include_null
                         )
                     elif typ and fmt is None:
                         prop = JsonSchema({"type": typ})
@@ -869,10 +887,10 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                         prop = JsonSchema({"type": typ, "format": fmt})
 
                 if slot_is_multivalued:
-                    prop = JsonSchema.array_of(prop, include_null, required=slot.required)
+                    prop = JsonSchema.array_of(prop, include_null, required=non_null_value)
                 else:
                     # handle optionals - bools like any_of, etc. below as they call this method recursively
-                    if not slot.required and not slot_is_boolean and include_null:
+                    if not non_null_value and not slot_is_boolean and include_null:
                         if "type" in prop:
                             prop["type"] = [prop["type"], "null"]
 
@@ -905,7 +923,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
             bool_subschema["anyOf"] = _deduplicate_subschemas(
                 [self.get_subschema_for_slot(s, include_null=False) for s in slot.any_of]
             )
-            if not slot.required and not prop.is_array and include_null:
+            if not non_null_value and not prop.is_array and include_null:
                 bool_subschema["anyOf"].append({"type": "null"})
 
         if slot.all_of is not None and len(slot.all_of) > 0:
@@ -929,7 +947,7 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
             if prop.is_array:
                 if "items" not in prop:
                     prop["items"] = {}
-                if slot.required or not include_null:
+                if non_null_value or not include_null:
                     prop["type"] = "array"
                 else:
                     prop["type"] = ["array", "null"]

--- a/tests/linkml/test_generators/test_jsonschemagen.py
+++ b/tests/linkml/test_generators/test_jsonschemagen.py
@@ -1096,3 +1096,90 @@ def test_add_lax_def_missing_required():
     schema["$defs"]["NormalClass"] = {"type": "object", "properties": {"id": {}}, "required": ["id", "name"]}
     schema.add_lax_def("NormalClass", "id")
     assert schema["$defs"]["NormalClass__identifier_optional"]["required"] == ["name"]
+
+
+NULLABLE_REQUIRED_SCHEMA = """
+id: https://example.org/nullable-required
+name: nullable_required
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  C:
+    tree_root: true
+    attributes:
+      req_normal:
+        required: true
+      req_nullable:
+        required: true
+        value_presence: UNCOMMITTED
+      opt:
+        required: false
+      req_nullable_ref:
+        required: true
+        value_presence: UNCOMMITTED
+        range: D
+        inlined: true
+      req_nullable_multivalued:
+        required: true
+        multivalued: true
+        value_presence: UNCOMMITTED
+  D:
+    attributes:
+      x:
+"""
+
+
+def test_required_slot_with_uncommitted_value_presence_is_nullable():
+    """A ``required`` slot with ``value_presence: UNCOMMITTED`` keeps its key in the
+    ``required`` list while allowing an explicit ``null`` value.
+
+    See: making a slot required but with a nullable value.
+    """
+    generated = json.loads(JsonSchemaGenerator(NULLABLE_REQUIRED_SCHEMA).serialize())
+    props = generated["$defs"]["C"]["properties"]
+    required = generated["$defs"]["C"]["required"]
+
+    # Key presence: all required slots must be listed as required, including the nullable ones
+    assert "req_normal" in required
+    assert "req_nullable" in required
+    assert "req_nullable_ref" in required
+    assert "req_nullable_multivalued" in required
+    assert "opt" not in required
+
+    # Value nullability
+    assert props["req_normal"]["type"] == "string"
+    assert props["req_nullable"]["type"] == ["string", "null"]
+    assert props["opt"]["type"] == ["string", "null"]
+    assert {"type": "null"} in props["req_nullable_ref"]["anyOf"]
+    assert props["req_nullable_multivalued"]["type"] == ["array", "null"]
+
+
+def test_required_nullable_slot_validates_null_and_missing_key():
+    """The generated schema accepts an explicit ``null`` value but still rejects a
+    missing key for a ``required`` slot with ``value_presence: UNCOMMITTED``."""
+    generated = json.loads(JsonSchemaGenerator(NULLABLE_REQUIRED_SCHEMA).serialize())
+
+    # Explicit null for the nullable-required slots is valid
+    jsonschema.validate(
+        {
+            "req_normal": "x",
+            "req_nullable": None,
+            "req_nullable_ref": None,
+            "req_nullable_multivalued": None,
+        },
+        generated,
+    )
+
+    # Omitting the key entirely is still invalid (required means key must be present)
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(
+            {
+                "req_normal": "x",
+                "req_nullable_ref": None,
+                "req_nullable_multivalued": None,
+            },
+            generated,
+        )


### PR DESCRIPTION
## Summary

In some situations it might be desired to declare that a slot is required, but it might be `null`. Which can be the intention of such a weird thing? To ensure that the slot has not been kept by accident empty, but to enforce the declaration to exist and to be empty.

Unfortunately the semantic of a `required` slot is that the slot must exist and must have a value.

Such a thing can be expressed in JSON-Schema putting a `property` in the `required` list of an object and then giving that property the attribute `nullable: true`. This PR adds support to the JSON-Schema Generator to manifest it saying that a slot is `required` and `value_presence: UNCOMMITTED`. In the end the current behavior is like an implicit `value_presence: PRESENT` and therefore `UNCOMMITTED` can be used for this purpose.

This PR is partially addressing topics mentioned in discussion #3813.

## How was this tested?

Specific tests added.

## Areas of uncertainty

Unclear if support for nullable, required slots is also required for other generators other than the JSON-Schema one.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
