### PR TITLE
Remove YARRRML generator codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,11 +37,6 @@
 /tests/linkml_runtime/test_loaders_dumpers/test_dumpers_pydantic.py  @sneakers-the-rat @kevinschaper
 /tests/linkml_runtime/test_loaders_dumpers/test_loaders_pydantic.py  @sneakers-the-rat @kevinschaper
 
-# yarrrml:
-/docs/generators/yarrrml.rst                          @Ostrzyciel @lapkinvladimir
-/packages/linkml/src/linkml/generators/yarrrmlgen.py  @Ostrzyciel @lapkinvladimir
-/tests/linkml/test_generators/test_yarrrmlgen.py      @Ostrzyciel @lapkinvladimir
-
 # openapigen:
 #
 # EXPERIMENT: delegated self-contained area, see


### PR DESCRIPTION
As mentioned [here](https://github.com/linkml/linkml/pull/3664#issuecomment-5318125680), we are no longer using or developing this generator, or the Python implementation of LinkML in general. We are focusing our efforts on [LinkML-Scala](https://github.com/NeverBlink-OSS/linkml-scala) instead.

## Summary

Fixes #

<!-- Briefly describe what this PR does and why. -->

## How was this tested?

<!-- Describe how you verified your changes (e.g. new tests, existing test suite, manual testing). -->

## Areas of uncertainty

<!-- Are there parts of this change you'd like reviewers to look at more closely? -->

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [ ] I have added tests that prove my fix/feature works
- [ ] Existing tests pass locally with my changes

## AI Assistance
none
