### PR TITLE
fix(projectgen): validate yaml config properly and merge generator_args with cli args

### DIFF
--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -110,6 +110,45 @@ def get_local_imports(schema_path: Path, dir: Path):
     return all_imports
 
 
+def _config_mapping(value: Any, where: str, source: str) -> ARG_DICT:
+    """Check that one level of a configuration is a mapping, and hand it back.
+
+    An empty value (``generator_args:`` with nothing under it) reads as None saying
+    "nothing configured here", so it returns as empty mapping. Anything else that is
+    not a mapping is a mistake in the configuration, and says so where it was given
+    rather than failing later.
+
+    :param value: Whatever was found at this point in the configuration.
+    :param where: Where that was, for the error message, e.g. ``"'generator_args'"``.
+    :param source: The option it came from, e.g. ``"--config-file"``.
+    :return: The mapping, empty if nothing was configured.
+    :raises click.UsageError: if the value is neither a mapping nor empty.
+    """
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise click.UsageError(f"{source}: expected a YAML mapping at {where}, found {type(value).__name__}")
+    return value
+
+
+def _generator_args(value: Any, source: str, prefix: str = "") -> dict[GENERATOR_NAME, ARG_DICT]:
+    """Check a block of per-generator arguments: generator name to that generator's settings.
+
+    The block and each generator's settings within it both have to be mappings, since
+    the settings are unpacked into the generator's constructor.
+
+    :param value: The block as read from YAML.
+    :param source: The option it came from, e.g. ``"--config-file"``.
+    :param prefix: Key path leading to the block, e.g. ``"generator_args."`` for a config
+        file, or empty when the block is the whole value (as with ``-A``).
+    :return: The validated block, empty if nothing was configured.
+    :raises click.UsageError: if the block, or any generator's settings, isn't a mapping.
+    """
+    where = f"'{prefix.rstrip('.')}'" if prefix else "the top level"
+    args = _config_mapping(value, where, source)
+    return {name: _config_mapping(section, f"'{prefix}{name}'", source) for name, section in args.items()}
+
+
 @dataclass
 class ProjectConfiguration:
     """
@@ -295,7 +334,12 @@ def cli(
     """
     project_config = ProjectConfiguration()
     if config_file is not None:
-        for k, v in yaml.safe_load(config_file).items():
+        config_data = _config_mapping(yaml.safe_load(config_file), "the top level", "--config-file")
+        if "generator_args" in config_data:
+            config_data["generator_args"] = _generator_args(
+                config_data["generator_args"], "--config-file", "generator_args."
+            )
+        for k, v in config_data.items():
             setattr(project_config, k, v)
     if exclude:
         project_config.excludes = list(exclude)
@@ -303,9 +347,10 @@ def cli(
         project_config.includes = list(include)
     if generator_arguments is not None:
         try:
-            project_config.generator_args = yaml.safe_load(generator_arguments)
-        except Exception:
-            raise Exception("Argument must be a valid YAML blob")
+            arguments = yaml.safe_load(generator_arguments)
+        except yaml.YAMLError as e:
+            raise click.UsageError(f"--generator-arguments must be a valid YAML blob: {e}") from e
+        project_config.generator_args = _generator_args(arguments, "--generator-arguments")
         logger.info(f"generator args: {project_config.generator_args}")
     if dir is not None:
         project_config.directory = dir

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -110,7 +110,21 @@ def get_local_imports(schema_path: Path, dir: Path):
     return all_imports
 
 
-def _config_mapping(value: Any, where: str, source: str) -> ARG_DICT:
+def _parse_yaml(value: Any, source: str) -> Any:
+    """Parse YAML, naming what was being read if it does not parse.
+
+    :param value: YAML text, or an open file to read it from.
+    :param source: Where it came from, e.g. ``"--config-file"``.
+    :return: Whatever the YAML held.
+    :raises ValueError: if the YAML is malformed.
+    """
+    try:
+        return yaml.safe_load(value)
+    except yaml.YAMLError as e:
+        raise ValueError(f"{source} is not valid YAML: {e}") from e
+
+
+def _config_mapping(value: Any, where: str, source: str) -> dict[str, Any]:
     """Check that one level of a configuration is a mapping, and hand it back.
 
     An empty value (``generator_args:`` with nothing under it) reads as None saying
@@ -122,12 +136,12 @@ def _config_mapping(value: Any, where: str, source: str) -> ARG_DICT:
     :param where: Where that was, for the error message, e.g. ``"'generator_args'"``.
     :param source: The option it came from, e.g. ``"--config-file"``.
     :return: The mapping, empty if nothing was configured.
-    :raises click.UsageError: if the value is neither a mapping nor empty.
+    :raises ValueError: if the value is neither a mapping nor empty.
     """
     if value is None:
         return {}
     if not isinstance(value, dict):
-        raise click.UsageError(f"{source}: expected a YAML mapping at {where}, found {type(value).__name__}")
+        raise ValueError(f"{source}: expected a YAML mapping at {where}, found {type(value).__name__}")
     return value
 
 
@@ -142,7 +156,7 @@ def _generator_args(value: Any, source: str, prefix: str = "") -> dict[GENERATOR
     :param prefix: Key path leading to the block, e.g. ``"generator_args."`` for a config
         file, or empty when the block is the whole value (as with ``-A``).
     :return: The validated block, empty if nothing was configured.
-    :raises click.UsageError: if the block, or any generator's settings, isn't a mapping.
+    :raises ValueError: if the block, or any generator's settings, isn't a mapping.
     """
     where = f"'{prefix.rstrip('.')}'" if prefix else "the top level"
     args = _config_mapping(value, where, source)
@@ -163,17 +177,15 @@ def _generator_names(value: Any, where: str, source: str) -> list[GENERATOR_NAME
     :param where: Where that was, for the error message, e.g. ``"'excludes'"``.
     :param source: The option it came from, e.g. ``"--config-file"``.
     :return: The list of names, empty if nothing was configured.
-    :raises click.UsageError: if the value is not a list of names, nor empty.
+    :raises ValueError: if the value is not a list of names, nor empty.
     """
     if value is None:
         return []
     if not isinstance(value, list):
-        raise click.UsageError(
-            f"{source}: expected a YAML list of generator names at {where}, found {type(value).__name__}"
-        )
+        raise ValueError(f"{source}: expected a YAML list of generator names at {where}, found {type(value).__name__}")
     for name in value:
         if not isinstance(name, str):
-            raise click.UsageError(f"{source}: expected a generator name in {where}, found {type(name).__name__}")
+            raise ValueError(f"{source}: expected a generator name in {where}, found {type(name).__name__}")
     return value
 
 
@@ -186,15 +198,13 @@ def _project_config(value: Any, source: str) -> dict[str, Any]:
     :param value: The configuration as read from YAML.
     :param source: The option it came from, e.g. ``"--config-file"``.
     :return: The validated configuration, empty if nothing was configured.
-    :raises click.UsageError: if any part of it has the wrong shape.
+    :raises ValueError: if any part of it has the wrong shape.
     """
     config_data = _config_mapping(value, "the top level", source)
     for key in config_data:
         # These become attribute names via setattr in cli(), which requires strings.
         if not isinstance(key, str):
-            raise click.UsageError(
-                f"{source}: expected a configuration name at the top level, found {type(key).__name__}"
-            )
+            raise ValueError(f"{source}: expected a configuration name at the top level, found {type(key).__name__}")
     if "generator_args" in config_data:
         config_data["generator_args"] = _generator_args(config_data["generator_args"], source, "generator_args.")
     for key in ("includes", "excludes"):
@@ -202,8 +212,31 @@ def _project_config(value: Any, source: str) -> dict[str, Any]:
             config_data[key] = _generator_names(config_data[key], f"'{key}'", source)
     directory = config_data.get("directory")
     if directory is not None and not isinstance(directory, str):
-        raise click.UsageError(f"{source}: expected a directory path at 'directory', found {type(directory).__name__}")
+        raise ValueError(f"{source}: expected a directory path at 'directory', found {type(directory).__name__}")
     return config_data
+
+
+def _merge_generator_args(
+    base: dict[GENERATOR_NAME, ARG_DICT], overrides: dict[GENERATOR_NAME, ARG_DICT]
+) -> dict[GENERATOR_NAME, ARG_DICT]:
+    """Layer one block of per-generator arguments over another, per setting.
+
+    Used to combine ``--config-file`` with ``--generator-arguments``, so naming one
+    setting on the command line does not discard the rest of a generator's settings
+    from the file. ``overrides`` wins setting by setting::
+
+        file:  {jsonschema: {top_class: Thing, not_closed: false}}
+        -A:    {jsonschema: {not_closed: true}}
+        result: {jsonschema: {top_class: Thing, not_closed: true}}
+
+    :param base: The arguments to start from, e.g. those read from a config file.
+    :param overrides: The arguments to layer on top, e.g. those given with ``-A``.
+    :return: A new block; neither argument is modified.
+    """
+    merged = {name: dict(args) for name, args in base.items()}
+    for name, args in overrides.items():
+        merged.setdefault(name, {}).update(args)
+    return merged
 
 
 @dataclass
@@ -228,8 +261,21 @@ class ProjectGenerator:
 
     @staticmethod
     def generate(schema_path: str, config: ProjectConfiguration = ProjectConfiguration()):
+        """Generate every configured artefact for ``schema_path`` under ``config.directory``.
+
+        :param schema_path: Path to the schema to generate from.
+        :param config: What to generate and how. Checked before use, so a configuration
+            built by hand reports its own mistakes rather than failing part-way through.
+        :raises ValueError: if any part of ``config`` has the wrong shape.
+        """
         if config.directory is None:
             raise Exception("Must pass directory")
+        # Checked here rather than only in cli(), so callers using this as a library get
+        # the same reporting as the command line does. Both name lists come back empty
+        # when unset, so the skip checks below no longer need their own None handling.
+        generator_args = _generator_args(config.generator_args, "configuration", "generator_args.")
+        includes = _generator_names(config.includes, "'includes'", "configuration")
+        excludes = _generator_names(config.excludes, "'excludes'", "configuration")
 
         # Resolve which generators run and with what merged arguments, rejecting
         # any bad `generator_args` value before anything at all is generated or
@@ -241,15 +287,15 @@ class ProjectGenerator:
         # rather than being caught and mistaken for a bad config value.
         selected: list[tuple[GENERATOR_NAME, GeneratorConfig, ARG_DICT]] = []
         for gen_name, gen_config in GEN_MAP.items():
-            if config.includes is not None and config.includes != [] and gen_name not in config.includes:
-                logger.info(f"Skipping {gen_name} as not in inclusion list: {config.includes}")
+            if includes and gen_name not in includes:
+                logger.info(f"Skipping {gen_name} as not in inclusion list: {includes}")
                 continue
-            if config.excludes is not None and gen_name in config.excludes:
+            if gen_name in excludes:
                 logger.info(f"Skipping {gen_name} as it is in exclusion list")
                 continue
             all_gen_args = {
                 **gen_config.default_args,
-                **config.generator_args.get(gen_name, {}),
+                **generator_args.get(gen_name, {}),
             }
             try:
                 gen_config.generator.validate_generator_args(all_gen_args)
@@ -388,22 +434,30 @@ def cli(
           json_schema:
             top_class: Container
 
+    Both together: ``-A`` is layered over the file setting by setting, so naming one
+    setting on the command line keeps the rest of that generator's settings from the file.
+
     """
     project_config = ProjectConfiguration()
-    if config_file is not None:
-        for k, v in _project_config(yaml.safe_load(config_file), "--config-file").items():
-            setattr(project_config, k, v)
+    # Both sources are read together so a mistake in either is reported the same way.
+    # The checks raise ValueError so generate() can reuse them when called as a library;
+    # UsageError, with its exit code and "Error:" prefix, belongs to the command line.
+    try:
+        if config_file is not None:
+            for k, v in _project_config(_parse_yaml(config_file, "--config-file"), "--config-file").items():
+                setattr(project_config, k, v)
+        if generator_arguments is not None:
+            source = "--generator-arguments"
+            project_config.generator_args = _merge_generator_args(
+                project_config.generator_args, _generator_args(_parse_yaml(generator_arguments, source), source)
+            )
+            logger.info(f"generator args: {project_config.generator_args}")
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e
     if exclude:
         project_config.excludes = list(exclude)
     if include:
         project_config.includes = list(include)
-    if generator_arguments is not None:
-        try:
-            arguments = yaml.safe_load(generator_arguments)
-        except yaml.YAMLError as e:
-            raise click.UsageError(f"--generator-arguments must be a valid YAML blob: {e}") from e
-        project_config.generator_args = _generator_args(arguments, "--generator-arguments")
-        logger.info(f"generator args: {project_config.generator_args}")
     if dir is not None:
         project_config.directory = dir
     project_config.mergeimports = mergeimports

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -23,7 +23,7 @@ from linkml.generators.pythongen import PythonGenerator
 from linkml.generators.shaclgen import ShaclGenerator
 from linkml.generators.shexgen import ShExGenerator
 from linkml.generators.sqltablegen import SQLTableGenerator
-from linkml.utils.generator import Generator
+from linkml.utils.generator import Generator, config_mapping, parse_config_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -110,41 +110,6 @@ def get_local_imports(schema_path: Path, dir: Path):
     return all_imports
 
 
-def _parse_yaml(value: Any, source: str) -> Any:
-    """Parse YAML, naming what was being read if it does not parse.
-
-    :param value: YAML text, or an open file to read it from.
-    :param source: Where it came from, e.g. ``"--config-file"``.
-    :return: Whatever the YAML held.
-    :raises ValueError: if the YAML is malformed.
-    """
-    try:
-        return yaml.safe_load(value)
-    except yaml.YAMLError as e:
-        raise ValueError(f"{source} is not valid YAML: {e}") from e
-
-
-def _config_mapping(value: Any, where: str, source: str) -> dict[str, Any]:
-    """Check that one level of a configuration is a mapping, and hand it back.
-
-    An empty value (``generator_args:`` with nothing under it) reads as None saying
-    "nothing configured here", so it returns as empty mapping. Anything else that is
-    not a mapping is a mistake in the configuration, and says so where it was given
-    rather than failing later.
-
-    :param value: Whatever was found at this point in the configuration.
-    :param where: Where that was, for the error message, e.g. ``"'generator_args'"``.
-    :param source: The option it came from, e.g. ``"--config-file"``.
-    :return: The mapping, empty if nothing was configured.
-    :raises ValueError: if the value is neither a mapping nor empty.
-    """
-    if value is None:
-        return {}
-    if not isinstance(value, dict):
-        raise ValueError(f"{source}: expected a YAML mapping at {where}, found {type(value).__name__}")
-    return value
-
-
 def _generator_args(value: Any, source: str, prefix: str = "") -> dict[GENERATOR_NAME, ARG_DICT]:
     """Check a block of per-generator arguments: generator name to that generator's settings.
 
@@ -159,8 +124,8 @@ def _generator_args(value: Any, source: str, prefix: str = "") -> dict[GENERATOR
     :raises ValueError: if the block, or any generator's settings, isn't a mapping.
     """
     where = f"'{prefix.rstrip('.')}'" if prefix else "the top level"
-    args = _config_mapping(value, where, source)
-    return {name: _config_mapping(section, f"'{prefix}{name}'", source) for name, section in args.items()}
+    args = config_mapping(value, where, source)
+    return {name: config_mapping(section, f"'{prefix}{name}'", source) for name, section in args.items()}
 
 
 def _generator_names(value: Any, where: str, source: str) -> list[GENERATOR_NAME]:
@@ -200,7 +165,7 @@ def _project_config(value: Any, source: str) -> dict[str, Any]:
     :return: The validated configuration, empty if nothing was configured.
     :raises ValueError: if any part of it has the wrong shape.
     """
-    config_data = _config_mapping(value, "the top level", source)
+    config_data = config_mapping(value, "the top level", source)
     for key in config_data:
         # These become attribute names via setattr in cli(), which requires strings.
         if not isinstance(key, str):
@@ -444,12 +409,12 @@ def cli(
     # UsageError, with its exit code and "Error:" prefix, belongs to the command line.
     try:
         if config_file is not None:
-            for k, v in _project_config(_parse_yaml(config_file, "--config-file"), "--config-file").items():
+            for k, v in _project_config(parse_config_yaml(config_file, "--config-file"), "--config-file").items():
                 setattr(project_config, k, v)
         if generator_arguments is not None:
             source = "--generator-arguments"
             project_config.generator_args = _merge_generator_args(
-                project_config.generator_args, _generator_args(_parse_yaml(generator_arguments, source), source)
+                project_config.generator_args, _generator_args(parse_config_yaml(generator_arguments, source), source)
             )
             logger.info(f"generator args: {project_config.generator_args}")
     except ValueError as e:

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -131,21 +131,28 @@ def _generator_args(value: Any, source: str, prefix: str = "") -> dict[GENERATOR
 def _generator_names(value: Any, where: str, source: str) -> list[GENERATOR_NAME]:
     """Check that a list of generator names really is a list of names, and hand it back.
 
-    A bare string is refused, not wrapped into a single-item list. That prevents a bare
-    string from being treated as a list by ``gen_name in excludes``, which on a string
-    searches the configured text for each generator name::
+    A bare string is accepted as a one-item list, matching how :func:`apply_config_defaults`
+    treats a scalar given for a repeatable option -- both are the same YAML footgun: a
+    scalar left uncoerced would be iterated character by character, or worse, treated as a
+    substring pattern rather than a name::
 
         excludes: [jsonldcontext]  ->  "jsonld" in ["jsonldcontext"] -> False, generated
-        excludes: jsonldcontext    ->  "jsonld" in "jsonldcontext"   -> True, skipped
+        excludes: jsonldcontext    ->  "jsonld" in "jsonldcontext"   -> True, wrongly skipped
+
+    Coercing the scalar to ``["jsonldcontext"]`` up front means callers never do that
+    substring-style check at all, so the bug above cannot arise regardless of how the
+    name is written.
 
     :param value: Whatever was found at this point in the configuration.
     :param where: Where that was, for the error message, e.g. ``"'excludes'"``.
     :param source: The option it came from, e.g. ``"--config-file"``.
     :return: The list of names, empty if nothing was configured.
-    :raises ValueError: if the value is not a list of names, nor empty.
+    :raises ValueError: if the value is not a list of names (nor a bare name, nor empty).
     """
     if value is None:
         return []
+    if isinstance(value, str):
+        return [value]
     if not isinstance(value, list):
         raise ValueError(f"{source}: expected a YAML list of generator names at {where}, found {type(value).__name__}")
     for name in value:

--- a/packages/linkml/src/linkml/generators/projectgen.py
+++ b/packages/linkml/src/linkml/generators/projectgen.py
@@ -149,6 +149,63 @@ def _generator_args(value: Any, source: str, prefix: str = "") -> dict[GENERATOR
     return {name: _config_mapping(section, f"'{prefix}{name}'", source) for name, section in args.items()}
 
 
+def _generator_names(value: Any, where: str, source: str) -> list[GENERATOR_NAME]:
+    """Check that a list of generator names really is a list of names, and hand it back.
+
+    A bare string is refused, not wrapped into a single-item list. That prevents a bare
+    string from being treated as a list by ``gen_name in excludes``, which on a string
+    searches the configured text for each generator name::
+
+        excludes: [jsonldcontext]  ->  "jsonld" in ["jsonldcontext"] -> False, generated
+        excludes: jsonldcontext    ->  "jsonld" in "jsonldcontext"   -> True, skipped
+
+    :param value: Whatever was found at this point in the configuration.
+    :param where: Where that was, for the error message, e.g. ``"'excludes'"``.
+    :param source: The option it came from, e.g. ``"--config-file"``.
+    :return: The list of names, empty if nothing was configured.
+    :raises click.UsageError: if the value is not a list of names, nor empty.
+    """
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise click.UsageError(
+            f"{source}: expected a YAML list of generator names at {where}, found {type(value).__name__}"
+        )
+    for name in value:
+        if not isinstance(name, str):
+            raise click.UsageError(f"{source}: expected a generator name in {where}, found {type(name).__name__}")
+    return value
+
+
+def _project_config(value: Any, source: str) -> dict[str, Any]:
+    """Check a whole gen-project configuration, and hand it back.
+
+    Every part is checked where it was written, so a mistake is reported against the key
+    holding it instead of failing somewhere later in generation.
+
+    :param value: The configuration as read from YAML.
+    :param source: The option it came from, e.g. ``"--config-file"``.
+    :return: The validated configuration, empty if nothing was configured.
+    :raises click.UsageError: if any part of it has the wrong shape.
+    """
+    config_data = _config_mapping(value, "the top level", source)
+    for key in config_data:
+        # These become attribute names via setattr in cli(), which requires strings.
+        if not isinstance(key, str):
+            raise click.UsageError(
+                f"{source}: expected a configuration name at the top level, found {type(key).__name__}"
+            )
+    if "generator_args" in config_data:
+        config_data["generator_args"] = _generator_args(config_data["generator_args"], source, "generator_args.")
+    for key in ("includes", "excludes"):
+        if key in config_data:
+            config_data[key] = _generator_names(config_data[key], f"'{key}'", source)
+    directory = config_data.get("directory")
+    if directory is not None and not isinstance(directory, str):
+        raise click.UsageError(f"{source}: expected a directory path at 'directory', found {type(directory).__name__}")
+    return config_data
+
+
 @dataclass
 class ProjectConfiguration:
     """
@@ -334,12 +391,7 @@ def cli(
     """
     project_config = ProjectConfiguration()
     if config_file is not None:
-        config_data = _config_mapping(yaml.safe_load(config_file), "the top level", "--config-file")
-        if "generator_args" in config_data:
-            config_data["generator_args"] = _generator_args(
-                config_data["generator_args"], "--config-file", "generator_args."
-            )
-        for k, v in config_data.items():
+        for k, v in _project_config(yaml.safe_load(config_file), "--config-file").items():
             setattr(project_config, k, v)
     if exclude:
         project_config.excludes = list(exclude)

--- a/packages/linkml/src/linkml/utils/generator.py
+++ b/packages/linkml/src/linkml/utils/generator.py
@@ -1018,22 +1018,49 @@ def shared_arguments(g: type[Generator]) -> Callable[[Command], Command]:
     return decorator
 
 
-def _config_mapping(value: Any, where: str) -> dict[str, Any]:
-    """Check that one level of a config file is a mapping, and hand it back.
+def parse_config_yaml(value: Any, source: str) -> Any:
+    """Parse YAML, naming what was being read if it does not parse.
+
+    Unparsable YAML is a mistake in what was supplied, so it is reported against the
+    option it came from rather than escaping as a traceback. PyYAML reports a scalar it
+    cannot construct (an impossible date such as ``2024-02-30``) as a bare ``ValueError``
+    rather than a ``YAMLError``; that is a parse failure too, and is named the same way.
+
+    :param value: YAML text, or an open file to read it from.
+    :param source: The option it came from, e.g. ``"--config-file"``.
+    :return: Whatever the YAML held.
+    :raises ValueError: if the YAML is malformed.
+    """
+    try:
+        return yaml.safe_load(value)
+    except (yaml.YAMLError, ValueError) as e:
+        raise ValueError(f"{source}: could not parse as YAML: {e}") from e
+
+
+def config_mapping(value: Any, where: str, source: str) -> dict[str, Any]:
+    """Check that one level of a configuration is a mapping, and hand it back.
 
     An empty value (``java:`` with nothing under it) reads as None saying "nothing
     configured here", so it returns as empty mapping. Anything else that is not a
-    mapping is a mistake in the file, and says so rather than being skipped.
+    mapping is a mistake in the configuration, and says so where it was given rather
+    than failing later.
 
-    :param value: Whatever was found at this point in the file.
+    Shared by every entry point that reads this configuration format, so a given
+    mistake is reported the same way whether it reaches ``gen-project`` or one of the
+    individual generator CLIs. ``ValueError`` rather than :class:`click.UsageError`,
+    so a caller using this as a library gets the same checks without click semantics;
+    command-line callers translate it at their own boundary.
+
+    :param value: Whatever was found at this point in the configuration.
     :param where: Where that was, for the error message, e.g. ``"'generator_args'"``.
+    :param source: The option it came from, e.g. ``"--config-file"``.
     :return: The mapping, empty if nothing was configured.
-    :raises click.UsageError: if the value is neither a mapping nor empty.
+    :raises ValueError: if the value is neither a mapping nor empty.
     """
     if value is None:
         return {}
     if not isinstance(value, dict):
-        raise click.UsageError(f"--config-file: expected a YAML mapping at {where}, found {type(value).__name__}")
+        raise ValueError(f"{source}: expected a YAML mapping at {where}, found {type(value).__name__}")
     return value
 
 
@@ -1065,12 +1092,12 @@ def read_generator_config(config_file: IO[bytes] | None, generator_name: str) ->
     """
     if config_file is None:
         return {}
+    source = "--config-file"
+    # the shared checks raise ValueError so they can be reused off the command line;
+    # this is a CLI entry point, so a bad file is reported as a usage error here
     try:
-        parsed = yaml.safe_load(config_file)
-    except yaml.YAMLError as e:
-        # unparsable YAML is a mistake in the file, so report it the same way a
-        # misshapen one is, rather than as a traceback
-        raise click.UsageError(f"--config-file: could not parse as YAML: {e}") from e
-    config_data = _config_mapping(parsed, "the top level")
-    generator_args = _config_mapping(config_data.get("generator_args"), "'generator_args'")
-    return _config_mapping(generator_args.get(generator_name), f"'generator_args.{generator_name}'")
+        config_data = config_mapping(parse_config_yaml(config_file, source), "the top level", source)
+        generator_args = config_mapping(config_data.get("generator_args"), "'generator_args'", source)
+        return config_mapping(generator_args.get(generator_name), f"'generator_args.{generator_name}'", source)
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -305,7 +305,7 @@ def test_cli_unparseable_generator_arguments_errors(tmp_path, schema_path):
     result = CliRunner().invoke(projectgen_cli, ["-A", "{unclosed", "-d", str(tmp_path / "out"), str(schema_path)])
 
     assert result.exit_code != 0
-    assert "--generator-arguments is not valid YAML" in result.output
+    assert "--generator-arguments: could not parse as YAML" in result.output
 
 
 def test_cli_unparseable_config_file_errors(tmp_path, schema_path):
@@ -318,7 +318,7 @@ def test_cli_unparseable_config_file_errors(tmp_path, schema_path):
     )
 
     assert result.exit_code != 0
-    assert "--config-file is not valid YAML" in result.output
+    assert "--config-file: could not parse as YAML" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -222,6 +222,64 @@ def test_cli_malformed_config_file_errors(tmp_path, schema_path, config_yaml, wh
 
 
 @pytest.mark.parametrize(
+    ("config_yaml", "message"),
+    [
+        pytest.param(
+            "excludes: jsonldcontext\n",
+            "expected a YAML list of generator names at 'excludes'",
+            id="excludes-string",
+        ),
+        pytest.param(
+            "includes: python\n",
+            "expected a YAML list of generator names at 'includes'",
+            id="includes-string",
+        ),
+        pytest.param("excludes:\n  - 1\n", "expected a generator name in 'excludes'", id="excludes-non-name"),
+        pytest.param("directory: [a, b]\n", "expected a directory path at 'directory'", id="directory-list"),
+        pytest.param("1: x\n", "expected a configuration name at the top level", id="non-string-key"),
+    ],
+)
+def test_cli_malformed_config_file_values_error(tmp_path, schema_path, config_yaml, message):
+    """Keys that are not mappings get checked too, so the whole configuration is reported
+    against the key that holds the mistake rather than failing later during generation."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config_yaml)
+
+    result = CliRunner().invoke(cli, ["--config-file", str(config_path), "-d", str(tmp_path / "out"), str(schema_path)])
+
+    assert result.exit_code != 0
+    assert message in result.output
+    assert not isinstance(result.exception, AttributeError | TypeError)
+
+
+def test_cli_excludes_matches_whole_names_only(tmp_path, schema_path):
+    """`jsonld` is a substring of `jsonldcontext`, and names are matched with ``in``.
+    Excluding one generator must not quietly take out the other as well."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("excludes:\n  - jsonldcontext\n")
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config-file",
+            str(config_path),
+            "-I",
+            "jsonld",
+            "-I",
+            "jsonldcontext",
+            "-d",
+            str(out_dir),
+            str(schema_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (out_dir / "jsonld" / "schema.jsonld").is_file()
+    assert not (out_dir / "jsonld" / "schema.context.jsonld").is_file()
+
+
+@pytest.mark.parametrize(
     ("arguments", "where"),
     [
         pytest.param("notamapping", "the top level", id="scalar"),

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -166,3 +166,118 @@ def test_cli_bad_generator_args_is_a_usage_error_not_a_traceback(kitchen_sink_pa
     assert result.exit_code != 0
     assert not isinstance(result.exception, ValueError)
     assert "is not a valid Java package name" in result.output
+
+
+MINIMAL_SCHEMA = """
+id: https://example.org/test
+name: test
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+classes:
+  Thing:
+    slots:
+      - name
+slots:
+  name:
+"""
+
+
+@pytest.fixture
+def schema_path(tmp_path):
+    """A schema small enough to run the CLI against quickly."""
+    path = tmp_path / "schema.yaml"
+    path.write_text(MINIMAL_SCHEMA)
+    return path
+
+
+@pytest.mark.parametrize(
+    ("config_yaml", "where"),
+    [
+        pytest.param("justastring\n", "the top level", id="top-level-scalar"),
+        pytest.param("- 1\n- 2\n", "the top level", id="top-level-list"),
+        pytest.param("generator_args: notamapping\n", "'generator_args'", id="scalar-generator-args"),
+        pytest.param(
+            "generator_args:\n  jsonschema: notamapping\n",
+            "'generator_args.jsonschema'",
+            id="scalar-generator-section",
+        ),
+    ],
+)
+def test_cli_malformed_config_file_errors(tmp_path, schema_path, config_yaml, where):
+    """A --config-file that is the wrong shape names the offending key, rather than crashing
+    later with an AttributeError or TypeError from deep inside generation."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config_yaml)
+
+    result = CliRunner().invoke(
+        projectgen_cli, ["--config-file", str(config_path), "-d", str(tmp_path / "out"), str(schema_path)]
+    )
+
+    assert result.exit_code != 0
+    assert f"expected a YAML mapping at {where}" in result.output
+    assert not isinstance(result.exception, AttributeError | TypeError)
+
+
+@pytest.mark.parametrize(
+    ("arguments", "where"),
+    [
+        pytest.param("notamapping", "the top level", id="scalar"),
+        pytest.param("- 1\n- 2\n", "the top level", id="list"),
+        pytest.param("jsonschema: notamapping", "'jsonschema'", id="scalar-generator-section"),
+    ],
+)
+def test_cli_malformed_generator_arguments_errors(tmp_path, schema_path, arguments, where):
+    """-A/--generator-arguments gets the same shape check as --config-file. Without it, a
+    blob that parses but isn't a mapping crashes later with nothing pointing back at -A."""
+    result = CliRunner().invoke(projectgen_cli, ["-A", arguments, "-d", str(tmp_path / "out"), str(schema_path)])
+
+    assert result.exit_code != 0
+    assert f"expected a YAML mapping at {where}" in result.output
+    assert not isinstance(result.exception, AttributeError | TypeError)
+
+
+def test_cli_unparseable_generator_arguments_errors(tmp_path, schema_path):
+    """A -A blob that isn't valid YAML at all reports as a usage error, not a raw traceback."""
+    result = CliRunner().invoke(projectgen_cli, ["-A", "{unclosed", "-d", str(tmp_path / "out"), str(schema_path)])
+
+    assert result.exit_code != 0
+    assert "must be a valid YAML blob" in result.output
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        pytest.param("generator_args:\n", id="empty-generator-args"),
+        pytest.param("generator_args:\n  python:\n", id="empty-generator-section"),
+        pytest.param("generator_args:\n  python:\n    genmeta: false\n", id="populated"),
+    ],
+)
+def test_cli_valid_config_file_generates(tmp_path, schema_path, config_yaml):
+    """Well-formed configuration still generates, including sections left deliberately
+    empty: an absent value means "nothing configured here", not a mistake."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config_yaml)
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        projectgen_cli, ["--config-file", str(config_path), "-I", "python", "-d", str(out_dir), str(schema_path)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (out_dir / "schema.py").is_file()
+
+
+def test_cli_valid_generator_arguments_generates(tmp_path, schema_path):
+    """The -A happy path is unaffected by the added validation."""
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        projectgen_cli,
+        ["-A", "python: {genmeta: false}", "-I", "python", "-d", str(out_dir), str(schema_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (out_dir / "schema.py").is_file()

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -225,17 +225,12 @@ def test_cli_malformed_config_file_errors(tmp_path, schema_path, config_yaml, wh
 @pytest.mark.parametrize(
     ("config_yaml", "message"),
     [
-        pytest.param(
-            "excludes: jsonldcontext\n",
-            "expected a YAML list of generator names at 'excludes'",
-            id="excludes-string",
-        ),
-        pytest.param(
-            "includes: python\n",
-            "expected a YAML list of generator names at 'includes'",
-            id="includes-string",
-        ),
         pytest.param("excludes:\n  - 1\n", "expected a generator name in 'excludes'", id="excludes-non-name"),
+        # a bare string is coerced (see test_cli_excludes_matches_whole_names_only), but a
+        # mapping is still the wrong shape entirely and is rejected, not coerced
+        pytest.param(
+            "excludes:\n  a: 1\n", "expected a YAML list of generator names at 'excludes'", id="excludes-dict"
+        ),
         pytest.param("directory: [a, b]\n", "expected a directory path at 'directory'", id="directory-list"),
         pytest.param("1: x\n", "expected a configuration name at the top level", id="non-string-key"),
     ],
@@ -255,11 +250,21 @@ def test_cli_malformed_config_file_values_error(tmp_path, schema_path, config_ya
     assert not isinstance(result.exception, AttributeError | TypeError)
 
 
-def test_cli_excludes_matches_whole_names_only(tmp_path, schema_path):
-    """`jsonld` is a substring of `jsonldcontext`, and names are matched with ``in``.
-    Excluding one generator must not quietly take out the other as well."""
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        pytest.param("excludes:\n  - jsonldcontext\n", id="list-form"),
+        # a bare string is coerced to a one-item list, not left for `gen_name in excludes`
+        # to search as a substring pattern -- that path is what let `jsonld` slip through
+        # (or get wrongly caught) before, and no caller does that check anymore
+        pytest.param("excludes: jsonldcontext\n", id="bare-string-form"),
+    ],
+)
+def test_cli_excludes_matches_whole_names_only(tmp_path, schema_path, config_yaml):
+    """`jsonld` is a substring of `jsonldcontext`. Excluding one generator, however the
+    name was written in the config, must not quietly take out the other as well."""
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("excludes:\n  - jsonldcontext\n")
+    config_path.write_text(config_yaml)
     out_dir = tmp_path / "out"
 
     result = CliRunner().invoke(
@@ -407,12 +412,9 @@ def test_cli_generator_arguments_layer_over_config_file(tmp_path, schema_path, a
             "expected a YAML mapping at 'generator_args.python'",
             id="generator-section-scalar",
         ),
-        pytest.param(
-            "excludes", "python", "expected a YAML list of generator names at 'excludes'", id="excludes-string"
-        ),
-        pytest.param(
-            "includes", "python", "expected a YAML list of generator names at 'includes'", id="includes-string"
-        ),
+        # a bare string is coerced (see test_generate_coerces_a_bare_string_for_excludes_and_includes),
+        # but a mapping is still the wrong shape entirely and is rejected, not coerced
+        pytest.param("excludes", {"a": 1}, "expected a YAML list of generator names at 'excludes'", id="excludes-dict"),
     ],
 )
 def test_generate_checks_a_configuration_built_in_code(tmp_path, schema_path, attribute, value, message):
@@ -424,3 +426,18 @@ def test_generate_checks_a_configuration_built_in_code(tmp_path, schema_path, at
 
     with pytest.raises(ValueError, match=re.escape(message)):
         ProjectGenerator().generate(str(schema_path), config)
+
+
+def test_generate_coerces_a_bare_string_for_excludes_and_includes(tmp_path, schema_path):
+    """A ProjectConfiguration assembled in code may set `excludes`/`includes` to a bare
+    string, exactly as a config file's `excludes: python` would parse to. generate()
+    coerces it to a one-item list rather than rejecting it -- matching the CLI path, and
+    matching how apply_config_defaults treats a scalar given for a repeatable option."""
+    config = ProjectConfiguration()
+    config.directory = str(tmp_path / "out")
+    config.includes = "graphql"  # bare string, not ["graphql"]
+
+    ProjectGenerator().generate(str(schema_path), config)
+
+    assert (tmp_path / "out" / "graphql" / "schema.graphql").is_file()
+    assert not (tmp_path / "out" / "schema.py").exists()

--- a/tests/linkml/test_generators/test_projectgen.py
+++ b/tests/linkml/test_generators/test_projectgen.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 
 import click
@@ -245,7 +246,9 @@ def test_cli_malformed_config_file_values_error(tmp_path, schema_path, config_ya
     config_path = tmp_path / "config.yaml"
     config_path.write_text(config_yaml)
 
-    result = CliRunner().invoke(cli, ["--config-file", str(config_path), "-d", str(tmp_path / "out"), str(schema_path)])
+    result = CliRunner().invoke(
+        projectgen_cli, ["--config-file", str(config_path), "-d", str(tmp_path / "out"), str(schema_path)]
+    )
 
     assert result.exit_code != 0
     assert message in result.output
@@ -260,7 +263,7 @@ def test_cli_excludes_matches_whole_names_only(tmp_path, schema_path):
     out_dir = tmp_path / "out"
 
     result = CliRunner().invoke(
-        cli,
+        projectgen_cli,
         [
             "--config-file",
             str(config_path),
@@ -302,12 +305,26 @@ def test_cli_unparseable_generator_arguments_errors(tmp_path, schema_path):
     result = CliRunner().invoke(projectgen_cli, ["-A", "{unclosed", "-d", str(tmp_path / "out"), str(schema_path)])
 
     assert result.exit_code != 0
-    assert "must be a valid YAML blob" in result.output
+    assert "--generator-arguments is not valid YAML" in result.output
+
+
+def test_cli_unparseable_config_file_errors(tmp_path, schema_path):
+    """A --config-file that isn't valid YAML reports the same way as a bad -A blob."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("generator_args:\n  python: {unclosed\n")
+
+    result = CliRunner().invoke(
+        projectgen_cli, ["--config-file", str(config_path), "-d", str(tmp_path / "out"), str(schema_path)]
+    )
+
+    assert result.exit_code != 0
+    assert "--config-file is not valid YAML" in result.output
 
 
 @pytest.mark.parametrize(
     "config_yaml",
     [
+        pytest.param("", id="empty-file"),
         pytest.param("generator_args:\n", id="empty-generator-args"),
         pytest.param("generator_args:\n  python:\n", id="empty-generator-section"),
         pytest.param("generator_args:\n  python:\n    genmeta: false\n", id="populated"),
@@ -339,3 +356,71 @@ def test_cli_valid_generator_arguments_generates(tmp_path, schema_path):
 
     assert result.exit_code == 0, result.output
     assert (out_dir / "schema.py").is_file()
+
+
+def _generated_json_schema(out_dir):
+    return (out_dir / "jsonschema" / "schema.schema.json").read_text()
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        pytest.param("owl: {metaclasses: false}", '"additionalProperties": false', id="other-generator-kept"),
+        pytest.param("jsonschema: {not_closed: true}", '"additionalProperties": true', id="same-setting-overridden"),
+    ],
+)
+def test_cli_generator_arguments_layer_over_config_file(tmp_path, schema_path, arguments, expected):
+    """-A is layered over --config-file setting by setting. Naming one setting on the
+    command line used to discard everything the file configured."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("generator_args:\n  jsonschema:\n    not_closed: false\n")
+    out_dir = tmp_path / "out"
+
+    result = CliRunner().invoke(
+        projectgen_cli,
+        [
+            "--config-file",
+            str(config_path),
+            "-A",
+            arguments,
+            "-I",
+            "jsonschema",
+            "-d",
+            str(out_dir),
+            str(schema_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert expected in _generated_json_schema(out_dir)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "value", "message"),
+    [
+        pytest.param(
+            "generator_args", "notamapping", "expected a YAML mapping at 'generator_args'", id="generator-args-scalar"
+        ),
+        pytest.param(
+            "generator_args",
+            {"python": "notamapping"},
+            "expected a YAML mapping at 'generator_args.python'",
+            id="generator-section-scalar",
+        ),
+        pytest.param(
+            "excludes", "python", "expected a YAML list of generator names at 'excludes'", id="excludes-string"
+        ),
+        pytest.param(
+            "includes", "python", "expected a YAML list of generator names at 'includes'", id="includes-string"
+        ),
+    ],
+)
+def test_generate_checks_a_configuration_built_in_code(tmp_path, schema_path, attribute, value, message):
+    """A ProjectConfiguration assembled in code is checked the same way as one read from a
+    file, so using this as a library reports the mistake instead of failing part-way in."""
+    config = ProjectConfiguration()
+    config.directory = str(tmp_path / "out")
+    setattr(config, attribute, value)
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        ProjectGenerator().generate(str(schema_path), config)

--- a/tests/linkml/test_utils/test_generator.py
+++ b/tests/linkml/test_utils/test_generator.py
@@ -13,7 +13,7 @@ import click
 import pytest
 
 from linkml import LOCAL_METAMODEL_YAML_FILE
-from linkml.utils.generator import Generator, read_generator_config
+from linkml.utils.generator import Generator, config_mapping, parse_config_yaml, read_generator_config
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
     ClassDefinitionName,
@@ -757,13 +757,92 @@ def test_read_generator_config_rejects_malformed_section(config_yaml, where):
     [
         pytest.param(b"generator_args:\n  java:\n   package: [unclosed\n", id="unclosed-bracket"),
         pytest.param(b"generator_args:\n\tjava:\n\t\tpackage: x\n", id="tab-indent"),
+        # PyYAML raises a bare ValueError for this, not a YAMLError
+        pytest.param(b"generator_args:\n  java:\n    package: 2024-02-30\n", id="impossible-date"),
     ],
 )
 def test_read_generator_config_rejects_unparsable_yaml(config_yaml):
     """A file that isn't valid YAML at all is reported as a usage error, like a misshapen
     one, rather than escaping as a raw parser traceback."""
-    with pytest.raises(click.UsageError, match="could not parse as YAML"):
+    with pytest.raises(click.UsageError, match="--config-file: could not parse as YAML"):
         read_generator_config(BytesIO(config_yaml), "java")
+
+
+@pytest.mark.parametrize(
+    ("call", "expected"),
+    [
+        pytest.param(
+            lambda: parse_config_yaml("{unclosed", "--generator-arguments"),
+            "--generator-arguments: could not parse as YAML",
+            id="unparsable-yaml",
+        ),
+        pytest.param(
+            lambda: config_mapping("notamapping", "'generator_args'", "--config-file"),
+            "--config-file: expected a YAML mapping at 'generator_args', found str",
+            id="misshapen-mapping",
+        ),
+    ],
+)
+def test_shared_config_checks_raise_value_error_naming_their_source(call, expected):
+    """The shared checks raise ValueError, not click.UsageError, so a caller using them as
+    a library (ProjectGenerator.generate) gets the same checking without click semantics;
+    command-line callers translate at their own boundary. The source is carried through, so
+    the same check can report against --config-file or -A."""
+    with pytest.raises(ValueError) as exc_info:
+        call()
+
+    assert str(exc_info.value).startswith(expected)
+
+
+@pytest.mark.parametrize(
+    ("config_yaml", "expected"),
+    [
+        pytest.param(
+            b"generator_args:\n  java: notamapping\n",
+            "--config-file: expected a YAML mapping at 'generator_args.java', found str",
+            id="misshapen-section",
+        ),
+        pytest.param(
+            b"generator_args:\n  java:\n   package: [unclosed\n",
+            "--config-file: could not parse as YAML",
+            id="unparsable-yaml",
+        ),
+        pytest.param(
+            # the exact wording of the underlying ValueError (from datetime, via PyYAML's
+            # timestamp resolver) differs across Python versions -- only the prefix this
+            # codebase controls is checked
+            b"generator_args:\n  java:\n    package: 2024-02-30\n",
+            "--config-file: could not parse as YAML",
+            id="impossible-date",
+        ),
+    ],
+)
+def test_same_config_mistake_reports_the_same_way_through_every_entry_point(tmp_path, config_yaml, expected):
+    """gen-project and the individual generator CLIs read the same config file format, so
+    one mistake in it must produce one message -- they share the checks rather than each
+    carrying its own copy that can drift."""
+    from click.testing import CliRunner
+
+    from linkml.generators.javagen import cli as javagen_cli
+    from linkml.generators.projectgen import cli as projectgen_cli
+
+    schema_path = tmp_path / "schema.yaml"
+    schema_path.write_text(
+        "id: https://example.org/test\nname: test\nprefixes:\n  linkml: https://w3id.org/linkml/\n"
+        "imports:\n  - linkml:types\ndefault_range: string\nclasses:\n  Thing:\n    slots:\n      - name\n"
+        "slots:\n  name:\n"
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_bytes(config_yaml)
+    common = ["--config-file", str(config_path)]
+
+    project = CliRunner().invoke(projectgen_cli, [*common, "-I", "java", "-d", str(tmp_path / "p"), str(schema_path)])
+    java = CliRunner().invoke(javagen_cli, [*common, "--output-directory", str(tmp_path / "j"), str(schema_path)])
+
+    assert project.exit_code != 0, project.output
+    assert java.exit_code != 0, java.output
+    assert expected in project.output
+    assert expected in java.output
 
 
 def test_validate_generator_args_default_is_a_noop():


### PR DESCRIPTION
## Summary

Fixes #3858

- Various bugs found in projectgen configuration management
- **Allow merging configuration supplied by CLI (`-A` wins) and configuration file (`-C config.yaml`)**
- fix test gap: empty config file causing crashes was inadvertently  fixed (missing test case)

Starts addressing https://github.com/linkml/linkml/issues/3972 following PR comment.

## How was this tested?

expanded tests

## Areas of uncertainty

- merging generator_args with cli args (-A) is new behavior but old behavior was silent skip / undocumented

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance
LLM assisted