### PR TITLE
Add Codeownership for Java, Zod and OpenAPI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,14 @@
 # --- Per-subsystem ownership (overrides the default for these paths) ---
 
 # javagen
-/docs/generators/java.rst                            @gouttegd
-/packages/linkml/src/linkml/generators/javagen.py    @gouttegd
-/packages/linkml/src/linkml/generators/javagen/      @gouttegd
-/tests/linkml/test_generators/test_javagen.py        @gouttegd
+#
+# EXPERIMENT: delegated self-contained area, see
+# docs/maintainers/codeowners.md#experiment-delegating-self-contained-areas
+
+/docs/generators/java.rst                            @gouttegd @noelmcloughlin
+/packages/linkml/src/linkml/generators/javagen.py    @gouttegd @noelmcloughlin
+/packages/linkml/src/linkml/generators/javagen/      @gouttegd @noelmcloughlin
+/tests/linkml/test_generators/test_javagen.py        @gouttegd @noelmcloughlin
 
 # pydanticgen:
 /packages/linkml/src/linkml/generators/pydanticgen/                  @sneakers-the-rat @kevinschaper
@@ -37,3 +41,22 @@
 /docs/generators/yarrrml.rst                          @Ostrzyciel @lapkinvladimir
 /packages/linkml/src/linkml/generators/yarrrmlgen.py  @Ostrzyciel @lapkinvladimir
 /tests/linkml/test_generators/test_yarrrmlgen.py      @Ostrzyciel @lapkinvladimir
+
+# openapigen:
+#
+# EXPERIMENT: delegated self-contained area, see
+# docs/maintainers/codeowners.md#experiment-delegating-self-contained-areas
+# @Silvanoc and @noelmcloughlin jointly own the OpenAPI generator and can
+# review each other's changes and merge them without core-team approval.
+
+/docs/generators/openapi.rst                             @Silvanoc @noelmcloughlin
+/packages/linkml/src/linkml/generators/openapigen.py     @Silvanoc @noelmcloughlin
+/tests/linkml/test_generators/test_openapigen.py         @Silvanoc @noelmcloughlin
+/tests/linkml/test_generators/input/openapi/             @Silvanoc @noelmcloughlin
+/tests/linkml/test_scripts/test_gen_openapi.py           @Silvanoc @noelmcloughlin
+
+# zodgen:
+/docs/generators/zod.rst                                          @linkml/core-team @noelmcloughlin
+/packages/linkml/src/linkml/generators/zodgen.py                  @linkml/core-team @noelmcloughlin
+/packages/linkml/src/linkml/generators/zod_ifabsent_processor.py  @linkml/core-team @noelmcloughlin
+/tests/linkml/test_generators/test_zodgen.py                      @linkml/core-team @noelmcloughlin

--- a/docs/maintainers/codeowners.md
+++ b/docs/maintainers/codeowners.md
@@ -85,6 +85,18 @@ including PRs authored by CODEOWNERS or core developers. The mechanisms
 below — the 1-month fallback, the project-direction override, and the
 stepping-down process — exist within that frame.
 
+## Experiment: delegating self-contained areas
+
+A few generators are self-contained enough that core-team review adds little.
+Where trusted, established community members know such an area well, we hand
+it to them outright: they review each other's changes and merge without
+core-team sign-off.
+
+The goal is to let those areas move at the pace of the people who care about
+them rather than at the pace of core-team availability. Rules covering them
+are marked `EXPERIMENT` in
+[`.github/CODEOWNERS`](https://github.com/linkml/linkml/blob/main/.github/CODEOWNERS).
+
 ## Avoiding review bottlenecks: the 1-month fallback
 
 CODEOWNERS is a stewardship signal, **not a veto**. If CODEOWNERS become

--- a/docs/maintainers/codeowners.md
+++ b/docs/maintainers/codeowners.md
@@ -90,7 +90,7 @@ stepping-down process — exist within that frame.
 A few generators are self-contained enough that core-team review adds little.
 Where trusted, established community members know such an area well, we hand
 it to them outright: they review each other's changes and merge without
-core-team sign-off. 
+core-team sign-off.
 This does not preclude participants, at their discretion, from occasionally
 explicitly requesting approval from the core-team for some reason.
 

--- a/docs/maintainers/codeowners.md
+++ b/docs/maintainers/codeowners.md
@@ -90,7 +90,9 @@ stepping-down process — exist within that frame.
 A few generators are self-contained enough that core-team review adds little.
 Where trusted, established community members know such an area well, we hand
 it to them outright: they review each other's changes and merge without
-core-team sign-off.
+core-team sign-off. 
+This does not preclude participants, at their discretion, from occasionally
+explicitly requesting approval from the core-team for some reason.
 
 The goal is to let those areas move at the pace of the people who care about
 them rather than at the pace of core-team availability. Rules covering them


### PR DESCRIPTION
This is an experimental change to  delegating self-contained areas to trusted, established community members to unblock them from the shacles of core team reviews.