### PR TITLE
Fix openapi bugs 3970 3960

### DIFF
--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -138,7 +138,12 @@ class OpenApiGenerator(Generator):
                             result.add(resource_name)
                 if "parameters" in req_spec:
                     for param_spec in req_spec["parameters"]:
-                        if "$ref" in param_spec["schema"]:
+                        # a $ref parameter directly references a reusable parameter object
+                        # (whose schema lives inside components/parameters), so it cannot
+                        # reference a component schema on its own
+                        if "$ref" in param_spec:
+                            continue
+                        if param_spec.get("schema", {}).get("$ref"):
                             resource_name = param_spec["schema"]["$ref"].removeprefix("#/components/schemas/")
                             result.add(resource_name)
                 if "responses" in req_spec:

--- a/packages/linkml/src/linkml/generators/openapigen.py
+++ b/packages/linkml/src/linkml/generators/openapigen.py
@@ -123,6 +123,8 @@ class OpenApiGenerator(Generator):
                         f"x-linkml-schema '{schema['x-linkml-schema']}' "
                         f"but the loaded schema has id '{self.schemaview.schema.id}'"
                     )
+                if "x-linkml-source" not in schema:
+                    raise KeyError(f"Template data schema '{name}' is missing required 'x-linkml-source'")
 
     def _find_referenced_schemas(self) -> set[str]:
         """Return the set of resource names referenced by the template's endpoints."""

--- a/tests/linkml/test_generators/input/openapi/schema_missing_xlinkml_source.yaml
+++ b/tests/linkml/test_generators/input/openapi/schema_missing_xlinkml_source.yaml
@@ -1,0 +1,18 @@
+# LinkML schema used in tests for the bug
+# reporter's reproduction
+id: https://example.org/foo
+name: foo
+default_range: string
+imports:
+  - linkml:types
+
+classes:
+  Foo:
+    attributes:
+      name:
+        range: string
+
+  Bar:
+    attributes:
+      name:
+        range: string

--- a/tests/linkml/test_generators/input/openapi/schema_referenced_parameter.yaml
+++ b/tests/linkml/test_generators/input/openapi/schema_referenced_parameter.yaml
@@ -1,0 +1,9 @@
+# LinkML schema used in tests for bug report about
+# referenced (not inlined) parameters in the template
+id: https://example.org/g1
+name: g1
+imports:
+  - linkml:types
+
+classes:
+  Foo: {}

--- a/tests/linkml/test_generators/input/openapi/spec-missing-x-linkml-source.openapi.yaml
+++ b/tests/linkml/test_generators/input/openapi/spec-missing-x-linkml-source.openapi.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info: {title: Foo API, version: "1.0"}
+paths:
+  /foo:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Foo'}
+components:
+  schemas:
+    Foo:
+      type: object
+      x-linkml-schema: https://example.org/foo
+      x-linkml-source: Foo
+    Bar:
+      type: object
+      x-linkml-schema: https://example.org/foo

--- a/tests/linkml/test_generators/input/openapi/spec-referenced-parameter.openapi.yaml
+++ b/tests/linkml/test_generators/input/openapi/spec-referenced-parameter.openapi.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: t
+  version: '1.0.0'
+paths:
+  /foo:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Foo'
+components:
+  parameters:
+    Limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+  schemas:
+    Foo:
+      type: object
+      x-linkml-schema: https://example.org/g1
+      x-linkml-source: Foo

--- a/tests/linkml/test_generators/test_openapigen.py
+++ b/tests/linkml/test_generators/test_openapigen.py
@@ -115,6 +115,18 @@ def test_schema_id_mismatch_raises(input_path, kitchen_sink_path):
         OpenApiGenerator(kitchen_sink_path).serialize(head_path)
 
 
+def test_missing_x_linkml_source_raises(input_path):
+    """Test that a template schema missing x-linkml-source raises a descriptive KeyError.
+
+    x-linkml-schema presence/value are validated nicely, but x-linkml-source was
+    skipped, surfacing as a bare ``KeyError: 'x-linkml-source'`` during instantiation.
+    """
+    schema_path = str(input_path("openapi/schema_missing_xlinkml_source.yaml"))
+    head_path = str(input_path("openapi/spec-missing-x-linkml-source.openapi.yaml"))
+    with pytest.raises(KeyError, match="Bar.*missing required 'x-linkml-source'"):
+        OpenApiGenerator(schema_path, keep_unreferenced=True).serialize(head_path)
+
+
 def test_missing_schema_declaration_raises(tmp_path, kitchen_sink_path):
     """Test that referencing a non-existent schema in the template raises an error."""
     template = tmp_path / "bad.yaml"

--- a/tests/linkml/test_generators/test_openapigen.py
+++ b/tests/linkml/test_generators/test_openapigen.py
@@ -127,6 +127,23 @@ def test_missing_x_linkml_source_raises(input_path):
         OpenApiGenerator(schema_path, keep_unreferenced=True).serialize(head_path)
 
 
+def test_referenced_parameter_does_not_crash(input_path):
+    """Test that a template parameter given as a $ref does not raise KeyError.
+
+    A parameter entry of the form ``{$ref: '#/components/parameters/Limit'}`` has no
+    ``schema`` key of its own (the schema lives inside ``components/parameters``), so
+    reading ``param_spec["schema"]`` unconditionally crashed before generation.
+    """
+    schema_path = str(input_path("openapi/schema_referenced_parameter.yaml"))
+    head_path = str(input_path("openapi/spec-referenced-parameter.openapi.yaml"))
+    spec = yaml.safe_load(OpenApiGenerator(schema_path).serialize(head_path))
+    # the reusable parameter survives untouched
+    assert spec["paths"]["/foo"]["get"]["parameters"] == [{"$ref": "#/components/parameters/Limit"}]
+    # and the endpoint schema is generated as usual
+    assert "Foo" in spec["components"]["schemas"]
+    assert validate(spec, cls=OpenAPIV30SpecValidator) is None
+
+
 def test_missing_schema_declaration_raises(tmp_path, kitchen_sink_path):
     """Test that referencing a non-existent schema in the template raises an error."""
     template = tmp_path / "bad.yaml"


### PR DESCRIPTION
## Summary

Fixes #3960
Fixes #3970

Fixed:

- #3970 — Missing x-linkml-source in template schema produced a bare KeyError. _validate_oad_template validated x-linkml-schema presence/value with a descriptive error but skipped x-linkml-source. A schema declaring x-linkml-schema without x-linkml-source later surfaced as KeyError: 'x-linkml-source' during instantiation. Now the same descriptive error as for x-linkml-schema is raised, naming the offending template schema.
- #3960 — Referenced ($ref) parameters crashed generation before it started. _find_referenced_schemas read param_spec["schema"] unconditionally. A parameter entry of the form {$ref: '#/components/parameters/Limit'} carries its schema inside components/parameters and has no schema key of its own, so generation died with KeyError: 'schema'. Referenced parameters are now skipped (they cannot reference a component schema), and inline parameters are dereferenced safely.

## How was this tested?

Regression tests added.

## Areas of uncertainty

None

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
