### PR TITLE
Request: Add @gouttegd as "code owner" for the Java generator.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,12 @@
 
 # --- Per-subsystem ownership (opt-in) ---
 
+# javagen
+/docs/generators/java.rst                            @gouttegd
+/packages/linkml/src/linkml/generators/javagen.py    @gouttegd
+/packages/linkml/src/linkml/generators/javagen/      @gouttegd
+/tests/linkml/test_generators/test_javagen.py        @gouttegd
+
 # pydanticgen:
 /packages/linkml/src/linkml/generators/pydanticgen/                  @sneakers-the-rat @kevinschaper
 /docs/generators/pydantic.rst                                        @sneakers-the-rat @kevinschaper


### PR DESCRIPTION
**Path(s) added:** 

* `packages/linkml/src/linkml/generators/javagen.py`
* `packages/linkml/src/linkml/generators/javagen/`
* `tests/linkml/test_generators/test_javagen.py`
* `docs/generators/java.rst`

### Merged PRs justifying codeownership

- #1710 — Fix the rendering of data and time fields in Java code – Nov 2023
- #3069 – Add support for “true” enumerated types in Java – Jan 2026
- #3124 – Refactor the Java code generator to allow “template variants” – Feb 2026
- #3255 – Misc improvements to the Java generator (including: fix support for `linkml:Any`, add the possibility to generate a visitor interface pattern, preventing clashes with reserved Java keywords, support for LinkML-Java runtime) – Mar 2026
- #3326 – Honour slot aliases when deriving field names – Apr 2026
- #3589 – Enforce typing constraints for “refined inherited slots” – Jun 2026

### Reviews I have given

- #3204 – Pointed out that the proposed label-based workflow for managing PR was not workable
- #3410 – Suggested improvements to the command line interface for `linkml validate`
- #3758 – Suggested _not_ returning the entire Java generated code as a `str` (pointless for Java) and _not_ doing “invasive testing” (testing _how_ a method does its job rather than just testing that it does its job); suggestions followed in subsequently merged PR #3756

### What I will do as a CODEOWNER

Keep an eye for any activity that touches or somehow involves/impacts the Java generator and provide reviews whenever needed (something I am already doing anyway, but being “code owner” would make that easier since I’ll be automatically notified of any PR that touches the corresponding files).

### ORCID (optional)

<https://orcid.org/0000-0002-6095-8718>