### PR TITLE
build(deps): check for updates daily instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,10 @@ updates:
 
   - package-ecosystem: "uv"
     directory: "/"
+    # Daily refills the three open slots as they drain, rather than once a week.
+    # The limit below, not the interval, is what bounds concurrent CI load.
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
     groups:
       # Individual pull requests for major/minor updates and grouped for patch updates
       patch-updates:


### PR DESCRIPTION
`uv` updates are checked weekly on Sunday. With `open-pull-requests-limit: 3`, that caps throughput at three updates per week regardless of how quickly they're merged.

Measured against current main with `uv lock --upgrade --dry-run`:

```
108 package updates available
     11 major   52 minor   27 patch   18 multi-version
```

With patches grouped and major/minor individual, that's on the order of 60 PRs. At three per week it's months; at three per day as slots drain, it's a few weeks.

## This does not increase CI load

The two settings are independent:

- **`open-pull-requests-limit`** bounds how many PRs can be open, and therefore how many rebase simultaneously when main moves. That's what drives concurrent CI load, and it stays at 3.
- **`interval`** only controls how quickly a freed slot gets reused.

So the storm ceiling is unchanged — three open PRs, same as today. Only the refill rate moves.

Worth stating plainly since "daily" sounds like more: one PR consumes 19 of the account's 20 concurrent job slots, so bounding *concurrent* PRs is what matters. Refilling them faster costs nothing extra at any instant.

`github-actions` stays monthly — it groups into a single PR and rarely moves.