### PR TITLE
fix(rustgen): don't duplicate or drop the type_designator on OrSubtype enums

### DIFF
--- a/packages/linkml/src/linkml/generators/rustgen/templates/struct_or_subtype_enum.rs.jinja
+++ b/packages/linkml/src/linkml/generators/rustgen/templates/struct_or_subtype_enum.rs.jinja
@@ -1,19 +1,73 @@
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 {% if type_designator_field %}
-#[cfg_attr(feature="serde", serde(tag = "{{ type_designator_field }}"))]
+{#- Tagged case: `Serialize`/`Deserialize` are hand-written below rather than
+    derived with `serde(tag = ...)`. An internally tagged derive *consumes* the
+    designator key, so it would both emit it twice (once as the enum tag, once as
+    the variant struct's own field) and strip it from the struct on the way back
+    in. Delegating instead keeps the designator a normal slot on every struct. -#}
 {% else %}
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature="serde", serde(untagged))]
 {% endif %}
 pub enum {{ enum_name }} {
 {%- for t in struct_names -%}
-    {% if type_designator_field  %}
-    {% set tds = type_designators[t] %}
-    #[serde(rename = "{{ tds[0] }}",  {% for t in tds[1:] %} alias="{{ t }}", {% endfor %} )]
-    {% endif %}
     {{ t }}({{ t }}){% if not loop.last %}, {% endif %}
 {%- endfor -%}
 }
+
+{% if type_designator_field %}
+#[cfg(feature = "serde")]
+impl Serialize for {{ enum_name }} {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // The designator is a real field on the variant struct, so serializing the
+        // inner value already emits it -- no enum-level tag to add.
+        match self {
+{%- for t in struct_names %}
+            {{ enum_name }}::{{ t }}(inner) => inner.serialize(serializer),
+{%- endfor %}
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for {{ enum_name }} {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+
+        const EXPECTED: &[&str] = &[
+        {%- for t in struct_names %}
+            {%- for d in type_designators[t] %}
+            "{{ d }}",
+            {%- endfor %}
+        {%- endfor %}
+        ];
+
+        // Buffer the input so the designator can be read without consuming it: it
+        // is passed on to the variant struct, which keeps it as its own field.
+        let value = Value::deserialize(deserializer)?;
+        let tag = match &value {
+            Value::Map(map) => map
+                .get(&Value::String("{{ type_designator_field }}".to_string()))
+                .and_then(|v| match v {
+                    Value::String(s) => Some(s.clone()),
+                    _ => None,
+                }),
+            _ => None,
+        };
+        let tag = tag.ok_or_else(|| D::Error::missing_field("{{ type_designator_field }}"))?;
+
+        match tag.as_str() {
+{%- for t in struct_names %}
+            {% for d in type_designators[t] %}"{{ d }}"{% if not loop.last %} | {% endif %}{% endfor %} => {{ t }}::deserialize(
+                serde_value::ValueDeserializer::<D::Error>::new(value),
+            )
+            .map({{ enum_name }}::{{ t }}),
+{%- endfor %}
+            other => Err(D::Error::unknown_variant(other, EXPECTED)),
+        }
+    }
+}
+{% endif %}
 
 {% for t in struct_names %}
 impl From<{{ t }}>   for {{ enum_name }} { fn from(x: {{ t }})   -> Self { Self::{{ t }}(x) } }

--- a/tests/linkml/test_generators/test_rustgen.py
+++ b/tests/linkml/test_generators/test_rustgen.py
@@ -1371,15 +1371,21 @@ _TYPE_DESIGNATOR_SCHEMA = textwrap.dedent(
 )
 
 
-def test_rustgen_type_designator_emits_serde_tag(temp_dir):
-    """A ``designates_type`` slot on a class with subtypes produces an internally
-    tagged ``*OrSubtype`` enum (``#[serde(tag = ...)]``), not an untagged one.
+def test_rustgen_type_designator_dispatches_on_designator(temp_dir):
+    """A ``designates_type`` slot on a class with subtypes discriminates the
+    ``*OrSubtype`` enum by the designator value, and does so through hand-written
+    serde impls rather than ``#[serde(tag = ...)]``.
+
+    An internally tagged derive *consumes* the designator key, which both emits it
+    twice (enum tag + the variant struct's own field) and strips it from the struct
+    on the way back in. The generated impls delegate serialization to the inner
+    struct and re-feed the buffered input -- designator included -- to it.
 
     Regression for two compounding bugs: ``type_designators`` was typed
     ``dict[str, str]`` while the generator supplies ``list[str]`` (which crashed
     generation with a ``ValidationError``), and the enum was built with a
     ``type_designator_name`` kwarg that did not match the model field
-    ``type_designator_field`` (silently dropped, so the tag was never emitted).
+    ``type_designator_field`` (silently dropped, so no dispatch was emitted).
     """
     schema_path = Path(temp_dir) / "rustgen_type_designator.yaml"
     schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
@@ -1397,13 +1403,116 @@ def test_rustgen_type_designator_emits_serde_tag(temp_dir):
 
     contents = out_file.read_text(encoding="utf-8")
 
-    # The designator slot drives an internally tagged enum.
-    assert 'serde(tag = "category")' in contents
-    # And the fall-back untagged form is no longer used for the OrSubtype enum.
+    # No enum-level tag: it would collide with the struct's own designator field.
+    assert 'serde(tag = "category")' not in contents
+    # Nor the fall-back untagged form, which cannot discriminate the variants.
     assert "serde(untagged)" not in contents
-    # Each subtype variant is renamed to the value carried by the designator.
-    assert 'serde(rename = "EmploymentEvent"' in contents
-    assert 'serde(rename = "MedicalEvent"' in contents
+
+    # Instead, hand-written impls that delegate to / from the variant structs.
+    assert "impl Serialize for EventOrSubtype" in contents
+    assert "impl<'de> Deserialize<'de> for EventOrSubtype" in contents
+    assert 'Value::String("category".to_string())' in contents
+
+    # Dispatch is keyed on the designator value of each subtype.
+    assert '"EmploymentEvent" => EmploymentEvent::deserialize' in contents
+    assert '"MedicalEvent" => MedicalEvent::deserialize' in contents
+
+    # And the designator remains an ordinary field on the variant structs, so the
+    # generated structs are still usable on their own.
+    assert contents.count("pub category: Option<String>") == 3
+
+
+def test_rustgen_type_designator_preserves_designator_on_variant(temp_dir):
+    """The designator value survives a round-trip *and* stays readable on the
+    variant struct itself.
+
+    Regression: the enum was internally tagged with ``#[serde(tag = ...)]`` while
+    the designator was also an ordinary field on every variant struct. Serializing
+    emitted the key twice (a literal duplicate key, which strict formats such as
+    ``serde_json`` reject), and deserializing consumed the tag before the struct
+    saw it, so ``inner.category`` came back ``None``.
+    """
+    schema_path = Path(temp_dir) / "rustgen_type_designator_keep.yaml"
+    schema_path.write_text(_TYPE_DESIGNATOR_SCHEMA, encoding="utf-8")
+
+    out_dir = _generate_rust_crate(str(schema_path), Path(temp_dir) / "type_designator_keep_crate")
+
+    cargo_toml = (out_dir / "Cargo.toml").read_text(encoding="utf-8")
+    crate_match = re.search(r"^name\s*=\s*\"([A-Za-z0-9_-]+)\"", cargo_toml, re.MULTILINE)
+    assert crate_match
+    crate_ident = crate_match.group(1).replace("-", "_")
+
+    tests_dir = out_dir / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "designator_kept.rs").write_text(
+        (
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn designator_is_kept_on_the_variant_struct() {\n"
+            f"    use {crate_ident}::EventOrSubtype;\n"
+            '    let yaml = "category: MedicalEvent\\nname: x\\ndiagnosis: flu\\n";\n'
+            '    let v: EventOrSubtype = serde_yml::from_str(yaml).expect("decode");\n'
+            "    match &v {\n"
+            "        EventOrSubtype::MedicalEvent(inner) => {\n"
+            "            assert_eq!(\n"
+            "                inner.category.as_deref(),\n"
+            '                Some("MedicalEvent"),\n'
+            '                "designator was consumed as the enum tag instead of reaching the struct"\n'
+            "            );\n"
+            '            assert_eq!(inner.diagnosis.as_deref(), Some("flu"));\n'
+            "        }\n"
+            '        _ => panic!("expected MedicalEvent variant"),\n'
+            "    }\n"
+            '    let out = serde_yml::to_string(&v).expect("encode");\n'
+            "    assert_eq!(\n"
+            '        out.matches("category:").count(),\n'
+            "        1,\n"
+            '        "designator emitted twice (enum tag + struct field): {out}"\n'
+            "    );\n"
+            '    assert!(out.contains("category: MedicalEvent"), "{out}");\n'
+            "}\n"
+            "\n"
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn variant_struct_serializes_designator_standalone() {\n"
+            f"    use {crate_ident}::MedicalEvent;\n"
+            "    let m = MedicalEvent {\n"
+            '        category: Some("MedicalEvent".to_string()),\n'
+            "        name: None,\n"
+            '        diagnosis: Some("flu".to_string()),\n'
+            "    };\n"
+            '    let out = serde_yml::to_string(&m).expect("encode struct");\n'
+            '    assert!(out.contains("category: MedicalEvent"), "{out}");\n'
+            "}\n"
+            "\n"
+            '#[cfg(feature = "serde")]\n'
+            "#[test]\n"
+            "fn unknown_and_missing_designator_are_rejected() {\n"
+            f"    use {crate_ident}::EventOrSubtype;\n"
+            '    let unknown = "category: NoSuchEvent\\nname: x\\n";\n'
+            "    assert!(serde_yml::from_str::<EventOrSubtype>(unknown).is_err());\n"
+            '    let missing = "name: x\\n";\n'
+            "    assert!(serde_yml::from_str::<EventOrSubtype>(missing).is_err());\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.setdefault("RUST_BACKTRACE", "1")
+    result = subprocess.run(
+        ["cargo", "test", "--features", "serde", "--test", "designator_kept"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    # These tests only run under --with-rustgen, which implies a Rust toolchain, so
+    # a non-zero exit is a real regression rather than a missing cargo.
+    if result.returncode != 0:
+        pytest.fail(
+            f"cargo test failed for the type-designator crate.\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n"
+        )
 
 
 def test_rustgen_type_designator_tagged_roundtrip(temp_dir):


### PR DESCRIPTION
## Summary

This is a solution for the problem shown in #3835 by @elasticdotventures.

On main, when serializing a `OrSubtype` enum, any type_designator fields are emitted twice in the yaml (and a failure to serialize json).

Conversely, when deserializing, the `OrSubtype` would consume the type_designator value from the yaml, leaving the type_designator slot on the plain rust struct empty.

This PR fixes both problems in the serialisation/deserialisation code unlike in #3835 where the type_designator slot was omitted from the plain struct.

Instead of `#[serde(tag = "...")]`, a tagged `OrSubtype` enum now gets hand-written impls: `Serialize` delegates to the inner struct (which already emits the designator), and `Deserialize` buffers the input, reads the designator to pick the
variant, then re-feeds the whole value — designator included — to that variant. Untagged enums keep the derived impls.

## How was this tested?

Two tests, both failing before the fix:

- `test_rustgen_type_designator_dispatches_on_designator` — asserts the generated
  impls, that no enum-level tag is emitted, and that the designator remains a
  field on every variant struct.
- `test_rustgen_type_designator_preserves_designator_on_variant` — compiles the
  generated crate and runs `cargo test`: the designator survives a round-trip and
  is readable on the variant struct, is written exactly once, unknown/missing
  designator values are rejected, and the struct still serializes standalone.

`#3661`'s `test_rustgen_type_designator_emits_serde_tag` asserted the now-removed
`serde(tag = ...)`, so it is reworked into the new contract rather than deleted.

## Areas of uncertainty

N/A

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
