### PR TITLE
ci: cancel superseded runs on the same pull request

### DIFF
--- a/.github/workflows/check-external-links.yaml
+++ b/.github/workflows/check-external-links.yaml
@@ -1,6 +1,12 @@
 name: Check Sphinx external links
 env:
   UV_VERSION: "0.11.21"
+concurrency:
+  # Cancel superseded runs on the same PR. github.ref is refs/pull/<n>/merge,
+  # so each PR is its own group and never cancels another's runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -9,6 +9,12 @@ env:
   UV_PREVIEW: "1"          # Enables the preview uv audit and malware engines
   UV_MALWARE_CHECK: "1"    # Automatically blocks malicious installs on sync/run
 
+concurrency:
+  # Cancel superseded runs on the same PR. github.ref is refs/pull/<n>/merge,
+  # so each PR is its own group and never cancels another's runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,5 +1,11 @@
 name: Build Docker Image
 
+concurrency:
+  # Cancel superseded runs on the same PR. github.ref is refs/pull/<n>/merge,
+  # so each PR is its own group and never cancels another's runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/docs-test.yaml
+++ b/.github/workflows/docs-test.yaml
@@ -1,6 +1,12 @@
 name: Build and test documentation
 env:
   UV_VERSION: "0.11.21"
+concurrency:
+  # Cancel superseded runs on the same PR. github.ref is refs/pull/<n>/merge,
+  # so each PR is its own group and never cancels another's runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,12 @@
 name: Build and test linkml
 env:
   UV_VERSION: "0.11.21"
+concurrency:
+  # Cancel superseded runs on the same PR. github.ref is refs/pull/<n>/merge,
+  # so each PR is its own group and never cancels another's runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/rustgen.yaml
+++ b/.github/workflows/rustgen.yaml
@@ -3,6 +3,12 @@ name: Build and test linkml (rustgen)
 env:
   UV_VERSION: "0.11.21"
 
+concurrency:
+  # Cancel superseded runs on the same PR. github.ref is refs/pull/<n>/merge,
+  # so each PR is its own group and never cancels another's runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/typedb-integration.yaml
+++ b/.github/workflows/typedb-integration.yaml
@@ -1,5 +1,11 @@
 # .github/workflows/typedb-integration.yaml
 name: TypeDB Integration Tests
+concurrency:
+  # Cancel superseded runs on the same PR. github.ref is refs/pull/<n>/merge,
+  # so each PR is its own group and never cancels another's runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
## The constraint

One PR needs **19 jobs**. The account's Actions concurrency cap is **20**. So a single PR very nearly saturates the entire pool, and anything else queues by arithmetic.

```
19 jobs per PR   (14 of them "Build and test linkml", plus 5 single-job workflows)
20 concurrent job cap
```

Measured while writing this: **18 jobs running, 56 queued.**

## What this fixes

Nothing currently cancels obsolete runs. A rebase or a follow-up push leaves the previous run executing to completion, holding slots for a commit that no longer exists. Caught during a dependabot rebase storm — two branches were building two SHAs each at the same time:

```
dependabot/uv/rdflib-7.6.0         5957aa484 + e2e5fd7e0
dependabot/uv/patch-updates-...    8c2d02ffe + e5e6d0ba2
```

Against a 20-slot pool, that is real. Dependabot rebases every open PR when main moves, so each storm can leave the previous storm still running underneath it.

## Scope, and why each PR is safe from every other

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

For `pull_request` events `github.ref` is `refs/pull/<n>/merge` — verified from a run log, which checked out `refs/remotes/pull/3862/merge`. The PR number is in the key, so **every PR forms its own group and can never cancel another PR's runs**. The dangerous variant would be grouping on `${{ github.workflow }}` alone, where all PRs share one group; this is not that.

`cancel-in-progress` is gated on the event, so pushes to `main`, `merge_group` runs and `workflow_dispatch` are never cancelled — only superseded PR commits.

Applied to the seven PR-triggered workflows:

| Workflow | Applied | Why |
| --- | --- | --- |
| main, docs-test, docker-build, rustgen, dependency-audit, check-external-links, typedb-integration | yes | run on `pull_request` |
| pypi-publish | **no** | release; never cancel a publish |
| doc-pages | **no** | deploys docs |
| metamodel-compat, stale, update-feature-dashboard | **no** | scheduled; no PR trigger |

## What this does not do

It creates no headroom against the cap — it only stops obsolete work consuming it. With 19 jobs per PR against 20 slots, concurrent development still isn't really possible; that needs either a higher concurrency tier or fewer jobs per PR, and neither belongs in this change.