### PR TITLE
fix(openapigen): handle linkml examples slot mapping to example field

### DIFF
--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -185,6 +185,8 @@ class OpenApiGenerator(Generator):
 
         - ``const`` becomes ``enum`` with a single value (OpenAPI 3.0 doesn't support ``const``)
         - ``type`` as a list (e.g. nullable ``["string", "null"]``) becomes ``anyOf``
+        - ``examples`` (a list) becomes ``example`` (its first element); OpenAPI 3.0 has
+          no plural ``examples`` keyword on the Schema Object, only singular ``example``
         - ``$ref`` paths are rewritten from ``#/$defs/`` to ``#/components/schemas/``
         """
         fixed_element = None
@@ -195,6 +197,13 @@ class OpenApiGenerator(Generator):
                     fixed_element["enum"] = [value]
                 elif key == "type" and isinstance(value, list):
                     fixed_element["anyOf"] = [{"type": item} for item in value if item != "null"]
+                elif key == "examples" and isinstance(value, list):
+                    if value:
+                        # lossy by necessity: OpenAPI 3.0 allows only one example.
+                        # assigned rather than recursed into, since an example is data,
+                        # not schema -- recursing could rewrite a `const`/`type` key
+                        # that happens to appear inside the example value itself
+                        fixed_element["example"] = value[0]
                 else:
                     if isinstance(value, dict | list):
                         value = self._fix_openapi_spec(value)

--- a/tests/linkml/test_generators/input/openapi/schema_examples.yaml
+++ b/tests/linkml/test_generators/input/openapi/schema_examples.yaml
@@ -1,0 +1,16 @@
+# LinkML schema with a slot declaring multiple examples
+id: https://w3id.org/linkml/tests/examples
+name: examples
+default_prefix: examples
+imports:
+  - linkml:types
+
+classes:
+  WithExamples:
+    description: A thing with example values
+    attributes:
+      name:
+        range: string
+        examples:
+          - value: sample
+          - value: second

--- a/tests/linkml/test_generators/input/openapi/spec-examples.openapi.yaml
+++ b/tests/linkml/test_generators/input/openapi/spec-examples.openapi.yaml
@@ -1,0 +1,24 @@
+# OpenAPI template referring a class whose slot declares multiple examples
+openapi: 3.0.3
+info:
+  title: LinkML examples test
+  version: 1.0.0
+servers:
+  - url: https://example.org/
+paths:
+  /api/with-examples:
+    get:
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WithExamples'
+
+components:
+  schemas:
+    WithExamples:
+      type: object
+      x-linkml-schema: https://w3id.org/linkml/tests/examples
+      x-linkml-source: WithExamples

--- a/tests/linkml/test_generators/test_openapigen.py
+++ b/tests/linkml/test_generators/test_openapigen.py
@@ -147,3 +147,20 @@ def test_renaming(input_path, kitchen_sink_path):
     assert "Person" not in schemas
     # all $ref values in the spec must use the renamed
     assert "Person" not in str(spec).replace("PersonResource", "")
+
+
+def test_openapi_examples_converted_to_singular_example(input_path):
+    """Test that a slot's ``examples`` list is converted to OpenAPI's singular ``example``.
+
+    OpenAPI 3.0 has no plural ``examples`` keyword on the Schema Object, only ``example``.
+    Without this conversion, generation fails validation entirely for any schema with a
+    slot declaring ``examples`` -- this is a blocker, not a cosmetic gap.
+    """
+    schema_path = str(input_path("openapi/schema_examples.yaml"))
+    head_path = str(input_path("openapi/spec-examples.openapi.yaml"))
+    spec = yaml.safe_load(OpenApiGenerator(schema_path).serialize(head_path))
+    name_schema = spec["components"]["schemas"]["WithExamples"]["properties"]["name"]
+    # first example is kept; the plural form is gone entirely
+    assert name_schema["example"] == "sample"
+    assert "examples" not in name_schema
+    assert validate(spec, cls=OpenAPIV30SpecValidator) is None


### PR DESCRIPTION
## Summary

Fixes #3962

In `_fix_openapi_spec`, convert `examples` (list) -> `example`(first element) on the Schema Object. Its lossy becuase openapi 3.0.3 `example` field is singular, but what else can we do.

Also this [json-ld issue comment](https://github.com/json-ld/json-ld.org/issues/612#issuecomment-1431076708) mentions "_... following the spirit of the OAS recommendations to deprecate the use of examples within API specifications and add them as schema annotations ..._"  - which suggests examples in (open)API schema are promoted in general.

## How was this tested?

Added tests

## Areas of uncertainty

- To solve (?)  lossy conversion we could pre-merge linkml examples into a singular 'thing' for over engineering?
- The  `examples` field in Media Type / Parameter Objects is out of scope is my understanding.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
