### PR TITLE
pydantic: Correctly handle a titled enum value in ifabsent.

### DIFF
--- a/packages/linkml/src/linkml/generators/pydanticgen/pydantic_ifabsent_processor.py
+++ b/packages/linkml/src/linkml/generators/pydanticgen/pydantic_ifabsent_processor.py
@@ -10,4 +10,4 @@ class PydanticIfAbsentProcessor(PythonIfAbsentProcessor):
     def map_enum_default_value(
         self, enum_name: EnumDefinitionName, permissible_value_name: str, slot: SlotDefinition, cls: ClassDefinition
     ):
-        return f"{enum_name}.{permissible_value_name}"
+        return f'{enum_name}("{permissible_value_name}")'

--- a/tests/linkml/test_issues/test_linkml_issue_3942.py
+++ b/tests/linkml/test_issues/test_linkml_issue_3942.py
@@ -1,3 +1,5 @@
+import pytest
+
 from linkml.generators.pydanticgen import PydanticGenerator
 from linkml_runtime.linkml_model import (
     ClassDefinition,
@@ -7,6 +9,8 @@ from linkml_runtime.linkml_model import (
     SlotDefinition,
 )
 from linkml_runtime.utils.compile_python import compile_python
+
+pytestmark = [pytest.mark.pydanticgen]
 
 
 def test_pydantic_generator_correctly_reference_default_enum_values():

--- a/tests/linkml/test_issues/test_linkml_issue_3942.py
+++ b/tests/linkml/test_issues/test_linkml_issue_3942.py
@@ -1,0 +1,35 @@
+from linkml.generators.pydanticgen import PydanticGenerator
+from linkml_runtime.linkml_model import (
+    ClassDefinition,
+    EnumDefinition,
+    PermissibleValue,
+    SchemaDefinition,
+    SlotDefinition,
+)
+from linkml_runtime.utils.compile_python import compile_python
+
+
+def test_pydantic_generator_correctly_reference_default_enum_values():
+    """ifabsent: MyEnum(MyValue) should work when MyValue has a title."""
+    schema = SchemaDefinition(
+        id="ifabsent_referencing_titled_enum_value",
+        name="ifabsent_referencing_titled_enum_value",
+        enums=[
+            EnumDefinition(
+                name="LengthUnit",
+                permissible_values=[
+                    PermissibleValue(text="mm", title="millimeter"),
+                    PermissibleValue(text="cm", title="centimeter"),
+                ],
+            ),
+        ],
+        classes=[
+            ClassDefinition(
+                name="MyClass",
+                attributes=[SlotDefinition(name="length_unit", range="LengthUnit", ifabsent="LengthUnit(mm)")],
+            ),
+        ],
+    )
+    gen = PydanticGenerator(schema=schema)
+    code = gen.serialize()
+    compile_python(code)

--- a/tests/linkml/test_issues/test_linkml_issue_3942.py
+++ b/tests/linkml/test_issues/test_linkml_issue_3942.py
@@ -36,4 +36,5 @@ def test_pydantic_generator_correctly_reference_default_enum_values():
     )
     gen = PydanticGenerator(schema=schema)
     code = gen.serialize()
-    compile_python(code)
+    mod = compile_python(code)
+    assert mod.MyClass.model_fields["length_unit"].default is mod.LengthUnit.millimeter


### PR DESCRIPTION
## Summary

Fixes #3942

This commit amends the _PydanticIfAbsentProcessor_ to make sure it does not produce invalid (unloadable) code when a `ifabsent` attribute refers to an enum value that has a `title`.

When an enum value has a title, the symbol for the value is derived from the title rather than from the value’s `text`, so trying to resolve the default value with `{enum_name}.{permissible_value_name}` will result in an attribute error when the generated module is loaded because `permissible_value_name` is always derived from the value’s `text`, regardless of whether the permissible value has a `title` or not.

To fix, we make the generator reference the default value as `{enum_name}("permissible_value_name")` instead – that is, calling the enum constructor with the text of the default value.

## How was this tested?

Added an explicit test case with a schema that (i) defines an enum with “titled values” (permissible values that have a `title` attribute) and (ii) defines a class with an attribute with a range set to the enum and a `ifabsent` referencing one of the permissible values. The test generates the Pydantic code for that schema and attempts to compile it – which would currently fail without the fix in this PR.

## Areas of uncertainty

Not really.

Of note, I would personally have preferred to make the _PydanticIfAbsentProcessor_ reference the default value as `EnumName.ValueSymbol` (where `ValueSymbol` is derived either from the permissible value’s `text` or from its `title`, depending on whether it has a title or not), rather than as `EnumName("value")`. But this would have required, either

* duplicating the logic of [`oocodegen.generate_enum_label`](https://github.com/linkml/linkml/blob/bb14aef63f721e741e7a50e28a11ee0738e340be/packages/linkml/src/linkml/generators/oocodegen.py#L194) – not keen to do that as it introduces a risk of the duplicated logic not being kept in sync with the original;
* somehow find a way to call `oocodegen.generate_enum_label` from the _PydanticIfAbsentProcessor_, which does not seem easily doable because the processor has seemingly no handle to the code generator that called it.

So in the end, relying on the enum constructor to do the right thing (`EnumName("value")`) seems by far the easiest and least intrusive fix.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

None.
