### PR TITLE
fix(rustgen): exclude type-designator slot from tagged variant structs

### DIFF
--- a/packages/linkml/src/linkml/generators/rustgen/rustgen.py
+++ b/packages/linkml/src/linkml/generators/rustgen/rustgen.py
@@ -574,7 +574,7 @@ class RustGenerator(Generator, LifecycleMixin):
             return RustStructOrSubtypeEnum(
                 enum_name=get_name(cls) + "OrSubtype",
                 struct_names=[get_name(self.schemaview.get_class(d)) for d in descendants],
-                type_designator_name=get_name(td) if td else None,
+                type_designator_field=get_name(td) if td else None,
                 as_key_value=get_key_or_identifier_slot(cls, self.schemaview) is not None,
                 type_designators=td_mapping,
                 key_property_type=key_type,

--- a/packages/linkml/src/linkml/generators/rustgen/rustgen.py
+++ b/packages/linkml/src/linkml/generators/rustgen/rustgen.py
@@ -500,6 +500,22 @@ class RustGenerator(Generator, LifecycleMixin):
         """
         cls = self.before_generate_class(cls, self.schemaview)
         induced_attrs = [self.schemaview.induced_slot(sn, cls.name) for sn in self.schemaview.class_slots(cls.name)]
+
+        # Exclude the type-designator slot from a class's own struct fields
+        # when this class is a concrete variant of some tagged ancestor
+        # OrSubtype enum. The tag is emitted at the enum level
+        # (#[serde(tag = "...")]); if the variant struct ALSO carries the
+        # same-named field, serde emits a duplicate JSON key on serialize
+        # and rejects it on deserialize ("duplicate field"). The field stays
+        # on the ancestor's own struct (it isn't wrapped as anyone's variant).
+        for ancestor_name in self.schemaview.class_ancestors(cls.name, reflexive=False):
+            if not has_real_subtypes(self.schemaview, ancestor_name):
+                continue
+            td = self.schemaview.get_type_designator_slot(ancestor_name)
+            if td is None:
+                continue
+            induced_attrs = [a for a in induced_attrs if a.name != td.name]
+
         induced_attrs = self.before_generate_slots(induced_attrs, self.schemaview)
         slot_range_unions = []
         for a in induced_attrs:
@@ -982,6 +998,17 @@ class RustGenerator(Generator, LifecycleMixin):
         for superclass in superclasses:
             attribs_sc = self.schemaview.class_induced_slots(superclass.name)
             attribs = [a for a in attribs if a.name not in [sc.name for sc in attribs_sc]]
+
+        # Mirror generate_class's exclusion: when cls generates a tagged
+        # OrSubtype enum, the type-designator slot no longer exists as a
+        # real field on descendant structs (its value is implicit in the
+        # enum tag / constant per variant), so it must not be exposed as a
+        # dynamic polymorphic-trait accessor either -- the trait impl body
+        # would otherwise reference a struct field that generate_class no
+        # longer emits.
+        td = self.schemaview.get_type_designator_slot(cls.name)
+        if td is not None:
+            attribs = [a for a in attribs if a.name != td.name]
 
         rust_attribs = []
         for a in attribs:

--- a/packages/linkml/src/linkml/generators/rustgen/template.py
+++ b/packages/linkml/src/linkml/generators/rustgen/template.py
@@ -402,7 +402,7 @@ class RustStructOrSubtypeEnum(RustTemplateModel):
     struct_names: list[str]
     as_key_value: bool = False
     type_designator_field: str | None = None
-    type_designators: dict[str, str]
+    type_designators: dict[str, list[str]]
     key_property_type: str = "String"
 
 

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -1326,3 +1326,131 @@ def test_subproperty_of_cargo_check(temp_dir):
         pytest.fail(
             f"cargo check failed for subproperty_of schema.\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
         )
+
+
+_TYPE_DESIGNATOR_SCHEMA = textwrap.dedent(
+    """
+    id: https://example.org/rustgen/type_designator
+    name: rustgen_type_designator
+    prefixes:
+      ex: https://example.org/rustgen/
+      linkml: https://w3id.org/linkml/
+    default_prefix: ex
+    default_range: string
+    imports:
+      - linkml:types
+
+    classes:
+      Event:
+        tree_root: true
+        slots:
+          - category
+          - name
+        slot_usage:
+          category:
+            designates_type: true
+      EmploymentEvent:
+        is_a: Event
+        slots:
+          - employer
+      MedicalEvent:
+        is_a: Event
+        slots:
+          - diagnosis
+
+    slots:
+      category:
+        range: string
+      name:
+        range: string
+      employer:
+        range: string
+      diagnosis:
+        range: string
+    """
+)
+
+
+def test_rustgen_type_designator_emits_serde_tag(temp_dir):
+    """A ``designates_type`` slot on a class with subtypes produces an internally
+    tagged ``*OrSubtype`` enum (``#[serde(tag = ...)]``), not an untagged one.
+
+    Regression for two compounding bugs: ``type_designators`` was typed
+    ``dict[str, str]`` while the generator supplies ``list[str]`` (which crashed
+    generation with a ``ValidationError``), and the enum was built with a
+    ``type_designator_name`` kwarg that did not match the model field
+    ``type_designator_field`` (silently dropped, so the tag was never emitted).
+    """
+    schema_path = Path(temp_dir) / "rustgen_type_designator.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_file = Path(temp_dir) / "type_designator.rs"
+    gen = RustGenerator(
+        str(schema_path),
+        mode="file",
+        pyo3=False,
+        serde=True,
+        output=str(out_file),
+    )
+    # Generation itself must not raise (covers the dict[str, list[str]] crash).
+    gen.serialize(force=True)
+
+    contents = out_file.read_text(encoding="utf-8")
+
+    # The designator slot drives an internally tagged enum.
+    assert 'serde(tag = "category")' in contents
+    # And the fall-back untagged form is no longer used for the OrSubtype enum.
+    assert "serde(untagged)" not in contents
+    # Each subtype variant is renamed to the value carried by the designator.
+    assert 'serde(rename = "EmploymentEvent"' in contents
+    assert 'serde(rename = "MedicalEvent"' in contents
+
+
+def test_rustgen_type_designator_tagged_roundtrip(temp_dir):
+    """The tagged ``*OrSubtype`` enum discriminates variants by the designator
+    value and round-trips it through serde."""
+    schema_path = Path(temp_dir) / "rustgen_type_designator_rt.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_dir = _generate_rust_crate(str(schema_path), Path(temp_dir) / "type_designator_crate")
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "type_designator.rs").write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn tagged_discriminates_by_designator() {\n"
+            f"    use {crate_ident}::EventOrSubtype;\n"
+            '    let yaml = "category: MedicalEvent\\nname: x\\ndiagnosis: flu\\n";\n'
+            '    let value: EventOrSubtype = serde_yml::from_str(yaml).expect("decode tagged");\n'
+            "    match value {\n"
+            "        EventOrSubtype::MedicalEvent(_) => {}\n"
+            '        _ => panic!("expected MedicalEvent variant"),\n'
+            "    }\n"
+            '    let out = serde_yml::to_string(&value).expect("encode");\n'
+            '    assert!(out.contains("category: MedicalEvent"), "designator tag not round-tripped: {out}");\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "type_designator"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "cargo test failed, likely due to a missing Rust toolchain:\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )


### PR DESCRIPTION
## Summary

Builds on #3661 (included here as the first commit so this branch is
independently buildable/testable — happy to rebase down to just the
second commit once #3661 merges).

Once #3661 fixes tagged `OrSubtype` enum generation (`#[serde(tag = "...")]`
for classes with a `designates_type` slot), a further bug surfaces: the
type-designator slot is *also* emitted as a regular field on each
concrete variant struct (via `generate_class`'s `induced_attrs`, and
`gen_poly_trait`'s polymorphic trait accessor/impls).

Since the tag now lives at the enum level, a variant struct carrying the
same-named field collides with it. Serializing produces a JSON object
with a **literal duplicate key**:

```json
{"stereotype_kind":"Role","stereotype_kind":"Role","name":"..."}
```

which `serde_json` correctly rejects on deserialize (`"duplicate field"`).
This reliably reproduces for any `is_a` hierarchy of sibling subtypes
that differ only in the discriminant — exactly the shape a UFO-style
ontology stereotype taxonomy has (`Kind`/`SubKind`/`Role`/`Relator`/`Mode`,
all differing only by a type tag), which is how I found it: porting an
existing hand-written Rust enum of that shape to a LinkML schema.

## Fix

Exclude the type-designator slot from a class's own struct fields (and
from the polymorphic trait's accessor/impls) whenever that class is a
concrete descendant of some ancestor that generates a tagged
`OrSubtype` enum. The field stays on the *ancestor's own* struct — it's
only stripped from classes that appear as tagged variants of someone
else's enum, since only those actually collide with the enum-level tag.

Two call sites needed the same exclusion:
- `generate_class`'s `induced_attrs` (the struct's own serialized fields)
- `gen_poly_trait`'s `attribs` (the polymorphic trait property + impl
  generation, which otherwise emits `&self.<field>` for a field that
  no longer exists on the struct once the first fix is applied alone)

## Test plan

- [x] New `is_a` hierarchy with sibling subtypes sharing an attribute set
      generates, compiles, and round-trips correctly through
      `serde_json` (tagged, not duplicate-keyed)
- [x] Verified against this exact branch (cherry-picked on top of #3661's
      commit, rebased onto current `main`) — `cargo test` 4/4 passing,
      including a case that specifically exercises `Role`/`Mode` (variants
      that would previously deserialize as the wrong variant under
      `#[serde(untagged)]`, or fail to serialize at all once tagged with
      this bug present)
- [x] `linkml validate` on the reproduction schema: no issues

Happy to add a repo-native test fixture under `tests/linkml/test_generators/input/` if that's preferred over the ad-hoc schema I used locally — let me know the preferred location/format and I'll fold it in.