### PR TITLE
fix(jsonschema): emit CURIE $ref targets under --use-curies

### DIFF
--- a/packages/linkml/src/linkml/generators/jsonschemagen.py
+++ b/packages/linkml/src/linkml/generators/jsonschemagen.py
@@ -218,6 +218,7 @@ def _slot_examples_for_json_schema(
 class JsonSchema(dict):
     OPTIONAL_IDENTIFIER_SUFFIX = "__identifier_optional"
     PRESERVE_NAMES: bool = False
+    USE_CURIES: bool = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -247,7 +248,7 @@ class JsonSchema(dict):
             names = [names]
 
         for name in names:
-            canonical_name = name if self.PRESERVE_NAMES else camelcase(name)
+            canonical_name = name if self.PRESERVE_NAMES or self.USE_CURIES else camelcase(name)
 
             if "$defs" not in self or canonical_name not in self["$defs"]:
                 self._lax_forward_refs[canonical_name] = identifier_name
@@ -319,7 +320,7 @@ class JsonSchema(dict):
     @classmethod
     def ref_for(cls, class_name: str | list[str], identifier_optional: bool = False, required: bool = True):
         def _ref(class_name):
-            def_name = class_name if cls.PRESERVE_NAMES else camelcase(class_name)
+            def_name = class_name if cls.PRESERVE_NAMES or cls.USE_CURIES else camelcase(class_name)
             def_suffix = cls.OPTIONAL_IDENTIFIER_SUFFIX if identifier_optional else ""
             return JsonSchema({"$ref": f"#/$defs/{def_name}{def_suffix}"})
 
@@ -476,6 +477,9 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
 
         # Set the class variable for JsonSchema to use
         JsonSchema.PRESERVE_NAMES = self.preserve_names
+        # Under --use-curies, class $defs are keyed by CURIE and $ref targets are
+        # pre-converted to CURIEs, so they must not be camelcased again.
+        JsonSchema.USE_CURIES = self.use_curies
 
         if self.top_class:
             if self.schemaview.get_class(self.top_class) is None:
@@ -756,6 +760,13 @@ class JsonSchemaGenerator(Generator, LifecycleMixin):
                     reference = descendants
                 else:
                     reference = slot.range
+                if self.use_curies:
+                    # $defs for classes are keyed by CURIE under --use-curies,
+                    # so the $ref targets must use the same CURIE keys.
+                    if isinstance(reference, list):
+                        reference = [self._curie(self.schemaview.get_class(r)) for r in reference]
+                    else:
+                        reference = self._curie(self.schemaview.get_class(reference))
             else:
                 id_slot = self.schemaview.get_identifier_slot(slot.range)
                 return self.get_type_info_for_slot_subschema(id_slot)

--- a/tests/linkml/test_generators/test_jsonschemagen.py
+++ b/tests/linkml/test_generators/test_jsonschemagen.py
@@ -1133,6 +1133,52 @@ def test_use_uris(caplog, input_path, use_curies):
         assert "saref_location" in generated["$defs"]["SarefEvent"]["properties"]
 
 
+def _collect_refs(node):
+    """Recursively yield every ``$ref`` string value in a JSON schema fragment."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str):
+                yield value
+            else:
+                yield from _collect_refs(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _collect_refs(item)
+
+
+def test_use_curies_refs_resolve_to_defs(kitchen_sink_path):
+    """Regression test for https://github.com/linkml/linkml/issues/3981.
+
+    Under ``--use-curies`` the ``$defs`` entries for classes are keyed by their
+    CURIE (e.g. ``ks:Company``), but the internal ``$ref`` targets that point at
+    those classes were emitted with the camelCased element name (e.g.
+    ``#/$defs/Company``), producing dangling references. Every ``$ref`` into
+    ``#/$defs/`` must resolve to an existing key in ``$defs``.
+
+    The kitchen sink schema exercises this on many inlined class-range slots and
+    emits CURIE-form class references, so it reproduces the original bug (each
+    such reference was dangling before the fix).
+    """
+    generator = JsonSchemaGenerator(kitchen_sink_path, mergeimports=True, use_curies=True)
+    generated = json.loads(generator.serialize())
+
+    # The generated schema must be structurally valid JSON Schema.
+    jsonschema.Draft7Validator.check_schema(generated)
+
+    def_keys = set(generated["$defs"])
+    # CURIE keying must be active (guards the test against a no-op schema).
+    assert any(":" in key for key in def_keys)
+
+    prefix = "#/$defs/"
+    defs_refs = [ref for ref in _collect_refs(generated) if ref.startswith(prefix)]
+    # At least one class reference must be in CURIE form, otherwise the fixed
+    # code path is never exercised and the test could pass vacuously.
+    assert any(":" in ref[len(prefix) :] for ref in defs_refs)
+
+    dangling = [ref for ref in defs_refs if ref[len(prefix) :] not in def_keys]
+    assert dangling == [], f"dangling $refs not present in $defs: {dangling}"
+
+
 # --------------------------------------------------
 # Arrays!!!
 # --------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #3981

Under `--use-curies`, class `$defs` are keyed by CURIE (e.g. `ex:Item`), but
`$ref` targets were still emitted with the camelCased element name (e.g.
`#/$defs/Item`), producing dangling references that fail `$ref` resolution.
Every inlined class-range slot was affected (single-valued, multivalued
inlined lists, and inlined-as-dict `additionalProperties`).

This PR:

- Converts class-range references to CURIEs in
  `get_type_info_for_slot_subschema()` when `use_curies` is set.
- Adds a `USE_CURIES` class variable on `JsonSchema` (mirroring the existing
  `PRESERVE_NAMES` mechanism) so `ref_for()` and `add_lax_def()` leave
  already-CURIE names untouched instead of camelcasing them.

The default (`--not-use-curies`) path is unchanged.

As usual on my bug-fixing PRs:

1. Commit that can be used to reproduce the bug and avoid future regressions.
2. Commit that fixes the bug.

## How was this tested?

- Added a regression test (`test_use_curies_refs_resolve_to_defs`) using the
  minimal schema from #3981. It walks every `$ref` in the generated schema and
  asserts each `#/$defs/` target resolves to an existing `$defs` key. The test
  fails on `main` (dangling `#/$defs/Item`) and passes with this fix.
- Existing `test_use_uris` still passes.

## Areas of uncertainty

- Enum ranges are intentionally not CURIE-keyed; this PR leaves them untouched.
  Worth a reviewer sanity-check that no other reference path (descendants
  lists, identifier-slot ranges) needs the same conversion.

## Checklist

- [x] My code follows the [contributor guidelines](https://linkml.io/linkml/maintainers/contributing.html)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally with my changes

## AI Assistance

If you used AI tools while preparing this PR, you are still the author and responsible for understanding, verifying, and defending your submission. Please engage with reviewers personally rather than through your agent during feedback and revisions. See our [AI Covenant](AI_COVENANT.md) for details.
