### PR TITLE
docs(shacl): document rule-to-SHACL-SPARQL constraint generation

### DIFF
--- a/docs/generators/shacl.rst
+++ b/docs/generators/shacl.rst
@@ -84,6 +84,83 @@ Example Output:
         shacl:targetClass <https://w3id.org/linkml/tests/kitchen_sink/Person> .
 
 
+Rule constraints (SHACL-SPARQL)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+LinkML `rules <https://linkml.io/linkml/schemas/advanced.html#rules>`_ express
+cross-parameter, conditional validation ("if slot A holds X, slot B must
+..."). Plain per-slot SHACL property shapes cannot express these, so the
+generator translates recognised rule shapes into
+`SHACL-SPARQL constraints <https://www.w3.org/TR/shacl/#sparql-constraints>`_
+(``sh:sparql`` / ``sh:SPARQLConstraint``) on the class's ``sh:NodeShape``.
+Generation is controlled by ``--emit-rules/--no-emit-rules`` (default: on).
+
+Three named patterns are recognised first:
+
+* **Boolean guard** — precondition ``value_presence: PRESENT`` on a value
+  slot, postcondition ``equals_string: "true"`` on a *boolean-range* flag
+  slot: if the value is present, the flag must be true.
+* **Presence implies value** — precondition ``value_presence: PRESENT``,
+  postcondition ``equals_string`` / ``equals_string_in`` on a target slot:
+  if the guard is present, the target must hold one of the allowed values.
+  Enum values resolve to their ``meaning`` IRIs; values without ``meaning``
+  compare as string literals.
+* **Exclusive value** — precondition ``equals_string`` and postcondition
+  ``maximum_cardinality`` on the *same* multivalued slot: if the value is
+  present, the slot has at most N values.
+
+Combinations outside the named patterns are handled by a compositional
+fallback that conjoins the preconditions and negates a single postcondition:
+conditional-required (``required: true``), conditional-absent
+(``value_presence: ABSENT``), numeric threshold preconditions
+(``minimum_value`` / ``maximum_value``), a one-hop nested precondition into
+an inlined child object (``range_expression.slot_conditions``), and
+``has_member`` list membership.
+
+The translation contract is *skip, never mis-translate*: a rule whose
+conditions set any operator outside the translated set (including
+expression-level ``any_of``/``all_of``/``none_of``/``exactly_one_of``), or
+whose slot keys resolve to no slot, is skipped and logged at ``DEBUG``.
+``deactivated`` rules are skipped; ``bidirectional``, ``open_world``, and
+``elseconditions`` warn (the forward direction is emitted).
+
+Example:
+
+.. code-block:: yaml
+
+    classes:
+      Weather:
+        slots: [sun_altitude, daytime]
+        rules:
+          - description: If sun_altitude is present, daytime must be day or twilight.
+            preconditions:
+              slot_conditions:
+                sun_altitude:
+                  value_presence: PRESENT
+            postconditions:
+              slot_conditions:
+                daytime:
+                  equals_string_in: [day, twilight]
+
+generates (abridged):
+
+.. code-block:: turtle
+
+    ex:Weather a sh:NodeShape ;
+        sh:sparql [ a sh:SPARQLConstraint ;
+            sh:message "If sun_altitude is present, daytime must be day or twilight." ;
+            sh:select """SELECT $this WHERE {
+        $this <https://example.org/sun_altitude> ?value .
+        OPTIONAL { $this <https://example.org/daytime> ?target . }
+        FILTER ( !BOUND(?target) || ?target NOT IN (<https://example.org/Day>, <https://example.org/Twilight>) )
+    }""" ] .
+
+``$this`` is pre-bound to each focus node per
+`SHACL §5.3.1 <https://www.w3.org/TR/shacl/#sparql-constraints-prebound>`_.
+Note that SPARQL-based constraints require a SHACL processor with
+SHACL-SPARQL support (e.g. ``pyshacl`` with ``advanced=True``).
+
+
 Command Line
 ^^^^^^^^^^^^
 

--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import string
 from collections.abc import Callable
@@ -446,8 +447,11 @@ class ShaclGenerator(Generator):
           multivalued slot, the total number of values must not exceed the
           given cardinality (typically 1 for mutual exclusion).
 
-        Operator combinations outside these named patterns are not translated;
-        the rule is skipped rather than partially represented.
+        Operator combinations outside these named patterns are handled by a
+        small compositional fallback (:meth:`_compose_rule_sparql`) covering
+        conditional-required / conditional-absent postconditions, numeric
+        threshold and nested-object preconditions, and ``has_member`` list
+        membership.
 
         See `W3C SHACL §5 <https://www.w3.org/TR/shacl/#sparql-constraints>`_.
         """
@@ -687,7 +691,216 @@ class ShaclGenerator(Generator):
                 )
 
         # Fallback: a small compositional builder for operator combinations not
+        # covered by the three named patterns above (conditional-required,
+        # threshold preconditions, list membership, ...).  Tried only after the
+        # named patterns, so their output is unchanged.
+        composed = self._compose_rule_sparql(sv, cls, rule)
+        if composed is not None:
+            return composed
+
         return None
+
+    def _compose_rule_sparql(self, sv, cls: ClassDefinition, rule) -> str | None:
+        """Compose a SHACL-SPARQL violation query for rule shapes not covered
+        by the three named patterns.
+
+        Translates a conjunction of *precondition* slot conditions and a single
+        *postcondition* slot condition into one ``SELECT $this`` query that
+        selects focus nodes which satisfy every precondition but violate the
+        postcondition.  Supported operators grow incrementally in
+        :meth:`_precondition_patterns` and :meth:`_postcondition_violation`;
+        the method returns ``None`` (rule skipped, never mis-translated) as soon
+        as any operator is unsupported.
+
+        A rule's ``postconditions`` are a conjunction, so violating a single
+        slot condition is sufficient; the single-postcondition case covers the
+        modeled cross-parameter rules.
+
+        Conforms to `SHACL §5.3.1
+        <https://www.w3.org/TR/shacl/#sparql-constraints-prebound>`_: ``$this``
+        is pre-bound to each focus node.
+        """
+        pre = getattr(rule, "preconditions", None)
+        post = getattr(rule, "postconditions", None)
+        if not pre or not post:
+            return None
+
+        pre_slots = getattr(pre, "slot_conditions", None) or {}
+        post_slots = getattr(post, "slot_conditions", None) or {}
+        if not pre_slots or len(post_slots) != 1:
+            return None
+
+        pre_lines = self._precondition_patterns(sv, cls, pre_slots)
+        if pre_lines is None:
+            return None
+
+        post_slot_name, post_cond = next(iter(post_slots.items()))
+        violation = self._postcondition_violation(sv, cls, post_slot_name, post_cond)
+        if violation is None:
+            return None
+
+        body = "\n".join(f"    {line}" for line in (pre_lines + violation))
+        return f"SELECT $this WHERE {{\n{body}\n}}"
+
+    def _scalar_filters(self, var: str, cond, resolve: Callable[[str], str]) -> list[str] | None:
+        """Return the SPARQL ``FILTER`` lines for the scalar operators on *cond*.
+
+        Unlike a first-match dispatch, **every** recognised operator contributes
+        a line, so a condition combining operators — e.g. a bounded range
+        ``{minimum_value: X, maximum_value: Y}`` — emits *both* bounds instead of
+        silently keeping only the first and under-constraining the query.
+        ``value_presence: PRESENT`` contributes no filter (the caller's triple
+        binding already enforces presence).
+
+        *resolve* maps an ``equals_string`` value to a SPARQL term (an enum
+        ``meaning`` IRI or an escaped string literal).
+
+        Returns ``None`` when *cond* sets no recognised scalar operator, sets
+        any operator *outside* the recognised set (per
+        :meth:`_set_operator_fields` — partial translation would drop a
+        conjunct), sets ``value_presence`` to anything but ``PRESENT``, or
+        carries a non-numeric threshold bound.  In every such case the caller
+        skips the rule it cannot faithfully translate rather than emitting an
+        under-constrained (or vacuous) query.
+        """
+        op_fields = self._set_operator_fields(cond)
+        if not op_fields or not op_fields <= {"value_presence", "equals_string", "minimum_value", "maximum_value"}:
+            return None  # unsupported operator present (or none at all): skip
+        if "value_presence" in op_fields and cond.value_presence != PresenceEnum(PresenceEnum.PRESENT):
+            # ABSENT (or a future presence value) cannot be expressed as a
+            # triple binding + filter; translating the other operators anyway
+            # would invert the declared trigger.
+            return None
+
+        filters: list[str] = []
+        if "equals_string" in op_fields:
+            filters.append(f"FILTER ( {var} = {resolve(cond.equals_string)} )")
+        if "minimum_value" in op_fields:
+            minimum = self._sparql_number(cond.minimum_value)
+            if minimum is None:
+                return None
+            filters.append(f"FILTER ( {var} >= {minimum} )")
+        if "maximum_value" in op_fields:
+            maximum = self._sparql_number(cond.maximum_value)
+            if maximum is None:
+                return None
+            filters.append(f"FILTER ( {var} <= {maximum} )")
+        return filters
+
+    def _precondition_patterns(self, sv, cls: ClassDefinition, pre_slots) -> list[str] | None:
+        """Translate a conjunction of precondition slot conditions into SPARQL
+        graph patterns (plus ``FILTER`` lines) that bind focus nodes satisfying
+        every condition.
+
+        Returns ``None`` if any condition sets no recognised operator.
+
+        Supported operators, which **combine** on a single condition (so a
+        bounded range ``{minimum_value: X, maximum_value: Y}`` emits both
+        bounds): ``value_presence: PRESENT``, ``equals_string``, and the numeric
+        thresholds ``minimum_value`` / ``maximum_value`` (inclusive, per the
+        LinkML metamodel).  A ``range_expression`` with inner ``slot_conditions``
+        reaches one hop into an inlined child object.
+        """
+        lines: list[str] = []
+        for i, (slot_name, cond) in enumerate(pre_slots.items()):
+            path = self._slot_uri(sv, slot_name, cls)
+            if path is None:
+                return None
+            var = f"?pre{i}"
+            if self._set_operator_fields(cond) == {"range_expression"}:
+                # One-hop into an inlined child object: bind the child node and
+                # apply the inner slot conditions to it.  The nested expression
+                # must itself be a plain conjunction of slot conditions; a
+                # condition mixing range_expression with scalar operators (or a
+                # nested any_of/...) is skipped rather than partially
+                # translated.
+                range_expr = cond.range_expression
+                if self._set_operator_fields(range_expr) != {"slot_conditions"}:
+                    return None
+                node = f"{var}_node"
+                lines.append(f"$this <{path}> {node} .")
+                inner = self._member_conditions(sv, cls, slot_name, node, range_expr.slot_conditions)
+                if inner is None:
+                    return None
+                lines.extend(inner)
+                continue
+            filters = self._scalar_filters(
+                var, cond, lambda v, sn=slot_name: self._resolve_enum_value_ref(sv, sn, v, cls)
+            )
+            if filters is None:
+                return None
+            lines.append(f"$this <{path}> {var} .")
+            lines.extend(filters)
+        return lines
+
+    def _member_conditions(
+        self, sv, cls: ClassDefinition, container_slot_name: str, node_var: str, slot_conditions
+    ) -> list[str] | None:
+        """Constrain the object bound to *node_var* — an instance of the range
+        class of *container_slot_name* — by a set of inner slot conditions.
+
+        Shared by the nested ``range_expression`` precondition (single inlined
+        child) and the ``has_member`` postcondition (a list member).  Inner
+        slots live on the container slot's **range class**, so both their
+        property IRIs and their enum values are resolved in that class's
+        induced context (the container slot itself is induced against *cls*,
+        honouring a ``slot_usage`` range narrowing).  Resolving against the
+        outer class instead would emit predicates the member nodes never carry
+        — the ``sh:path`` on the member shape and the SPARQL body would
+        diverge, making ``FILTER NOT EXISTS`` member checks vacuously true
+        (false positives) or preconditions never bind (false negatives).
+
+        Like preconditions, combining operators on one condition emits all of
+        them.  Returns ``None`` for unsupported inner operators or when the
+        container's range is not a class (inner conditions on a non-class
+        range cannot be resolved faithfully).
+        """
+        container = self._rule_slot(sv, container_slot_name, cls)
+        range_name = getattr(container, "range", None)
+        if not range_name or range_name not in sv.all_classes():
+            return None
+        range_cls = sv.get_class(range_name)
+
+        lines: list[str] = []
+        for j, (inner_name, icond) in enumerate(slot_conditions.items()):
+            ipath = self._slot_uri(sv, inner_name, range_cls)
+            if ipath is None:
+                return None
+            ivar = f"{node_var}_{j}"
+            filters = self._scalar_filters(
+                ivar,
+                icond,
+                lambda v, inm=inner_name: self._resolve_enum_value_ref(sv, inm, v, range_cls),
+            )
+            if filters is None:
+                return None
+            lines.append(f"{node_var} <{ipath}> {ivar} .")
+            lines.extend(filters)
+        return lines
+
+    @staticmethod
+    def _sparql_number(value) -> str | None:
+        """Render a numeric threshold bound as a SPARQL numeric literal, or
+        ``None`` when the value is not a finite number (callers then skip the
+        rule).
+
+        The metamodel range of ``minimum_value`` / ``maximum_value`` is
+        ``Anything``, so YAML strings, dates, booleans, ``.nan`` / ``.inf``
+        all pass through SchemaView unchanged.  Interpolating them raw is
+        unsound: ``"abc"`` yields unparsable SPARQL that poisons the whole
+        shapes graph at validation time, and a date like ``2020-01-01`` parses
+        as the arithmetic expression ``2020-01-01 = 2018`` and silently never
+        fires.  Only ``int`` / finite ``float`` (including the
+        ``extended_int`` / ``extended_float`` runtime subclasses) are
+        rendered; their ``str`` yields a plain numeric token (e.g. ``4000`` or
+        ``0.0``) that SPARQL compares with numeric promotion against
+        ``xsd:float`` / ``xsd:decimal`` data values.
+        """
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            return None
+        if isinstance(value, float) and not math.isfinite(value):
+            return None
+        return str(value)
 
     @staticmethod
     def _sparql_string_literal(value: str) -> str:
@@ -709,6 +922,50 @@ class ShaclGenerator(Generator):
             .replace("\t", "\\t")
         )
         return f'"{escaped}"'
+
+    def _postcondition_violation(self, sv, cls: ClassDefinition, slot_name: str, cond) -> list[str] | None:
+        """Translate a single postcondition slot condition into SPARQL that
+        matches a *violation* of it.
+
+        Returns ``None`` for operators not handled here, or when the condition
+        sets anything beyond the single operator a branch translates (dropping
+        a co-set operator would weaken the postcondition — the rule is skipped
+        instead).
+
+        Supported operators:
+
+        * ``required: true`` — violation = the target slot is absent on a focus
+          node that satisfies the preconditions.
+        * ``value_presence: ABSENT`` — violation = the target slot *is* present
+          (inapplicable-slot / conditional-absent).
+        * ``has_member`` with a nested ``range_expression`` — violation = *no*
+          member of the (multivalued) target slot matches the inner conditions
+          (list-membership; e.g. the light-group list must contain a
+          ``{group: Vehicle, type: front_fog_light}`` entry).
+        """
+        path = self._slot_uri(sv, slot_name, cls)
+        if path is None:
+            return None
+        op_fields = self._set_operator_fields(cond)
+        if op_fields == {"required"} and cond.required is True:
+            return [f"FILTER NOT EXISTS {{ $this <{path}> ?post . }}"]
+        if op_fields == {"value_presence"} and cond.value_presence == PresenceEnum(PresenceEnum.ABSENT):
+            return [f"$this <{path}> ?post ."]
+        if op_fields == {"has_member"}:
+            has_member = cond.has_member
+            if self._set_operator_fields(has_member) != {"range_expression"}:
+                return None
+            range_expr = has_member.range_expression
+            if self._set_operator_fields(range_expr) != {"slot_conditions"}:
+                return None
+            member_lines = [f"$this <{path}> ?mem ."]
+            inner = self._member_conditions(sv, cls, slot_name, "?mem", range_expr.slot_conditions)
+            if inner is None:
+                return None
+            member_lines.extend(inner)
+            block = " ".join(member_lines)
+            return [f"FILTER NOT EXISTS {{ {block} }}"]
+        return None
 
     def _build_boolean_guard_sparql(
         self, sv, cls: ClassDefinition, flag_slot_name: str, value_slot_name: str

--- a/packages/linkml/src/linkml/generators/shaclgen.py
+++ b/packages/linkml/src/linkml/generators/shaclgen.py
@@ -147,11 +147,15 @@ class ShaclGenerator(Generator):
 
     When ``True`` (default), recognised rule patterns are translated into
     SHACL-SPARQL constraints (``sh:SPARQLConstraint``) on the corresponding
-    ``sh:NodeShape``.  Currently two patterns are recognised:
+    ``sh:NodeShape``.  Currently three patterns are recognised:
 
     * *Boolean guard* — a precondition with ``value_presence: PRESENT`` on a
       value slot and a postcondition with ``equals_string: "true"`` on a
       boolean flag slot.
+    * *Presence implies value* — a precondition with ``value_presence: PRESENT``
+      on a value slot and a postcondition with ``equals_string`` or
+      ``equals_string_in`` on a (typically enum-valued) target slot.  This
+      generalises the boolean guard to arbitrary required values.
     * *Exclusive value* — a precondition with ``equals_string`` on a slot and
       a postcondition with ``maximum_cardinality`` on the *same* slot.
 
@@ -429,11 +433,21 @@ class ShaclGenerator(Generator):
           ``value_presence: PRESENT`` on a value slot and a *postcondition*
           with ``equals_string: "true"`` on a boolean flag slot.
 
+        * **Presence implies value** — a *precondition* with
+          ``value_presence: PRESENT`` on a value slot and a *postcondition*
+          with ``equals_string`` or ``equals_string_in`` on a target slot.
+          Enforces that when the value slot is present, the target slot must
+          be present and hold one of the allowed values (generalises the
+          boolean guard to enum-valued targets).
+
         * **Exclusive value** — a *precondition* with ``equals_string`` on
           a slot and a *postcondition* with ``maximum_cardinality`` on the
           *same* slot.  Enforces that when a specific value is present in a
           multivalued slot, the total number of values must not exceed the
           given cardinality (typically 1 for mutual exclusion).
+
+        Operator combinations outside these named patterns are not translated;
+        the rule is skipped rather than partially represented.
 
         See `W3C SHACL §5 <https://www.w3.org/TR/shacl/#sparql-constraints>`_.
         """
@@ -462,11 +476,11 @@ class ShaclGenerator(Generator):
                     cls.name,
                 )
 
-            if getattr(rule, "elseconditions", None):
+            if getattr(rule, "elseconditions", None) is not None:
                 logger.warning(
                     "Rule in class %r has elseconditions; "
-                    "only the forward (if/then) branch is emitted as sh:sparql. "
-                    "The else branch cannot be represented in SHACL-SPARQL.",
+                    "SHACL-SPARQL generation emits the forward (if/then) direction only. "
+                    "The else branch is not enforced.",
                     cls.name,
                 )
 
@@ -489,22 +503,137 @@ class ShaclGenerator(Generator):
 
             g.add((constraint, SH.select, Literal(sparql_query)))
 
+    # Fields on a slot condition / class expression that carry no constraint
+    # semantics: they never change which instances satisfy the condition, so
+    # they are ignored by the operator accounting below.  Anything set on a
+    # condition that is neither here nor explicitly translated by a converter
+    # makes the rule untranslatable — the converters must SKIP such a rule
+    # rather than emit a query that silently drops a conjunct (which would
+    # widen the trigger or narrow the check: a mis-translation, not a skip).
+    _NON_OPERATOR_FIELDS = frozenset(
+        {
+            "name",
+            "description",
+            "title",
+            "deprecated",
+            "todos",
+            "notes",
+            "comments",
+            "examples",
+            "in_subset",
+            "from_schema",
+            "imported_from",
+            "source",
+            "in_language",
+            "see_also",
+            "deprecated_element_has_exact_replacement",
+            "deprecated_element_has_possible_replacement",
+            "aliases",
+            "structured_aliases",
+            "local_names",
+            "mappings",
+            "exact_mappings",
+            "close_mappings",
+            "related_mappings",
+            "narrow_mappings",
+            "broad_mappings",
+            "created_by",
+            "contributors",
+            "created_on",
+            "last_updated_on",
+            "modified_by",
+            "status",
+            "rank",
+            "categories",
+            "keywords",
+            "extensions",
+            "annotations",
+            "alt_descriptions",
+            "id_prefixes",
+            "id_prefixes_are_closed",
+            "definition_uri",
+            "conforms_to",
+            "implements",
+            "instantiates",
+        }
+    )
+
+    @classmethod
+    def _set_operator_fields(cls, cond) -> set[str]:
+        """Return the names of the constraint-bearing fields actually set on a
+        rule condition or class expression.
+
+        A field counts as *set* when it is not ``None`` and not an empty
+        collection (SchemaView materialises unset multivalued fields as empty
+        lists / dicts).  Scalars are never judged by truthiness, so legitimate
+        falsy constraints such as ``minimum_value: 0`` or
+        ``equals_string: ""`` still count as set.  Metadata fields
+        (:data:`_NON_OPERATOR_FIELDS`) are excluded.
+
+        The converters compare this set against the exact operator set they
+        translate and skip the rule on any mismatch, so an unrecognised (or
+        future-metamodel) operator can never be silently dropped.
+        """
+        fields: set[str] = set()
+        for name, value in vars(cond).items():
+            if name.startswith("_") or name in cls._NON_OPERATOR_FIELDS:
+                continue
+            if value is None:
+                continue
+            if isinstance(value, list | dict) and not value:
+                continue
+            if isinstance(value, JsonObj) and not as_dict(value):
+                continue
+            fields.add(name)
+        return fields
+
+    def _rule_slot(self, sv, slot_name: str, cls: ClassDefinition):
+        """Resolve a rule condition's slot key to the slot it names, or ``None``
+        when no such slot exists.
+
+        Resolution order mirrors ``sh:path`` in the main slot loop: the induced
+        (class-specific) slot when the key names one of the class's slots, then
+        the underscored alias form (a rule key ``my_slot`` for a slot named
+        ``my slot`` — SchemaView normalises names the same way elsewhere), then
+        the base slot.  Callers treat ``None`` as *unknown slot* and skip the
+        rule rather than fabricating a predicate no shape uses.
+        """
+        class_slot_names = sv.class_slots(cls.name)
+        if slot_name in class_slot_names:
+            return sv.induced_slot(slot_name, cls.name)
+        canonical = next((s for s in class_slot_names if underscore(s) == underscore(slot_name)), None)
+        if canonical is not None:
+            return sv.induced_slot(canonical, cls.name)
+        return sv.get_slot(slot_name)
+
     def _rule_to_sparql(self, sv, cls: ClassDefinition, rule) -> str | None:
         """Convert a ``ClassRule`` to a SPARQL SELECT query string.
 
         Returns ``None`` when the rule does not match any supported pattern.
+        Each pattern requires its conditions to set **exactly** the operators
+        it translates; a rule whose pre/postconditions carry anything more
+        (extra scalar operators, expression-level ``any_of``/``all_of``/
+        ``none_of``/``exactly_one_of``, ...) is skipped rather than partially
+        translated.
         """
         pre = getattr(rule, "preconditions", None)
         post = getattr(rule, "postconditions", None)
         if not pre or not post:
             return None
 
-        pre_slots = getattr(pre, "slot_conditions", None) or {}
-        post_slots = getattr(post, "slot_conditions", None) or {}
+        # Expression-level exactness: only a plain conjunction of slot
+        # conditions is translatable.  An any_of/all_of/none_of/exactly_one_of
+        # branch cannot be honoured by any converter below; dropping it would
+        # widen the precondition (false positives) or weaken the postcondition
+        # (false negatives), so the whole rule is skipped.
+        if self._set_operator_fields(pre) != {"slot_conditions"}:
+            return None
+        if self._set_operator_fields(post) != {"slot_conditions"}:
+            return None
 
-        # Pattern: boolean guard
-        # preconditions: exactly one slot with value_presence PRESENT
-        # postconditions: exactly one slot with equals_string "true"
+        pre_slots = pre.slot_conditions or {}
+        post_slots = post.slot_conditions or {}
+
         if len(pre_slots) == 1 and len(post_slots) == 1:
             pre_slot_name = next(iter(pre_slots))
             post_slot_name = next(iter(post_slots))
@@ -512,31 +641,83 @@ class ShaclGenerator(Generator):
             pre_cond = pre_slots[pre_slot_name]
             post_cond = post_slots[post_slot_name]
 
-            # Note: PresenceEnum.PRESENT is a PermissibleValue, but parsed schemas
-            # return PresenceEnum instances — wrapping ensures type-compatible comparison.
-            is_value_present = getattr(pre_cond, "value_presence", None) == PresenceEnum(PresenceEnum.PRESENT)
-            is_flag_true = getattr(post_cond, "equals_string", None) == "true"
+            pre_ops = self._set_operator_fields(pre_cond)
+            post_ops = self._set_operator_fields(post_cond)
 
-            if is_value_present and is_flag_true:
+            is_value_present = pre_ops == {"value_presence"} and pre_cond.value_presence == PresenceEnum(
+                PresenceEnum.PRESENT
+            )
+
+            # Pattern: boolean guard
+            # preconditions: exactly one slot with (only) value_presence PRESENT
+            # postconditions: exactly one boolean-range slot with (only)
+            # equals_string "true".  The range gate matters: on a non-boolean
+            # slot the string "true" must be compared as a string, which is
+            # the presence-implies-value pattern below — without the gate the
+            # boolean comparison mistranslates and flags conforming data.
+            if (
+                is_value_present
+                and post_ops == {"equals_string"}
+                and post_cond.equals_string == "true"
+                and getattr(self._rule_slot(sv, post_slot_name, cls), "range", None) == "boolean"
+            ):
                 return self._build_boolean_guard_sparql(sv, cls, post_slot_name, pre_slot_name)
 
+            # Pattern: presence implies value (enum guard)
+            # preconditions: value slot with (only) value_presence PRESENT
+            # postconditions: target slot with (only) equals_string or (only)
+            # equals_string_in.
+            # Semantics: "If the value slot is present, the target slot must be
+            # present and hold one of the allowed values."  Generalises the
+            # boolean guard (equals_string "true") to arbitrary enum values.
+            if is_value_present and post_ops in ({"equals_string"}, {"equals_string_in"}):
+                if post_ops == {"equals_string_in"}:
+                    allowed = list(post_cond.equals_string_in)
+                else:
+                    allowed = [post_cond.equals_string]
+                return self._build_presence_implies_value_sparql(sv, cls, pre_slot_name, post_slot_name, allowed)
+
             # Pattern: exclusive value
-            # preconditions: slot X has equals_string (a specific enum value)
-            # postconditions: same slot X has maximum_cardinality N
+            # preconditions: slot X with (only) equals_string (a specific enum value)
+            # postconditions: same slot X with (only) maximum_cardinality N
             # Semantics: "If value V is present in slot X, then X has at most N values."
-            pre_equals = getattr(pre_cond, "equals_string", None)
-            post_max_card = getattr(post_cond, "maximum_cardinality", None)
+            if pre_ops == {"equals_string"} and post_ops == {"maximum_cardinality"} and pre_slot_name == post_slot_name:
+                return self._build_exclusive_value_sparql(
+                    sv, cls, pre_slot_name, pre_cond.equals_string, int(post_cond.maximum_cardinality)
+                )
 
-            if pre_equals is not None and post_max_card is not None and pre_slot_name == post_slot_name:
-                return self._build_exclusive_value_sparql(sv, cls, pre_slot_name, pre_equals, int(post_max_card))
-
+        # Fallback: a small compositional builder for operator combinations not
         return None
 
-    def _build_boolean_guard_sparql(self, sv, cls: ClassDefinition, flag_slot_name: str, value_slot_name: str) -> str:
+    @staticmethod
+    def _sparql_string_literal(value: str) -> str:
+        """Render *value* as a double-quoted SPARQL string literal, escaping the
+        characters the grammar forbids raw.
+
+        ``equals_string`` / permissible-value names are schema-controlled but
+        may legitimately contain a double quote, backslash, or newline; without
+        escaping these would break the ``sh:select`` query (or allow SPARQL
+        injection).  See `SPARQL 1.1 §19.7 escape sequences
+        <https://www.w3.org/TR/sparql11-query/#grammarEscapes>`_.
+        """
+        escaped = (
+            str(value)
+            .replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
+        return f'"{escaped}"'
+
+    def _build_boolean_guard_sparql(
+        self, sv, cls: ClassDefinition, flag_slot_name: str, value_slot_name: str
+    ) -> str | None:
         """Build a SPARQL SELECT query for the boolean-guard pattern.
 
         The query detects violations where the value property is present
-        but the boolean flag is absent or not ``true``.
+        but the boolean flag is absent or not ``true``.  Returns ``None``
+        (rule skipped) when either slot name resolves to no slot.
 
         Conforms to `SHACL §5.3.1
         <https://www.w3.org/TR/shacl/#sparql-constraints-prebound>`_:
@@ -544,6 +725,8 @@ class ShaclGenerator(Generator):
         """
         flag_uri = self._slot_uri(sv, flag_slot_name, cls)
         value_uri = self._slot_uri(sv, value_slot_name, cls)
+        if flag_uri is None or value_uri is None:
+            return None
 
         return (
             f"SELECT $this WHERE {{\n"
@@ -553,6 +736,44 @@ class ShaclGenerator(Generator):
             f'        ( !BOUND(?flag) || str(?flag) != "true" ) &&\n'
             f"        BOUND(?value)\n"
             f"    )\n"
+            f"}}"
+        )
+
+    def _build_presence_implies_value_sparql(
+        self,
+        sv,
+        cls: ClassDefinition,
+        value_slot_name: str,
+        target_slot_name: str,
+        allowed_values: list[str],
+    ) -> str | None:
+        """Build a SPARQL SELECT query for the presence-implies-value pattern.
+
+        Detects violations where the *value slot* is present but the *target
+        slot* is absent or holds a value outside the allowed set.  This
+        generalises the boolean-guard pattern to enum-valued targets: it
+        supports a single required value (``equals_string``) or a set of
+        acceptable values (``equals_string_in``).
+
+        Each allowed value is resolved via the target slot's enum ``meaning``
+        to a full IRI; values without a ``meaning`` (or non-enum targets) fall
+        back to a plain string literal.
+
+        Conforms to `SHACL §5.3.1
+        <https://www.w3.org/TR/shacl/#sparql-constraints-prebound>`_:
+        ``$this`` is pre-bound to each focus node.
+        """
+        value_uri = self._slot_uri(sv, value_slot_name, cls)
+        target_uri = self._slot_uri(sv, target_slot_name, cls)
+        if value_uri is None or target_uri is None:
+            return None
+        refs = ", ".join(self._resolve_enum_value_ref(sv, target_slot_name, v, cls) for v in allowed_values)
+
+        return (
+            f"SELECT $this WHERE {{\n"
+            f"    $this <{value_uri}> ?value .\n"
+            f"    OPTIONAL {{ $this <{target_uri}> ?target . }}\n"
+            f"    FILTER ( !BOUND(?target) || ?target NOT IN ({refs}) )\n"
             f"}}"
         )
 
@@ -583,7 +804,9 @@ class ShaclGenerator(Generator):
         ``$this`` is pre-bound to each focus node.
         """
         slot_uri = self._slot_uri(sv, slot_name, cls)
-        value_ref = self._resolve_enum_value_ref(sv, slot_name, value_name)
+        if slot_uri is None:
+            return None
+        value_ref = self._resolve_enum_value_ref(sv, slot_name, value_name, cls)
 
         if max_card == 1:
             return (
@@ -606,15 +829,20 @@ class ShaclGenerator(Generator):
             f"}}"
         )
 
-    def _resolve_enum_value_ref(self, sv, slot_name: str, value_name: str) -> str:
+    def _resolve_enum_value_ref(self, sv, slot_name: str, value_name: str, cls: ClassDefinition | None = None) -> str:
         """Resolve an enum value name to a SPARQL term (IRI or literal).
 
         Looks up the slot's range as an enum, finds the permissible value
         matching *value_name*, and returns its ``meaning`` as a full IRI
-        wrapped in angle brackets.  Falls back to a quoted literal if the
-        slot is not an enum or the value lacks a ``meaning``.
+        wrapped in angle brackets.  Falls back to an escaped quoted literal if
+        the slot is not an enum or the value lacks a ``meaning``.
+
+        When *cls* is given and the slot is declared on it, the slot is resolved
+        in the class's induced context, so a range narrowed via ``slot_usage``
+        (a class-specific enum) selects the correct permissible values instead
+        of the base slot's enum.
         """
-        slot = sv.get_slot(slot_name)
+        slot = self._rule_slot(sv, slot_name, cls) if cls is not None else sv.get_slot(slot_name)
         if slot:
             range_name = slot.range
             if range_name and range_name in sv.all_enums():
@@ -623,17 +851,27 @@ class ShaclGenerator(Generator):
                 if pv and pv.meaning:
                     iri = sv.expand_curie(pv.meaning)
                     return f"<{iri}>"
-        return f'"{value_name}"'
+        return self._sparql_string_literal(value_name)
 
-    def _slot_uri(self, sv, slot_name: str, cls: ClassDefinition) -> str:
-        """Resolve a slot name to a full IRI string for use in SPARQL queries.
+    def _slot_uri(self, sv, slot_name: str, cls: ClassDefinition) -> str | None:
+        """Resolve a slot name to a full IRI string for use in SPARQL queries,
+        or ``None`` when the name resolves to no slot at all (callers then skip
+        the rule).
 
-        Mirrors the resolution logic used for ``sh:path`` in the main slot loop:
-        prefer ``sv.get_uri()`` for slots registered in the schema map, fall
-        back to ``default_prefix:underscored_name``.
+        Mirrors the resolution logic used for ``sh:path`` in the main slot loop,
+        including the **induced** (class-specific) slot: a ``slot_usage``
+        override of ``slot_uri`` must yield the same IRI as ``sh:path``.
+        Otherwise the SPARQL body would query a property the data never uses and
+        the constraint would silently never fire (a false negative).  A slot
+        that resolves but is not registered in the schema's element map falls
+        back to ``default_prefix:underscored_name``, again matching ``sh:path``;
+        an *unknown* name must NOT take that fallback — it would fabricate a
+        predicate no shape uses and emit a vacuous constraint.
         """
-        slot = sv.get_slot(slot_name)
-        if slot and slot_name in sv.element_by_schema_map():
+        slot = self._rule_slot(sv, slot_name, cls)
+        if slot is None:
+            return None
+        if slot.name in sv.element_by_schema_map():
             return sv.get_uri(slot, expand=True)
         pfx = sv.schema.default_prefix
         return sv.expand_curie(f"{pfx}:{underscore(slot_name)}")
@@ -924,8 +1162,9 @@ def add_simple_data_type(func: Callable, r: ElementName) -> None:
     show_default=True,
     help=(
         "Emit sh:sparql constraints from LinkML rules: blocks. "
-        "When enabled (default), recognised rule patterns (e.g. boolean-guard) "
-        "are translated into SHACL-SPARQL constraints on the corresponding "
+        "When enabled (default), recognised rule patterns (boolean-guard, "
+        "presence-implies-value, exclusive-value) are translated into "
+        "SHACL-SPARQL constraints on the corresponding "
         "sh:NodeShape. Use --no-emit-rules to suppress rule generation."
     ),
 )

--- a/tests/linkml/test_generators/test_shaclgen.py
+++ b/tests/linkml/test_generators/test_shaclgen.py
@@ -3098,6 +3098,135 @@ def test_presence_implies_value_pyshacl_end_to_end():
 # holds but the required slot is absent (FILTER NOT EXISTS).
 # ===========================================================================
 
+_CONDITIONAL_REQUIRED_SCHEMA_YAML = """
+id: https://example.org/conditional-required
+name: conditional_required_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/conditional-required/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+enums:
+  SkyModelEnum:
+    permissible_values:
+      ClearSky:
+        meaning: ex:ClearSky
+      OvercastSky:
+        meaning: ex:OvercastSky
+      MeasuredOvercastSky:
+        meaning: ex:MeasuredOvercastSky
+
+slots:
+  sky_model:
+    range: SkyModelEnum
+    slot_uri: ex:sky_model
+  overcast_sky_illuminance:
+    range: float
+    slot_uri: ex:overcast_sky_illuminance
+
+classes:
+  Weather:
+    class_uri: ex:Weather
+    slots:
+      - sky_model
+      - overcast_sky_illuminance
+    rules:
+      - description: The MeasuredOvercastSky model requires the sky illuminance.
+        preconditions:
+          slot_conditions:
+            sky_model:
+              equals_string: MeasuredOvercastSky
+        postconditions:
+          slot_conditions:
+            overcast_sky_illuminance:
+              required: true
+"""
+
+EX_CR = rdflib.Namespace("https://example.org/conditional-required/")
+
+
+def test_conditional_required_generates_sparql():
+    """equals_string precondition + required postcondition → one sh:sparql constraint."""
+    g = _parse_shacl(_CONDITIONAL_REQUIRED_SCHEMA_YAML)
+
+    shape = EX_CR.Weather
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    assert len(sparql_nodes) == 1, f"Expected 1 sh:sparql constraint, got {len(sparql_nodes)}"
+
+    node = sparql_nodes[0]
+    assert (node, RDF.type, SH.SPARQLConstraint) in g
+    query = str(list(g.objects(node, SH.select))[0])
+
+    assert "$this" in query, "SPARQL must use $this pre-bound variable (SHACL §5.3.1)"
+    assert "FILTER NOT EXISTS" in query, "required violation must use FILTER NOT EXISTS"
+    # precondition references the enum meaning IRI and the trigger slot
+    assert f"<{EX_CR.MeasuredOvercastSky}>" in query, f"precondition must use the enum IRI, got:\n{query}"
+    assert str(EX_CR.sky_model) in query
+    assert str(EX_CR.overcast_sky_illuminance) in query
+
+
+def test_conditional_required_message_from_description():
+    """Rule description is emitted as sh:message."""
+    g = _parse_shacl(_CONDITIONAL_REQUIRED_SCHEMA_YAML)
+    messages = [str(m) for node in g.objects(EX_CR.Weather, SH.sparql) for m in g.objects(node, SH.message)]
+    assert any("requires the sky illuminance" in m for m in messages), messages
+
+
+def test_conditional_required_sparql_syntax_valid():
+    """Generated SPARQL must be syntactically valid."""
+    from rdflib.plugins.sparql import prepareQuery
+
+    g = _parse_shacl(_CONDITIONAL_REQUIRED_SCHEMA_YAML)
+    for node in g.objects(EX_CR.Weather, SH.sparql):
+        prepareQuery(str(list(g.objects(node, SH.select))[0]))
+
+
+def test_conditional_required_pyshacl_end_to_end():
+    """End-to-end: pyshacl passes conforming instances and flags the violation."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_CONDITIONAL_REQUIRED_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+
+    # Conforming: MeasuredOvercastSky WITH illuminance; ClearSky needs nothing.
+    conforming = """
+    @prefix ex: <https://example.org/conditional-required/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wMeasured a ex:Weather ;
+        ex:sky_model ex:MeasuredOvercastSky ;
+        ex:overcast_sky_illuminance "4200.0"^^xsd:float .
+
+    ex:wClear a ex:Weather ;
+        ex:sky_model ex:ClearSky .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Conforming instances should pass:\n{txt}"
+
+    # Violating: MeasuredOvercastSky WITHOUT the required illuminance.
+    violating = """
+    @prefix ex: <https://example.org/conditional-required/> .
+
+    ex:wBad a ex:Weather ;
+        ex:sky_model ex:MeasuredOvercastSky .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"MeasuredOvercastSky without illuminance should fail:\n{txt}"
+
 
 # ===========================================================================
 # Compositional fallback: conditional-absent pattern (M2)
@@ -3112,6 +3241,124 @@ def test_presence_implies_value_pyshacl_end_to_end():
 # precondition holds and the forbidden slot is present.
 # ===========================================================================
 
+_CONDITIONAL_ABSENT_SCHEMA_YAML = """
+id: https://example.org/conditional-absent
+name: conditional_absent_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/conditional-absent/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+enums:
+  SkyModelEnum:
+    permissible_values:
+      ClearSky:
+        meaning: ex:ClearSky
+      OvercastSky:
+        meaning: ex:OvercastSky
+
+slots:
+  sky_model:
+    range: SkyModelEnum
+    slot_uri: ex:sky_model
+  overcast_sky_illuminance:
+    range: float
+    slot_uri: ex:overcast_sky_illuminance
+
+classes:
+  Weather:
+    class_uri: ex:Weather
+    slots:
+      - sky_model
+      - overcast_sky_illuminance
+    rules:
+      - description: ClearSky makes overcast_sky_illuminance inapplicable.
+        preconditions:
+          slot_conditions:
+            sky_model:
+              equals_string: ClearSky
+        postconditions:
+          slot_conditions:
+            overcast_sky_illuminance:
+              value_presence: ABSENT
+"""
+
+EX_CA = rdflib.Namespace("https://example.org/conditional-absent/")
+
+
+def test_conditional_absent_generates_sparql():
+    """equals_string precondition + value_presence ABSENT → one sh:sparql constraint."""
+    g = _parse_shacl(_CONDITIONAL_ABSENT_SCHEMA_YAML)
+
+    sparql_nodes = list(g.objects(EX_CA.Weather, SH.sparql))
+    assert len(sparql_nodes) == 1, f"Expected 1 sh:sparql constraint, got {len(sparql_nodes)}"
+
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert "$this" in query
+    # violation = precondition holds AND the forbidden slot is present; the
+    # forbidden-slot triple must NOT be wrapped in NOT EXISTS.
+    assert "FILTER NOT EXISTS" not in query, f"conditional-absent must not use NOT EXISTS, got:\n{query}"
+    assert f"<{EX_CA.ClearSky}>" in query
+    assert str(EX_CA.overcast_sky_illuminance) in query
+
+
+def test_conditional_absent_sparql_syntax_valid():
+    """Generated SPARQL must be syntactically valid."""
+    from rdflib.plugins.sparql import prepareQuery
+
+    g = _parse_shacl(_CONDITIONAL_ABSENT_SCHEMA_YAML)
+    for node in g.objects(EX_CA.Weather, SH.sparql):
+        prepareQuery(str(list(g.objects(node, SH.select))[0]))
+
+
+def test_conditional_absent_pyshacl_end_to_end():
+    """End-to-end: pyshacl passes conforming instances and flags the violation."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_CONDITIONAL_ABSENT_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+
+    # Conforming: ClearSky without illuminance; OvercastSky may set illuminance.
+    conforming = """
+    @prefix ex: <https://example.org/conditional-absent/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wClear a ex:Weather ;
+        ex:sky_model ex:ClearSky .
+
+    ex:wOvercast a ex:Weather ;
+        ex:sky_model ex:OvercastSky ;
+        ex:overcast_sky_illuminance "5000.0"^^xsd:float .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Conforming instances should pass:\n{txt}"
+
+    # Violating: ClearSky WITH the inapplicable illuminance.
+    violating = """
+    @prefix ex: <https://example.org/conditional-absent/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wBad a ex:Weather ;
+        ex:sky_model ex:ClearSky ;
+        ex:overcast_sky_illuminance "5000.0"^^xsd:float .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"ClearSky with illuminance should fail:\n{txt}"
+
 
 # ===========================================================================
 # Compositional fallback: numeric threshold precondition (M3)
@@ -3124,6 +3371,113 @@ def test_presence_implies_value_pyshacl_end_to_end():
 # Semantics: "If X <= N, then Y must be present."  The threshold becomes a
 # SPARQL FILTER; combined here with the M1 required violation.
 # ===========================================================================
+
+_THRESHOLD_SCHEMA_YAML = """
+id: https://example.org/threshold
+name: threshold_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/threshold/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+slots:
+  meteorological_optical_range:
+    range: float
+    slot_uri: ex:meteorological_optical_range
+  fog_note:
+    range: string
+    slot_uri: ex:fog_note
+
+classes:
+  Weather:
+    class_uri: ex:Weather
+    slots:
+      - meteorological_optical_range
+      - fog_note
+    rules:
+      - description: In fog (optical range at or below 4000) a fog note is required.
+        preconditions:
+          slot_conditions:
+            meteorological_optical_range:
+              maximum_value: 4000
+        postconditions:
+          slot_conditions:
+            fog_note:
+              required: true
+"""
+
+EX_THR = rdflib.Namespace("https://example.org/threshold/")
+
+
+def test_threshold_precondition_generates_sparql():
+    """maximum_value precondition emits a numeric FILTER on the trigger slot."""
+    g = _parse_shacl(_THRESHOLD_SCHEMA_YAML)
+
+    sparql_nodes = list(g.objects(EX_THR.Weather, SH.sparql))
+    assert len(sparql_nodes) == 1, f"Expected 1 sh:sparql constraint, got {len(sparql_nodes)}"
+
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert "<= 4000" in query, f"threshold must emit '<= 4000', got:\n{query}"
+    assert "FILTER NOT EXISTS" in query, "required postcondition violation must use NOT EXISTS"
+    assert str(EX_THR.meteorological_optical_range) in query
+    assert str(EX_THR.fog_note) in query
+
+
+def test_threshold_precondition_sparql_syntax_valid():
+    """Generated SPARQL must be syntactically valid."""
+    from rdflib.plugins.sparql import prepareQuery
+
+    g = _parse_shacl(_THRESHOLD_SCHEMA_YAML)
+    for node in g.objects(EX_THR.Weather, SH.sparql):
+        prepareQuery(str(list(g.objects(node, SH.select))[0]))
+
+
+def test_threshold_precondition_pyshacl_end_to_end():
+    """End-to-end: below-threshold requires the note; above-threshold does not."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_THRESHOLD_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+
+    # Conforming: foggy (400) with a note; clear (5000) needs nothing.
+    conforming = """
+    @prefix ex: <https://example.org/threshold/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wFog a ex:Weather ;
+        ex:meteorological_optical_range "400.0"^^xsd:float ;
+        ex:fog_note "reduced visibility" .
+
+    ex:wClear a ex:Weather ;
+        ex:meteorological_optical_range "5000.0"^^xsd:float .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Conforming instances should pass:\n{txt}"
+
+    # Violating: foggy (400) without the required note.
+    violating = """
+    @prefix ex: <https://example.org/threshold/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wBad a ex:Weather ;
+        ex:meteorological_optical_range "400.0"^^xsd:float .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Fog without the required note should fail:\n{txt}"
 
 
 # ===========================================================================
@@ -3138,6 +3492,125 @@ def test_presence_implies_value_pyshacl_end_to_end():
 # Semantics: "If the child's inner value satisfies the condition, then Y must
 # be present."  The SPARQL binds the child node with one extra hop.
 # ===========================================================================
+
+_NESTED_SCHEMA_YAML = """
+id: https://example.org/nested
+name: nested_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/nested/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+slots:
+  sun_position:
+    range: SunPosition
+    inlined: true
+    slot_uri: ex:sun_position
+  elevation:
+    range: float
+    slot_uri: ex:elevation
+  headlight_note:
+    range: string
+    slot_uri: ex:headlight_note
+
+classes:
+  SunPosition:
+    class_uri: ex:SunPosition
+    slots:
+      - elevation
+  Weather:
+    class_uri: ex:Weather
+    slots:
+      - sun_position
+      - headlight_note
+    rules:
+      - description: When the sun is at or below the horizon a headlight note is required.
+        preconditions:
+          slot_conditions:
+            sun_position:
+              range_expression:
+                slot_conditions:
+                  elevation:
+                    maximum_value: 0.0
+        postconditions:
+          slot_conditions:
+            headlight_note:
+              required: true
+"""
+
+EX_NEST = rdflib.Namespace("https://example.org/nested/")
+
+
+def test_nested_precondition_generates_sparql():
+    """A nested range_expression precondition emits a two-hop graph pattern."""
+    g = _parse_shacl(_NESTED_SCHEMA_YAML)
+
+    sparql_nodes = list(g.objects(EX_NEST.Weather, SH.sparql))
+    assert len(sparql_nodes) == 1, f"Expected 1 sh:sparql constraint, got {len(sparql_nodes)}"
+
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert str(EX_NEST.sun_position) in query, "must traverse the container slot"
+    assert str(EX_NEST.elevation) in query, "must traverse the inner slot"
+    assert "<= 0.0" in query, f"inner threshold must appear, got:\n{query}"
+    assert "FILTER NOT EXISTS" in query
+    assert str(EX_NEST.headlight_note) in query
+
+
+def test_nested_precondition_sparql_syntax_valid():
+    """Generated SPARQL must be syntactically valid."""
+    from rdflib.plugins.sparql import prepareQuery
+
+    g = _parse_shacl(_NESTED_SCHEMA_YAML)
+    for node in g.objects(EX_NEST.Weather, SH.sparql):
+        prepareQuery(str(list(g.objects(node, SH.select))[0]))
+
+
+def test_nested_precondition_pyshacl_end_to_end():
+    """End-to-end: sun below horizon requires the note; above horizon does not."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_NESTED_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+
+    # Conforming: night (elevation -90) with a note; day (45) needs nothing.
+    conforming = """
+    @prefix ex: <https://example.org/nested/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wNight a ex:Weather ;
+        ex:sun_position [ a ex:SunPosition ; ex:elevation "-90.0"^^xsd:float ] ;
+        ex:headlight_note "on" .
+
+    ex:wDay a ex:Weather ;
+        ex:sun_position [ a ex:SunPosition ; ex:elevation "45.0"^^xsd:float ] .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Conforming instances should pass:\n{txt}"
+
+    # Violating: night (elevation -90) without the required note.
+    violating = """
+    @prefix ex: <https://example.org/nested/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wBad a ex:Weather ;
+        ex:sun_position [ a ex:SunPosition ; ex:elevation "-90.0"^^xsd:float ] .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Night without a headlight note should fail:\n{txt}"
 
 
 # ===========================================================================
@@ -3155,6 +3628,150 @@ def test_presence_implies_value_pyshacl_end_to_end():
 # class (LightControlGroup), which disambiguates the reused `type` slot.
 # ===========================================================================
 
+_HAS_MEMBER_SCHEMA_YAML = """
+id: https://example.org/has-member
+name: has_member_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/has-member/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+enums:
+  LightGroupEnum:
+    permissible_values:
+      Vehicle:
+        meaning: ex:Vehicle
+      StreetLight:
+        meaning: ex:StreetLight
+  LightTypeEnum:
+    permissible_values:
+      low_beam_headlight:
+        meaning: ex:low_beam_headlight
+      front_fog_light:
+        meaning: ex:front_fog_light
+
+slots:
+  fog_declared:
+    range: string
+    slot_uri: ex:fog_declared
+  enabled_light_control_groups:
+    range: LightControlGroup
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+    slot_uri: ex:enabled_light_control_groups
+  group:
+    range: LightGroupEnum
+    slot_uri: ex:group
+  type:
+    range: LightTypeEnum
+    slot_uri: ex:type
+
+classes:
+  LightControlGroup:
+    class_uri: ex:LightControlGroup
+    slots:
+      - group
+      - type
+  Weather:
+    class_uri: ex:Weather
+    slots:
+      - fog_declared
+      - enabled_light_control_groups
+    rules:
+      - description: When fog is declared, a front fog light group must be enabled.
+        preconditions:
+          slot_conditions:
+            fog_declared:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            enabled_light_control_groups:
+              has_member:
+                range_expression:
+                  slot_conditions:
+                    group:
+                      equals_string: Vehicle
+                    type:
+                      equals_string: front_fog_light
+"""
+
+EX_HM = rdflib.Namespace("https://example.org/has-member/")
+
+
+def test_has_member_generates_sparql():
+    """has_member postcondition emits a FILTER NOT EXISTS over list members."""
+    g = _parse_shacl(_HAS_MEMBER_SCHEMA_YAML)
+
+    sparql_nodes = list(g.objects(EX_HM.Weather, SH.sparql))
+    assert len(sparql_nodes) == 1, f"Expected 1 sh:sparql constraint, got {len(sparql_nodes)}"
+
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert "FILTER NOT EXISTS" in query, "list-membership violation must use FILTER NOT EXISTS"
+    assert str(EX_HM.enabled_light_control_groups) in query
+    assert str(EX_HM.group) in query and str(EX_HM.type) in query
+    # inner enum values resolve against the member class (LightControlGroup),
+    # so the reused `type` slot picks LightTypeEnum, not another enum.
+    assert f"<{EX_HM.Vehicle}>" in query, f"group value must be the enum IRI, got:\n{query}"
+    assert f"<{EX_HM.front_fog_light}>" in query, f"type value must be the enum IRI, got:\n{query}"
+
+
+def test_has_member_sparql_syntax_valid():
+    """Generated SPARQL must be syntactically valid."""
+    from rdflib.plugins.sparql import prepareQuery
+
+    g = _parse_shacl(_HAS_MEMBER_SCHEMA_YAML)
+    for node in g.objects(EX_HM.Weather, SH.sparql):
+        prepareQuery(str(list(g.objects(node, SH.select))[0]))
+
+
+def test_has_member_pyshacl_end_to_end():
+    """End-to-end: fog requires a front-fog-light member; otherwise it fails."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_HAS_MEMBER_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+
+    # Conforming: fog declared WITH a front-fog-light group; and no fog at all.
+    conforming = """
+    @prefix ex: <https://example.org/has-member/> .
+
+    ex:wFog a ex:Weather ;
+        ex:fog_declared "yes" ;
+        ex:enabled_light_control_groups
+            [ a ex:LightControlGroup ; ex:group ex:Vehicle ; ex:type ex:front_fog_light ] .
+
+    ex:wNoFog a ex:Weather .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Conforming instances should pass:\n{txt}"
+
+    # Violating: fog declared but only a low-beam group (no front fog light).
+    violating = """
+    @prefix ex: <https://example.org/has-member/> .
+
+    ex:wBad a ex:Weather ;
+        ex:fog_declared "yes" ;
+        ex:enabled_light_control_groups
+            [ a ex:LightControlGroup ; ex:group ex:Vehicle ; ex:type ex:low_beam_headlight ] .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Fog without a front-fog-light group should fail:\n{txt}"
+
 
 # ===========================================================================
 # Rule-converter robustness regressions (review hardening)
@@ -3168,6 +3785,202 @@ def test_presence_implies_value_pyshacl_end_to_end():
 #   3. An `equals_string` value containing a quote/backslash produced invalid,
 #      unparsable SPARQL (broken artifact / injection).
 # ===========================================================================
+
+_COMBINED_BOUNDS_SCHEMA_YAML = """
+id: https://example.org/combined-bounds
+name: combined_bounds_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/combined-bounds/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+slots:
+  reading_value:
+    range: integer
+    slot_uri: ex:reading_value
+  reading_note:
+    range: string
+    slot_uri: ex:reading_note
+
+classes:
+  Reading:
+    class_uri: ex:Reading
+    slots:
+      - reading_value
+      - reading_note
+    rules:
+      - description: A mid-range reading requires an explanatory note.
+        preconditions:
+          slot_conditions:
+            reading_value:
+              minimum_value: 10
+              maximum_value: 20
+        postconditions:
+          slot_conditions:
+            reading_note:
+              required: true
+"""
+
+EX_CB = rdflib.Namespace("https://example.org/combined-bounds/")
+
+
+def test_rule_precondition_combines_min_and_max_bounds():
+    """A precondition with both minimum_value and maximum_value must emit both
+    bounds; the pre-fix first-match dispatch kept only the maximum."""
+    g = _parse_shacl(_COMBINED_BOUNDS_SCHEMA_YAML)
+
+    nodes = list(g.objects(EX_CB.Reading, SH.sparql))
+    assert len(nodes) == 1, f"Expected 1 sh:sparql constraint, got {len(nodes)}"
+    query = str(list(g.objects(nodes[0], SH.select))[0])
+    assert ">= 10" in query, f"lower bound must be emitted, got:\n{query}"
+    assert "<= 20" in query, f"upper bound must be emitted, got:\n{query}"
+
+
+def test_rule_combined_bounds_pyshacl_end_to_end():
+    """End-to-end: only values inside [10, 20] trigger the required note.
+
+    The below-threshold case is the key assertion — without the lower bound it
+    would be flagged as a violation."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_COMBINED_BOUNDS_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+
+    conforming = """
+    @prefix ex: <https://example.org/combined-bounds/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:mid a ex:Reading ; ex:reading_value 15 ; ex:reading_note "in range" .
+    ex:low a ex:Reading ; ex:reading_value 5 .
+    ex:high a ex:Reading ; ex:reading_value 25 .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Out-of-range readings must not require a note:\n{txt}"
+
+    violating = """
+    @prefix ex: <https://example.org/combined-bounds/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:bad a ex:Reading ; ex:reading_value 15 .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"A mid-range reading without a note must fail:\n{txt}"
+
+
+_SLOT_URI_OVERRIDE_SCHEMA_YAML = """
+id: https://example.org/slot-uri-override
+name: slot_uri_override_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/slot-uri-override/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+slots:
+  trigger:
+    range: string
+    slot_uri: ex:GLOBAL_trigger
+  dependent:
+    range: string
+    slot_uri: ex:GLOBAL_dependent
+
+classes:
+  Scene:
+    class_uri: ex:Scene
+    slots:
+      - trigger
+      - dependent
+    slot_usage:
+      trigger:
+        slot_uri: ex:LOCAL_trigger
+      dependent:
+        slot_uri: ex:LOCAL_dependent
+    rules:
+      - description: If the trigger is present the dependent slot is required.
+        preconditions:
+          slot_conditions:
+            trigger:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            dependent:
+              required: true
+"""
+
+EX_OVR = rdflib.Namespace("https://example.org/slot-uri-override/")
+
+
+def test_rule_slot_uri_override_matches_sh_path():
+    """The SPARQL body must use the same induced (class-local) IRIs as sh:path.
+
+    A slot_usage slot_uri override changes sh:path; if the SPARQL keeps the base
+    IRI the query targets a property the data never uses and never fires."""
+    g = _parse_shacl(_SLOT_URI_OVERRIDE_SCHEMA_YAML)
+
+    paths = {str(o) for o in g.objects(None, SH.path)}
+    assert str(EX_OVR.LOCAL_trigger) in paths
+    assert str(EX_OVR.LOCAL_dependent) in paths
+
+    nodes = list(g.objects(EX_OVR.Scene, SH.sparql))
+    assert len(nodes) == 1
+    query = str(list(g.objects(nodes[0], SH.select))[0])
+    assert str(EX_OVR.LOCAL_trigger) in query, f"SPARQL must use the induced IRI, got:\n{query}"
+    assert str(EX_OVR.LOCAL_dependent) in query, f"SPARQL must use the induced IRI, got:\n{query}"
+    assert "GLOBAL_" not in query, f"SPARQL must not fall back to the base slot_uri, got:\n{query}"
+
+
+def test_rule_slot_uri_override_pyshacl_end_to_end():
+    """End-to-end: the constraint actually fires on data that uses the induced
+    (LOCAL) IRIs.  Before the fix the SPARQL queried the base IRIs, so a missing
+    dependent slot slipped through as conforming."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_SLOT_URI_OVERRIDE_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+
+    conforming = """
+    @prefix ex: <https://example.org/slot-uri-override/> .
+
+    ex:ok a ex:Scene ; ex:LOCAL_trigger "t" ; ex:LOCAL_dependent "d" .
+    ex:noTrigger a ex:Scene ; ex:LOCAL_dependent "d" .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Trigger-with-dependent (and no-trigger) must pass:\n{txt}"
+
+    violating = """
+    @prefix ex: <https://example.org/slot-uri-override/> .
+
+    ex:bad a ex:Scene ; ex:LOCAL_trigger "t" .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Trigger present without the required dependent must fail:\n{txt}"
 
 
 _ENUM_NARROWING_SCHEMA_YAML = """
@@ -3668,6 +4481,426 @@ def test_rule_equals_true_on_string_slot_pyshacl_end_to_end():
         advanced=True,
     )
     assert not conforms, f"status 'other' violates the rule:\n{txt}"
+
+
+_INNER_OVERRIDE_SCHEMA_YAML = """
+id: https://example.org/inner-override
+name: inner_override
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/inner-override/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  sun_position:
+    range: SunPosition
+    inlined: true
+    slot_uri: ex:sun_position
+  elevation:
+    range: float
+    slot_uri: ex:elevation
+  headlight_note:
+    slot_uri: ex:headlight_note
+classes:
+  SunPosition:
+    class_uri: ex:SunPosition
+    slots: [elevation]
+    slot_usage:
+      elevation:
+        slot_uri: ex:localElevation
+  Scene:
+    class_uri: ex:Scene
+    slots: [sun_position, headlight_note]
+    rules:
+      - description: Below the horizon a headlight note is required.
+        preconditions:
+          slot_conditions:
+            sun_position:
+              range_expression:
+                slot_conditions:
+                  elevation:
+                    maximum_value: 0
+        postconditions:
+          slot_conditions:
+            headlight_note:
+              required: true
+"""
+
+
+def test_rule_nested_inner_slot_uri_resolved_on_range_class():
+    """The inner slot of a nested precondition lives on the container's range
+    class; a slot_usage slot_uri override there must be honoured (sh:path /
+    SPARQL-body parity one hop down)."""
+    g = _parse_shacl(_INNER_OVERRIDE_SCHEMA_YAML)
+    shape = URIRef("https://example.org/inner-override/Scene")
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    assert len(sparql_nodes) == 1
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert "https://example.org/inner-override/localElevation" in query, (
+        f"inner slot must use the range class's induced slot_uri, got:\n{query}"
+    )
+    assert "https://example.org/inner-override/elevation" not in query, (
+        "the base slot_uri must not leak into the member pattern"
+    )
+
+
+def test_rule_nested_inner_slot_uri_override_pyshacl_end_to_end():
+    """A night scene without the required note must be flagged — with the
+    base-URI mistranslation the constraint silently never fired."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_INNER_OVERRIDE_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+    # The float is typed explicitly so the sh:datatype property constraint is
+    # satisfied and the outcome discriminates on the rule constraint alone.
+    violating = """
+    @prefix ex: <https://example.org/inner-override/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:night a ex:Scene ; ex:sun_position ex:sp .
+    ex:sp a ex:SunPosition ; ex:localElevation "-5.0"^^xsd:float .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Night scene without headlight note must fail:\n{txt}"
+
+    conforming = """
+    @prefix ex: <https://example.org/inner-override/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:noon a ex:Scene ; ex:sun_position ex:sp2 .
+    ex:sp2 a ex:SunPosition ; ex:localElevation "45.0"^^xsd:float .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Daytime scene needs no headlight note:\n{txt}"
+
+
+_INNER_COLLISION_SCHEMA_YAML = """
+id: https://example.org/inner-collision
+name: inner_collision
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/inner-collision/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  marker_flag:
+    slot_uri: ex:marker_flag
+  items:
+    range: Item
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+    slot_uri: ex:items
+  type:
+    slot_uri: ex:defaultType
+classes:
+  Item:
+    class_uri: ex:Item
+    slots: [type]
+    slot_usage:
+      type:
+        slot_uri: ex:itemType
+  Box:
+    class_uri: ex:Box
+    slots: [marker_flag, items, type]
+    slot_usage:
+      type:
+        slot_uri: ex:boxType
+    rules:
+      - description: A flagged box must contain a marker item.
+        preconditions:
+          slot_conditions:
+            marker_flag:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            items:
+              has_member:
+                range_expression:
+                  slot_conditions:
+                    type:
+                      equals_string: marker
+"""
+
+
+def test_rule_has_member_inner_slot_not_shadowed_by_outer_class():
+    """An inner slot name that also exists on the OUTER class with a different
+    slot_usage URI must still resolve against the member class."""
+    g = _parse_shacl(_INNER_COLLISION_SCHEMA_YAML)
+    shape = URIRef("https://example.org/inner-collision/Box")
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    assert len(sparql_nodes) == 1
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert "https://example.org/inner-collision/itemType" in query, (
+        f"member condition must use the member class's slot URI, got:\n{query}"
+    )
+    assert "boxType" not in query, "the outer class's slot_usage URI must not shadow the member's"
+
+
+def test_rule_has_member_inner_slot_collision_pyshacl_end_to_end():
+    """A conforming box (marker item present via the member class's predicate)
+    must conform — the outer-class shadowing made FILTER NOT EXISTS vacuous."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_INNER_COLLISION_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+    conforming = """
+    @prefix ex: <https://example.org/inner-collision/> .
+
+    ex:b a ex:Box ; ex:marker_flag "y" ; ex:items ex:i1 .
+    ex:i1 a ex:Item ; ex:itemType "marker" .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Box with a marker item must conform:\n{txt}"
+
+
+_CONTAINER_NARROWED_SCHEMA_YAML = """
+id: https://example.org/container-narrowed
+name: container_narrowed
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/container-narrowed/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+enums:
+  BaseKindEnum:
+    permissible_values:
+      special:
+        meaning: ex:BASE_special
+  SpecialKindEnum:
+    permissible_values:
+      special:
+        meaning: ex:SPECIAL_special
+slots:
+  part:
+    range: BasePart
+    inlined: true
+    slot_uri: ex:part
+  kind:
+    range: BaseKindEnum
+    slot_uri: ex:kind
+  label_note:
+    slot_uri: ex:label_note
+classes:
+  BasePart:
+    class_uri: ex:BasePart
+    slots: [kind]
+  SpecialPart:
+    class_uri: ex:SpecialPart
+    is_a: BasePart
+    slot_usage:
+      kind:
+        range: SpecialKindEnum
+  Assembly:
+    class_uri: ex:Assembly
+    slots: [part, label_note]
+    slot_usage:
+      part:
+        range: SpecialPart
+    rules:
+      - description: A special part requires a label note.
+        preconditions:
+          slot_conditions:
+            part:
+              range_expression:
+                slot_conditions:
+                  kind:
+                    equals_string: special
+        postconditions:
+          slot_conditions:
+            label_note:
+              required: true
+"""
+
+
+def test_rule_container_range_narrowing_resolves_inner_enum():
+    """A slot_usage range-narrowing of the CONTAINER slot must resolve inner
+    enum values against the narrowed range class's enum."""
+    g = _parse_shacl(_CONTAINER_NARROWED_SCHEMA_YAML)
+    shape = URIRef("https://example.org/container-narrowed/Assembly")
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    assert len(sparql_nodes) == 1
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert "SPECIAL_special" in query, f"inner enum must resolve via the narrowed range, got:\n{query}"
+    assert "BASE_special" not in query, "the base range's enum must not be used"
+
+
+_NON_NUMERIC_BOUNDS_SCHEMA_YAML = """
+id: https://example.org/non-numeric-bounds
+name: non_numeric_bounds
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/non-numeric-bounds/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  v:
+    range: integer
+    slot_uri: ex:v
+  note:
+    slot_uri: ex:note
+classes:
+  Obs:
+    class_uri: ex:Obs
+    slots: [v, note]
+    rules:
+      - preconditions:
+          slot_conditions:
+            v:
+              minimum_value: "abc"
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+      - preconditions:
+          slot_conditions:
+            v:
+              minimum_value: 2020-01-01
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+      - preconditions:
+          slot_conditions:
+            v:
+              maximum_value: .nan
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+      - preconditions:
+          slot_conditions:
+            v:
+              minimum_value: true
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+"""
+
+
+def test_rule_non_numeric_bounds_skipped():
+    """Non-numeric threshold bounds (string, date, NaN, boolean) must skip the
+    rule: raw interpolation produced unparsable SPARQL (poisoning the whole
+    shapes graph) or silently-wrong arithmetic (2020-01-01 == 2018)."""
+    g = _parse_shacl(_NON_NUMERIC_BOUNDS_SCHEMA_YAML)
+    shape = URIRef("https://example.org/non-numeric-bounds/Obs")
+    assert list(g.objects(shape, SH.sparql)) == []
+
+
+def test_rule_non_numeric_bounds_shapes_graph_still_validates():
+    """The generated shapes graph must remain usable by pyshacl — one bad bound
+    used to raise a ParseException for every validation run."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_NON_NUMERIC_BOUNDS_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+    data = """
+    @prefix ex: <https://example.org/non-numeric-bounds/> .
+
+    ex:o a ex:Obs ; ex:v 1 .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=data,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Shapes graph must stay parseable and the data conform:\n{txt}"
+
+
+def test_has_member_zero_members_pyshacl_end_to_end():
+    """A node meeting the precondition with ZERO members violates has_member
+    ('must contain a matching member'); locks the semantics in."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_HAS_MEMBER_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+    violating = """
+    @prefix ex: <https://example.org/has-member/> .
+
+    ex:wZero a ex:Weather ; ex:fog_declared "fog" .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Zero members cannot contain the required member:\n{txt}"
+
+
+_ALIAS_KEY_SCHEMA_YAML = """
+id: https://example.org/alias-key
+name: alias_key
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/alias-key/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  my slot:
+    slot_uri: ex:customMySlot
+  note:
+    slot_uri: ex:note
+classes:
+  Obs:
+    class_uri: ex:Obs
+    slots: ["my slot", note]
+    rules:
+      - description: Underscored alias key must resolve to the declared slot.
+        preconditions:
+          slot_conditions:
+            my_slot:
+              equals_string: trigger
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+"""
+
+
+def test_rule_alias_form_slot_key_resolves_override():
+    """A rule key written `my_slot` for a slot named `my slot` must resolve to
+    that slot's URI (sh:path parity) instead of fabricating a default-prefix
+    predicate that makes the constraint vacuous."""
+    g = _parse_shacl(_ALIAS_KEY_SCHEMA_YAML)
+    shape = URIRef("https://example.org/alias-key/Obs")
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    assert len(sparql_nodes) == 1
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert "https://example.org/alias-key/customMySlot" in query, (
+        f"alias-form key must resolve to the declared slot_uri, got:\n{query}"
+    )
+    assert "https://example.org/alias-key/my_slot" not in query, (
+        "the fabricated default-prefix predicate must not be emitted"
+    )
 
 
 _UNKNOWN_KEY_SCHEMA_YAML = """

--- a/tests/linkml/test_generators/test_shaclgen.py
+++ b/tests/linkml/test_generators/test_shaclgen.py
@@ -2784,3 +2784,928 @@ classes:
     has_boolean = any("BOUND" in q for q in queries)
     assert has_exclusive, "Expected one exclusive-value SPARQL constraint"
     assert has_boolean, "Expected one boolean-guard SPARQL constraint"
+
+
+# ===========================================================================
+# Presence-implies-value pattern tests (enum guard)
+# ===========================================================================
+#
+# The "presence implies value" pattern generalises the boolean guard to
+# enum-valued targets.  It translates a LinkML rule where:
+#   - preconditions: a value slot has value_presence: PRESENT
+#   - postconditions: a target slot has equals_string (single required value)
+#     or equals_string_in (a set of acceptable values)
+#
+# Semantics: "If the value slot is present, the target slot must be present
+# and hold one of the allowed values."  The motivating use case is the aiSim
+# environment model, e.g. "if texture_sky_color is set, sky_model must be
+# TextureSky" and "if overcast_sky_illuminance is set, sky_model must be an
+# overcast model".
+#
+# References:
+#   - W3C SHACL §5 <https://www.w3.org/TR/shacl/#sparql-constraints>
+#   - W3C SHACL §5.3.1 <https://www.w3.org/TR/shacl/#sparql-constraints-prebound>
+# ===========================================================================
+
+_PRESENCE_IMPLIES_VALUE_SCHEMA_YAML = """
+id: https://example.org/presence-implies-value
+name: presence_implies_value_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/presence-implies-value/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+enums:
+  SkyModelEnum:
+    permissible_values:
+      ClearSky:
+        meaning: ex:ClearSky
+      OvercastSky:
+        meaning: ex:OvercastSky
+      MeasuredOvercastSky:
+        meaning: ex:MeasuredOvercastSky
+      TextureSky:
+        meaning: ex:TextureSky
+
+  ModeEnum:
+    permissible_values:
+      Auto:
+        description: Automatic mode (no meaning IRI).
+      Manual:
+        description: Manual mode (no meaning IRI).
+
+slots:
+  sky_model:
+    range: SkyModelEnum
+    slot_uri: ex:sky_model
+  texture_sky_color:
+    range: string
+    slot_uri: ex:texture_sky_color
+  overcast_sky_illuminance:
+    range: float
+    slot_uri: ex:overcast_sky_illuminance
+  mode:
+    range: ModeEnum
+    slot_uri: ex:mode
+  manual_value:
+    range: decimal
+    slot_uri: ex:manual_value
+
+classes:
+  Weather:
+    class_uri: ex:Weather
+    slots:
+      - sky_model
+      - texture_sky_color
+      - overcast_sky_illuminance
+    rules:
+      - description: If texture_sky_color is provided, sky_model must be TextureSky.
+        preconditions:
+          slot_conditions:
+            texture_sky_color:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            sky_model:
+              equals_string: "TextureSky"
+      - description: If overcast_sky_illuminance is provided, sky_model must be an overcast model.
+        preconditions:
+          slot_conditions:
+            overcast_sky_illuminance:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            sky_model:
+              equals_string_in:
+                - OvercastSky
+                - MeasuredOvercastSky
+
+  Device:
+    class_uri: ex:Device
+    slots:
+      - mode
+      - manual_value
+    rules:
+      - description: If manual_value is provided, mode must be Manual (literal fallback).
+        preconditions:
+          slot_conditions:
+            manual_value:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            mode:
+              equals_string: "Manual"
+"""
+
+EX_PIV = rdflib.Namespace("https://example.org/presence-implies-value/")
+
+
+def test_presence_implies_value_generates_sparql():
+    """Presence-implies-value rules produce sh:sparql constraints on the NodeShape."""
+    g = _parse_shacl(_PRESENCE_IMPLIES_VALUE_SCHEMA_YAML)
+
+    shape = EX_PIV.Weather
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    assert len(sparql_nodes) == 2, f"Expected 2 sh:sparql constraints, got {len(sparql_nodes)}"
+
+    for node in sparql_nodes:
+        assert (node, RDF.type, SH.SPARQLConstraint) in g
+        selects = list(g.objects(node, SH.select))
+        assert len(selects) == 1, "Each constraint must have exactly one sh:select"
+        query = str(selects[0])
+        assert "$this" in query, "SPARQL must use $this pre-bound variable"
+        assert "NOT IN" in query, "presence-implies-value SPARQL must use NOT IN membership test"
+        assert "FILTER" in query, "SPARQL must have a FILTER clause"
+
+
+def test_presence_implies_value_single_uses_enum_iri():
+    """A single equals_string target resolves to the enum meaning IRI."""
+    g = _parse_shacl(_PRESENCE_IMPLIES_VALUE_SCHEMA_YAML)
+
+    shape = EX_PIV.Weather
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    queries = [str(list(g.objects(n, SH.select))[0]) for n in sparql_nodes]
+
+    texture_query = [q for q in queries if "texture_sky_color" in q]
+    assert len(texture_query) == 1, "Expected exactly one texture_sky_color rule"
+    query = texture_query[0]
+
+    # value slot and target slot URIs both present
+    assert str(EX_PIV.texture_sky_color) in query
+    assert str(EX_PIV.sky_model) in query
+    # target value resolves to the TextureSky meaning IRI in angle brackets
+    assert f"<{EX_PIV.TextureSky}>" in query, f"Expected TextureSky IRI, got:\n{query}"
+
+
+def test_presence_implies_value_set_uses_all_iris():
+    """equals_string_in resolves every allowed value to its enum meaning IRI."""
+    g = _parse_shacl(_PRESENCE_IMPLIES_VALUE_SCHEMA_YAML)
+
+    shape = EX_PIV.Weather
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    queries = [str(list(g.objects(n, SH.select))[0]) for n in sparql_nodes]
+
+    overcast_query = [q for q in queries if "overcast_sky_illuminance" in q]
+    assert len(overcast_query) == 1, "Expected exactly one overcast rule"
+    query = overcast_query[0]
+
+    assert f"<{EX_PIV.OvercastSky}>" in query, f"Expected OvercastSky IRI, got:\n{query}"
+    assert f"<{EX_PIV.MeasuredOvercastSky}>" in query, f"Expected MeasuredOvercastSky IRI, got:\n{query}"
+
+
+def test_presence_implies_value_no_meaning_falls_back_to_literal():
+    """When the target enum value lacks a meaning IRI, it is compared as a literal."""
+    g = _parse_shacl(_PRESENCE_IMPLIES_VALUE_SCHEMA_YAML)
+
+    shape = EX_PIV.Device
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    assert len(sparql_nodes) == 1
+
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert '"Manual"' in query, f"No-meaning enum should use literal '\"Manual\"', got:\n{query}"
+    assert f"<{EX_PIV}Manual>" not in query, "Should not emit as IRI when meaning is absent"
+
+
+def test_presence_implies_value_message_from_description():
+    """Rule description is emitted as sh:message on the SPARQLConstraint."""
+    g = _parse_shacl(_PRESENCE_IMPLIES_VALUE_SCHEMA_YAML)
+
+    shape = EX_PIV.Weather
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    messages = [str(m) for node in sparql_nodes for m in g.objects(node, SH.message)]
+
+    assert any("sky_model must be TextureSky" in m for m in messages), (
+        f"Expected message about TextureSky, got: {messages}"
+    )
+
+
+def test_presence_implies_value_sparql_syntax_valid():
+    """Generated SPARQL for presence-implies-value rules must be syntactically valid."""
+    from rdflib.plugins.sparql import prepareQuery
+
+    g = _parse_shacl(_PRESENCE_IMPLIES_VALUE_SCHEMA_YAML)
+
+    for shape in (EX_PIV.Weather, EX_PIV.Device):
+        sparql_nodes = list(g.objects(shape, SH.sparql))
+        for node in sparql_nodes:
+            query_text = str(list(g.objects(node, SH.select))[0])
+            prepareQuery(query_text)
+
+
+def test_presence_implies_value_pyshacl_end_to_end():
+    """End-to-end: pyshacl passes conforming instances and flags violations."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_PRESENCE_IMPLIES_VALUE_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+
+    # Conforming: guarded slots paired with an allowed sky_model; and an
+    # unguarded instance (no texture/overcast) is unaffected by the rules.
+    conforming_data = """
+    @prefix ex: <https://example.org/presence-implies-value/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wTexture a ex:Weather ;
+        ex:texture_sky_color "0,0,0" ;
+        ex:sky_model ex:TextureSky .
+
+    ex:wOvercast a ex:Weather ;
+        ex:overcast_sky_illuminance "5000.0"^^xsd:float ;
+        ex:sky_model ex:OvercastSky .
+
+    ex:wMeasured a ex:Weather ;
+        ex:overcast_sky_illuminance "4200.0"^^xsd:float ;
+        ex:sky_model ex:MeasuredOvercastSky .
+
+    ex:wClear a ex:Weather ;
+        ex:sky_model ex:ClearSky .
+    """
+
+    conforms, _, results_text = pyshacl.validate(
+        data_graph=conforming_data,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Conforming instances should pass SHACL validation:\n{results_text}"
+
+    # Violating: texture_sky_color present but sky_model is ClearSky (not TextureSky).
+    violating_wrong_value = """
+    @prefix ex: <https://example.org/presence-implies-value/> .
+
+    ex:wBad a ex:Weather ;
+        ex:texture_sky_color "0,0,0" ;
+        ex:sky_model ex:ClearSky .
+    """
+    conforms, _, results_text = pyshacl.validate(
+        data_graph=violating_wrong_value,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Wrong-value instance should fail SHACL validation:\n{results_text}"
+
+    # Violating: overcast_sky_illuminance present but sky_model is TextureSky
+    # (not in the allowed overcast set).
+    violating_not_in_set = """
+    @prefix ex: <https://example.org/presence-implies-value/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:wBad2 a ex:Weather ;
+        ex:overcast_sky_illuminance "5000.0"^^xsd:float ;
+        ex:sky_model ex:TextureSky .
+    """
+    conforms, _, results_text = pyshacl.validate(
+        data_graph=violating_not_in_set,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Not-in-set instance should fail SHACL validation:\n{results_text}"
+
+    # Violating: texture_sky_color present but sky_model entirely absent.
+    violating_missing_target = """
+    @prefix ex: <https://example.org/presence-implies-value/> .
+
+    ex:wBad3 a ex:Weather ;
+        ex:texture_sky_color "0,0,0" .
+    """
+    conforms, _, results_text = pyshacl.validate(
+        data_graph=violating_missing_target,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"Missing-target instance should fail SHACL validation:\n{results_text}"
+
+
+# ===========================================================================
+# Compositional fallback: conditional-required pattern (M1)
+# ===========================================================================
+#
+# Rule shape:
+#   - preconditions:  slot X has equals_string V
+#   - postconditions: slot Y has required: true
+#
+# Semantics: "If X = V, then Y must be present."  Emitted as an
+# sh:SPARQLConstraint whose SELECT matches focus nodes where the precondition
+# holds but the required slot is absent (FILTER NOT EXISTS).
+# ===========================================================================
+
+
+# ===========================================================================
+# Compositional fallback: conditional-absent pattern (M2)
+# ===========================================================================
+#
+# Rule shape:
+#   - preconditions:  slot X has equals_string V
+#   - postconditions: slot Y has value_presence: ABSENT
+#
+# Semantics: "If X = V, then Y must NOT be present" (inapplicable slot).
+# Emitted as an sh:SPARQLConstraint whose SELECT matches focus nodes where the
+# precondition holds and the forbidden slot is present.
+# ===========================================================================
+
+
+# ===========================================================================
+# Compositional fallback: numeric threshold precondition (M3)
+# ===========================================================================
+#
+# Rule shape:
+#   - preconditions:  slot X has maximum_value N (or minimum_value)
+#   - postconditions: slot Y has required: true
+#
+# Semantics: "If X <= N, then Y must be present."  The threshold becomes a
+# SPARQL FILTER; combined here with the M1 required violation.
+# ===========================================================================
+
+
+# ===========================================================================
+# Compositional fallback: nested range_expression precondition (M4)
+# ===========================================================================
+#
+# Rule shape:
+#   - preconditions:  slot X (inlined child) has range_expression on an inner
+#     slot (e.g. sun_position.elevation <= 0)
+#   - postconditions: slot Y has required: true
+#
+# Semantics: "If the child's inner value satisfies the condition, then Y must
+# be present."  The SPARQL binds the child node with one extra hop.
+# ===========================================================================
+
+
+# ===========================================================================
+# Compositional fallback: has_member list-membership postcondition (M5)
+# ===========================================================================
+#
+# Rule shape:
+#   - preconditions:  any supported precondition (here value_presence PRESENT)
+#   - postconditions: multivalued slot has_member with a nested
+#     range_expression constraining the member's inner slots
+#
+# Semantics: "If the precondition holds, the list must contain a member
+# matching the inner conditions."  Violation = no such member (FILTER NOT
+# EXISTS over the members).  Inner enum values resolve against the member
+# class (LightControlGroup), which disambiguates the reused `type` slot.
+# ===========================================================================
+
+
+# ===========================================================================
+# Rule-converter robustness regressions (review hardening)
+#
+# These guard three defects found while reviewing the rule converters:
+#   1. A single precondition combining minimum_value + maximum_value dropped
+#      all but the first bound (silent under-constraint / false positives).
+#   2. A slot_usage `slot_uri` (or enum `range`) override made the SPARQL body
+#      query the *base* IRI while `sh:path` used the *induced* IRI, so the
+#      constraint silently never fired (false negative).
+#   3. An `equals_string` value containing a quote/backslash produced invalid,
+#      unparsable SPARQL (broken artifact / injection).
+# ===========================================================================
+
+
+_ENUM_NARROWING_SCHEMA_YAML = """
+id: https://example.org/enum-narrowing
+name: enum_narrowing_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/enum-narrowing/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+enums:
+  BaseMode:
+    permissible_values:
+      Active:
+        meaning: ex:GLOBAL_Active
+  SceneMode:
+    permissible_values:
+      Active:
+        meaning: ex:LOCAL_Active
+
+slots:
+  activator:
+    range: string
+    slot_uri: ex:activator
+  mode:
+    range: BaseMode
+    slot_uri: ex:mode
+
+classes:
+  Scene:
+    class_uri: ex:Scene
+    slots:
+      - activator
+      - mode
+    slot_usage:
+      mode:
+        range: SceneMode
+    rules:
+      - description: If an activator is present the mode must be Active.
+        preconditions:
+          slot_conditions:
+            activator:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            mode:
+              equals_string: Active
+"""
+
+EX_EN = rdflib.Namespace("https://example.org/enum-narrowing/")
+
+
+def test_rule_enum_range_narrowed_by_slot_usage():
+    """A slot_usage range override to a class-specific enum must resolve the
+    value's meaning against the induced (narrowed) enum, not the base range."""
+    g = _parse_shacl(_ENUM_NARROWING_SCHEMA_YAML)
+
+    nodes = list(g.objects(EX_EN.Scene, SH.sparql))
+    assert len(nodes) == 1
+    query = str(list(g.objects(nodes[0], SH.select))[0])
+    assert str(EX_EN.LOCAL_Active) in query, f"must resolve the narrowed enum meaning, got:\n{query}"
+    assert "GLOBAL_Active" not in query, f"must not resolve the base enum meaning, got:\n{query}"
+
+
+_ESCAPING_SCHEMA_YAML = """
+id: https://example.org/escaping
+name: escaping_rules
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/escaping/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+
+slots:
+  trigger:
+    range: string
+    slot_uri: ex:trigger
+  label:
+    range: string
+    slot_uri: ex:label
+
+classes:
+  Item:
+    class_uri: ex:Item
+    slots:
+      - trigger
+      - label
+    rules:
+      - description: If a trigger is present the label must equal the quoted marker.
+        preconditions:
+          slot_conditions:
+            trigger:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            label:
+              equals_string: 'a"b\\\\c'
+"""
+
+EX_ESC = rdflib.Namespace("https://example.org/escaping/")
+
+
+def test_rule_equals_string_special_chars_escaped():
+    """An equals_string value with a quote and backslash must be escaped so the
+    generated SPARQL stays syntactically valid (no injection / broken query)."""
+    from rdflib.plugins.sparql import prepareQuery
+
+    g = _parse_shacl(_ESCAPING_SCHEMA_YAML)
+    nodes = list(g.objects(EX_ESC.Item, SH.sparql))
+    assert len(nodes) == 1
+    query = str(list(g.objects(nodes[0], SH.select))[0])
+
+    # Would raise ParseException on the unescaped `... = "a"b\c"` form.
+    prepareQuery(query)
+    assert '\\"' in query, f"double quote must be escaped, got:\n{query}"
+    assert "\\\\" in query, f"backslash must be escaped, got:\n{query}"
+
+
+# ===========================================================================
+# Audit-fix regression tests: operator exactness, nested-slot resolution,
+# numeric bound gating, elseconditions warning
+# ===========================================================================
+
+_PIV_EXTRA_PRE_SCHEMA_YAML = """
+id: https://example.org/piv-extra-pre
+name: piv_extra_pre
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/piv-extra-pre/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  temp:
+    range: integer
+    slot_uri: ex:temp
+  mode:
+    range: string
+    slot_uri: ex:mode
+classes:
+  Device:
+    class_uri: ex:Device
+    slots: [temp, mode]
+    rules:
+      - description: Above 100 the mode must be High (extra precondition operator).
+        preconditions:
+          slot_conditions:
+            temp:
+              value_presence: PRESENT
+              minimum_value: 100
+        postconditions:
+          slot_conditions:
+            mode:
+              equals_string: "High"
+"""
+
+
+def test_rule_extra_precondition_operator_skipped():
+    """A precondition combining PRESENT with a threshold must not dispatch to
+    presence-implies-value: dropping the threshold widens the trigger."""
+    g = _parse_shacl(_PIV_EXTRA_PRE_SCHEMA_YAML)
+    shape = URIRef("https://example.org/piv-extra-pre/Device")
+    assert list(g.objects(shape, SH.sparql)) == [], "rule with an untranslated conjunct must be skipped"
+
+
+def test_rule_extra_precondition_operator_pyshacl_end_to_end():
+    """A device below the threshold satisfies the rule vacuously and must conform."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_PIV_EXTRA_PRE_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+    data = """
+    @prefix ex: <https://example.org/piv-extra-pre/> .
+
+    ex:cool a ex:Device ; ex:temp 50 ; ex:mode "Low" .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=data,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Below-threshold device must not be flagged:\n{txt}"
+
+
+_POST_BOTH_EQUALS_SCHEMA_YAML = """
+id: https://example.org/post-both-equals
+name: post_both_equals
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/post-both-equals/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  guard:
+    slot_uri: ex:guard
+  target:
+    slot_uri: ex:target
+classes:
+  Thing:
+    class_uri: ex:Thing
+    slots: [guard, target]
+    rules:
+      - preconditions:
+          slot_conditions:
+            guard:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            target:
+              equals_string: "a"
+              equals_string_in: ["b", "c"]
+"""
+
+
+def test_rule_post_with_both_equals_forms_skipped():
+    """equals_string and equals_string_in set together is ambiguous — skip,
+    do not let one form silently win."""
+    g = _parse_shacl(_POST_BOTH_EQUALS_SCHEMA_YAML)
+    shape = URIRef("https://example.org/post-both-equals/Thing")
+    assert list(g.objects(shape, SH.sparql)) == []
+
+
+_MIXED_SCALAR_SCHEMA_YAML = """
+id: https://example.org/mixed-scalar
+name: mixed_scalar
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/mixed-scalar/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  code:
+    slot_uri: ex:code
+  note:
+    slot_uri: ex:note
+classes:
+  Obs:
+    class_uri: ex:Obs
+    slots: [code, note]
+    rules:
+      - preconditions:
+          slot_conditions:
+            code:
+              equals_string: fog
+              pattern: "^f"
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+"""
+
+
+def test_rule_recognized_plus_unrecognized_operator_skipped():
+    """A condition mixing a supported operator (equals_string) with an
+    unsupported one (pattern) must skip — translating only the supported part
+    widens the trigger."""
+    g = _parse_shacl(_MIXED_SCALAR_SCHEMA_YAML)
+    shape = URIRef("https://example.org/mixed-scalar/Obs")
+    assert list(g.objects(shape, SH.sparql)) == []
+
+
+_EXPR_ANY_OF_SCHEMA_YAML = """
+id: https://example.org/expr-any-of
+name: expr_any_of
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/expr-any-of/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  code:
+    slot_uri: ex:code
+  other:
+    slot_uri: ex:other
+  note:
+    slot_uri: ex:note
+classes:
+  Obs:
+    class_uri: ex:Obs
+    slots: [code, other, note]
+    rules:
+      - preconditions:
+          slot_conditions:
+            code:
+              equals_string: fog
+          any_of:
+            - slot_conditions:
+                other:
+                  equals_string: x
+            - slot_conditions:
+                other:
+                  equals_string: y
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+"""
+
+
+def test_rule_expression_level_any_of_skipped():
+    """Expression-level any_of on the preconditions cannot be honoured by any
+    converter; dropping the branch widens the trigger, so the rule is skipped."""
+    g = _parse_shacl(_EXPR_ANY_OF_SCHEMA_YAML)
+    shape = URIRef("https://example.org/expr-any-of/Obs")
+    assert list(g.objects(shape, SH.sparql)) == []
+
+
+def test_rule_expression_level_any_of_pyshacl_end_to_end():
+    """An instance whose any_of branch is unmet satisfies the rule vacuously
+    and must conform."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_EXPR_ANY_OF_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+    data = """
+    @prefix ex: <https://example.org/expr-any-of/> .
+
+    ex:o a ex:Obs ; ex:code "fog" ; ex:other "z" .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=data,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"Instance with unmet any_of branch must not be flagged:\n{txt}"
+
+
+_POST_MIXED_SCHEMA_YAML = """
+id: https://example.org/post-mixed
+name: post_mixed
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/post-mixed/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  guard:
+    slot_uri: ex:guard
+  target:
+    slot_uri: ex:target
+classes:
+  Thing:
+    class_uri: ex:Thing
+    slots: [guard, target]
+    rules:
+      - preconditions:
+          slot_conditions:
+            guard:
+              equals_string: on
+        postconditions:
+          slot_conditions:
+            target:
+              required: true
+              pattern: "^x"
+"""
+
+
+def test_rule_post_mixed_operators_skipped():
+    """A postcondition combining required with an untranslated operator must
+    skip — checking only required weakens the postcondition."""
+    g = _parse_shacl(_POST_MIXED_SCHEMA_YAML)
+    shape = URIRef("https://example.org/post-mixed/Thing")
+    assert list(g.objects(shape, SH.sparql)) == []
+
+
+_ABSENT_COMBINED_SCHEMA_YAML = """
+id: https://example.org/absent-combined
+name: absent_combined
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/absent-combined/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  count:
+    range: integer
+    slot_uri: ex:count
+  note:
+    slot_uri: ex:note
+classes:
+  Obs:
+    class_uri: ex:Obs
+    slots: [count, note]
+    rules:
+      - preconditions:
+          slot_conditions:
+            count:
+              value_presence: ABSENT
+              minimum_value: 5
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+"""
+
+
+def test_rule_absent_combined_with_bound_skipped():
+    """value_presence ABSENT combined with another operator must skip: the
+    triple-binding translation would invert the declared trigger."""
+    g = _parse_shacl(_ABSENT_COMBINED_SCHEMA_YAML)
+    shape = URIRef("https://example.org/absent-combined/Obs")
+    assert list(g.objects(shape, SH.sparql)) == []
+
+
+_STRING_TRUE_SCHEMA_YAML = """
+id: https://example.org/string-true
+name: string_true
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/string-true/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  opt:
+    slot_uri: ex:opt
+  status:
+    range: string
+    slot_uri: ex:status
+classes:
+  Conf:
+    class_uri: ex:Conf
+    slots: [opt, status]
+    rules:
+      - description: If opt is present, status must be the string "true".
+        preconditions:
+          slot_conditions:
+            opt:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            status:
+              equals_string: "true"
+"""
+
+
+def test_rule_equals_true_on_string_slot_uses_piv():
+    """equals_string "true" on a NON-boolean slot must dispatch to
+    presence-implies-value (string comparison), not the boolean guard."""
+    g = _parse_shacl(_STRING_TRUE_SCHEMA_YAML)
+    shape = URIRef("https://example.org/string-true/Conf")
+    sparql_nodes = list(g.objects(shape, SH.sparql))
+    assert len(sparql_nodes) == 1
+    query = str(list(g.objects(sparql_nodes[0], SH.select))[0])
+    assert "NOT IN" in query, f"string-range 'true' must be a string comparison, got:\n{query}"
+    assert '"true"' in query, "the comparison term must be the string literal"
+
+
+def test_rule_equals_true_on_string_slot_pyshacl_end_to_end():
+    """status "true" (string) satisfies the rule; the boolean-guard hijack used
+    to flag it."""
+    import pyshacl
+
+    shacl_ttl = ShaclGenerator(_STRING_TRUE_SCHEMA_YAML, mergeimports=False, emit_rules=True).serialize()
+    conforming = """
+    @prefix ex: <https://example.org/string-true/> .
+
+    ex:ok a ex:Conf ; ex:opt "x" ; ex:status "true" .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=conforming,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert conforms, f"status 'true' satisfies the rule and must conform:\n{txt}"
+
+    violating = """
+    @prefix ex: <https://example.org/string-true/> .
+
+    ex:bad a ex:Conf ; ex:opt "x" ; ex:status "other" .
+    """
+    conforms, _, txt = pyshacl.validate(
+        data_graph=violating,
+        shacl_graph=shacl_ttl,
+        data_graph_format="turtle",
+        shacl_graph_format="turtle",
+        advanced=True,
+    )
+    assert not conforms, f"status 'other' violates the rule:\n{txt}"
+
+
+_UNKNOWN_KEY_SCHEMA_YAML = """
+id: https://example.org/unknown-key
+name: unknown_key
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/unknown-key/
+imports:
+  - linkml:types
+default_prefix: ex
+default_range: string
+slots:
+  code:
+    slot_uri: ex:code
+  note:
+    slot_uri: ex:note
+classes:
+  Obs:
+    class_uri: ex:Obs
+    slots: [code, note]
+    rules:
+      - description: A rule keyed on a nonexistent slot must be skipped.
+        preconditions:
+          slot_conditions:
+            no_such_slot:
+              equals_string: trigger
+        postconditions:
+          slot_conditions:
+            note:
+              required: true
+"""
+
+
+def test_rule_unknown_slot_key_skipped():
+    """A rule whose condition keys a slot that does not exist must be skipped:
+    fabricating a default-prefix predicate would emit a constraint that can
+    never fire (or, for has_member, always fires)."""
+    g = _parse_shacl(_UNKNOWN_KEY_SCHEMA_YAML)
+    shape = URIRef("https://example.org/unknown-key/Obs")
+    assert list(g.objects(shape, SH.sparql)) == []


### PR DESCRIPTION
## Summary

The SHACL generator translates LinkML `rules:` into `sh:sparql` constraints, but
the generator documentation did not mention it — so the feature was
undiscoverable and its limits undocumented.

Adds a **Rule constraints (SHACL-SPARQL)** section to `docs/generators/shacl.rst`
covering:

- the recognised named patterns (boolean guard, presence implies value,
  exclusive value) and the compositional fallback;
- the `--emit-rules` / `--no-emit-rules` flag (default: on);
- the *skip, never mis-translate* contract, and which rule attributes warn
  (`bidirectional`, `open_world`, `elseconditions`) versus are silently skipped
  (`deactivated`);
- a worked YAML → Turtle example;
- the note that `sh:sparql` needs a processor with SHACL-SPARQL support
  (e.g. `pyshacl` with `advanced=True`).

Documentation only — no source or test changes.

## Stack position

```
main
└─ #3989  presence-implies-value
   └─ #3990  compositional fallback (M1–M5)
      └─ #3991  documentation   ← this PR
```

> [!IMPORTANT]
> **Depends on #3989 and #3990.** This section documents behaviour introduced by
> both, so it should merge last.
>
> Because this PR targets `main`, its diff **includes both of their commits**.
> Only the third commit — the docs change — is new here. If #3990 is deferred,
> the paragraph describing the compositional fallback needs to be dropped from
> this PR.
