### PR TITLE
ci: warn weekly when the vendored model pin is behind the latest release

### DIFF
--- a/.github/workflows/metamodel-compat.yaml
+++ b/.github/workflows/metamodel-compat.yaml
@@ -203,3 +203,97 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Nothing updates UPSTREAM_SHA automatically -- `make update_model` is run by
+      # hand -- so a new linkml-model (pre)release can sit unadopted indefinitely
+      # with every check still green. This notices that. Comparing against the
+      # newest release rather than main is deliberate: main moves constantly, but a
+      # release means someone upstream decided something was ready to take.
+      #
+      # Resolution is delegated to `make print_latest_model_release`, the same
+      # target `make update_model` uses, so this check and the vendoring command
+      # cannot disagree about what "latest" means.
+      - name: Check whether the vendored pin is behind the latest release
+        id: pin_check
+        if: always()
+        run: |
+          PINNED=$(tr -d '[:space:]' < packages/linkml_runtime/src/linkml_runtime/linkml_model/UPSTREAM_SHA)
+          read -r TAG LATEST < <(make -C packages/linkml_runtime -s print_latest_model_release)
+
+          # Fail loudly rather than guessing: with no outputs set, neither the
+          # open-issue nor the close-issue step below will fire.
+          if [ -z "${PINNED}" ] || [ -z "${TAG}" ] || [ -z "${LATEST}" ]; then
+            echo "::error::Could not resolve the vendored pin or the latest release (pinned='${PINNED}' tag='${TAG}' latest='${LATEST}')"
+            exit 1
+          fi
+
+          echo "pinned=${PINNED}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"
+          if [ "${PINNED}" = "${LATEST}" ]; then
+            echo "Vendored pin matches ${TAG}."
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Vendored pin ${PINNED} is behind ${TAG} (${LATEST})."
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for existing stale-pin issue
+        if: always() && steps.pin_check.outputs.stale == 'true'
+        id: check_pin_issue
+        run: |
+          EXISTING_ISSUE=$(gh issue list --label "vendored-model-stale-pin" --state open --json number --jq '.[0].number // empty')
+          echo "existing_issue=${EXISTING_ISSUE}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create or update issue when the pin is stale
+        if: always() && steps.pin_check.outputs.stale == 'true'
+        run: |
+          ISSUE_TITLE="Vendored linkml-model pin is behind the latest release"
+          mkdir -p temp
+
+          {
+            cat <<EOF
+          ## Vendored linkml-model Pin Is Stale
+
+          A newer linkml-model (pre)release exists than the one the vendored copy is
+          pinned to. Nothing adopts it automatically.
+
+          | | |
+          | --- | --- |
+          | Pinned (\`UPSTREAM_SHA\`) | \`${{ steps.pin_check.outputs.pinned }}\` |
+          | Latest release | \`${{ steps.pin_check.outputs.tag }}\` |
+          | Its commit | \`${{ steps.pin_check.outputs.latest }}\` |
+
+          To adopt it, run \`make update_model\` in \`packages/linkml_runtime/\` and
+          commit the result. Expect generated-artifact snapshots to need regenerating
+          in the same change.
+
+          This does not block any PR. It stays open until the pin is updated.
+
+          **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EOF
+          } > temp/stale_pin_issue.md
+
+          if [ -n "${{ steps.check_pin_issue.outputs.existing_issue }}" ]; then
+            gh issue comment "${{ steps.check_pin_issue.outputs.existing_issue }}" --body-file temp/stale_pin_issue.md
+          else
+            gh issue create \
+              --title "${ISSUE_TITLE}" \
+              --body-file temp/stale_pin_issue.md \
+              --label "vendored-model-stale-pin"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close stale-pin issue once the pin is current
+        if: always() && steps.pin_check.outputs.stale == 'false'
+        run: |
+          EXISTING_ISSUE=$(gh issue list --label "vendored-model-stale-pin" --state open --json number --jq '.[0].number // empty')
+          if [ -n "${EXISTING_ISSUE}" ]; then
+            gh issue close "${EXISTING_ISSUE}" \
+              --comment "Vendored pin now matches ${{ steps.pin_check.outputs.tag }}. Closing."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/metamodel-compat.yaml
+++ b/.github/workflows/metamodel-compat.yaml
@@ -238,6 +238,19 @@ jobs:
             echo "stale=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # gh issue create fails outright on an unknown label, so create it here rather
+      # than depending on someone having made it by hand. --force makes this a no-op
+      # when it already exists.
+      - name: Ensure the stale-pin label exists
+        if: always() && steps.pin_check.outputs.stale == 'true'
+        run: |
+          gh label create "vendored-model-stale-pin" \
+            --description "Vendored linkml-model pin is behind the latest release" \
+            --color "FBCA04" \
+            --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check for existing stale-pin issue
         if: always() && steps.pin_check.outputs.stale == 'true'
         id: check_pin_issue

--- a/packages/linkml_runtime/Makefile
+++ b/packages/linkml_runtime/Makefile
@@ -23,13 +23,25 @@ import sys
 import urllib.request
 
 BASE = "https://api.github.com/repos/linkml/linkml-model"
+TIMEOUT_SECONDS = 30
 
-releases = json.load(urllib.request.urlopen(BASE + "/releases?per_page=1"))
+
+def get(path):
+    # urlopen has no default timeout, so a wedged API would hang the weekly job
+    # until the runner limit rather than failing.
+    with urllib.request.urlopen(BASE + path, timeout=TIMEOUT_SECONDS) as response:
+        return json.load(response)
+
+
+# Releases are ordered newest-first and the list includes drafts for anyone with
+# push access. A draft is not something to vendor -- its tag may not exist yet --
+# so skip them. Prereleases are kept: release candidates are exactly what we pin to.
+releases = [release for release in get("/releases?per_page=10") if not release["draft"]]
 if not releases:
-    sys.exit("No linkml-model releases returned. Refusing to guess a revision.")
+    sys.exit("No published linkml-model releases returned. Refusing to guess a revision.")
 
 tag = releases[0]["tag_name"]
-sha = json.load(urllib.request.urlopen(BASE + "/commits/" + tag))["sha"]
+sha = get("/commits/" + tag)["sha"]
 print(tag, sha)
 endef
 export LATEST_MODEL_RELEASE_PY

--- a/packages/linkml_runtime/Makefile
+++ b/packages/linkml_runtime/Makefile
@@ -9,21 +9,45 @@
 
 UPSTREAM_SHA_FILE = src/linkml_runtime/linkml_model/UPSTREAM_SHA
 
+# Single source of truth for "which linkml-model revision should we be on".
+# `update_model` vendors it; the weekly metamodel-compat workflow compares it
+# against UPSTREAM_SHA to notice a release we have not adopted. Keeping one
+# resolver means the two can never disagree about what "latest" means.
+#
+# The commits endpoint is used rather than /git/refs/tags because it dereferences
+# annotated tags to a commit; /git/refs/tags returns the tag *object* SHA, which
+# `git fetch <sha>` cannot resolve.
+define LATEST_MODEL_RELEASE_PY
+import json
+import sys
+import urllib.request
+
+BASE = "https://api.github.com/repos/linkml/linkml-model"
+
+releases = json.load(urllib.request.urlopen(BASE + "/releases?per_page=1"))
+if not releases:
+    sys.exit("No linkml-model releases returned. Refusing to guess a revision.")
+
+tag = releases[0]["tag_name"]
+sha = json.load(urllib.request.urlopen(BASE + "/commits/" + tag))["sha"]
+print(tag, sha)
+endef
+export LATEST_MODEL_RELEASE_PY
+
 all: update_model update_validation_model
 
-update_model:
-	# Resolve the latest release or pre-release tag from the GitHub Releases API
-	$(eval LINKML_MODEL_TAG := $(shell \
-		curl -fsSL "https://api.github.com/repos/linkml/linkml-model/releases?per_page=1" \
-		| python3 -c "import sys, json; releases = json.load(sys.stdin); print(releases[0]['tag_name'])"))
+# Prints "<tag> <commit-sha>" for the newest release, prereleases included.
+.PHONY: print_latest_model_release
+print_latest_model_release:
+	@python3 -c "$$LATEST_MODEL_RELEASE_PY"
 
-	# Resolve the tag to its commit SHA. The commits endpoint dereferences the ref for
-	# us, so this yields a commit SHA for annotated tags as well as lightweight ones --
-	# /git/refs/tags returns the tag *object* SHA for annotated tags, which is not
-	# something `git fetch <sha>` can resolve.
-	$(eval LINKML_MODEL_SHA := $(shell \
-		curl -fsSL "https://api.github.com/repos/linkml/linkml-model/commits/$(LINKML_MODEL_TAG)" \
-		| python3 -c "import sys, json; print(json.load(sys.stdin)['sha'])"))
+update_model:
+	$(eval LINKML_MODEL_RELEASE := $(shell $(MAKE) -s print_latest_model_release))
+	$(eval LINKML_MODEL_TAG := $(word 1,$(LINKML_MODEL_RELEASE)))
+	$(eval LINKML_MODEL_SHA := $(word 2,$(LINKML_MODEL_RELEASE)))
+
+	@test -n "$(LINKML_MODEL_TAG)" -a -n "$(LINKML_MODEL_SHA)" \
+		|| { echo "Could not resolve the latest linkml-model release; aborting."; exit 1; }
 
 	@echo "Vendoring linkml-model $(LINKML_MODEL_TAG) @ $(LINKML_MODEL_SHA)"
 


### PR DESCRIPTION
Closes the last gap in the vendored-model story: **nothing tells us we haven't picked up a new release.**

`UPSTREAM_SHA` only moves when someone runs `make update_model` by hand. That's deliberate — adopting a new model revision should be a decision, not something that lands on whoever runs CI next. But it means an rc can sit unadopted indefinitely while every existing check stays green:

| Check | Question it answers | Steady state |
| --- | --- | --- |
| hard drift (per-PR, blocking) | do the vendored files match the pinned SHA? | yes — the pin doesn't move |
| soft drift (weekly) | do they match upstream `main`? | almost always no — `main` moves constantly |
| **this (weekly)** | **is there a release we haven't adopted?** | **usually no — speaks only when actionable** |

Comparing against the newest release rather than `main` is the point. `main` diverges the moment anything merges upstream, so that signal is on most of the time and easy to tune out. A release means someone upstream decided something was ready to take.

Runs in the existing weekly `metamodel-compat` job and opens a `vendored-model-stale-pin` tracking issue, closed automatically once the pin catches up. It never blocks a PR.

## One resolver, not two

`update_model` already resolved "latest (pre)release → commit SHA" with two inlined API calls. Rather than repeating them in the workflow, that logic moves into a single Makefile target:

```
make -C packages/linkml_runtime -s print_latest_model_release
# -> v1.11.1-rc1 7657de64dc7098a55dc51dbc9ec500e66f2a1b4f
```

`update_model` and the weekly check now both call it, so they cannot disagree about what "latest" means. The extracted version also guards the empty-list case, which previously surfaced as a bare `IndexError`.

## Verification

Both branches exercised against the live API:

```
pin matches latest   -> exit 0, stale=false
pin altered          -> exit 0, stale=true, tag + commit populated for the issue body
make -n update_model -> resolves v1.11.1-rc1, clones that tag
```

Failure is fail-safe: if resolution returns nothing the step exits non-zero with an explicit message, and since neither `stale=true` nor `stale=false` is set, neither the open-issue nor the close-issue step fires. A broken API cannot silently open a spurious issue or close a real one.

## Note for the reviewer

The workflow now creates the `vendored-model-stale-pin` label itself via `gh label create --force`, so nothing needs doing by hand before the first weekly run — unlike `vendored-model-drift`, which had to be created manually when #3709 landed.

Worth considering separately: now that this covers the actionable case, the soft `main` comparison may be worth dropping. It reports drift in steady state, so its tracking issue will tend to sit permanently open and stop being read.