### PR TITLE
fix(ci): eliminate two intermittent test failures

### DIFF
--- a/notebooks/examples.ipynb
+++ b/notebooks/examples.ipynb
@@ -18,7 +18,7 @@
     }
    },
    "source": [
-    "!uv pip -q --disable-pip-version-check install yamlmagic\n",
+    "!uv pip install -q --disable-pip-version-check yamlmagic\n",
     "%reload_ext yamlmagic"
    ],
    "outputs": [],

--- a/tests/linkml_runtime/test_utils/input/mcc/creature_schema_remote.yaml
+++ b/tests/linkml_runtime/test_utils/input/mcc/creature_schema_remote.yaml
@@ -5,6 +5,6 @@ description: |
   Schema for testing remote imports via a prefix. This produces yields exactly the same schema
   as creature_schema.yaml, but pulls in the files via remote import.
 prefixes:
-  mcc: https://github.com/linkml/linkml/raw/refs/heads/main/tests/linkml_runtime/test_utils/input/mcc/
+  mcc: https://raw.githubusercontent.com/linkml/linkml/refs/heads/main/tests/linkml_runtime/test_utils/input/mcc/
 imports:
   - mcc:creature_schema

--- a/tests/linkml_runtime/test_utils/test_schemaview.py
+++ b/tests/linkml_runtime/test_utils/test_schemaview.py
@@ -57,7 +57,7 @@ SCHEMA_RULES_IMPORT = INPUT_DIR_PATH / "rules_import" / "base.yaml"
 
 CREATURE_SCHEMA = "creature_schema"
 CREATURE_SCHEMA_BASE_URL = "https://github.com/linkml/linkml/tree/main/tests/linkml_runtime/test_utils/input/mcc"
-CREATURE_SCHEMA_RAW_URL = "https://github.com/linkml/linkml/raw/refs/heads/main/tests/linkml_runtime/test_utils/input/mcc/creature_schema.yaml"
+CREATURE_SCHEMA_RAW_URL = "https://raw.githubusercontent.com/linkml/linkml/refs/heads/main/tests/linkml_runtime/test_utils/input/mcc/creature_schema.yaml"
 
 CREATURE_SCHEMA_BASE_PATH = INPUT_DIR_PATH / "mcc"
 


### PR DESCRIPTION
Two unrelated causes have been reddening required checks on PRs that have nothing to do with either. Both are small, both are test-infrastructure only, and they're together because each was blocking the other's PR from going green.

## 1. `examples.ipynb` install cell

The flags precede the subcommand:

```
!uv pip -q --disable-pip-version-check install yamlmagic     # rejected by uv
!uv pip install -q --disable-pip-version-check yamlmagic     # the three sibling notebooks
```

uv errors with `unexpected argument '--disable-pip-version-check'`, yamlmagic is never installed, and the next line's `%reload_ext yamlmagic` raises `ModuleNotFoundError`.

Notebooks share one venv, so this only surfaces when `examples.ipynb` runs before a sibling that installs yamlmagic correctly. Order comes from `os.listdir` — filesystem order, unstable across runners. So: coin flip.

The uncomfortable half — **`examples.ipynb` has been broken all along and passing most of the time**, on a dependency it never installed itself.

## 2. Creature fixtures fetching through a redirect

`RemoteDisconnected: Remote end closed connection without response`, four times today, each taking out all six parametrisations of `test_creature_schema_entities_with_without_imports` at once.

Both remote fixtures fetched via `github.com/.../raw/...`, which 302s to `raw.githubusercontent.com`:

```
302, 1 redirect, final 200   https://github.com/linkml/linkml/raw/refs/heads/main/...
200, 0 redirects             https://raw.githubusercontent.com/linkml/linkml/refs/heads/main/...
```

Two URLs move — `CREATURE_SCHEMA_RAW_URL` (used by `creature_view_direct_url`) and the `mcc` prefix in `creature_schema_remote.yaml` (the fetch base for `creature_view_remote`'s import).

**The `github.com/.../tree/...` URLs elsewhere under `mcc/` are deliberately untouched.** Those are schema identifiers and CURIE bases, not fetch targets — rewriting them would change schema identity without fixing anything.

## Verification

Notebook fix, against a venv with yamlmagic absent so nothing could mask it:
- before — fails with `unexpected argument` then `ModuleNotFoundError`
- after — passes, and yamlmagic is importable afterwards, installed by the cell

URL fix:
- both new URLs resolve `200` with zero redirects
- `test_schemaview.py` — 1226 passed
- `tests/linkml_runtime` — 1829 passed

Notebook suite from a clean venv: 8 passed, 1 failed. That failure is `SQL-examples.ipynb` (`OperationalError: no such table: Person`), which reproduces identically with and without these changes and passes in CI — pre-existing and unrelated.

## Scope

Neither issue is fully closed by this:

- **#3879** — the shared mutating venv plus unstable `os.listdir` ordering is untouched. Note that sorting the order would make runs deterministic but would *not* fix masking; it'd make `examples.ipynb` consistently masked instead of intermittently. Having each notebook install its own dependencies, as here, is what breaks the coupling.
- **#3421** — also covers a `biolink.github.io` 503 on a different host, which this does not address.